### PR TITLE
Added email row in user

### DIFF
--- a/Shared/SQL/init_db.sql
+++ b/Shared/SQL/init_db.sql
@@ -16,6 +16,7 @@ CREATE TABLE user(
 		newpassword	TINYINT(1) NULL,
 		creator			INT UNSIGNED NULL,
 		superuser		TINYINT(1) NULL,
+		email			VARCHAR(256) DEFAULT NULL,
 		PRIMARY KEY(uid)		
 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 


### PR DESCRIPTION
I've added a row in the user table that allows email addresses of users to be stored. For the time being, the attribute is declared to be default null so we don't run into issues with there already being users that have no email address, so either the database may need to be changed in the future or the constraint that a user must have a specified email needs to be controlled on the back end or front end.