### PR TITLE
loginbox

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -243,6 +243,10 @@ function processLogin(kind) {
 					$("#loginbutton").addClass("loggedin");
 
 					hideLoginPopup();
+					
+					$("#login #username").val("");
+					$("#login #password").val("");		
+					
 					$("#loginbutton").click(function(){processLogout();});
 
 					if(kind=="COURSE") AJAXService("GET",{},"COURSE")


### PR DESCRIPTION
Take away values in username and password input boxes after user have logged in. This is so that when the user loggout and want to loggin again, the user should not see old username and password from before.
