### PR TITLE
Fixed bug in "fileed.js"

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -43,6 +43,10 @@ $(document).on('click','thead',function(){
 	$('.arrowComp', this).slideToggle();
 });
 
+$(document).on('click','.last',function(e) {
+     e.stopPropagation();
+  });
+
 
 function createLink()
 {


### PR DESCRIPTION
The content collapsed when you clicked "Add File" in the file-upload
page. This bug is now fixed using Jquery's "stopPropagation();".

Part of issue #2434