### PR TITLE
Fixed #2580 - correct mousepos for chrome,edge and

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -661,12 +661,15 @@ function mousemoveevt(ev, t){
 		mox=cx;
 		moy=cy;
 
-		if (ev.layerX||ev.layerX==0) { // Firefox
-		    cx=ev.layerX-acanvas.offsetLeft;
-		    cy=ev.layerY-acanvas.offsetTop;
+		if (ev.pageX || ev.pageY == 0){ // Chrome
+			cx=ev.pageX-acanvas.offsetLeft;
+			cy=ev.pageY-acanvas.offsetTop;
+		} else if (ev.layerX||ev.layerX==0) { // Firefox
+			cx=ev.layerX-acanvas.offsetLeft;
+			cy=ev.layerY-acanvas.offsetTop;
 		} else if (ev.offsetX || ev.offsetX == 0) { // Opera
-		    cx=ev.offsetX-acanvas.offsetLeft;
-		    cy=ev.offsetY-acanvas.offsetTop;
+			cx=ev.offsetX-acanvas.offsetLeft;
+			cy=ev.offsetY-acanvas.offsetTop;
 		}
 
 		if(md==0){

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -10,7 +10,7 @@ pdoConnect();
 <head>
 	<link rel="icon" type="image/ico" href="../Shared/icons/favicon.ico"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1 maximum-scale=1">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome = 1">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<title>Section Editor</title>
 


### PR DESCRIPTION
Changed diagram.js and diagram.php so that mousepos is working correctly for chrome,edge and firefox