### PR TITLE
Added "version" hash on courseed page

### DIFF
--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -3,6 +3,10 @@ session_start();
 include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 pdoConnect();
+
+$versionFile = fopen("../.git/refs/heads/master", "r"); 	
+$version = fgets($versionFile);
+fclose($versionFile);
 ?>
 <!DOCTYPE html>
 <html>
@@ -36,6 +40,8 @@ pdoConnect();
 		<div id='Courselist'>
 		</div>
 	</div>
+	<!-- version identification -->
+	<div id="version" class='version'>Master hash <br /><?php echo $version ?></div>
 	<!-- content END -->
 	<?php
 	include '../Shared/loginbox.php';

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -57,6 +57,15 @@ hr {
  *                               Lists and Content                              *
  * --------------================################================-------------- */
 
+.version {
+    color:#EFF;
+    text-shadow:1px 1px #000;
+    text-align:center;
+    padding: 10px;
+    font-size: 10pt;
+    font-family: Calibri,Sans-Serif;
+}
+
 .err{
 
     color:#FFE;


### PR DESCRIPTION
The courseed page now displays the current master branch hash on the bottom of the page. 

See issue #826 