### PR TITLE
Code view#873 markdown list

### DIFF
--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -1688,7 +1688,9 @@ function getLocalStorageProperties(templateId){
 //----------------------------------------------------------------------------------
 function parseMarkdown(inString)
 {	
-	var returnString = " ";							
+	var removeExtraTagsNumberedList = new RegExp('</ol>' + '\n' + '<ol>', 'g');
+	var removeExtraTagsUnorderedList = new RegExp('</ul>' + '\n' + '<ul>', 'g');
+	
 	inString = inString.replace(/\*{3}(.*?\S)\*{3}/gm, '<font style="font-weight:bold; font-style:italic"><em>$1</font>');	
 	inString = inString.replace(/\*{2}(.*?\S)\*{2}/gm, '<font style="font-weight:bold;">$1</font>');
 	inString = inString.replace(/\*{1}(.*?\S)\*{1}/gm, '<font style="font-style:italic;">$1</font>');
@@ -1701,7 +1703,10 @@ function parseMarkdown(inString)
 	inString = inString.replace(/^\#{3} (.*)=*/gm, '<h3>$1</h3>');
 	inString = inString.replace(/^\#{2} (.*)=*/gm, '<h2>$1</h2>');
 	inString = inString.replace(/^\#{1} (.*)=*/gm, '<h1>$1</h1>');
-	returnString = inString;
-
-	return returnString;
+	inString = inString.replace(/^\s*\d*\.\s(.*)/gm, '<ol><li>$1</li></ol>');
+	inString = inString.replace(removeExtraTagsNumberedList, '');
+	inString = inString.replace(/^\s*\-\s(.*)/gm, '<ul><li>$1</li></ul>');
+	inString = inString.replace(removeExtraTagsUnorderedList, '');
+	
+	return inString;
 }

--- a/CodeViewer/descupload/test.txt
+++ b/CodeViewer/descupload/test.txt
@@ -1,1 +1,20 @@
-This is a test description, if you see this, then that means it works.
+1. ordered list entry 1 
+2. ordered list entry 2
+4. ordered list entry 3
+3. ordered list entry 4
+1. ordered list entry 5
+235. ordered list entry 6
+
+- 1 unordered list 
+- 2 unordered list
+
+- 1 ordered list - 2 not list entry - 3 not list entry - 4 not list entry
+
+- unordered list 
+- unordered list
+- unordered list
+-Should not be list
+
+1.Should not be list
+2.Should not be list
+Should not be list 1. Should not be list

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -24,6 +24,15 @@
     font-style: italic;
 }
 
+.box ol{
+	margin-left: 2em;
+}
+
+.box ul{
+	list-style-type: disc;
+	display: list-item;
+	margin-left: 1.5em;
+}
 
 .box span.codestyle{
     color: #666;


### PR DESCRIPTION
The first pull-request was into master so this is a reopen of #1123.

#873
Using regular expression to replace certain symbols with html list tags.

For ordered lists type any integer value followed by a dot and then some text, e. g.
1. entry 1
2. entry 2
4. entry 3

For unordered lists type a line, followed by a space, followed by some text e.g.

    entry 1
    entry 2

If you are unsure if the input is parsed correctly try the same input here http://spec.commonmark.org/dingus/. If the our parser translates input differently it is regarded as unexpected behavior.
