### PR TITLE
Fixed correct output of special chars in textfields for 'Section Title' and 'Title'.

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -333,8 +333,8 @@ function editImpWords(editType)
 //----------------------------------------------------------------------------------¨
 function displayEditExample(boxid)
 {
-	$("#title").val(retData['examplename']);
-	$("#secttitle").val(retData['sectionname']);
+	$("#title").val($('<textarea />').html(retData['examplename']).text());
+	$("#secttitle").val($('<textarea />').html(retData['sectionname']).text());
 	$("#playlink").val(retData['playlink']);
 	
 	var iw=retData['impwords'];


### PR DESCRIPTION
It is not possible to change to a title with 'åäö' in code editor and see the correct name when changing title later.