### PR TITLE
Ds21#1480 Improvement of kryss duggas

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -179,6 +179,12 @@ function selectVariant(vid,param,answer,template)
 			var test=document.getElementById("exampleAnswer");
 			test.innerHTML = "Example: " + exampleDugga.exampleAnswerDugga4;
 			break;
+		case "kryss":
+			var ep=document.getElementById("examplePara");
+			ep.innerHTML = "Example: " + exampleDugga.exampleParaKryss;
+			var test=document.getElementById("exampleAnswer");
+			test.innerHTML = "Example: " + exampleDugga.exampleAnswerKryss;
+			break;
 		default:
 			var ep=document.getElementById("examplePara");
 			ep.innerHTML = "Example parameter: " + "No example available";

--- a/DuggaSys/templates/dugga.css
+++ b/DuggaSys/templates/dugga.css
@@ -193,4 +193,68 @@ input.submit-button:hover {
 .instructions-button:hover {
 	background-color:#939393;	
 }
+
+/* --------------================################================-------------- *
+ *                      	    Quizdugga				        *
+ * --------------================################================-------------- */
+
+.quiz-wrapper{
+	width:70%;
+	margin:auto;
+	background-color:#ccc;
+}
+
+.quiz-header{
+ 	background-color: #614875;
+	padding:15px;
+}
+
+.quiz-header h1{
+	color:#fff;
+}
+
+.quiz-question{
+	background-color:#614875;
+	padding:6px 15px 6px 15px;	
+}
+
+.quiz-question h3{
+	color:#fff;
+}
+
+.quiz-answer{
+	padding:6px 15px 6px 15px;	
+}
+
+
+.quiz-question-number {
+	height: 30px;
+	width: 30px;
+	-moz-border-radius: 15px;
+	-webkit-border-radius:15px;
+	border-radius: 20px;
+	border:1px solid #fff;
+	text-align: center;
+	display: inline-block;
+	margin-right: 5px;
+}
+
+.submit{
+	background-color:#614875;
+	border:0px;
+	padding:10px;
+	margin:7px;
+    	color:#fff;
+    	cursor:pointer;
+    	font-size:14px;
+    	transition:1s background-color;
+    	border-radius:4px;	
+
+}
+
+.submit:hover {
+    	background-color:#7B5A96;
+    	border-radius:4px;	
+}
+
 						

--- a/DuggaSys/templates/exampledugga.js
+++ b/DuggaSys/templates/exampledugga.js
@@ -9,5 +9,8 @@ var exampleDugga={
 	exampleAnswerDugga3 : "Variant",
 	
 	exampleParaDugga4 : "{*variant*:*40 13 7 20 0*}",
-	exampleAnswerDugga4 : "Variant"
+	exampleAnswerDugga4 : "Variant",
+	
+	exampleParaKryss : "{question*Who is Ss best soccer player: A*Zlatan: B *Hysen: C*Robin: D*Aslan}",
+	exampleAnswerKryss : "A"
 };

--- a/DuggaSys/templates/kryss.html
+++ b/DuggaSys/templates/kryss.html
@@ -6,4 +6,4 @@
 </div>
 <table class='fouter' width="100%" style='margin-bottom:20px;' >
 </table>
-<div id="output"></div>
+<div id="output" class="quiz-wrapper"></div>

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -1,5 +1,5 @@
 /*
-THIS IS A QUIZTAMPLATE
+THIS IS A QUIZTEMPLATE
 DO NOT CHANGE THE QUIZ MAIN FUNCTION NAME AND PARAMETER, IT SHOULD ALWAYS BE THE SAME.
 quiz(parameters)
 
@@ -11,29 +11,28 @@ This description will be visible on the interface for adding or change a quiz.
    Documentation 
 
 *********************************************************************************
-This template separates each question between dots and then seperates each parameter between commas within the question,
+This template separates each question between : and then separates each parameter between : within the question,
 Example seed
 ---------------------
-	Param:  {question*Who is Ss best soccer player, A*Zlatan, B *Hysen, C*Robin, D*Aslan.}
-	Answer: {A}
-	
-	NOTE! If it is a single question or if it is the last question it should NOT include a dot (.) in the end of the question.
-
+	Param:  {question*Who is the best soccer player: A*Zlatan: B *Hysen: C*Robin: D*Aslan}
+	Answer: A
 -------------==============######## Documentation End ###########==============-------------
 */
 var idunique = 0;
 function quiz(parameters) {
 	if(parameters != undefined) {
 		console.log("pram:" + parameters);
-		var qeustionsplit = parameters.split(".");
-		
+		parameters = parameters.replace(/NONE!/g, '');
+		parameters = parameters.replace(/{/g, '');
+		var qeustionsplit = parameters.split("}");
 		var answerValue;
 		var answerID;
 		var app ="";
-		for(var iy = 0;iy < qeustionsplit.length;iy++){	
-		idunique++;
-		var inputSplit = qeustionsplit[iy].split(",");
-		app += idunique+" -----------------------------------------------------";
+		app+="<div class='quiz-header'><h1>Quiz</h1></div>";
+		for(var iy = 0;iy < qeustionsplit.length - 1;iy++){
+			idunique++;
+			var inputSplit = qeustionsplit[iy].split(":");
+			//app += idunique+" -----------------------------------------------------";
 			for(var i = 0;i < inputSplit.length;i++){
 				
 				var splited = inputSplit[i].split("*");
@@ -42,20 +41,23 @@ function quiz(parameters) {
 				answerID = answerID.replace(/^\s+|\s+$/g, '') ;
 				
 				if((answerID == "question")||(answerID == "NONE!question")) {
-					app += "<h2>";
-					app += answerValue + "<br>";
-					app += "</h2>";
+					app += "<div class='quiz-question'>";
+					app += "<h3>";
+					app += "<div class='quiz-question-number'>" + idunique +"</div>" + answerValue;
+					app += "</h3>";
+					app += "</div>";
 				}
 				else {
-					app += "<input type='radio' name='answers"+idunique+"' value='"+answerValue+"' id='"+answerID+"'>"+answerValue+"</input>";
+					app += "<div class='quiz-answer'>";
+					app += "<input type='radio' name='answers"+idunique+"' value='"+answerValue+"' id='"+answerID+"'>" +answerValue+"</input>";
 					app += "<br>";
-					
+					app += "</div>";
 				}
 			}
 		}
 
-		app += "<button class='submit' onclick='checkQuizAnswer();'>Check answers</button>";
-
+		app += "<button class='submit' style='margin:15px;' onclick='checkQuizAnswer();'>Check answers</button>";
+		
 		$("#output").html(app);
 	}
 	else {
@@ -64,8 +66,6 @@ function quiz(parameters) {
 			dangerBox('Problem loading quiz', 'This quiz has no parameters in order to show it.</br>Contact quiz author or admin.');
 		}, 500);
 	}
-
-	
 }
 
 //----------------------------------------------------------------------------------

--- a/Shared/SQL/init_db.sql
+++ b/Shared/SQL/init_db.sql
@@ -158,8 +158,8 @@ CREATE TABLE userAnswer (
  */
 DROP VIEW IF EXISTS highscore_quiz_time;
 CREATE VIEW highscore_quiz_time AS
-	SELECT userAnswer.cid, userAnswer.quiz, userAnswer.uid, userAnswer.grade, userAnswer.timeSpent
-		FROM userAnswer ORDER BY userAnswer.timeSpent ASC LIMIT 10;
+	SELECT userAnswer.cid, userAnswer.quiz, userAnswer.uid, userAnswer.grade, userAnswer.score
+		FROM userAnswer ORDER BY userAnswer.score ASC LIMIT 10;
 
 CREATE TABLE vers(
 	cid				INT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/Shared/SQL/testdata.sql
+++ b/Shared/SQL/testdata.sql
@@ -25,14 +25,15 @@ INSERT INTO vers (cid,coursecode,coursename,coursenamealt,vers,versname) values(
 INSERT INTO vers (cid,coursecode,coursename,coursenamealt,vers,versname) values('2', 'IT118G', 'Webbutveckling - datorgrafik', 'UNK', '97731', 'HT14');
 
 /* Insert tests */
-INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (1, 2, 1, 2, 'Bitdugga1', 'dugga1', '2015-09-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
-INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (2, 2, 1, 2, 'Bitdugga2', 'dugga1', '0000-00-00 00:00:00', '0000-00-00 00:00:00', NOW(), 2);
-INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (3, 2, 1, 2, 'colordugga1', 'dugga2', '0000-00-00 00:00:00', '0000-00-00 00:00:00', NOW(), 2);
-INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (4, 2, 1, 2, 'colordugga2', 'dugga2', '0000-00-00 00:00:00', '0000-00-00 00:00:00', NOW(), 2);
-INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (5, 2, 1, 2, 'linjedugga1', 'dugga3', '0000-00-00 00:00:00', '0000-00-00 00:00:00', NOW(), 2);
-INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (6, 2, 1, 2, 'linjedugga2', 'dugga3', '0000-00-00 00:00:00', '0000-00-00 00:00:00', NOW(), 2);
-INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (7, 2, 1, 2, 'dugga1', 'dugga4', '0000-00-00 00:00:00', '0000-00-00 00:00:00', NOW(), 2);
-INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (8, 2, 1, 2, 'dugga2', 'dugga4', '0000-00-00 00:00:00', '0000-00-00 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (1, 2, 1, 2, 'Bitdugga1', 'dugga1', '2015-02-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (2, 2, 1, 2, 'Bitdugga2', 'dugga1', '2015-03-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (3, 2, 1, 2, 'colordugga1', 'dugga2', '2015-04-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (4, 2, 1, 2, 'colordugga2', 'dugga2', '2015-04-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (5, 2, 1, 2, 'linjedugga1', 'dugga3', '2015-02-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (6, 2, 1, 2, 'linjedugga2', 'dugga3', '2015-03-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (7, 2, 1, 2, 'dugga1', 'dugga4', '2015-02-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (8, 2, 1, 2, 'dugga2', 'dugga4', '2015-03-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
+INSERT INTO quiz (id, cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, modified, creator) VALUES (9, 2, 1, 2, 'Quiz', 'kryss', '2015-02-01 00:00:00', '2015-12-31 00:00:00', NOW(), 2);
 
 /* Insert variants of tests */
 INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUES (1, 1, '{*tal*:*2*}', '{*danswer*:*00000010 0 2*}', NOW(), 2);
@@ -51,6 +52,11 @@ INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUE
 INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUES (14, 6, '{*linje*:*10,30,81 10 20,81 65 10,63 20 30 75 35,19 30 60 75 70 50 35,19 100 10 85 95 45 50,19 40 40 50 40 15 55,63 10 60 10 50,81 20 30*}', '{Variant}', NOW(), 2);
 INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUES (15, 7, '{*variant*:*40 13 7 20 0*}', '{Variant}', NOW(), 2);
 INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUES (16, 8, '{*variant*:*26 38 33 43 17 5 23 26 30 40 0 17 5 13 22 1 27 11 7 17 22 2 27 26 16 8 13 22 2 27 15 10 19 23 0*}', '{Variant}', NOW(), 2);
+INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUES (17, 9, '{question*One byte is equivalent to how many bits?: A*4: B*8: C*16: D*32}', 'B', NOW(), 2);
+INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUES (18, 9, '{question*RGB and CMYK are abbreviations for what?: A*Red, Green, Blue and Cyan Magenta, Yellow, Key (black): B*Red, Grey, Black and Cyclone, Magenta, Yellow, Kayo: C*Randy´s Green Brick and Cactus Magnolia Yronema Kalmia}', 'A', NOW(), 2);
+INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUES (19, 9, '{question*Which of these are examples of actual shaders?: A*B32shader, 554shader: B*Context shaders, Shadow shaders and Block shaders: C*Vertex shaders, Pixel shaders and Geometry shaders}', 'C', NOW(), 2);
+INSERT INTO variant (vid, quizID, param, variantanswer, modified, creator) VALUES (20, 9, '{question*Points, lines and curves are examples of geometrical...: A*Primitives: B*Substitutes: C*Formations: D*Partitions}', 'A', NOW(), 2);
+
 
 /* Insert items on coursepage */
 INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers) VALUES(1001, 1, 'PHP examples', 'UNK', 1, 1, 1, 1,'45656');
@@ -83,19 +89,25 @@ INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible,
 INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2010, 2, 'Transformationer 3,5HP', '', 4, 9, 1, 1, '97732', 2010, 2, 0);
 INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2011, 2, 'Transformationsdugga 1', '7', 3, 10, 1, 1, '97732', 2010, 2, 0);
 INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2012, 2, 'Transformationsdugga 2', '8', 3, 11, 1, 1, '97732', 2010, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2013, 2, 'Frågeduggor 1HP', '', 4, 12, 1, 1, '97732', 2013, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2014, 2, 'Frågedugga 1', '9', 3, 13, 1, 1, '97732', 2013, 2, 0);
 
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2013, 2, 'Bit count test 1HP', '', 4, 0, 1, 1, '97731', 2013, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2014, 2, 'Bit count test 1', '1', 3, 1, 1, 1, '97731', 2013, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2015, 2, 'Bit count test 2', '2', 3, 2, 1, 1, '97731', 2013, 0, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2016, 2, 'Color test 1HP', '', 4, 3, 1, 1, '97731', 2016, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2017, 2, 'Hex color test 1', '3', 3, 4, 1, 1, '97731', 2016, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2018, 2, 'Hex color test 2', '4', 3, 5, 1, 1, '97731', 2016, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2019, 2, 'Geometry 2HP', '', 4, 6, 1, 1, '97731', 2019, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2020, 2, 'Geometry test 1', '5', 3, 7, 1, 1, '97731', 2019, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2021, 2, 'Geometry test 2', '6', 3, 8, 1, 1, '97731', 2019, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2022, 2, 'Transforms 3,5HP', '', 4, 9, 1, 1, '97731', 2022, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2023, 2, 'Transforms test 1', '7', 3, 10, 1, 1, '97731', 2022, 2, 0);
-INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2024, 2, 'Transforms test 2', '8', 3, 11, 1, 1, '97731', 2022, 2, 0);
+
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2015, 2, 'Bit count test 1HP', '', 4, 0, 1, 1, '97731', 2015, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2016, 2, 'Bit count test 1', '1', 3, 1, 1, 1, '97731', 2015, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2017, 2, 'Bit count test 2', '2', 3, 2, 1, 1, '97731', 2015, 0, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2018, 2, 'Color test 1HP', '', 4, 3, 1, 1, '97731', 2018, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2019, 2, 'Hex color test 1', '3', 3, 4, 1, 1, '97731', 2018, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2020, 2, 'Hex color test 2', '4', 3, 5, 1, 1, '97731', 2018, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2021, 2, 'Geometry 2HP', '', 4, 6, 1, 1, '97731', 2021, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2022, 2, 'Geometry test 1', '5', 3, 7, 1, 1, '97731', 2021, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2023, 2, 'Geometry test 2', '6', 3, 8, 1, 1, '97731', 2021, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2024, 2, 'Transforms 3,5HP', '', 4, 9, 1, 1, '97731', 2024, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2025, 2, 'Transforms test 1', '7', 3, 10, 1, 1, '97731', 2024, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2026, 2, 'Transforms test 2', '8', 3, 11, 1, 1, '97731', 2024, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2027, 2, 'Quizzes 1HP', '', 4, 12, 1, 1, '97731', 2027, 2, 0);
+INSERT INTO listentries (lid, cid, entryname, link, kind, pos, creator, visible, vers, moment, gradesystem, highscoremode) VALUES (2028, 2, 'Quiz 1', '9', 3, 13, 1, 1, '97731', 2027, 2, 0);
+
 
 /* Insert access for users */
 INSERT INTO user_course (uid, cid, result, creator, access, period, term) VALUES (1010, 1, '0.0', 1, 'R', 0, '');


### PR DESCRIPTION
Change syntax for param when adding a variant of a kryss dugga so that the question and answer can contain "," and ".".
Improvement of the layout on kryss duggas.
Added testdata for one kryss dugga.
Fixed init_db.sql because it did not work after the column "timespent" was renamed to "score".

issue #1480 