### PR TITLE
Update codeviewer.js

### DIFF
--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -1600,11 +1600,15 @@ function resizeBoxes(parent, templateId)
 		$(boxValArray['box1']['id']).resizable({
 			containment: parent,
 			handles: "e",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){
 				alignBoxesWidth(boxValArray, 1, 2);
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 	}else if(templateId == 2){
@@ -1613,12 +1617,16 @@ function resizeBoxes(parent, templateId)
 		$(boxValArray['box1']['id']).resizable({
 			containment: parent,
 			handles: "s",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){
 				alignBoxesHeight2boxes(boxValArray, 1, 2);
 				$(boxValArray['box1']['id']).width("100%");
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 	}else if(templateId == 3){
@@ -1627,6 +1635,9 @@ function resizeBoxes(parent, templateId)
 		$(boxValArray['box1']['id']).resizable({
 			containment: parent,
 			handles: "e",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){
 				alignBoxesWidth3Boxes(boxValArray, 1, 2, 3);
 				$("#box2wrapper").css("left", ""); 
@@ -1634,18 +1645,23 @@ function resizeBoxes(parent, templateId)
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 
 		$(boxValArray['box2']['id']).resizable({
 			containment: parent,
 			handles: "s",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){
 				alignBoxesHeight2boxes(boxValArray, 2, 3);
 				$(boxValArray['box2']['id']).css("left", " ");
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 	}else if(templateId == 4){
@@ -1654,6 +1670,9 @@ function resizeBoxes(parent, templateId)
 		$(boxValArray['box1']['id']).resizable({
 			containment: parent,
 			handles: "e,s",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){
 				alignBoxesWidth(boxValArray, 1, 2);
 				alignBoxesHeight3boxes(boxValArray, 1, 2, 3);
@@ -1661,12 +1680,16 @@ function resizeBoxes(parent, templateId)
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 		
 		$(boxValArray['box2']['id']).resizable({
 			containment: parent,
 			handles: "s",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){	
 				alignBoxesHeight3boxes(boxValArray, 2, 1, 3);
 				alignBoxesWidth(boxValArray, 2, 1);
@@ -1674,6 +1697,7 @@ function resizeBoxes(parent, templateId)
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 	}else if(templateId == 5){
@@ -1682,6 +1706,9 @@ function resizeBoxes(parent, templateId)
 		$(boxValArray['box1']['id']).resizable({
 			containment: parent,
 			handles: "e,s",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){
 				alignBoxesWidth(boxValArray, 1, 2);
 				alignBoxesHeight4boxes(boxValArray, 1, 2);
@@ -1689,29 +1716,38 @@ function resizeBoxes(parent, templateId)
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 		
 		$(boxValArray['box2']['id']).resizable({
 			containment: parent,
 			handles: "s",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){
 				alignBoxesHeight4boxes(boxValArray, 2, 1);
 				$("#box2wrapper").css("left", " ");
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 		
 		$(boxValArray['box3']['id']).resizable({
 			containment: parent,
 			handles: "e",
+			start: function(event, ui) {
+				$('iframe').css('pointer-events','none');
+			},
 			resize: function(e, ui){
 				alignBoxesWidth(boxValArray, 3, 4);
 			},
 			stop: function(e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
+				$('iframe').css('pointer-events','auto');
 			}
 		});
 	}else if(templateId == 6){
@@ -1723,21 +1759,26 @@ function resizeBoxes(parent, templateId)
 			$(boxValArray['box1']['id']).resizable({
 				containment: parent,
 				handles: "e",
+				start: function(event, ui) {
+					$('iframe').css('pointer-events','none');
+				},
 				resize: function(e, ui){
 					alignWidth4boxes(boxValArray, 1, 2, 3, 4);
 					$(boxValArray['box1']['id']).height(100 + "%");
 					
 				},
 				stop: function(e, ui) {
-					 
 					setLocalStorageProperties(templateId, boxValArray);
-					 
+					$('iframe').css('pointer-events','auto');
 				}
 			});
 			
 			$(boxValArray['box2']['id']).resizable({
 				containment: parent,
 				handles: "s",
+				start: function(event, ui) {
+					$('iframe').css('pointer-events','none');
+				},
 				resize: function(e, ui){
 					
 						alignBoxesHeight3stack(boxValArray, 2, 3, 4);
@@ -1749,14 +1790,17 @@ function resizeBoxes(parent, templateId)
 				stop: function(e, ui) {
 					 
 					setLocalStorageProperties(templateId, boxValArray);
+					$('iframe').css('pointer-events','auto');
 					 
 				}
 			});
 			
-			
 			$(boxValArray['box3']['id']).resizable({
 				containment: parent,
 				handles: "s",
+				start: function(event, ui) {
+					$('iframe').css('pointer-events','none');
+				},
 				resize: function(e, ui){
 					
 					console.log("");
@@ -1769,6 +1813,7 @@ function resizeBoxes(parent, templateId)
 					 
 					$(boxValArray['box4']['id']).css("top", " ");
 					setLocalStorageProperties(templateId, boxValArray);
+					$('iframe').css('pointer-events','auto');
 					 
 				}
 			});


### PR DESCRIPTION
Adds code that disables the pointer events for all iframes while the resizing function is working. Which means you cant use the iframes while your dragging the handle to resize the page. The functionality is restored when you drop the handle.