### PR TITLE
Ds19#1303 - "edit course", "edit version" and "new verison" dialogs should be more UX-friendly

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -101,15 +101,7 @@ function selectCourse(cid, coursename, coursecode, visi, vers, edvers)
 	$("#C" + cid).css("box-shadow", "1px 1px 3px #000 inset");
 	$(".item").css("background", "#fff");
 	$("#C" + cid).css("background", "#EDF");
-	// Set Name
-	$("#couresnamewrapper").html("<input class='form-control textinput' type='text' id='coursename' placeholder='"+coursename+"' />");
-	// Set Cid
-	$("#courseidwrapper").html("<input class='form-control textinput' type='text' id='coursecode' placeholder='"+coursecode+"' />");
-	// Set Code
-	$("#versidwrapper").html("<input size='8' class='form-control textinput' type='text' id='versid' placeholder='"+vers+"' />");
-	// Set Code
-	$("#versnamewrapper").html("<input size='8' class='form-control textinput' type='text' id='versname' placeholder='"+edvers+"' />");
-	// Set Visibiliy
+
 	// Set Name
 	$("#coursename").val(coursename);
 	// Set Cid
@@ -176,9 +168,7 @@ function selectCourse(cid, coursename, coursecode, visi, vers, edvers)
 
 	// Show dialog
 	$("#editCourse").css("display", "block");
-	
-	//resets all inputs
-	resetinputs();
+
 	return false;
 }
 

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -46,18 +46,14 @@ pdoConnect();
 			<h3>New Course</h3>
 			<div onclick='closeWindows();'>x</div>
 		</div>
-		<table width="100%">
-			<tr>
-				<input type='hidden' id='cid' value='Toddler' /></td>
-				<td>Course Name: <input class='form-control textinput' type='text' id='ncoursename' placeholder='Course Name' /></td>
-				<td>Course Code: <input class='form-control textinput' type='text' id='ncoursecode' placeholder='Course Code' /></td>
-			</tr>
-		</table>
-		<table width="100%">
-			<tr>
-				<td align='right'><input class='submit-button' type='button' value='Create' onclick='createNewCourse();' /></td>
-			</tr>
-		</table>
+		<div style='padding:5px;'>
+			<input type='hidden' id='cid' value='Toddler' />
+			<div class='inputwrapper'><span>Course Name:</span><input class='textinput' type='text' id='ncoursename' placeholder='Course Name' /></div>
+			<div class='inputwrapper'><span>Course code:</span><input class='textinput' type='text' id='ncoursecode' placeholder='Course Code' /></div>
+		</div>
+		<div style='padding:5px;'>
+			<input class='submit-button' type='button' value='Create' title='Create course' onclick='createNewCourse();' />
+		</div>
 	</div>
 	<!-- New Course Section Dialog END -->
 	
@@ -67,21 +63,15 @@ pdoConnect();
 			<h3>Edit Course</h3>
 			<div onclick='closeWindows();'>x</div>
 		</div>
-		<table width="100%">
-			<tr>
-				<input type='hidden' id='cid' value='Toddler' /></td>
-				<td>Course Name: <div id='couresnamewrapper'><input class='form-control textinput' type='text' id='coursename' value='Course Name' /></div></td>
-				<td>Course Code: <div id='courseidwrapper'><input class='form-control textinput' type='text' id='coursecode' value='Course Code' /></div></td>
-			</tr>
-			<tr>
-				<td>Visibility: <select style='float:right;' id='visib'></select></td>
-			</tr>
-		</table>
-		<table width="100%">
-			<tr>
-				<td align='right'><input class='submit-button' type='button' value='Save' title='Save changes' onclick='updateCourse();' /></td>
-			</tr>
-		</table>
+		<div style='padding:5px;'>
+			<input type='hidden' id='cid' value='Toddler' />
+			<div class='inputwrapper'><span>Course Name:</span><input class='textinput' type='text' id='coursename' placeholder='Course Name' /></div>
+			<div class='inputwrapper'><span>Course code:</span><input class='textinput' type='text' id='coursecode' placeholder='Course Code' /></div>
+			<div class='inputwrapper'><span>Visibility:</span><select class='selectinput' id='visib'></select></div>
+		</div>
+		<div style='padding:5px;'>
+			<input class='submit-button' type='button' value='Save' title='Save changes' onclick='updateCourse();' />
+		</div>
 	</div>
 	<!-- Edit Section Dialog END -->
 </body>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -48,62 +48,36 @@ pdoConnect();
 	<h3>Edit Dugga</h3>
 	<div onclick='closeEditDugga();'>x</div>
 	</div>
