### PR TITLE
Overflow control to codeviewer boxes. Issue#832

### DIFF
--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -1520,7 +1520,6 @@ function resizeBoxes(parent, templateId) {
 	
 	//Gets box measurments from localstorage and applies them onto the boxes on screen.
 	//This is done preinit of boxValArray, so that the init of that array gets these values.
-	//Also adds some basic css to the boxes.
 	function getLocalStorageProperties(templateId){
 		
 		var numBoxes = $("[id ^=box][id $=wrapper]").length;
@@ -1531,10 +1530,6 @@ function resizeBoxes(parent, templateId) {
 				
 				$("#box" + i + "wrapper").width(localStorage.getItem("template" + templateId + "box" + i + "widthPercent") + "%");
 				$("#box" + i + "wrapper").height(localStorage.getItem("template" + templateId +  "box" + i + "heightPercent") + "%");
-				
-				//setOverflow
-				$("#box" + i + "wrapper > #box" + i + "menu").css("overflow", "hidden");
-				$("#box" + i + "wrapper > #box" + i).css("overflow", "auto");
 				
 			}
 		}

--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -1520,6 +1520,7 @@ function resizeBoxes(parent, templateId) {
 	
 	//Gets box measurments from localstorage and applies them onto the boxes on screen.
 	//This is done preinit of boxValArray, so that the init of that array gets these values.
+	//Also adds some basic css to the boxes.
 	function getLocalStorageProperties(templateId){
 		
 		var numBoxes = $("[id ^=box][id $=wrapper]").length;
@@ -1530,6 +1531,10 @@ function resizeBoxes(parent, templateId) {
 				
 				$("#box" + i + "wrapper").width(localStorage.getItem("template" + templateId + "box" + i + "widthPercent") + "%");
 				$("#box" + i + "wrapper").height(localStorage.getItem("template" + templateId +  "box" + i + "heightPercent") + "%");
+				
+				//setOverflow
+				$("#box" + i + "wrapper > #box" + i + "menu").css("overflow", "hidden");
+				$("#box" + i + "wrapper > #box" + i).css("overflow", "auto");
 				
 			}
 		}

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -15,9 +15,8 @@
 }
 
 .box {
-	overflow: auto;
+    overflow: auto;
 }
-
 
 .box h1 {
 

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -14,6 +14,11 @@
     font-style: italic;
 }
 
+.box {
+	overflow: auto;
+}
+
+
 .box h1 {
 
     display: block;
@@ -45,6 +50,7 @@
     width: -moz-calc(100%);
     width: -webkit-calc(100%);
     margin: 0;
+    overflow: hidden;
 }
 .buttomenu2 table td img{
 	height: 25px;


### PR DESCRIPTION
Added overflow control for the boxes in codeviewer, to make the information accessable even after resizing the boxes to small ones.