### PR TITLE
Code view#874 markdown code/text field

### DIFF
--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -1688,7 +1688,8 @@ function getLocalStorageProperties(templateId){
 //----------------------------------------------------------------------------------
 function parseMarkdown(inString)
 {	
-	var returnString = " ";							
+	var returnString = " ";
+	
 	inString = inString.replace(/\*{3}(.*?\S)\*{3}/gm, '<font style="font-weight:bold; font-style:italic"><em>$1</font>');	
 	inString = inString.replace(/\*{2}(.*?\S)\*{2}/gm, '<font style="font-weight:bold;">$1</font>');
 	inString = inString.replace(/\*{1}(.*?\S)\*{1}/gm, '<font style="font-style:italic;">$1</font>');
@@ -1701,6 +1702,8 @@ function parseMarkdown(inString)
 	inString = inString.replace(/^\#{3} (.*)=*/gm, '<h3>$1</h3>');
 	inString = inString.replace(/^\#{2} (.*)=*/gm, '<h2>$1</h2>');
 	inString = inString.replace(/^\#{1} (.*)=*/gm, '<h1>$1</h1>');
+	inString = inString.replace(/~{3}((?:\r|\n|.)+)\~{3}/gm, '<pre><code>$1</code></pre>');
+	
 	returnString = inString;
 
 	return returnString;

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -847,7 +847,25 @@ a {
     	font-weight: normal;
 	font-style: normal;
 }
-
+.desc pre {
+    font-family: "Courier 10 Pitch", Courier, monospace;
+    font-size: 95%;
+    line-height: 140%;
+    white-space: pre;
+    white-space: pre-wrap;
+}  
+.descbox code {
+    font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+    font-size: 95%;
+    line-height: 140%;
+    white-space: pre;
+    white-space: pre-wrap;
+    background: #ffffff;	
+    display: inline-block;
+    padding: 0em 1em 1em 1em;
+	margin: 0.5em;
+    border: 1px solid #bebab0;	
+}
 
 
 

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -863,7 +863,7 @@ a {
     background: #ffffff;	
     display: inline-block;
     padding: 0em 1em 1em 1em;
-	margin: 0.5em;
+    margin: 0.5em;
     border: 1px solid #bebab0;	
 }
 


### PR DESCRIPTION
Fixes issue #874 . Implements code blocks with markdown.

To test this, view example number 9 and edit the test.txt file located in the CodeViewer/descupload folder.

To make a code block use the markdown symbol: ~~~ before and after the code you want in the block.
Example:
\~~~
// Kommentar
var variabel = 5;
if(variabel == 5){
	alert("Hej");
}
\~~~