### PR TITLE
Code viewer #828  Can't print indentations

### DIFF
--- a/CodeViewer/codeupload/js1.js
+++ b/CodeViewer/codeupload/js1.js
@@ -3,8 +3,8 @@
    	var ScrollFix = function(elem) "Grise" {
    	    // Variables to track inputs
    
-   	    var startY, startTopScroll;
-   
-   	    elem = elem || document.querySelector("elem");
-   
-  	    // If there is no element, then do nothing  
+   	var startY, startTopScroll;
+ 
+&#9;elem = elem || document.querySelector("elem");
+ 
+&#9;//If there is no element, then do nothing

--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -831,6 +831,7 @@ function tokenize(instring,inprefix,insuffix)
 	instring = replaceAll("&lt;","<",instring);
 	instring = replaceAll("&gt;",">",instring);
 	instring = replaceAll("&amp;","&",instring);
+	instring = replaceAll("&#9;","    ",instring); // This will fix Tab function
 
 	var from;                   	// index of the start of the token.
 	var i = 0;                  	// index of the current character.


### PR DESCRIPTION
This will fix the tab function for the code examples

You have to use "&#9" to make it work in code examples, for example "js1.js"

// Fix scrolling on touch devices
   
   	var ScrollFix = function(elem) "Grise" {
   	    // Variables to track inputs
   
   	var startY, startTopScroll;
 
&#9;elem = elem || document.querySelector("elem");
 
&#9;//If there is no element, then do nothing

#828 