### PR TITLE
CodeViewer #1289: Title fix

### DIFF
--- a/Shared/css/responsive.css
+++ b/Shared/css/responsive.css
@@ -5,6 +5,9 @@
     .showdesktop{
         display: none;
     }
+    #navHeading {
+        font-size: 1.5em;
+    }
     #exampleSection{
         display: none;
     }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -307,9 +307,8 @@ header td {
 }
 
 .navHeading {
-    font-size: 2.5em; /* Fallback if browser doesn't support vw*/
+    font-size: 2.5em;
     vertical-align: middle;
-    max-width: 500px;
     padding-left: 15px;
     -webkit-touch-callout: none;
     -webkit-user-select: none;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -272,6 +272,10 @@ header {
     left: 0px;
 }
 
+header td {
+    white-space: nowrap;
+}
+
 #duggaTimer {
     z-index: 9000;
     width: 100px;
@@ -288,16 +292,24 @@ header {
 
 
 .navButt {
-    width:50px;
+    width:32px;
     vertical-align: middle;
 }
 
 .navButt img {
     margin-left: 10px;
+    vertical-align: middle;
+    height: 32px;
+}
+
+.navButt:hover {
+    cursor: pointer;
 }
 
 .navHeading {
-    font-size: 2.5em;
+    font-size: 2.5em; /* Fallback if browser doesn't support vw*/
+    vertical-align: middle;
+    max-width: 500px;
     padding-left: 15px;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
@@ -306,6 +318,7 @@ header {
     -ms-user-select: none;
     user-select: none;
     cursor:default;
+    overflow: hidden;
 }
 
 .navName {
@@ -335,38 +348,26 @@ header {
 
 .loggedout {
     background-color: #c75050;
-    width:40px;
-    padding-top: 13px;
-    padding-bottom: 13px;
-    padding-left:14px;
 }
 
 .loggedout:hover {
     background-color: #50a750;
-    width:40px;
-    padding-top: 13px;
-    padding-bottom: 13px;
-    padding-left:14px;
 }
 
 .loggedin {
     background-color: #50a750;
-    width:40px;
-    padding-top: 13px;
-    padding-bottom: 13px;
-    padding-left:14px;
 }
 
 .loggedin:hover {
     background-color: #c75050;
-    width:40px;
-    padding-top: 13px;
-    padding-bottom: 13px;
-    padding-left:14px;
 }
 
 #loginbutton{
     cursor:pointer;
+    height:50px;
+    width: 50px;
+    vertical-align: middle;
+    text-align: center;
 }
 
 #div2


### PR DESCRIPTION
#1289 
* Codeexample title is now vertically centered
* The navigation buttons have "cursor: pointer".
* Codeexample title overflow is hidden
* Responsive title size.
* Removed unnessecary css for login button.
* The table in navheader is now the correct height (50px) instead of 54px.