### PR TITLE
Removed redundant cookies and use of the variable "loginvar"

### DIFF
--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -22,9 +22,7 @@
 	
 	<?php 
 		$noup=true;
-		$loginvar="ACCESS"; 
 		include '../Shared/navheader.php';
-		setcookie("loginvar", $loginvar);
 	?>
 		
 	<!-- content START -->

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -25,9 +25,7 @@ pdoConnect();
 
 	<?php 
 	$noup="NONE";
-	$loginvar="COURSE";
 	include '../Shared/navheader.php';
-	setcookie("loginvar", $loginvar);
 	?>
 
 	<!-- content START -->

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -23,9 +23,7 @@ pdoConnect();
 	
 	<?php 
 		$noup="SECTION";
-		$loginvar="DUGGA";
 		include '../Shared/navheader.php';
-		setcookie("loginvar", $loginvar);
 	?>
 		
 	<!-- content START -->

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -21,9 +21,7 @@ pdoConnect();
 	
 	<?php 
 		$noup="SECTION";
-		$loginvar="FILE";
 		include '../Shared/navheader.php';
-		setcookie("loginvar", $loginvar);
 	?>
 		
 <!-- content START -->

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -25,9 +25,7 @@ pdoConnect();
 	
 	<?php 
 		$noup="SECTION";
-		$loginvar="RESULT";
 		include '../Shared/navheader.php';
-		setcookie("loginvar", $loginvar);
 	?>
 		
 	<!-- content START -->

--- a/DuggaSys/resultlisted.php
+++ b/DuggaSys/resultlisted.php
@@ -25,9 +25,7 @@
 	
 	<?php 
 		$noup="SECTION";
-		$loginvar="RESULT";
 		include '../Shared/navheader.php';
-		setcookie("loginvar", $loginvar);
 	?>
 		
 	<!-- content START -->

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -26,9 +26,7 @@ pdoConnect();
 
 	<?php
 		$noup="COURSE";
-		$loginvar="SECTION"; 
 		include '../Shared/navheader.php';
-		setcookie("loginvar", $loginvar);
 	?>
 	
 	<!-- content START -->

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -96,7 +96,6 @@
 
 	<?php 
 	$noup="SECTION";
-	$loginvar="PDUGGA"; 
 	include '../Shared/navheader.php';
 	?>
 

--- a/DuggaSys/showdoc.php
+++ b/DuggaSys/showdoc.php
@@ -219,9 +219,7 @@ $readfile = false;
 <?php 
 		if($readfile == false){
 		$noup="SECTION";
-			$loginvar="LINK"; 
 			include '../Shared/navheader.php';
-			setcookie("loginvar", $loginvar); 
 		}
 		?>	
 		


### PR DESCRIPTION
The cookies and the "loginvar" variable were redundant as we have changed the processLogin and processLogout functions. 