### PR TITLE
Handle warning when .git folder is missing

### DIFF
--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -4,9 +4,13 @@ include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 pdoConnect();
 
-$versionFile = fopen("../.git/refs/heads/master", "r"); 	
-$version = fgets($versionFile);
-fclose($versionFile);
+if (file_exists("../.git/refs/heads/master")) {
+	$versionFile = fopen("../.git/refs/heads/master", "r"); 	
+	$version = fgets($versionFile);
+	fclose($versionFile);
+} else {
+	$version = ".git folder is missing";
+}
 ?>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
This update changes the file loading code in the php section of courseed.php to check whether the git/ref/master file exists before loading it, if it doesn't exist then the php error won't be displayed but rather a message under the "master hash" string that states that the .git folder was missing.

See issue #1512 