### PR TITLE
Fixed white gap on the codeborder

### DIFF
--- a/Shared/css/whiteTheme.css
+++ b/Shared/css/whiteTheme.css
@@ -104,7 +104,7 @@
 .normtextwrapper{
 	 /* Width of codeborder */
   	margin-left: 32px;
-  	padding: 5px 0px 5px 5px;
+  	padding: 5px 0px 0px 5px;
 }
 
 .normtext {


### PR DESCRIPTION
A white gap shows up on the code border when viewing certain templates. 
Issue: [#1288](https://github.com/HGustavs/LenaSYS/issues/1288)
Fixed it by removing padding from normtextwrapper.