### PR TITLE
Fixed window size.

### DIFF
--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -176,7 +176,7 @@ Testing Link:
 		<span id='forwdrop' style='left:100px;display:none;' class='dropdown dropdownStyle forwdrop'><div class='dropdownback dropdownbackStyle'>Forw</div><span id='forwdropc'>bii</span></span>
 		<!-- Dropdowns END -->
 		<!-- Example Content Cog Wheel Dialog START -->
-		<div id='editContent' class='loginBox' style='width:464px;display:none;'>
+		<div id='editContent' class='loginBox' style='width:510px;display:none;'>
 			<div class='loginBoxheader'>
 				<h3>Edit Content</h3>
 				<div onclick='closeEditContent();'>x</div>
@@ -227,7 +227,7 @@ Testing Link:
 		</div>
 		<!-- Example Content Cog Wheel Dialog END -->
 		<!-- Code Example Cog Wheel Dialog START -->
-		<div id='editExample' class='loginBox' style='width:464x;display:none;'>
+		<div id='editExample' class='loginBox' style='width:510px;display:none;'>
 			<div class='loginBoxheader'>
 				<h3>Edit Example</h3>
 				<div onclick='closeEditExample();'>x</div>


### PR DESCRIPTION
This should now show the editing window without textfield sticking out to the right.