### PR TITLE
fixed issue 2368

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -889,6 +889,7 @@ function returnedSection(data)
 		str+="<div class='err'><span style='font-weight:bold;'>Bummer!</span>This version does not seem to exist!</div>";										  
 		var slist=document.getElementById('Sectionlist');
 		slist.innerHTML=str;
+		if(data['writeaccess'])
 		showCreateVersion();
 		
 	}


### PR DESCRIPTION
added an if-statement that ensured that the "create new version" dialog is only shown if writeaccess is present when the courseversion does not exist https://github.com/HGustavs/LenaSYS/issues/2368