### PR TITLE
Code blocks inclusion and bug fix

### DIFF
--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -1947,6 +1947,9 @@ function parseMarkdown(inString)
 	//Regular expression for line
 	inString = inString.replace(/^(\-{3}\n)/gm, '<hr>');
 	
+	//Regular expression for code blocks
+	inString = inString.replace(/~{3}((?:\r|\n|.)+?)\~{3}/gm, '<pre><code>$1</code></pre>');
+	
 	return inString;
 }
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
The code for code blocks with markdown has yet again disappeared so I'm adding it back in. This fixes issue [#1211](http://github.com/HGustavs/LenaSYS/issues/1211).