### PR TITLE
Enables list entry with '-character

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -321,9 +321,9 @@ function returnedCourse(data)
 
 			if (data['writeaccess']) {
 				//str += "<a style='margin-right:15px;' href='sectioned.php?courseid=" + item['cid'] + "&coursename=" + item['coursename'] + "&coursevers=" + item['activeedversion'] + "'><img id='dorf' src='../Shared/icons/PenV.svg'></a>";
-				str += "<img id='dorf' src='../Shared/icons/PenV.svg' onclick='editVersion("+item['cid']+",\""+item['coursename']+"\",\""+item['coursecode']+"\")'>";
+				str += "<img id='dorf' src='../Shared/icons/PenV.svg' onclick='editVersion("+item['cid']+",\""+htmlFix(item['coursename'])+"\",\""+item['coursecode']+"\")'>";
 				str += "<img id='dorf' style='float:right;' src='../Shared/icons/Cogwheel.svg' ";
-				str += " onclick='selectCourse(\"" + item['cid'] + "\",\"" + item['coursename'] + "\",\"" + item['coursecode'] + "\",\"" + item['visibility'] + "\",\"" + item['activeversion'] + "\",\"" + item['activeedversion'] + "\");' >";
+				str += " onclick='selectCourse(\"" + item['cid'] + "\",\"" + htmlFix(item['coursename']) + "\",\"" + item['coursecode'] + "\",\"" + item['visibility'] + "\",\"" + item['activeversion'] + "\",\"" + item['activeedversion'] + "\");' >";
 			}
 
 			str += "</span>";
@@ -346,4 +346,17 @@ function returnedCourse(data)
 
 	resetinputs();
 	//resets all inputs
+}
+
+/* Used to enable using list entries with ' */
+function htmlFix(text){
+    var map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+    };
+
+    return text.replace(/[&<>"']/g, function(m) { return map[m]; });
 }


### PR DESCRIPTION
Makes it possible to add new list entry with ' (for example Erik's course) without breaking the edit or setting icon, which used to not work when using '.