### PR TITLE
[grp1w15]Fixing bugs for collapse system - #2174

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -249,7 +249,7 @@ function returnedDugga(data)
 			var variantz=item['variants'];
 			
 			if(variantz.length>0){
-				str+="<tr class='fuma'><td colspan='9' style='padding:0px;'>";
+				str+="<tr class='fuma'><td colspan='10' style='padding:0px;'>";
 				str+="<table width='100%' class='innertable'>";
 				for(j=0;j<variantz.length;j++){
 					var itemz=variantz[j];

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -308,6 +308,7 @@ function returnedDugga(data)
 	   		type: 'POST',
 	   		data: {ckn : 'duggedC'},
 	   	}).done(function(e){
+	   		console.log(e);
 	   		//set the results to the created array, split on ','
 	   		collapsedArr = e;
 	   		collapsedArr = collapsedArr.split(',');

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -308,7 +308,6 @@ function returnedDugga(data)
 	   		type: 'POST',
 	   		data: {ckn : 'duggedC'},
 	   	}).done(function(e){
-	   		console.log(e);
 	   		//set the results to the created array, split on ','
 	   		collapsedArr = e;
 	   		collapsedArr = collapsedArr.split(',');

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -287,6 +287,11 @@ function returnedDugga(data)
 
 		str+="</table>";
 
+		str+="<div style='float:right;padding-bottom:10px;'>";
+		str+="<input class='submit-button' style='width:170px' type='button' value='Add Dugga Template' onclick='showAddDuggaTemplate();'/>";
+		str+="<input class='submit-button' type='button' value='Add Dugga' onclick='createDugga();'/>";
+		str+="</div>";
+
 	}
 	alla = result;
 

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -178,13 +178,13 @@ function returnedDugga(data)
 		str+="<input class='submit-button' type='button' value='Add Dugga' onclick='createDugga();'/>";
 		str+="</div>";
 		str+="<table class='list'>";
-		str+="<tr><th class='first'>Name</th><th>Autograde</th><th>Gradesys</th><th>Template</th><th>Release</th><th>Deadline</th><th>Modified</th><th style='width:30px'></th><th style='width:30px' class='last'></th></tr>";
+		str+="<tr><th></th><th class='first'>Name</th><th>Autograde</th><th>Gradesys</th><th>Template</th><th>Release</th><th>Deadline</th><th>Modified</th><th style='width:30px'></th><th style='width:30px' class='last'></th></tr>";
 
 		for(i=0;i<data['entries'].length;i++){
 			
 			var item=data['entries'][i];
 			
-			str+="<tr class='fumo' onclick='collapseLight(this)'>";
+			str+="<tr class='fumo'><td onclick='collapseLight(this)'><img class='collapseArrow' src='../Shared/icons/DownT.svg'></td>";
 			result++;
 			str+="<td style='width:170px'><input type='text' id='duggav"+result+"' style='font-size:1em;border: 0;border-width:0px;' onchange='changename("+item['did']+","+result+")' placeholder='"+item['name']+"' /></td>";
 			if(item['autograde']=="1"){
@@ -309,8 +309,12 @@ function returnedDugga(data)
 
 	   		//Run through the divs to see which ones to hide
 			$('.fumo').each(function(index, el) {
-				if (collapsedArr[index] == 1)
+				if (collapsedArr[index] == 1){
 					$(this).closest('tr').next('.fuma').css('display', 'none');
+					$(this).toggleClass('selector');
+				}else{
+					$(this).children('td').children('img').addClass('collapsedArrow');
+				}
 			});
 
 	   	});
@@ -449,8 +453,9 @@ function hideAddDuggaTemplate(){
 }
 
 function collapseLight(elem){
+	$(elem).children('img').toggleClass('collapsedArrow');
 	//get the right element to collapse and collapse to the next moment.
-   	$(elem).next('.fuma').fadeToggle(0);
+   	$(elem).closest('.fumo').next('.fuma').fadeToggle(0);
 
    	//create a temporary array and run throug each moment div
    	var temparr = [];

--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -17,13 +17,6 @@ logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "duggaedservice.php")
 
 if(isset($_SESSION['uid'])){
 	$userid=$_SESSION['uid'];
-
-	$cookieName = crypt(($userid . "duggedC" . $_SESSION['coursename']),"$1$snuskaka$");
-	if (!isset($_COOKIE[$cookieName]) && ini_get('session.use_cookies')){
-		$params = session_get_cookie_params();
-		setcookie($cookieName,"0",time() + (86400 * 365),$params["path"], $params["domain"],$params["secure"], $params["httponly"]);
-	}
-
 }else{
 	$userid="1";		
 } 
@@ -45,6 +38,17 @@ $gradesys = getOP('gradesys');
 $template = getOP('template');
 $release = getOP('release');
 $deadline = getOP('deadline');
+
+//set the course info based on previous set session variables
+$courseinfo = $_SESSION['cid'] . $_SESSION['coursevers'];
+//crypt the cookie name with salt.
+$cookieName = crypt(($userid . "duggedC" . $courseinfo),"$1$snuskaka$");
+//check if cookie exitst and if using cookies
+if (!isset($_COOKIE[$cookieName]) && ini_get('session.use_cookies')){
+	$params = session_get_cookie_params();
+	//set the cookie
+	setcookie($cookieName,"0",time() + (86400 * 365),$params["path"], $params["domain"],$params["secure"], $params["httponly"]);
+}
 
 $debug="NONE!";
 

--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -39,15 +39,17 @@ $template = getOP('template');
 $release = getOP('release');
 $deadline = getOP('deadline');
 
-//set the course info based on previous set session variables
-$courseinfo = $_SESSION['cid'] . $_SESSION['coursevers'];
-//crypt the cookie name with salt.
-$cookieName = crypt(($userid . "duggedC" . $courseinfo),"$1$snuskaka$");
-//check if cookie exitst and if using cookies
-if (!isset($_COOKIE[$cookieName]) && ini_get('session.use_cookies')){
-	$params = session_get_cookie_params();
-	//set the cookie
-	setcookie($cookieName,"0",time() + (86400 * 365),$params["path"], $params["domain"],$params["secure"], $params["httponly"]);
+if ($_SESSION['loginname']) {
+	//Set the current course id to the session
+	$_SESSION['cid'] = $cid;
+	//prepare the cookie name
+	$cookie = ($_SESSION['loginname'] . "duggedC" . $cid . $_SESSION['coursevers']);
+	//check if cookie exitst and if using cookies
+	if (!isset($_COOKIE[$cookie]) && ini_get('session.use_cookies')){
+		$params = session_get_cookie_params();
+		//set the cookie
+		setcookie($cookie,"0",time() + (86400 * 365),$params["path"], $params["domain"],$params["secure"], $params["httponly"]);
+	}
 }
 
 $debug="NONE!";

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -854,8 +854,7 @@ function returnedHighscore(data){
 
 function collapseLight(elem){
 	//get the right element to collapse and collapse to the next moment.
- 	var a = "div." + elem.closest('div').className;
-   	$(elem).closest('div').nextUntil(a).fadeToggle(0);
+   	$(elem).closest('div').nextUntil('div.divMoment').fadeToggle(0);
 
    	//create a temporary array and run throug each moment div
    	var temparr = [];

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -470,7 +470,7 @@ $array = array(
 	'codeexamples' => $codeexamples,
 	'unmarked' => $unmarked
 );
-$debug = $cookieName;
+
 echo json_encode($array);
 logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "sectionedservice.php");
 ?>

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -16,13 +16,6 @@ session_start();
 
 if(isset($_SESSION['uid'])){
 	$userid=$_SESSION['uid'];
-
-	$cookieName = crypt(($userid . "sectC" . $_SESSION['coursename']),"$1$snuskaka$");
-	if (!isset($_COOKIE[$cookieName]) && ini_get('session.use_cookies')){
-		$params = session_get_cookie_params();
-		setcookie($cookieName,"0",time() + (86400 * 365),$params["path"], $params["domain"],$params["secure"], $params["httponly"]);
-	}
-
 }else{
 	$userid="0";
 	
@@ -49,6 +42,18 @@ $coursenamealt=getOP('coursenamealt');
 $log_uuid = getOP('log_uuid');
 $log_timestamp = getOP('log_timestamp');
 $unmarked = 0;
+
+//set the course id to session data so the cookie script can access it
+$_SESSION['cid'] = $courseid;
+
+//create the crypt out of various variables with salt.
+$cookieName = crypt(($userid . "sectC" . $courseid . $coursevers),"$1$snuskaka$");
+//check if cookie exists and that the session is using cookies
+if (!isset($_COOKIE[$cookieName]) && ini_get('session.use_cookies')){
+	$params = session_get_cookie_params();
+	//set the cookie
+	setcookie($cookieName,"0",time() + (86400 * 365),$params["path"], $params["domain"],$params["secure"], $params["httponly"]);
+}
 
 logServiceEvent($log_uuid, EventTypes::ServiceClientStart, "sectionedservice.php", $log_timestamp);
 logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "sectionedservice.php");

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -43,16 +43,15 @@ $log_uuid = getOP('log_uuid');
 $log_timestamp = getOP('log_timestamp');
 $unmarked = 0;
 
-//set the course id to session data so the cookie script can access it
-$_SESSION['cid'] = $courseid;
-
-//create the crypt out of various variables with salt.
-$cookieName = crypt(($userid . "sectC" . $courseid . $coursevers),"$1$snuskaka$");
-//check if cookie exists and that the session is using cookies
-if (!isset($_COOKIE[$cookieName]) && ini_get('session.use_cookies')){
-	$params = session_get_cookie_params();
-	//set the cookie
-	setcookie($cookieName,"0",time() + (86400 * 365),$params["path"], $params["domain"],$params["secure"], $params["httponly"]);
+if (isset($_SESSION['loginname'])) {
+	//prepare the cookie name
+	$cookie = ($_SESSION['loginname'] . "sectC" . $_SESSION['cid'] . $_SESSION['coursevers']);
+	//check if cookie exists and that the session is using cookies
+	if (!isset($_COOKIE[$cookie]) && ini_get('session.use_cookies')){
+		$params = session_get_cookie_params();
+		//set the cookie
+		setcookie($cookie,"0",time() + (86400 * 365),$params["path"], $params["domain"],$params["secure"], $params["httponly"]);
+	}
 }
 
 logServiceEvent($log_uuid, EventTypes::ServiceClientStart, "sectionedservice.php", $log_timestamp);
@@ -471,7 +470,7 @@ $array = array(
 	'codeexamples' => $codeexamples,
 	'unmarked' => $unmarked
 );
-
+$debug = $cookieName;
 echo json_encode($array);
 logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "sectionedservice.php");
 ?>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1216,6 +1216,18 @@ input.new-item-button:hover {
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
+
+.collapseArrow{
+    -moz-transform:rotate(-90deg);
+    -webkit-transform:rotate(-90deg);
+    transform:rotate(-90deg);
+}
+.collapsedArrow{
+   -moz-transform:rotate(0deg);
+    -webkit-transform:rotate(0deg);
+    transform:rotate(0deg);
+}
+
 /* End DuggaSys resulted*/
 /**************************/
 

--- a/Shared/getCookies.php
+++ b/Shared/getCookies.php
@@ -15,8 +15,6 @@
 
 		//$cookie = crypt(($userid . $COOKIENAME . $courseinfo),"$1$snuskaka$");
 		$cookie = ($userid . $COOKIENAME . $_SESSION['cid'] . $_SESSION['coursevers']);
-		//crypt the cookie name
-		$cookieCrypt = crypt($cookie,"$1$snuskaka$");
 
 		if (($COOKIENAME && isset($_COOKIE[$cookie])) && isset($_POST['clist'])) {
 			setcookie($cookie,$_POST['clist'],$defCookieTimer,'/');

--- a/Shared/getCookies.php
+++ b/Shared/getCookies.php
@@ -11,11 +11,12 @@
 		$defCookieTimer = (time() + (86400 * 365));
 		
 		//get session information for constructing the cookie name
-		$userid = $_SESSION['uid'];
-		$courseinfo = $_SESSION['cid'] . $_SESSION['coursevers'];
+		$userid = $_SESSION['loginname'];
 
+		//$cookie = crypt(($userid . $COOKIENAME . $courseinfo),"$1$snuskaka$");
+		$cookie = ($userid . $COOKIENAME . $_SESSION['cid'] . $_SESSION['coursevers']);
 		//crypt the cookie name
-		$cookie = crypt(($userid . $COOKIENAME . $courseinfo),"$1$snuskaka$");
+		$cookieCrypt = crypt($cookie,"$1$snuskaka$");
 
 		if (($COOKIENAME && isset($_COOKIE[$cookie])) && isset($_POST['clist'])) {
 			setcookie($cookie,$_POST['clist'],$defCookieTimer,'/');

--- a/Shared/getCookies.php
+++ b/Shared/getCookies.php
@@ -1,22 +1,25 @@
 <?php
+	//init the session to access session data
 	session_start();
+	//check if the POST is set
 	if (isset($_POST['ckn'])) {
 
+		//set the cookie name to the variable from POST
 		$COOKIENAME = $_POST['ckn'];
 
+		//define the timer of the cookies, cookies will be refreshed with this everytime they are modified
 		$defCookieTimer = (time() + (86400 * 365));
-
+		
+		//get session information for constructing the cookie name
 		$userid = $_SESSION['uid'];
-		$courseid = $_SESSION['coursename'];
-		$cookie = crypt(($userid . $COOKIENAME . $courseid),"$1$snuskaka$");
+		$courseinfo = $_SESSION['cid'] . $_SESSION['coursevers'];
 
-		if (($COOKIENAME == "sectC" && isset($_COOKIE[$cookie])) && isset($_POST['clist'])) {
+		//crypt the cookie name
+		$cookie = crypt(($userid . $COOKIENAME . $courseinfo),"$1$snuskaka$");
+
+		if (($COOKIENAME && isset($_COOKIE[$cookie])) && isset($_POST['clist'])) {
 			setcookie($cookie,$_POST['clist'],$defCookieTimer,'/');
-		}else if($COOKIENAME == "sectC" && isset($_COOKIE[$cookie])){
-			$ans = $_COOKIE[$cookie];
-		}else if (($COOKIENAME == "duggedC" && isset($_COOKIE[$cookie])) && isset($_POST['clist'])) {
-			setcookie($cookie,$_POST['clist'],$defCookieTimer,'/');
-		}else if($COOKIENAME == "duggedC" && isset($_COOKIE[$cookie])){
+		}else if($COOKIENAME && isset($_COOKIE[$cookie])){
 			$ans = $_COOKIE[$cookie];
 		}
 		echo $ans;


### PR DESCRIPTION
Pull Request for Issue #2174 

### Fixes to the collapse system that have been added are the following:

- Internet Explorer collapse bug solved, recognizing DOM elements with jQuery in IE
- Change duggaed page collapse system from _onlick_ on blankspace, to _onclick_ on arrows added to left hand side
- Ditch encryption for cookies as UID is no longer used to ident cookies, cookie ident is now: _username + cookie string + cid + course vers_

_dugged collapse_
![screen shot 2016-04-21 at 00 00 47](https://cloud.githubusercontent.com/assets/18159848/14691929/445a8322-0754-11e6-902b-876dc35d10ce.png)

_section collapse_
![screen shot 2016-04-21 at 00 01 16](https://cloud.githubusercontent.com/assets/18159848/14691940/49edb3a4-0754-11e6-9f61-e50462857fd8.png)
