### PR TITLE
Fixed issue #1938

### DIFF
--- a/DuggaSys/showdoc.php
+++ b/DuggaSys/showdoc.php
@@ -57,11 +57,17 @@
 				$instring = preg_replace("/^\#{2}\s(.*)=*/m", "<h2>$1</h2>",$instring);	
 				$instring = preg_replace("/^\#{1}\s(.*)=*/m", "<h1>$1</h1>",$instring);	
 
-				//Regular expressions for ordered lists both - and * lists are supported
-				$instring = preg_replace("/^\s*\d*\.\s(.*)/m", "<ol><li>$1</li></ol>",$instring);
-				
-				// Fix for superflous ol statements
-				$instring= str_replace ("</ol>\n<ol>","",$instring);
+				//Regular expressions for ordered lists
+				// (###) to start a list
+				// 1. Digit dot space
+				// 2. Digit dot space
+				// 		(###) to start a sublist
+				// 		1. Digit dot space
+				// 		(/###) to close the sublist
+				// (/###) to close the list
+				$instring = preg_replace("/[(]\#{3}[)]/", '<ol>',$instring);
+				$instring = preg_replace("/[\d]{1,}\.\s(.*)/", '<li>$1</li>',$instring);
+				$instring = preg_replace("/[(][\/]\#{3}[)]/", '</ol>',$instring);
 				
 				//Regular expressions for unordered lists
 				// (***) to start a list

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -127,10 +127,16 @@ function markdownBlock(inString)
 	inString = inString.replace(/^\#{1}\s(.*)=*/gm, '<h1>$1</h1>');
 	
 	//Regular expressions for ordered lists
-	inString = inString.replace(/^\s*\d*\.\s(.*)/gm, '<ol><li>$1</li></ol>');
-	
-	// Fix for superflous ol tags
-	inString = inString.replace(/\<\/ol\>(\r\n|\n|\r)\<ol\>/gm,"");
+	// (###) to start a list
+	// 1. Digit dot space
+	// 2. Digit dot space
+	// 		(###) to start a sublist
+	// 		1. Digit dot space
+	// 		(/###) to close the sublist
+	// (/###) to close the list
+	inString = inString.replace(/[(]\#{3}[)]/gm, '<ol>');
+	inString = inString.replace(/[\d]{1,}\.\s(.*)/gm, '<li>$1</li>');
+	inString = inString.replace(/[(][\/]\#{3}[)]/gm, '</ol>');
 	
 	//Regular expressions for unordered lists
 	// (***) to start a list


### PR DESCRIPTION
Changed the code so it would be able to handle stuff between numbered
lists without breaking the couting sequence. Also changed how lists are
implemented. This also fixes sublists for an ordered list. Added to
JavaScript and PHP.
(###) To start an ordered list.
1. Hi (number, dot, space, and content to start couting sequence).
(/###) To end an ordered list.
To create sublists just start a list within another list.