### PR TITLE
fixed issue 1920, and some things around it

### DIFF
--- a/DuggaSys/filereceive_dugga.php
+++ b/DuggaSys/filereceive_dugga.php
@@ -38,9 +38,9 @@ $duggaid=getOP('did');
 $fieldtype=getOP('field');
 $fieldkind=getOP('kind');
 $error=false;
+$type = getOP('type');
 
-$seq=0;
-					
+$seq=0;		
 if(isset($_SESSION['uid'])){
 	$userid=$_SESSION['uid'];
 	$loginname=$_SESSION['loginname'];
@@ -49,17 +49,16 @@ if(isset($_SESSION['uid'])){
 }else{
 	$userid="UNK";		
 } 	
-
 //  Handle files! One by one  -- if all is ok add file name to database
 //  login for user is successful & has either write access or is superuser					
-
 $ha = checklogin();
 if($ha){
-
 		// Create folder if link textinput or file
 		if($link=="UNK"){
 				$currcvd=getcwd();
-
+				if (!file_exists($currcvd."/submissions/")) {
+					mkdir($currcvd."/submissions/");
+				}
 				if(!file_exists ($currcvd."/submissions/".$cid)){
 						if(!mkdir($currcvd."/submissions/".$cid)){
 								echo "Error creating folder: ".$currcvd."/submissions/cid";
@@ -137,39 +136,55 @@ if($ha){
 				}			 				
 
 		}else if($link!="UNK"){
+				if (checkLinkValidity($link)) {
+					$query = $pdo->prepare("SELECT COUNT(*) AS Dusty FROM submission WHERE uid=:uid AND did=:did AND filepath=:fname AND cid=:cid;", array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));  
+					$query->bindParam(':uid', $userid);
+					$query->bindParam(':did', $duggaid);
+					$query->bindParam(':cid', $cid);
+					$query->bindParam(':fname', $link);
+					$query->execute();
+					foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
+								$seq=$row['Dusty']+1;
+					}			
 
-				$query = $pdo->prepare("SELECT COUNT(*) AS Dusty FROM submission WHERE uid=:uid AND did=:did AND filepath=:fname AND cid=:cid;", array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));  
-				$query->bindParam(':uid', $userid);
-				$query->bindParam(':did', $duggaid);
-				$query->bindParam(':cid', $cid);
-				$query->bindParam(':fname', $link);
-				$query->execute();
-				foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-							$seq=$row['Dusty']+1;
-				}			
-
-				$query = $pdo->prepare("INSERT INTO submission(fieldnme,uid,cid,vers,did,filepath,filename,extension,mime,kind,seq,updtime) VALUES(:field,:uid,:cid,:vers,:did,:filepath,null,null,null,:kind,:seq,now());");
+					$query = $pdo->prepare("INSERT INTO submission(fieldnme,uid,cid,vers,did,filepath,filename,extension,mime,kind,seq,updtime) VALUES(:field,:uid,:cid,:vers,:did,:filepath,null,null,null,:kind,:seq,now());");
+					
 				
-			
-				$query->bindParam(':uid', $userid);
-				$query->bindParam(':cid', $cid);
-				$query->bindParam(':vers', $vers);
-				$query->bindParam(':did', $duggaid);
-				$query->bindParam(':filepath', $link);
-				$query->bindParam(':field', $fieldtype);
-				$query->bindParam(':kind', $fieldkind);
-				$query->bindParam(':seq', $seq);
-				
-				if(!$query->execute()) {
-					$error=$query->errorInfo();
-					echo "Error updating file entries".$error[2];
-				}			 				
+					$query->bindParam(':uid', $userid);
+					$query->bindParam(':cid', $cid);
+					$query->bindParam(':vers', $vers);
+					$query->bindParam(':did', $duggaid);
+					$query->bindParam(':filepath', $link);
+					$query->bindParam(':field', $fieldtype);
+					$query->bindParam(':kind', $fieldkind);
+					$query->bindParam(':seq', $seq);
+					
+					if(!$query->execute()) {
+						$error=$query->errorInfo();
+						echo "Error updating file entries".$error[2];
+					}	
+				}
+				else{
+					$error = true;
+					echo "invalid link, http:// or https:// must be present.";
+				}
+						 				
 		}else{
 				// chdir('../'); 
 								
-				//  if the file is of type "GFILE"(global) or "MFILE"(course local) and it doesn't exists in the db, add a row into the db
+				//  if the file is of valid type and it doesn't exists in the db, add a row into the db
 				$allowedT = array("application/x-msdownload","application/x-pdf ","application/pdf","application/x-rar-compressed","application/zip", "application/octet-stream","application/force-download","application/x-download", "application/x-zip-compressed", "binary/octet-stream");
 				$allowedX = array("pdf","zip","rar");
+				//type of filesubmit,eg. if its from the pdf-submit, only allow pdf.
+				if (type === "pdf") {
+					$allowedX = array("pdf");
+					$allowedT = array("application/x-pdf ","application/pdf");
+				}
+				else if (type == "zip") {
+					$allowedX = array("zip","rar");
+					$allowedT = array("application/x-rar-compressed","application/zip","application/x-zip-compressed");
+				}
+
 				
 				$swizzled = swizzleArray($_FILES['uploadedfile']);
 				
@@ -194,7 +209,6 @@ if($ha){
 				
 								if(in_array($extension, $allowedX)&&in_array($filea['type'], $allowedT)){ 
 										//  if file type is allowed, continue the uploading process.
-																						
 										$seq=0;
 										$query = $pdo->prepare("SELECT COUNT(*) AS Dusty FROM submission WHERE uid=:uid AND did=:did AND filename=:fname AND cid=:cid;", array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));  
 										$query->bindParam(':did', $duggaid);
@@ -207,7 +221,6 @@ if($ha){
 										}															  
 		
 									  $movname=$currcvd."/submissions/".$cid."/".$vers."/".$duggaid."/".$userdir."/".$fname.$seq.".".$extension;	
-					
 										// check if upload is successful 
 										if(move_uploaded_file($filea["tmp_name"],$movname)){ 
 		
@@ -252,6 +265,17 @@ if($ha){
 if(!$error){
 		echo "<meta http-equiv='refresh' content='0;URL=showDugga.php?cid=".$cid."&coursevers=".$vers."&did=".$duggaid."&moment=".$moment."&segment=".$segment."&highscoremode=0' />";  //update page, redirect to "fileed.php" with the variables sent for course id and version id
 }
+
+
+function checkLinkValidity($link){
+	if ( strpos($data, 'http://') !== 0 && strpos($data, 'https://') !== 0 ) {
+			return false;
+		}
+	else
+		return true;
+
+}
+
 
 ?>
 </head>

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -21,15 +21,12 @@ var elapsedTime = 0;
 function setup() 
 {
 	inParams = parseGet();
-
 	AJAXService("GETPARAM", { }, "PDUGGA");
 }
 
 function returnedDugga(data) 
 {	
-
 	$("#content").css({"position":"relative","top":"50px"});
-
 	dataV = data;
 	
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
@@ -37,8 +34,8 @@ function returnedDugga(data)
 	if (data['param'] == "UNK") {
 		alert("UNKNOWN DUGGA!");
 	} else {
-		duggaParams = jQuery.parseJSON(data['param']);
-
+		duggaParams = JSON.parse(data['param']);
+		console.log(duggaParams);
 		if(duggaParams["type"]==="pdf"){
 				document.getElementById("snus").innerHTML="<embed src='showdoc.php?cid="+inParams["cid"]+"&fname="+duggaParams["filelink"]+"' width='100%' height='1000px' type='application/pdf'>";
 		}else if(duggaParams["type"]==="md" || duggaParams["type"]==="html"){
@@ -70,7 +67,6 @@ function returnedDugga(data)
 
 		duggaFiles = data['files'];
 		
-	  console.log(duggaFiles);
 	
 
 		if (duggaFiles.length > 0){
@@ -186,7 +182,6 @@ function showFacit(param, uanswer, danswer, userStats, files)
     		if (duggaParams['uploadInstruction'] !== null){
 				document.getElementById(duggaParams["submissions"][k].fieldname+"Instruction").innerHTML=duggaParams["submissions"][k].instruction;
 			}
-
 		}
 
 	}
@@ -218,8 +213,14 @@ function createFileUploadArea(fileuploadfileds){
 		}else if(type=="text"){
 				form +="<textarea rows='20' name='inputtext'  id='inputtext' style='-webkit-box-sizing: border-box; -moz-box-sizing: border-box;	box-sizing: border-box;	width: 100%;background:#f8f8ff;border-radius:8px;box-shadow: 2px 2px 4px #888 inset;padding:4px;' >Fumho</textarea>";
 				form +="<input type='hidden' name='kind' value='3' />";
-		}else{
-				form +="<input name='uploadedfile[]' type='file' multiple='multiple' />";
+		}
+		//only in multi type you its possible to upload multiple files. In types like pfd and zip its only one file
+		else if (type == "multi") {
+				form +="<input name='uploadedfile[]' type='file' multiple='true'  />";
+				form +="<input type='hidden' name='kind' value='1' />";
+		}
+		else{
+				form +="<input name='uploadedfile[]' type='file'  />";
 				form +="<input type='hidden' name='kind' value='1' />";
 		}
 		
@@ -230,6 +231,7 @@ function createFileUploadArea(fileuploadfileds){
 		form +="<input type='hidden' name='did' value='"+inParams["did"]+"' />";
 		form +="<input type='hidden' name='segment' value='"+inParams["segment"]+"' />";
 		form +="<input type='hidden' name='field' value='"+fieldname+"' />";
+		form +="<input type='hidden' name='type' value='"+type+"' />";
 		form +="</form>";
 		
 		if (type === "pdf"){


### PR DESCRIPTION
added validation for links and that you can only add one "zip/rar" or "pdf" when the submit is of those types, when using type "multi", different and multiple files can be added at the same time. 

even when you are in submit type "pdf" you cannot add multiple pdf at the same time. The reason is that only the first pdf is previewed anyways, so if multiple files must be added at the same time, use the "multi" submit type instead. 