### PR TITLE
Draggable box boundaries

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -510,7 +510,6 @@ header td {
     position: fixed;
     top: 40%;
     left: 50%;
-    margin-top: -100px;
     margin-left: -178px;
     box-shadow:2px 2px 4px #000;
 }

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -583,9 +583,10 @@ $(window).load(function() {
 });
 
 $(window).load(function() {
-      $('.loginBox').draggable({ handle:'.loginBoxheader'});
+	$('.loginBox').draggable({ handle:'.loginBoxheader'});
+	$('.loginBox').draggable({ containment: "window"});	//contains the draggable box within window-boundaries
 	//There is an issue with using this code, it generates errors that stop execution
-      $(window).keyup(function(event){
-      	if(event.keyCode == 27) closeWindows();
-      });
+	$(window).keyup(function(event){
+		if(event.keyCode == 27) closeWindows();
+	});
 });


### PR DESCRIPTION
Prevents the user from dragging the draggable boxes outside of window-space. See #1702 