### PR TITLE
Code view #1301   adding/removing imp rows

### DIFF
--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -341,11 +341,12 @@ function updateExample()
 // displayEditContent: Displays the dialogue box for editing a content pane
 //                Is called by createboxmenu in codeviewer.js
 //----------------------------------------------------------------------------------
+var openBoxID;
 
 function displayEditContent(boxid)
 {	
 	var box = retData['box'][boxid-1]; 	// The information stored about the box is fetched
-	var openBoxID = boxid;				// Keeps track of the currently open box. Used when saving the box content.
+	openBoxID = boxid;				// Keeps track of the currently open box. Used when saving the box content.
 
 	$("#boxtitle").val(box[4]);
 	$("#boxcontent").val(box[1]);  

--- a/CodeViewer/editorService.php
+++ b/CodeViewer/editorService.php
@@ -324,7 +324,7 @@
 		if(file_exists('./codeupload')){
 			$dir = opendir('./codeupload');
 			while (($file = readdir($dir)) !== false) {
-				if(endsWith($file,".js")){
+				if(endsWith($file,".js") || endsWith($file,".html") || endsWith($file,".php")){
 					array_push($codeDir,$file);		
 				}
 			}  


### PR DESCRIPTION
#1301 
The openBoxID was not a global variable.
The main problem was that the list with codeexamples only read files that ended with .js before.