### PR TITLE
Small-bug-fix-#2736

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -968,6 +968,10 @@ function mouseupevt(ev){
 function deleteObject(index){
   var canvas = document.getElementById("myCanvas");
   canvas.style.cursor="default";
+      points[diagram[index].topLeft] = waldoPoint;
+      points[diagram[index].bottomRight] = waldoPoint;
+      points[diagram[index].centerpoint] = waldoPoint;
+      points[diagram[index].middleDivider] = waldoPoint;
     for(i = 0; i < diagram.length; i++){
         if(!(diagram[i].symbolkind == 1)){
             var temp = true;


### PR DESCRIPTION
By mistake a earlier merge from local branches removed 4 lines of code, that removed the "crosses" when deleted object, added them again