### PR TITLE
Updated createboxmenu function!

### DIFF
--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -535,7 +535,7 @@ function createboxmenu(contentid, boxid, type)
 		// If reader doesn't have write access, only the boxtitle is shown
 		}else{
 			var str = '<table cellspacing="2"><tr>';
-			str+= '<td class="boxtitlewrap"><span class="boxtitle">'+retData['box'][boxid-1][3]+'</span></td>';
+			str+= '<td class="boxtitlewrap"><span class="boxtitle">'+retData['box'][boxid-1][4]+'</span></td>';
 			str+='</tr></table>';
 			boxmenu.innerHTML=str;	
 		}			


### PR DESCRIPTION
The wrong item in the array of information about the boxes had been chosen, which made it display a number instead of the boxtitle.

Only changed from item 3 to item 4 in that array to get the proper item.