### PR TITLE
Fixed #558

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -43,6 +43,8 @@ function closeSelect() {
 
 function newCourse() {
 	AJAXService("NEW", {}, "COURSE");
+	
+	AJAXService("GET", {}, "COURSE");
 }
 
 function copyVersion() {


### PR DESCRIPTION
Get all courses after you have added new course, so you don't have to update site to see the newly added course.