### PR TITLE
Codeviewer #1599 Important word exists twice

### DIFF
--- a/Shared/SQL/testdata.sql
+++ b/Shared/SQL/testdata.sql
@@ -311,7 +311,6 @@ INSERT INTO impwordlist(exampleid,word,uid) values (5,"createElement",1);
 INSERT INTO impwordlist(exampleid,word,uid) values (5,"innerHTML",1);
 INSERT INTO impwordlist(exampleid,word,uid) values (5,"appendChild",1);
 INSERT INTO impwordlist(exampleid,word,uid) values (5,"appendNode",1);
-INSERT INTO impwordlist(exampleid,word,uid) values (5,"appendChild",1);
 INSERT INTO impwordlist(exampleid,word,uid) values (5,"insertBefore",1);
 INSERT INTO impwordlist(exampleid,word,uid) values (5,"parentNode",1);
 INSERT INTO impwordlist(exampleid,word,uid) values (6,"value",1);


### PR DESCRIPTION
#1599
There where two occurences of the word appendChild, which caused som weird behavior.