### PR TITLE
issue1864 fix

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -721,7 +721,8 @@ function processLogin() {
 							$.ajax({
 								type:"POST",
 								url: "../Shared/allowCookiesForUser.php",
-								success:function(data) {								
+								success:function(data) {	
+									location.reload();								
 								},
 								error:function() {
 									console.log("error");
@@ -732,8 +733,7 @@ function processLogin() {
 						else{
 							processLogout();
 						}
-					}	
-					location.reload();			
+					}			
 				}else{
 					console.log("Failed to log in.");
 					if(typeof result.reason != "undefined") {


### PR DESCRIPTION
cancel button on cookiedialog was not logging out on some browsers/machines. the issue was problably that location.reload() was called while a ajax call executed in processLogout()