### PR TITLE
Fix link issue on update item

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -306,8 +306,8 @@ function updateItem()
 	lid=$("#lid").val();
 	kind=$("#type").val();
 	link;
-	//only tests has links to duggas
-	if(kind == 3 || kind == 2)
+	//Kind 2,3, and 5 have links (Code, Test, Link)
+	if(kind == 3 || kind == 2 || kind == 5)
 		link=$("#link").val();
 	else
 		link = "UNK";


### PR DESCRIPTION
Fixes that item type 'link' can't be updated in the section page.