### PR TITLE
Grp1w18 issue1864

### DIFF
--- a/Shared/allowCookiesForUser.php
+++ b/Shared/allowCookiesForUser.php
@@ -1,0 +1,17 @@
+<?php 
+session_start();
+include_once "../Shared/sessions.php";
+include_once "../Shared/basic.php";
+
+$ha = checklogin();
+
+if ($ha) {
+	$username = $_SESSION["loginname"];
+	//sets a cookie so its known that this particular user allows cookies and will not be bothered with a "do you allow cookies" dialog in a while
+	if (!isset($_COOKIE[$username."_allow_cookies"])) {
+		setcookie($username."_allow_cookies", "set", time() + (86400 * 60) ) ; //86400 = 1day
+	}
+}
+
+echo json_encode($ha);
+ ?>

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -698,8 +698,28 @@ function processLogin() {
 					$("#loginbutton").off("click");
 					console.log("Removed show login bind");
 					$("#loginbutton").click(function(){processLogout();});
-					
-					location.reload();
+
+					if(result["cookiesAllowed"] == false){
+						//byt ut window.confirm till en dialog istället
+						if (window.confirm("Do you accept cookies on this user. If not you will be logged out")) {
+							$.ajax({
+								type:"POST",
+								url: "../Shared/allowCookiesForUser.php",
+								success:function(data) {								
+									console.log(data);
+									window.alert("success");
+								},
+								error:function() {
+									console.log("error");
+								}
+							});
+
+						}
+						else{
+							processLogout();
+						}
+					}	
+					location.reload();			
 				}else{
 					console.log("Failed to log in.");
 					if(typeof result.reason != "undefined") {

--- a/Shared/sessions.php
+++ b/Shared/sessions.php
@@ -143,7 +143,7 @@ function login($username, $password, $savelogin)
 			
 //		update last login.
 		$query = $pdo->prepare("UPDATE user SET lastvisit=now() WHERE uid=:uid");
-		$query->bindParam(':uid', $row['uid']);
+		$query->bindParam(':uid', $_SESSION['uid']);
 		$query->execute();
 		return true;
 

--- a/Shared/sessions.php
+++ b/Shared/sessions.php
@@ -143,7 +143,7 @@ function login($username, $password, $savelogin)
 			
 //		update last login.
 		$query = $pdo->prepare("UPDATE user SET lastvisit=now() WHERE uid=:uid");
-		$query->bindParam(':uid', $_SESSION['uid']);
+		$query->bindParam(':uid', $row['uid']);
 		$query->execute();
 		return true;
 
@@ -265,6 +265,18 @@ function getUserAnswerHasGrade($userid, $courseid, $quizid, $vers, $moment)
 			return false;
 		}
 
+}
+/**
+ * Returns if user has allowed cookies
+ * @param string $username
+ * @return boolean
+ */
+function userAllowedCookies($username){
+	if(!isset($_COOKIE[$username."_allow_cookies"])){
+		return false;
+	}
+	else
+		return true;
 }
 
 ?>


### PR DESCRIPTION
Fixed the mainfunctionality that was asked for in https://github.com/HGustavs/LenaSYS/issues/1864. However, it is only a "window.confirm" right now because i did not know how to properly implement a custom made roll-down for this particular problem.

The issue is that the cookie-check is done when its known that a real user logged in. In window.confirm you can not continue after the login if you do not interact with the dialog at first. But with a custom made dialog I do not know how the implement the same idea in a clean way. You would be able to ignore the dialog and continue like nothing happened