### PR TITLE
Cv22#drag and drop fixes

### DIFF
--- a/CodeViewer/dragndrop.php
+++ b/CodeViewer/dragndrop.php
@@ -71,8 +71,6 @@ include_once("../Shared/basic.php");
 			echo "</div>";
 			echo "</div>";
 			
-			echo "<img id='exchangeButton' src='../Shared/icons/exchangeButton.svg'>";
-			
 			$query = $pdo->prepare("SELECT exampleid,examplename from codeexample where cid=$courseID");
 			$query->execute();
 			$data = array();

--- a/CodeViewer/dragndrop.php
+++ b/CodeViewer/dragndrop.php
@@ -71,6 +71,8 @@ include_once("../Shared/basic.php");
 			echo "</div>";
 			echo "</div>";
 			
+			echo "<img id='exchangeButton' src='../Shared/icons/exchangeButton.svg'>";
+			
 			$query = $pdo->prepare("SELECT exampleid,examplename from codeexample where cid=$courseID");
 			$query->execute();
 			$data = array();

--- a/CodeViewer/dragndropService.php
+++ b/CodeViewer/dragndropService.php
@@ -17,16 +17,19 @@ if ($_GET["action"] == "update"){
 		$last = end($item);
 		$count = 1;
 		foreach($item as $example){
-			if($example == $item[0]){
+			if($example == $item[0] && $example == $last){
+				$query = $pdo->prepare("UPDATE codeexample SET beforeid=$example, afterid=$example WHERE exampleid=$example");
+				$query->execute();
+			} else if($example == $item[0]){
 				$query = $pdo->prepare("UPDATE codeexample SET beforeid=$example, afterid=$item[$count] WHERE exampleid=$example");
 				$query->execute();
 				$count++;
 			} else if($example == $last) {
-				$count--;
+				$count = $count-2;
 				$query = $pdo->prepare("UPDATE codeexample SET beforeid=$item[$count], afterid=$example WHERE exampleid=$example");
 				$query->execute();
 			} else {
-				$before = $count-1;
+				$before = $count-2;
 				$query = $pdo->prepare("UPDATE codeexample SET beforeid=$item[$before], afterid=$item[$count] WHERE exampleid=$example");
 				$query->execute();
 				$count++;

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -659,18 +659,14 @@
 
 /* DragnDrop CSS */
 #SeqEdit {
-	border:1px solid #424242;
 	margin-top:10px;
-	background-color:#b3b3b3;
-	max-height:500px;
-	overflow-y:auto;
 }
 
 #sortListBox {
 	margin: 5px;
 	padding: 5px 3px 0px 3px;
 	border: 1px solid #424242;
-	width: 175px;
+	width: 200px;
 	background-color:#cccccc;
 	display:inline-block;
 	text-align:center;
@@ -686,11 +682,21 @@
 	margin:5px 5px 10px 5px;
 	padding: 5px 3px 0px 3px;
 	border: 1px solid #424242;
-	width: 175px;
+	width: 200px;
 	background-color:#cccccc;
 	display:inline-block;
 	text-align:center;
 	float:right;
+}
+
+#exampleList {
+	max-height:226px;
+	overflow-y:auto;
+}
+
+#sortList {
+	max-height:226px;
+	overflow-y:auto;
 }
 
 #exampleListBox span {
@@ -780,6 +786,14 @@
 	float:right;
 	margin-right:30px;
 	color:green;
+}
+
+#exchangeButton {
+	position:absolute;
+	width:30px;
+	margin-top:10px;
+	margin-left:-3px;
+	height:30px;
 }
 
 .loginBox {

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -788,14 +788,6 @@
 	color:green;
 }
 
-#exchangeButton {
-	position:absolute;
-	width:30px;
-	margin-top:10px;
-	margin-left:-3px;
-	height:30px;
-}
-
 .loginBox {
 	top:25%;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -955,47 +955,6 @@ input.new-item-button:hover {
 	height: 30px;
 }
 
-
-
-/* Shapes and color for the buttons in Editexample box*/
-.newSequence, .deleteSequence, .updateSequence  {
-    background-color: rgb(97, 72, 117);
-    border: 0px none;
-    height: 30px;
-    color: rgb(255, 255, 255);
-    cursor: pointer;
-    margin-bottom: 2px;
-    margin-left: 4px;
-    font-size: 14px;
-    float: right;
-    -webkit-transition: background-color 1s ease 0s;
-    -moz-transition: background-color 1s ease 0s;
-    -o-transition: background-color 1s ease 0s;
-     transition: background-color 1s ease 0s;
-
-}
-
-/* Shapes and color for the buttons in Editexample box*/
-.updateSequence {
-    margin-top: 26px;
-    margin-bottom: 4px;
-    margin-left: 4px;
-}
-
-/* Hover style for the buttons in Editexample box*/
-.newSequence:hover, .updateSequence:hover, .deleteSequence:hover {
-  background-color:#7B5A96;
-  border-radius:4px;	
-}
-
-#editExample {
-	position: absolute;
-	top: 0 auto;
-	width: 442px;
-
-}
-
-
 /* End DuggaSys Sectioneed*/
 /**************************/
 


### PR DESCRIPTION
This is a fix for issues #1629, #1585 and #1478.

CSS added in codeviewer for the scroll, fixing the bug with scroll not enabling the dragging of example to boxes. Removed duplicate old css from style.css that messed up and overwrote the css from codeviewer.css. 

Fixed the issue where the beforeid got updated wrong and was set to the current example id instead of the example id before it. 
