### PR TITLE
Styling of file-upload to match "sectioned"

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -36,21 +36,10 @@ function deleteFile(fileid,filename){
 		}
 }
 
-/*
- * This toggles the accordion between open and closed.
- * Input: the accordion id
- * The accordion construct requires that the accordion body is named [accordionID]_body
- */
-function toggleTableVisibility(tbody) {
-    
-		if (document.getElementById(tbody+"_body").style.display == "none"){
-				document.getElementById(tbody+"_body").style.display = "table-row-group";
-        document.getElementById(tbody+"_icon").src="../Shared/icons/desc_complement.svg"
-		} else {
-				document.getElementById(tbody+"_body").style.display = "none";
-        document.getElementById(tbody+"_icon").src="../Shared/icons/right_complement.svg"
-		}
-}
+// Function to toggle the content (tbody) under each header
+$(document).on('click','.toggleContent',function(){
+		$(this).closest('table').find('tbody').fadeToggle();
+});
 
 function createLink()
 {
@@ -151,7 +140,7 @@ function returnedFile(data)
 		str4="";
 		str1+="<table class='list' style='margin-bottom:8px;' >";
 		str1+="<thead>";
-		str1+="<tr onclick='toggleTableVisibility(\"links\");'><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><img id='links_icon' src='../Shared/icons/desc_complement.svg'/><span>ID<span></div></th><th>Link URL</th><th class='last'><input class='submit-button' type='button' value='Add Link' onclick='createLink();'/></th></tr>";
+		str1+="<tr><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><span>ID</span></div></th><th>Link URL<img id='links_icon' src='../Shared/icons/sort_white.svg' class='toggleContent' style='cursor:pointer;vertical-align:middle;'/></th><th class='last'><input class='submit-button' type='button' value='Add Link' onclick='createLink();'/></th></tr>";
 		//str1+="<tr><th class='first' style='width:64px;'>ID</th><th style='width:30px' ></th></tr>";
 		str1+="<thead><tbody id='links_body'>"
 
@@ -172,7 +161,7 @@ function returnedFile(data)
 			str1+="</tbody></table>";
 			str2+="<table class='list' style='margin-bottom:8px;' >";
       str2+="<thead>";      
-      str2+="<tr onclick='toggleTableVisibility(\"global\");'><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><img id='global_icon' src='../Shared/icons/desc_complement.svg'/><span>ID<span></div></th><th>Global File</th><th class='last'><input class='submit-button' type='button' value='Add File' onclick='createFile(\"GFILE\");'/></th></tr>";
+      str2+="<tr><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><span>ID</span></div></th><th>Global File<img id='global_icon' src='../Shared/icons/sort_white.svg' class='toggleContent' style='cursor:pointer;vertical-align:middle;'/></th><th class='last'><input class='submit-button' type='button' value='Add File' onclick='createFile(\"GFILE\");'/></th></tr>";
 			str2+="<thead><tbody id='global_body'>"
 			
 			for(i=0;i<data['entries'].length;i++){
@@ -195,7 +184,6 @@ function returnedFile(data)
 			str2+="</tbody></table>";
 			str3+="<table class='list' style='margin-bottom:8px;' >";
 			str3+="<thead>";
-      str3+="<tr onclick='toggleTableVisibility(\"course\");'><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><img id='course_icon' src='../Shared/icons/desc_complement.svg'/><span>ID<span></div></th><th>Course File</th><th class='last'><input class='submit-button' type='button' value='Add Link' onclick='createFile(\"MFILE\");'/></th></tr>";
 			str3+="<thead><tbody id='course_body'>";
 			for(i=0;i<data['entries'].length;i++){
 				var item=data['entries'][i];
@@ -216,7 +204,6 @@ function returnedFile(data)
 			str3+="</tbody></table>";
 			str4+="<table class='list' style='margin-bottom:8px;' >";
 			str4+="<thead>";
-      str4+="<tr onclick='toggleTableVisibility(\"local\");'><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><img id='local_icon' src='../Shared/icons/desc_complement.svg'/><span>ID<span></div></th><th>Course Local File</th><th class='last'><input class='submit-button' type='button' value='Add Link' onclick='createFile(\"LFILE\");'/></th></tr>";
 			str4+="<thead><tbody id='local_body'>"
 			for(i=0;i<data['entries'].length;i++){
 				var item=data['entries'][i];


### PR DESCRIPTION
The styling of the file-upload has been changed to match the collapsable
sections in "sectioned". Old toggle-function has been removed to be
replaced with Jquery. The arrows in the header are clickable with a
pointer as cursor. The animation doesnt match because "slideToggle"
doesn't work on tables. A part of issue #1867