### PR TITLE
#1577 - font size issue.

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -307,7 +307,7 @@ header td {
 }
 
 .navHeading {
-    font-size: 2.5em;
+    font-size: 26px;
     vertical-align: middle;
     padding-left: 15px;
     -webkit-touch-callout: none;


### PR DESCRIPTION
The font size on the class navHeading was defined as em instead of pixels. On lower resolutions, the text would scale up and cover the whole navHeader, hiding the loginButton. Instead of having a dynamic font size, we agreed to change it to  static pixel sixed. From 2.5em to 26px. 