### PR TITLE
Highscore modes update

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -20,7 +20,7 @@ $(document).ready(function(){
         $("#testbutton").css("background-color", "#614875");
     });
 });
-function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys)
+function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys,highscoremode)
 {
 		
 	xelink=elink;
@@ -107,6 +107,18 @@ function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys)
 	if(evisible==1) str+="<option selected='selected' value='1'>Public</option>"
 	else str+="<option value='1'>Public</option>";
 	$("#visib").html(str);
+	
+	// Add hichscore mode options
+	str = "";
+	if(highscoremode==0) str +="<option selected='selected' value ='0'>None</option>" 
+	else str +="<option value ='0'>None</option>"; 
+
+	if(highscoremode==1) str +="<option selected='selected' value ='1'>Time based</option>" 
+	else str +="<option value ='1'>Time based</option>"; 
+
+	if(highscoremode==2) str +="<option selected='selected' value ='2'>Click based</option>" 
+	else str +="<option value ='2'>Click based</option>"; 
+	$("#highscoremode").html(str);
 
 	// Set Link
 	$("#link").val(elink);
@@ -199,11 +211,12 @@ function updateItem()
 	lid=$("#lid").val();
 	kind=$("#type").val();
 	link=$("#link").val();
+	highscoremode=$("#highscoremode").val();
 	sectionname=$("#sectionname").val();
 	visibility=$("#visib").val();
 	moment=$("#moment").val();
 	gradesys=$("#gradesys").val();
-	AJAXService("UPDATE",{lid:lid,kind:kind,link:link,sectname:sectionname,visibility:visibility,moment:moment,gradesys:gradesys},"SECTION");
+	AJAXService("UPDATE",{lid:lid,kind:kind,link:link,sectname:sectionname,visibility:visibility,moment:moment,gradesys:gradesys,highscoremode:highscoremode},"SECTION");
 	$("#editSection").css("display","none");
 }
 
@@ -438,7 +451,7 @@ function returnedSection(data)
 						str+="<a style='cursor:pointer;margin-left:75px;' onClick='changeURL(\"showDoc.php?cid="+querystring['courseid']+"&coursevers="+querystring['coursevers']+"&fname="+item['link']+"\");' >"+item['entryname']+"</a>";
 					}	
 		
-					if(data['writeaccess']) str+="<img id='dorf' style='float:right;margin-right:8px;margin-top:3px;' src='../Shared/icons/Cogwheel.svg' onclick='selectItem(\""+item['lid']+"\",\""+item['entryname']+"\",\""+item['kind']+"\",\""+item['visible']+"\",\""+item['link']+"\",\""+momentexists+"\",\""+item['gradesys']+"\");' />";
+					if(data['writeaccess']) str+="<img id='dorf' style='float:right;margin-right:8px;margin-top:3px;' src='../Shared/icons/Cogwheel.svg' onclick='selectItem(\""+item['lid']+"\",\""+item['entryname']+"\",\""+item['kind']+"\",\""+item['visible']+"\",\""+item['link']+"\",\""+momentexists+"\",\""+item['gradesys']+"\",\""+item['highscoremode']+"\");' />";
 		
 					if(parseInt(item['kind']) === 3||parseInt(item['kind']) === 4){
 						var grady=-1;

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -67,6 +67,9 @@ pdoConnect();
 			<td>Moment:&nbsp;<select id='moment' disabled></select></td>
 			<td>GradeSystem:&nbsp;<select id='gradesys' ></select></td>
 		</tr>
+		<tr>
+			<td>High score:&nbsp;<select id='highscoremode' ></select></td>
+		</tr>
 	</table>
 	<table>
 		<tr>

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -32,6 +32,7 @@ $link=getOP('link');
 $visibility=getOP('visibility');
 $order=getOP('order');
 $gradesys=getOP('gradesys');
+$highscoremode=getOP('highscoremode');
 
 $versid=getOP('versid');
 $coursename=getOP('coursename');
@@ -83,10 +84,11 @@ if(checklogin()){
 				}
 			}
 		}else if(strcmp($opt,"UPDATE")===0){
-			$query = $pdo->prepare("UPDATE listentries set moment=:moment,entryname=:entryname,kind=:kind,link=:link,visible=:visible,gradesystem=:gradesys WHERE lid=:lid;");
+			$query = $pdo->prepare("UPDATE listentries set highscoremode=:highscoremode, moment=:moment,entryname=:entryname,kind=:kind,link=:link,visible=:visible,gradesystem=:gradesys WHERE lid=:lid;");
 			$query->bindParam(':lid', $sectid);
 			$query->bindParam(':entryname', $sectname);
-
+			$query->bindParam(':highscoremode', $highscoremode);
+			
 			if($moment=="null") $query->bindValue(':moment', null,PDO::PARAM_INT);
 			else $query->bindParam(':moment', $moment);
 				
@@ -191,9 +193,10 @@ foreach($query->fetchAll() as $row) {
 $entries=array();
 $reada = (checklogin() && (hasAccess($userid, $courseid, 'r')||isSuperUser($userid)));
 if($reada){
-	$query = $pdo->prepare("SELECT lid,moment,entryname,pos,kind,link,visible,code_id,gradesystem FROM listentries WHERE listentries.cid=:cid and vers=:coursevers ORDER BY pos");
+	$query = $pdo->prepare("SELECT lid,moment,entryname,pos,kind,link,visible,code_id,gradesystem,highscoremode FROM listentries WHERE listentries.cid=:cid and vers=:coursevers ORDER BY pos");
 	$query->bindParam(':cid', $courseid);
 	$query->bindParam(':coursevers', $coursevers);
+
 	$result=$query->execute();
 	if(!$query->execute()) {
 		$error=$query->errorInfo();
@@ -210,6 +213,7 @@ if($reada){
 				'moment' => $row['moment'],
 				'link'=> $row['link'],
 				'visible'=> $row['visible'],
+				'highscoremode'=> $row['highscoremode'],
 				'gradesys' => $row['gradesystem'],
 				'code_id' => $row['code_id']
 			)

--- a/Shared/SQL/init_db.sql
+++ b/Shared/SQL/init_db.sql
@@ -97,6 +97,7 @@ CREATE TABLE listentries (
 	vers			VARCHAR(8),
 	moment			INT UNSIGNED,
 	gradesystem 	TINYINT(1),
+	highscoremode		INT DEFAULT 0,
 	CONSTRAINT 		pk_listentries PRIMARY KEY(lid),
 	
 /*	FOREIGN KEY(code_id) REFERENCES codeexample(exampleid) ON UPDATE NO ACTION ON DELETE SET NULL, */


### PR DESCRIPTION
When a user creates a dugga list item, the user is now presented with the possibility of selecting how to count high scores. 
The database table 'listentries' was updated to include what kind of high score mode should be associated with a dugga, currently my thoughts are
    0. None
    1. Timer based
    2. Click based

See issue #1265 