### PR TITLE
Dugga stops timer when handed in

### DIFF
--- a/DuggaSys/timer.js
+++ b/DuggaSys/timer.js
@@ -3,6 +3,9 @@
 //---------------------------------------------------------------------------------------------------------------
 
 var Timer = {	
+	// Determines if the timer should update ui
+	update: 0,
+
 	// Declare the timer variable, will be accessible from this object in a dugga
 	timer: undefined,
 	
@@ -24,6 +27,9 @@ var Timer = {
 	stopTimer: function(){
 		var self = this;
 		clearInterval(self.timer);
+		
+		// Quick fix
+		this.update = 1;
 	},
 	
 	// Increments the time counter by one
@@ -53,6 +59,8 @@ var Timer = {
 		str += seconds;
 
 		// Push new value to ui thing
-		document.getElementById('scoreElement').innerHTML = str;
+		if(this.update == 0) {
+			document.getElementById('scoreElement').innerHTML = str;
+		}
 	}
 }	


### PR DESCRIPTION
With this update the dugga timer should stop immediately after a user has handed in a dugga. The code 'clearInterval(self.timer);' was not working for some reason and I don't know enough javascript to debug this without hassle so I just implemented a pretty naive solution which stops the timer updating the ui.

See issue #1634 