### PR TITLE
Update whiteTheme.css

### DIFF
--- a/Shared/css/whiteTheme.css
+++ b/Shared/css/whiteTheme.css
@@ -193,9 +193,9 @@
 }
 
 .normtext .impword {
-    color: #fff;
-    background-color: #614875;
-		border: 1px solid #f44;
+    color: #000;
+    background-color: #F2F2F2;
+		border: 1px solid #899;
 }
 
 .impo .impword {


### PR DESCRIPTION
Made changes to (.normtext .impword) so the text aint highlighted from the begining and only highlights when hovered. But border still marks important words.