### PR TITLE
Added a weekly event in the database, issue #903

### DIFF
--- a/Shared/SQL/init_db.sql
+++ b/Shared/SQL/init_db.sql
@@ -619,3 +619,16 @@ UPDATE codeexample
 SET beforeid='12', afterid='13'
 WHERE exampleid='13';
 
+/**
+ * Clears the eventlog table on a weekly basis
+ */
+DELIMITER $$
+CREATE EVENT weekly_eventlog_delete
+ON SCHEDULE EVERY 1 WEEK 
+DO
+BEGIN
+SET SQL_SAFE_UPDATES = 0;
+DELETE FROM eventlog;
+SET SQL_SAFE_UPDATES = 1;
+END $$
+DELIMITER ;


### PR DESCRIPTION
This event should perform a weekly clear of the eventlog table. The eventlog table can grow to a great size and old information in that table may not be relevant after a long time. Moreover, for performance and storage space reasons, this event is also an optimization. #903