### PR TITLE
Disables resizable functions in mobile theme

### DIFF
--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -218,6 +218,8 @@ function returned(data)
 	}
 	// Allows resizing of boxes on the page
 	resizeBoxes("#div2", retData["templateid"]);
+	//Disables resizable functionality in mobile theme
+	mobileDesktopResize("#div2", retData["templateid"]);
 }
 
 //---------------------------------------------------------------------------------
@@ -2163,6 +2165,38 @@ function setResizableToPer(boxValArray)
 		$(this).width(newWidth + "%");
 	});
 }
+
+//---------------------------------------------------------------------------------
+// Stops calling of the function when the user is in mobile mode.
+//				Is called at the same time as resizeboxes() in codeviewer.js
+//---------------------------------------------------------------------------------
+
+function mobileDesktopResize(parent, templateId){
+
+	$(window).resize(function(event){
+		 //This if statement has to do with resizable ui and window events overlapping in certain areas. This rules out the resizable ui ones.
+		 if (!$(event.target).hasClass('ui-resizable')) {
+			var windowWidth = $(window).width();
+			
+			if(windowWidth < 1100){
+				
+					var numBoxes = $("[id ^=box][id $=wrapper]").length;
+
+					for(var i = 1; i <= numBoxes; i++){
+						if ($("#box" + i + "wrapper").hasClass('ui-resizable')) {
+							$("#box" + i + "wrapper").resizable("destroy");
+						}
+					}
+				
+			}else{
+				if (!$("#box1wrapper").hasClass('ui-resizable')) {
+					resizeBoxes("#div2", retData["templateid"]);
+				}
+			}
+		}
+	});
+}
+
 //----------------------------------------------------------------------------------
 // fixQuotedHtml: replace all "<, and >" with "&lt and &gt". This makes sure the 
 //				  html tags are not rendered by the browser.	

--- a/CodeViewer/codeviewer.js
+++ b/CodeViewer/codeviewer.js
@@ -2173,6 +2173,17 @@ function setResizableToPer(boxValArray)
 
 function mobileDesktopResize(parent, templateId){
 
+		var windowWidth = $(window).width();
+			
+		if(windowWidth < 1100){
+				var numBoxes = $("[id ^=box][id $=wrapper]").length;
+				for(var i = 1; i <= numBoxes; i++){
+					if ($("#box" + i + "wrapper").hasClass('ui-resizable')) {
+						$("#box" + i + "wrapper").resizable("destroy");
+					}
+				}
+		}
+
 	$(window).resize(function(event){
 		 //This if statement has to do with resizable ui and window events overlapping in certain areas. This rules out the resizable ui ones.
 		 if (!$(event.target).hasClass('ui-resizable')) {


### PR DESCRIPTION
Does as the title says, this updated version of the function now features checks before every action if it should be run or not.

The parent width have been changed to window width.

Now, if the window becomes smaller than 1100px the mobile theme triggers, and the layout of the site dramatically changes. This abolishes the need for the resizable functions, and this destroys those functions if they are found. However if the site later becomes bigger than 1100px it also reinitializes the resizeboxes function and makes the codeboxes resizable again.