### PR TITLE
Fixed issue #1323

### DIFF
--- a/Shared/css/whiteTheme.css
+++ b/Shared/css/whiteTheme.css
@@ -275,6 +275,7 @@
 .normtext .impword {
     color: #fff;
     background-color: #9971AF;
+	display: inline-block;
 	font-family: Hack,MyWebFont, "Andale Mono", AndaleMono, monospace;
     font-size: 9px;
     line-height: 11px;


### PR DESCRIPTION
Added this one line to fix the overlapping highlights (important words)
in codeviewer.