-				
-	<table width="100%">
-		<tr>
+		<div style='padding:5px;'>
 			<input type='hidden' id='did' value='Toddler' /></td>
-			<td colspan='2' style='line-height:40px;'>Name: <div id='dugganamewrapper'><input style='float:right;width:390px;' class='form-control textinput' type='text' id='name' value='Name' /></div></td>		
-		</tr>
-		<tr>
-			<td>Auto-grade: <select style='float:right;' id='autograde'></select></td>
-			<td>Grade System: <select style='float:right;' id='gradesys'></select></td>
-		</tr>
-		<tr>
-			<td colspan="2">Template: <select id='template'></select></td>
-		</tr>
-		<tr>
-			<td>Release Date: <div id='releasedatewrapper'><input class='form-control textinput datepicker' type='text' id='release' value='None' /></div></td>		
-			<td>Deadline Date: <div id='deadlinedatewrapper'><input class='form-control textinput datepicker' type='text' id='deadline' value='None' /></div></td>
-		</tr>
-
-
-	</table>
-
-	<table width="100%"><tr>
-			<td align='right'><input class='submit-button' type='button' value='Save' onclick='updateDugga();' /></td>
-		</tr>
-	</table>
-
+			<div class='inputwrapper'><span>Name:</span><input class='textinput' type='text' id='name' value='Name' /></div>
+			<div class='inputwrapper'><span>Auto-grade:</span><select id='autograde'></select></div>
+			<div class='inputwrapper'><span>Grade System:</span><select id='gradesys'></select></div>
+			<div class='inputwrapper'><span>Template:</span><select id='template'></select></div>
+			<div class='inputwrapper'><span>Release Date:</span><input class='textinput datepicker' type='text' id='release' value='None' /></div>
+			<div class='inputwrapper'><span>Deadline Date:</span><input class='textinput datepicker' type='text' id='deadline' value='None' /></div>
+		</div>
+	<div style='padding:5px;'>
+		<input class='submit-button' type='button' value='Save' onclick='updateDugga();' />
+	</div>
 	</div>
 	<!--- Edit Dugga Dialog END --->
 	
 	<!--- Edit Variant Dialog START --->
 	<div id='editVariant' class='loginBox' style='width:464px;display:none;'>
-
 	<div class='loginBoxheader'>
 	<h3>Edit Variant</h3>
 	<div onclick='closeWindows();'>x</div>
 	</div>
