### PR TITLE
Deleted redundant loading of files.

### DIFF
--- a/CodeViewer/dragndrop.php
+++ b/CodeViewer/dragndrop.php
@@ -3,9 +3,6 @@ include_once("../Shared/basic.php");
 ?>
 <html>
 <head>
-	<link rel="stylesheet" href="../Shared/css/codeviewer.css" />
-	<script src="../Shared/js/jquery-1.11.0.min.js"></script>
-	<script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
 	<script src="dragndrop.js"></script>
 </head>
 <body>


### PR DESCRIPTION
The dragndrop.php file loaded files that were already loaded, which made for some unstable behaviour with the resizing functionality of the page. The page would sometimes not recognize the function resizable from jQuery ui, this due to that the framework was redundantly loaded again. The problem did not persist after these deletions.