### PR TITLE
Refactor shared navhead to work with all groups

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -13,7 +13,7 @@
 			}else if($noup=="SECTION"){
 				$cid=getOPG('cid');
 				$coursevers=getOPG('coursevers');
-				echo "<td class='navButt' id='home' title='Home'><a href='../DuggaSys/sectioned.php?courseid=".$cid."&coursevers=".$coursevers."'></a></td>";
+				echo "<td class='navButt' id='home' title='Home'><a href='../DuggaSys/sectioned.php?courseid=".$cid."&coursevers=".$coursevers."'><img src='../Shared/icons/Home.svg'></a></td>";
 			}else {
 				// None!
 			}

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -9,7 +9,10 @@
 			// Always show home button which links to course homepage
 			echo "<td class='navButt' id='home' title='Home'><a href='../DuggaSys/courseed.php'><img src='../Shared/icons/Home.svg'></a></td>";
 
-			// Create back button with different urls
+			// Generate different back buttons depending on which page is including
+			// this file navheader file. The switch case uses ternary operators to
+			// determine the href attribute value. (if(this) ? dothis : elsethis)
+			//---------------------------------------------------------------------
 			echo "<td class='navButt' id='home' title='Home'>";
 			switch ($noup) {
 				case 'COURSE':
@@ -33,11 +36,13 @@
 					echo "<img src='../Shared/icons/Up.svg'></a></td>";
 					break;
 				case 'NONE';
-					// Do nothing if NONE is set 
+					// This case is used for pages still under development
 					break;
 				default:
-					// Show generic back button to course
-					echo "<a href='" . $_SERVER['HTTP_REFERER'] . "'>";
+					// Show generic back button
+					echo "<a href='";
+					echo (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : "../DuggaSys/courseed.php");
+					echo "'>";
 					echo "<img src='../Shared/icons/Up.svg'></a></td>";
 					break;
 			}

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -6,16 +6,40 @@
 				
 			include_once "../Shared/basic.php";
 			
-			// Set the target for the 'Upward' Button
-			
-			if($noup=="COURSE"){
-				echo "<td class='navButt' id='home' title='Home'><a href='../DuggaSys/courseed.php'><img src='../Shared/icons/Home.svg'></a></td>";
-			}else if($noup=="SECTION"){
-				$cid=getOPG('cid');
-				$coursevers=getOPG('coursevers');
-				echo "<td class='navButt' id='home' title='Home'><a href='../DuggaSys/sectioned.php?courseid=".$cid."&coursevers=".$coursevers."'><img src='../Shared/icons/Home.svg'></a></td>";
-			}else {
-				// None!
+			// Always show home button which links to course homepage
+			echo "<td class='navButt' id='home' title='Home'><a href='../DuggaSys/courseed.php'><img src='../Shared/icons/Home.svg'></a></td>";
+
+			// Create back button with different urls
+			echo "<td class='navButt' id='home' title='Home'>";
+			switch ($noup) {
+				case 'COURSE':
+					echo "<a href='";
+					echo (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : "../DuggaSys/courseed.php");
+					echo "'>";
+					echo "<img src='../Shared/icons/Up.svg'></a></td>";
+					break;
+				case 'SECTION':
+					$cid=getOPG('cid');
+					$coursevers=getOPG('coursevers');
+					echo "<a href='";
+					echo ($cid != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$cid."&coursevers=".$coursevers : "../DuggaSys/courseed.php");
+					echo "'>";
+					echo "<img src='../Shared/icons/Up.svg'></a></td>";
+					break;
+				case 'CODEVIEWER':
+					echo "<a href='";
+					echo (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '../codeviewer/EditorV50.php');
+					echo "'>";
+					echo "<img src='../Shared/icons/Up.svg'></a></td>";
+					break;
+				case 'NONE';
+					// Do nothing if NONE is set 
+					break;
+				default:
+					// Show generic back button to course
+					echo "<a href='" . $_SERVER['HTTP_REFERER'] . "'>";
+					echo "<img src='../Shared/icons/Up.svg'></a></td>";
+					break;
 			}
 	
 			// Either generate code viewer specific nav menu or a spacer


### PR DESCRIPTION
Refactored how the "home" and "back" buttons work for all the groups. It relies on the $noup variable to see what the back button will link to.
Uses ternary operations.