### PR TITLE
Fixed issue 2237

### DIFF
--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -58,10 +58,7 @@
     line-height: 14px;
 }
 
-/* Base-size for images in description boxes */
-.box img{
-    width: 70%;
-}
+
 /* BOX STYLE STOP */
 
 /* BOXMENU STYLING START */


### PR DESCRIPTION
Markdown images were shown in bigger size than thumbnail, all images
should be thumbnail size at first glimpse. Therefore this code could be
deleted.