### PR TITLE
Code View #1314: Description box alignment

### DIFF
--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -854,8 +854,7 @@ a {
 	padding: 0px !important;
 }
 .descbox{
-	padding-top: 4px !important;
-	padding-left: 4px !important;
+	padding: 10px !important;
 }
 .descbox h1{
 	color: #000;
@@ -880,7 +879,7 @@ a {
     background: #ffffff;	
     display: inline-block;
     padding: 0em 1em 1em 1em;
-    margin: 0.5em;
+    margin: 0.5em 0px;
     border: 1px solid #bebab0;	
 }
 


### PR DESCRIPTION
#1314 
Just a small fix for the description box.

### Before: 
![untitled](https://cloud.githubusercontent.com/assets/11715493/7490589/233f7eee-f3e2-11e4-8c02-85d7bfa93d35.png)

### After:
![untitled2](https://cloud.githubusercontent.com/assets/11715493/7490624/5cd21400-f3e2-11e4-814f-20b0ced5ed06.png)