-				
-	<table width="100%">
-		<tr>
-			<input type='hidden' id='vid' value='Toddler' /></td>
-			<td colspan='2' style='line-height:40px;'>Param: <div id='parameternamewrapper'><input style='float:right;width:390px;' class='form-control textinput' type='text' id='parameter' value='Variant Param' /></div></td>		
-		</tr>	
-		<tr>
-			<td colspan='2' style='line-height:40px;'>Answer: <div id='answernamewrapper'><input style='float:right;width:390px;' class='form-control textinput' type='text' id='variantanswer' value='Variant Answer' /></div></td>		
-		</tr>
-	</table>
-
-	<table width="100%">
-		<tr>
-			<td align='left'><input class='submit-button' type='button' value='Delete' onclick='deleteVariant();' /></td>
-			<td align='center'></td>
-			<td align='right'><input class='submit-button' type='button' value='Save' onclick='updateVariant();' /></td>
-		</tr>
-		
-	</table>
-
+		<div style='padding:5px;'>
+			<input type='hidden' id='vid' value='Toddler' />
+			<div class='inputwrapper'><span>Param:</span><input class='textinput' type='text' id='parameter' value='Variant Param' /></div>	
+			<div class='inputwrapper'><span>Answer:</span><input class='textinput' type='text' id='variantanswer' value='Variant Answer' /></div>	
+		</div>	
+		<div style='padding:5px;'>
+			<input style='float:left;' class='submit-button' type='button' value='Delete' onclick='deleteVariant();' />
+			<input style='float:right;' class='submit-button' type='button' value='Save' onclick='updateVariant();' />
+		</div>	
 	</div>
 	<!--- Edit Variant Dialog END --->
 		

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -184,7 +184,6 @@ function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys,highscorem
 function changedType()
 {
 	kind=$("#type").val();		
-	iistr="";
 
 	if(kind==0){	
 		$("#inputwrapper-link").css("display","none");
@@ -195,10 +194,13 @@ function changedType()
 		$("#inputwrapper-gradesystem").css("display","none");
 		$("#inputwrapper-highscore").css("display","none");
 	}else if(kind==2){
+		iistr="";
+		$("#link").html(iistr);
 		$("#inputwrapper-link").css("display","block");
 		$("#inputwrapper-gradesystem").css("display","none");
 		$("#inputwrapper-highscore").css("display","none");
 	}else if(kind==3){
+		iistr="";
 		for(var ii=0;ii<retdata['duggor'].length;ii++){
 			var iitem=retdata['duggor'][ii];
 			if(xelink==iitem['id']){
@@ -216,6 +218,7 @@ function changedType()
 		$("#inputwrapper-gradesystem").css("display","block");
 		$("#inputwrapper-highscore").css("display","block");
 	}else if(kind==5){
+		iistr="";
 		for(var ii=0;ii<retdata['links'].length;ii++){
 			var iitem=retdata['links'][ii];
 			if(xelink==iitem['fileid']){

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -157,46 +157,83 @@ function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys,highscorem
 	}
 	
 	// Show dialog
+	if(kind==0){	
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==1){
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==2){
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==3){
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","block");
+		$("#inputwrapper-highscore").css("display","block");
+	}else if(kind==4){
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","block");
+		$("#inputwrapper-highscore").css("display","block");
+	}else if(kind==5){
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}
 	$("#editSection").css("display","block");
-		
 }
 
 function changedType()
 {
 	kind=$("#type").val();		
-	
+	iistr="";
 	// Graying of Link
-	if((kind==5)||(kind==3)){
-		$("#linklabel").css("opacity","1.0");				
-		$("#link").prop('disabled', false);					
-		iistr="";
-		if(kind==5){
-			for(var ii=0;ii<retdata['links'].length;ii++){
-				var iitem=retdata['links'][ii];
-				if(xelink==iitem['fileid']){
-					iistr+="<option selected='selected' value='"+iitem['filename']+"'>"+iitem['filename']+"</option>";								
-				}else{
-					iistr+="<option value='"+iitem['filename']+"'>"+iitem['filename']+"</option>";																
-				}
+	
+	if(kind==0){	
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==1){
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==2){
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==3){
+		for(var ii=0;ii<retdata['duggor'].length;ii++){
+			var iitem=retdata['duggor'][ii];
+			if(xelink==iitem['id']){
+				iistr+="<option selected='selected' value='"+iitem['id']+"'>"+iitem['qname']+"</option>";
+			}else{
+				iistr+="<option value='"+iitem['id']+"'>"+iitem['qname']+"</option>";
 			}
-			$("#link").html(iistr);					
-		}else if(kind==3){
-			for(var ii=0;ii<retdata['duggor'].length;ii++){
-				var iitem=retdata['duggor'][ii];
-				if(xelink==iitem['id']){
-					iistr+="<option selected='selected' value='"+iitem['id']+"'>"+iitem['qname']+"</option>";
-				}else{
-					iistr+="<option value='"+iitem['id']+"'>"+iitem['qname']+"</option>";
-				}
-			}
-						
 		}
-		$("#link").html(iistr);					
-	}else{
-		$("#linklabel").css("opacity","0.3");	
-		$("#link").prop('disabled', true);					
-		$("#createbutton").css('visibility', 'hidden');					
-	}	
+		$("#link").html(iistr);
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","block");
+		$("#inputwrapper-highscore").css("display","block");
+	}else if(kind==4){
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","block");
+		$("#inputwrapper-highscore").css("display","block");
+	}else if(kind==5){
+		for(var ii=0;ii<retdata['links'].length;ii++){
+			var iitem=retdata['links'][ii];
+			if(xelink==iitem['fileid']){
+				iistr+="<option selected='selected' value='"+iitem['filename']+"'>"+iitem['filename']+"</option>";								
+			}else{
+				iistr+="<option value='"+iitem['filename']+"'>"+iitem['filename']+"</option>";																
+			}
+		}
+		$("#link").html(iistr);
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}
 }
 
 function deleteItem()

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -67,7 +67,7 @@ function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys,highscorem
 	$("#moment").html(str);
 
 	// Set Name		
-	//$("#sectionname").val(entryname);
+	$("#sectionname").val(entryname);
 	$("sectionnamewrapper").html("<input type='text' class='form-control textinput' id='sectionname' value='"+entryname+"' style='width:448px;'/>");
 
 	// Set Lid	
@@ -122,37 +122,9 @@ function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys,highscorem
 
 	// Set Link
 	$("#link").val(elink);
-
-	// Graying of Link
-	if((kind==5)||(kind==3)){
-		$("#linklabel").css("opacity","1.0");				
-		$("#link").prop('disabled', false);					
-
-		iistr="";
-		if(kind==5){
-			for(var ii=0;ii<retdata['links'].length;ii++){
-				var iitem=retdata['links'][ii];
-				if(elink==iitem['fileid']){
-					iistr+="<option selected='selected' value='"+iitem['filename']+"'>"+iitem['filename']+"</option>";								
-				}else{
-					iistr+="<option value='"+iitem['filename']+"'>"+iitem['filename']+"</option>";																
-				}
-			}
-				$("#link").html(iistr);					
-		}else if(kind==3){
-			for(var ii=0;ii<retdata['duggor'].length;ii++){
-				var iitem=retdata['duggor'][ii];
-				if(elink==iitem['id']){
-					iistr+="<option selected='selected' value='"+iitem['id']+"'>"+iitem['qname']+"</option>";
-				}else{
-					iistr+="<option value='"+iitem['id']+"'>"+iitem['qname']+"</option>";
-				}
-			}
-		}
-	$("#link").html(iistr);					
-	}
 	
 	// Show dialog
+	iistr="";
 	if(kind==0){	
 		$("#inputwrapper-link").css("display","none");
 		$("#inputwrapper-gradesystem").css("display","none");
@@ -162,45 +134,11 @@ function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys,highscorem
 		$("#inputwrapper-gradesystem").css("display","none");
 		$("#inputwrapper-highscore").css("display","none");
 	}else if(kind==2){
-		$("#inputwrapper-link").css("display","block");
-		$("#inputwrapper-gradesystem").css("display","none");
-		$("#inputwrapper-highscore").css("display","none");
-	}else if(kind==3){
-		$("#inputwrapper-link").css("display","block");
-		$("#inputwrapper-gradesystem").css("display","block");
-		$("#inputwrapper-highscore").css("display","block");
-	}else if(kind==4){
-		$("#inputwrapper-link").css("display","none");
-		$("#inputwrapper-gradesystem").css("display","block");
-		$("#inputwrapper-highscore").css("display","block");
-	}else if(kind==5){
-		$("#inputwrapper-link").css("display","block");
-		$("#inputwrapper-gradesystem").css("display","none");
-		$("#inputwrapper-highscore").css("display","none");
-	}
-	$("#editSection").css("display","block");
-}
-
-function changedType()
-{
-	kind=$("#type").val();		
-
-	if(kind==0){	
-		$("#inputwrapper-link").css("display","none");
-		$("#inputwrapper-gradesystem").css("display","none");
-		$("#inputwrapper-highscore").css("display","none");
-	}else if(kind==1){
-		$("#inputwrapper-link").css("display","none");
-		$("#inputwrapper-gradesystem").css("display","none");
-		$("#inputwrapper-highscore").css("display","none");
-	}else if(kind==2){
-		iistr="";
 		$("#link").html(iistr);
 		$("#inputwrapper-link").css("display","block");
 		$("#inputwrapper-gradesystem").css("display","none");
 		$("#inputwrapper-highscore").css("display","none");
 	}else if(kind==3){
-		iistr="";
 		for(var ii=0;ii<retdata['duggor'].length;ii++){
 			var iitem=retdata['duggor'][ii];
 			if(xelink==iitem['id']){
@@ -218,7 +156,57 @@ function changedType()
 		$("#inputwrapper-gradesystem").css("display","block");
 		$("#inputwrapper-highscore").css("display","block");
 	}else if(kind==5){
-		iistr="";
+		for(var ii=0;ii<retdata['links'].length;ii++){
+			var iitem=retdata['links'][ii];
+			if(xelink==iitem['fileid']){
+				iistr+="<option selected='selected' value='"+iitem['filename']+"'>"+iitem['filename']+"</option>";								
+			}else{
+				iistr+="<option value='"+iitem['filename']+"'>"+iitem['filename']+"</option>";																
+			}
+		}
+		$("#link").html(iistr);
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}
+	$("#editSection").css("display","block");
+}
+
+function changedType()
+{
+	kind=$("#type").val();		
+	iistr="";
+	if(kind==0){	
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==1){
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==2){
+		$("#link").html(iistr);
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","none");
+		$("#inputwrapper-highscore").css("display","none");
+	}else if(kind==3){
+		for(var ii=0;ii<retdata['duggor'].length;ii++){
+			var iitem=retdata['duggor'][ii];
+			if(xelink==iitem['id']){
+				iistr+="<option selected='selected' value='"+iitem['id']+"'>"+iitem['qname']+"</option>";
+			}else{
+				iistr+="<option value='"+iitem['id']+"'>"+iitem['qname']+"</option>";
+			}
+		}
+		$("#link").html(iistr);
+		$("#inputwrapper-link").css("display","block");
+		$("#inputwrapper-gradesystem").css("display","block");
+		$("#inputwrapper-highscore").css("display","block");
+	}else if(kind==4){
+		$("#inputwrapper-link").css("display","none");
+		$("#inputwrapper-gradesystem").css("display","block");
+		$("#inputwrapper-highscore").css("display","block");
+	}else if(kind==5){
 		for(var ii=0;ii<retdata['links'].length;ii++){
 			var iitem=retdata['links'][ii];
 			if(xelink==iitem['fileid']){

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -150,10 +150,6 @@ function selectItem(lid,entryname,kind,evisible,elink,moment,gradesys,highscorem
 			}
 		}
 	$("#link").html(iistr);					
-	}else{
-		$("#linklabel").css("opacity","0.3");	
-		$("#link").prop('disabled', true);					
-		$("#createbutton").css('visibility', 'hidden');					
 	}
 	
 	// Show dialog
@@ -189,8 +185,7 @@ function changedType()
 {
 	kind=$("#type").val();		
 	iistr="";
-	// Graying of Link
-	
+
 	if(kind==0){	
 		$("#inputwrapper-link").css("display","none");
 		$("#inputwrapper-gradesystem").css("display","none");

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -46,103 +46,63 @@ pdoConnect();
 
 	<!-- Edit Section Dialog START -->
 	<div id='editSection' class='loginBox' style='width:460px;display:none;'>
-
-	<div class='loginBoxheader'>
-	<h3>Edit Item</h3>
-	<div onclick='closeWindows();'>x</div>
-	</div>
-			
-	<table style="width:100%;margin-bottom:20px;float:left">
-		<tr>
-			<td colspan='2'><input type='hidden' id='lid' value='Toddler' />Name: <div id='sectionnamewrapper'><br/><input type='text' class='form-control textinput' id='sectionname' value='sectionname' style='width:448px;' /></div></td>
-		</tr>
-		<tr>
-			<td colspan='2'><span id='linklabel'>Link:&nbsp;<select id='link' ></select></span></td>
-		</tr>
-		<tr>
-			<td>Type:&nbsp;<select id='type' onchange='changedType();'></select></td>
-			<td align='right'>Visibility:&nbsp;<select style='align:right;' id='visib'></select></td>
-		</tr>
-		<tr>
-			<td>Moment:&nbsp;<select id='moment' disabled></select></td>
-			<td>GradeSystem:&nbsp;<select id='gradesys' ></select></td>
-		</tr>
-		<tr>
-			<td>High score:&nbsp;<select id='highscoremode' ></select></td>
-		</tr>
-	</table>
-	<table>
-		<tr>
-			<div class='messagebox' style='display:none;color:red;font-weight:italic;text-align:center'>Create a Dugga before you can use it for a test. </div>
-		</tr>
-	</table>
-	
-	<!-- Error message, no duggas present-->
-	
-	<table style='width:460px;float:left'>
-		<tr>
-			<td align='left'><input class='submit-button' type='button' value='Delete' onclick='deleteItem();' /></td>
-			<td align='center'><input class='submit-button' type='button' value='Create' onclick='createItem();' id='createbutton' /></td>
-			<td align='right'><input class='submit-button' type='button' value='Save' onclick='updateItem();' /></td>
-		</tr>
-	</table>
-
+		<div class='loginBoxheader'>
+			<h3>Edit Item</h3>
+			<div onclick='closeWindows();'>x</div>
+		</div>
+		<div style='padding:5px;'>
+			<input type='hidden' id='lid' value='Toddler' />
+			<div id='inputwrapper-name' class='inputwrapper'><span>Name:</span><input type='text' class='textinput' id='sectionname' value='sectionname' /></div>
+			<div id='inputwrapper-type' class='inputwrapper'><span>Type:</span><select id='type' onchange='changedType();'></select></div>
+			<div id='inputwrapper-link' class='inputwrapper'><span>Link:</span><select id='link' ></select></div>
+			<div id='inputwrapper-gradesystem' class='inputwrapper'><span>GradeSystem:</span><select id='gradesys' ></select></div>
+			<div id='inputwrapper-highscore' class='inputwrapper'><span>High score:</span><select id='highscoremode' ></select></div>
+			<div id='inputwrapper-moment' class='inputwrapper'><span>Moment:</span><select id='moment' disabled></select></div>
+			<div id='inputwrapper-visibility' class='inputwrapper'><span>Visibility:</span><select style='align:right;' id='visib'></select></div>
+			<div id='inputwrapper-messagebox' class='messagebox' style='display:none;color:red;font-weight:italic;text-align:center'>Create a Dugga before you can use it for a test. </div>
+		</div>
+		<!-- Error message, no duggas present-->
+		<div style='padding:5px;'>
+				<input style='float:left;' class='submit-button' type='button' value='Delete' onclick='deleteItem();' />
+				<input style='float:right;' class='submit-button' type='button' value='Save' onclick='updateItem();' />
+		</div>
 	</div>
 	<!-- Edit Section Dialog END -->
 	
 	<!-- New Verison Dialog START -->
 	<div id='newCourseVersion' class='loginBox' style='width:464px;display:none;'>
-	<div class='loginBoxheader'>
-	<h3>New Course Verison</h3>
-	<div onclick='closeWindows();'>x</div>
-	</div>		
-	<table width="100%">
-		<tr>
-			<td>Version Name: <div id='versnamewrapper'><input size='8' class='form-control textinput' type='text' id='versname' placeholder='Version Name' /></div></td>	
-			<td>Version ID: <div id='versidwrapper'><input size='8' class='form-control textinput' type='text' id='versid' placeholder='Version ID' /></div></td>			
-			<input type='hidden' id='cid' value='Toddler' /></td>
-		</tr>
-		<tr>
-			<td>Copy content from:</td>		
-		</tr>
-		<tr>
-			<td><select style='float:left;' id='copyvers'></select></td>
-		</tr>
-		<tr>	
-			<td><br><div id='makeactivewrapper'><input type="checkbox" name="makeactive" id="makeactive" value="yes">Change this to default version</div></td>
-		</tr>
-	</table>
-	<table width="100%">
-		<tr>
-			<td align='right'><input class='submit-button' type='button' value='Create' onclick='createVersion();' /></td>
-		</tr>
-	</table>
-
+		<div class='loginBoxheader'>
+			<h3>New Course Verison</h3>
+			<div onclick='closeWindows();'>x</div>
+		</div>		
+		<div style='padding:5px;'>
+			<input type='hidden' id='cid' value='Toddler' />
+			<div class='inputwrapper'><span>Version Name:</span><input class='textinput' type='text' id='versname' placeholder='Version Name' /></div>
+			<div class='inputwrapper'><span>Version ID:</span><input class='textinput' type='text' id='versid' placeholder='Version ID' /></div>
+			<div class='inputwrapper'><span>Change this to default version</span><input type="checkbox" name="makeactive" id="makeactive" value="yes"></div>
+			<div class='inputwrapper'><span>Copy content from:</span><select id='copyvers'></select></div>
+		</div>
+		<div style='padding:5px;'>
+			<input class='submit-button' type='button' value='Save' title='Save changes' onclick='createVersion();' />
+		</div>
 	</div>
 	<!-- New Verison Dialog END -->
 	
 	<!-- Edit Verison Dialog START -->
 	<div id='editCourseVersion' class='loginBox' style='width:464px;display:none;'>
-	<div class='loginBoxheader'>
-	<h3>Edit Course Verison</h3>
-	<div onclick='closeWindows();'>x</div>
-	</div>		
-	<table width="100%">
-		<tr>
-			<td>Version Name: <div id='versnamewrapper'><input size='8' class='form-control textinput' type='text' id='eversname' placeholder='Version Name' /></div></td>	
-			<td>Version ID: <div id='versidwrapper'><input size='8' class='form-control textinput' type='text' id='eversid' placeholder='Version ID' disabled/></div></td>			
-			<input type='hidden' id='cid' value='Toddler' /></td>
-		</tr>
-		<tr>	
-			<td><br><div id='makeactivewrapper'><input type="checkbox" name="emakeactive" id="emakeactive" value="yes">Change this to default version</div></td>
-		</tr>
-	</table>
-	<table width="100%">
-		<tr>
-			<td align='right'><input class='submit-button' type='button' value='Save' onclick='updateVersion();' /></td>
-		</tr>
-	</table>
-
+		<div class='loginBoxheader'>
+			<h3>Edit Course Verison</h3>
+			<div onclick='closeWindows();'>x</div>
+		</div>		
+		<div style='padding:5px;'>
+			<input type='hidden' id='cid' value='Toddler' />
+			<div class='inputwrapper'><span>Version Name:</span><input class='textinput' type='text' id='eversname' placeholder='Version Name' /></div>
+			<div class='inputwrapper'><span>Version ID:</span><input class='textinput' type='text' id='eversid' placeholder='Version ID' disabled /></div>
+			<div class='inputwrapper'><span>Change this to default version</span><input type="checkbox" name="emakeactive" id="emakeactive" value="yes"></div>
+		</div>
+		<div style='padding:5px;'>
+			<input class='submit-button' type='button' value='Save' title='Save changes' onclick='updateVersion();' />
+		</div>
 	</div>
 	<!-- Edit Verison Dialog END -->
 	

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -556,8 +556,41 @@ header {
     width: 216px;
 }
 
+.loginBox .inputwrapper {
+    clear:both;
+	width:100%;
+	padding:3px 0 3px 0;
+	height:30px;
+	line-height:30px;
+}
 
-.loginBox select {font-size:14px;float:right;margin-right:4px;}
+.loginBox .inputwrapper span{
+    float:left;
+}
+
+.loginBox .inputwrapper input, .loginBox .inputwrapper select{
+    float:right;
+}
+
+.loginBox .inputwrapper input[type="checkbox"]{
+    margin-right:200px;
+	height:24px;
+}
+
+.loginBox select {
+    width: 216px;
+    height: 30px;
+    line-height: 18px;
+    color: #6f6f6f;
+    background-color: #ffffff;
+    border: 1px solid #cccccc;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    padding: 5px;
+    font-size: 14px;
+}
 
 .loginBoxheader {
     height: 25px;
@@ -646,7 +679,7 @@ header {
 .form-control {
     display: block;
     font-size: 14px;
-    line-height: 1.42857143;
+    line-height: 18px;
     color: #555;
     background-color: #fff;
     background-image: none;
@@ -663,8 +696,7 @@ header {
     width: 216px;
     height: 30px;
     padding: 6px 12px;
-    font-size: 15px;
-    line-height: 1.42857143;
+    line-height: 18px;
     color: #202020;
     background-color: #ffffff;
     background-image: none;
@@ -675,7 +707,7 @@ header {
     -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
     transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
     padding: 5px;
-    font-size: 12px;
+    font-size: 14px;
     letter-spacing: normal;
     word-spacing: normal;
     text-transform: none;
@@ -684,7 +716,6 @@ header {
     display: inline-block;
     text-align: start;
     border-radius: 0px;
-	
 }
 
 input.option {


### PR DESCRIPTION
Have changed the layout in the dialogs "new course", "edit course", "new version", "edit version", "edit item", "edit dugga" and "edit variant". All tables have been removed and instead added divs for the layout. Some new css for the new layout.

This is fix for issue #1303, #1305 and #1308 