### PR TITLE
fixing bug in unordered and ordered list regarding sublisting.

### DIFF
--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -9,15 +9,23 @@ Hello!
 ~~~
 
 ~~~
-#indent back (lightgreen)
-#stay (lightblue)
-#indent back (lightgreen)
+# indent forwards (red)
+# stay (blue)
+# indent backwards (green)
 ~~~
 
 * item 1
 * item 2
 * item 3
-    * item 4
+  * item 3.1
+  * item 3.2
+  * item 3.3
+* item 4
+  * item 4.1
+    * item 4.1.1
+  * item 4.2
+    * item 4.2.1
+    * item 4.2.2
+    * item 4.2.3
+      * item 4.2.3.1
 * item 5
-  * item 6
-    * item 7

--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -8,6 +8,12 @@ From the standpoint of the browser the result is identical.
 Hello!
 ~~~
 
+~~~
+#indent back (lightgreen)
+#stay (lightblue)
+#indent back (lightgreen)
+~~~
+
 * item 1
 * item 2
 * item 3

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -116,6 +116,7 @@ function parseMarkdown(inString)
 
 			str+=workstr;
 	}
+	alert(str);
 
 	return str;
 }
@@ -193,22 +194,28 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     var nextLineIndentation = nextLine.match(/^\s*/)[0].length;
     var indentationLevel = (currentLineIndentation - prevLineIndentation) / 2;
 
-    //var currentIndentationLevel = (prevLineIndentation - currentIndentationLevel) / 2;
+    if(!isUnorderdList(prevLine)) {
+    	markdown += "<p>Opening</p>";
+    }
 
     // indent forwards (lightred)
     if(currentLineIndentation > prevLineIndentation) { 
-    	
     	markdown += "<p style='color:red;'>" + value + " @should indent: " + indentationLevel + "</p>"; // should indent currentLine forward
     }
     // indent backwards (lightgreen)
     else if(currentLineIndentation < prevLineIndentation) { 
     	markdown += "<p style='color:green;'>" + value + " @should indent: " + indentationLevel +  "</p>"; // should indent currentLine backwards
+    	
+    	
     }
     // stay (lightblue)
     else {
     	markdown += "<p style='color:blue;'>" + value + " @should indent: 0</p>"; // ńo indentation
     }
     
+    if(!isUnorderdList(nextLine)) {
+    	markdown += "<p>Closing</p>";
+    }
 
 	return markdown;
 }

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -194,22 +194,21 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     var nextLineIndentation = nextLine.match(/^\s*/)[0].length;
 
     if(!isUnorderdList(prevLine)) {
-    	markdown += "<hr>";
     	markdown += "<ul>";
     }
 
     // indent forwards (lightred)
     if(currentLineIndentation < nextLineIndentation) { 
-    	markdown += "<li style='color:red;'>";
+    	markdown += "<li>";
     	markdown +=  value;
 
     	// open sublist
     	markdown += "<ul>" 
     }
-    // indent backwards (lightgreen)
+    // indent backwards
     else if(currentLineIndentation > nextLineIndentation) { 
-    	markdown += "<li style='color:green;'>"; 
-    	markdown +=  value + "should close";
+    	markdown += "<li>"; 
+    	markdown +=  value;
     	markdown += "</li>";
 
     	//close sublists
@@ -217,38 +216,64 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     	for(var i = 0; i < sublistsToClose; i++) {
     		markdown += "</ul></li>";
     	}
-    	
-
     }
-    // stay (lightblue)
+    // stay
     else {
-    	markdown += "<li style='color:blue;'>";
+    	markdown += "<li>";
     	markdown +=  value;
     	markdown += "</li>";
     }
     
     if(!isUnorderdList(nextLine)) {
     	markdown += "</ul>";
-    	markdown += "<hr>";
     }
 
 	return markdown;
 }
 
-function handleOrderedList(currentLine, prevLine, nextLine) { // function works the same way handleUnorderedList does().
+function handleOrderedList(currentLine, prevLine, nextLine) {
     var markdown = "";
-    var matches = currentLine.match(/^\s*\d*\.\s(.*)/gm);
-    if(currentLine.match(/^\s*\d*/)[0].length > prevLine.match(/^\s*\d*/)[0].length){
-        markdown += "<ol>";
-    }
-    else if(currentLine.match(/^\s*\d*/)[0].length < prevLine.match(/^\s*\d*/)[0].length){
-        markdown += "</ol>" + "</li>";
-    }else{
+	var value = currentLine.substr(currentLine.match(/^\s*\d*\.\s*/)[0].length, currentLine.length);
+	var currentLineIndentation = currentLine.match(/^\s*\d*/)[0].length;
+    var prevLineIndentation = prevLine.match(/^\s*\d*/)[0].length;
+    var nextLineIndentation = nextLine.match(/^\s*\d*/)[0].length;
 
+    if(!isOrderdList(prevLine)) {
+    	markdown += "<ol>";
     }
-    markdown += "<li>" + currentLine.substr(currentLine.match(/^\s*\d*\.\s*/)[0].length, currentLine.length);
 
-    return markdown;
+    // indent forwards
+    if(currentLineIndentation < nextLineIndentation) { 
+    	markdown += "<li>";
+    	markdown +=  value;
+
+    	// open sublist
+    	markdown += "<ol>" 
+    }
+    // indent backwards
+    else if(currentLineIndentation > nextLineIndentation) { 
+    	markdown += "<li>"; 
+    	markdown +=  value;
+    	markdown += "</li>";
+
+    	//close sublists
+    	var sublistsToClose = (currentLineIndentation - nextLineIndentation) / 2;
+    	for(var i = 0; i < sublistsToClose; i++) {
+    		markdown += "</ol></li>";
+    	}
+    }
+    // stay
+    else {
+    	markdown += "<li>";
+    	markdown +=  value;
+    	markdown += "</li>";
+    }
+    
+    if(!isOrderdList(nextLine)) {
+    	markdown += "</ol>";
+    }
+
+	return markdown;
 }
 
 //----------------------------------------------------------------------------------

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -116,7 +116,6 @@ function parseMarkdown(inString)
 
 			str+=workstr;
 	}
-	alert(str);
 
 	return str;
 }
@@ -199,7 +198,7 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
 
     // indent forwards (lightred)
     if(currentLineIndentation < nextLineIndentation) { 
-    	markdown += "<li>";
+    	markdown += "<lii>";
     	markdown +=  value;
 
     	// open sublist

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -195,17 +195,18 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     //var currentIndentationLevel = (prevLineIndentation - currentIndentationLevel) / 2;
 
     // indent forwards (lightred)
-    if(currentLineIndentation > prevLineIndentation) { // should indent currentLine forward
-    	markdown += "<p style='color:red;'>" + value +  "</p>";
-    }
-    // stay (lightblue)
-    else if(true) { // no indentation
-    	markdown += "<p style='color:blue;'>" + value +  "</p>";
+    if(currentLineIndentation > prevLineIndentation) { 
+    	markdown += "<p style='color:red;'>" + value +  "</p>"; // should indent currentLine forward
     }
     // indent backwards (lightgreen)
-    else if(true) { // should indent currentLine backwards
-    	markdown += "<p style='color:green;'>" + value +  "</p>";
+    else if(currentLineIndentation < prevLineIndentation) { 
+    	markdown += "<p style='color:green;'>" + value +  "</p>"; // should indent currentLine backwards
     }
+    // stay (lightblue)
+    else {
+    	markdown += "<p style='color:blue;'>" + value +  "</p>"; // ńo indentation
+    }
+    
 
 	return markdown;
 }

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -192,16 +192,18 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     var prevLineIndentation = prevLine.match(/^\s*/)[0].length;
     var nextLineIndentation = nextLine.match(/^\s*/)[0].length;
 
-    // indent forward (lightred)
-    if(true) {
+    //var currentIndentationLevel = (prevLineIndentation - currentIndentationLevel) / 2;
+
+    // indent forwards (lightred)
+    if(currentLineIndentation > prevLineIndentation) { // should indent currentLine forward
     	markdown += "<p style='color:red;'>" + value +  "</p>";
     }
     // stay (lightblue)
-    else if(true) {
+    else if(true) { // no indentation
     	markdown += "<p style='color:blue;'>" + value +  "</p>";
     }
-    // indent back (lightgreen)
-    else if(true) {
+    // indent backwards (lightgreen)
+    else if(true) { // should indent currentLine backwards
     	markdown += "<p style='color:green;'>" + value +  "</p>";
     }
 

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -192,6 +192,18 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     var prevLineIndentation = prevLine.match(/^\s*/)[0].length;
     var nextLineIndentation = nextLine.match(/^\s*/)[0].length;
 
+    // indent forward (lightred)
+    if(true) {
+    	markdown += "<p style='color:red;'>" + value +  "</p>";
+    }
+    // stay (lightblue)
+    else if(true) {
+    	markdown += "<p style='color:blue;'>" + value +  "</p>";
+    }
+    // indent back (lightgreen)
+    else if(true) {
+    	markdown += "<p style='color:green;'>" + value +  "</p>";
+    }
 
 	return markdown;
 }

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -191,20 +191,22 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
 	var currentLineIndentation = currentLine.match(/^\s*/)[0].length;
     var prevLineIndentation = prevLine.match(/^\s*/)[0].length;
     var nextLineIndentation = nextLine.match(/^\s*/)[0].length;
+    var indentationLevel = (currentLineIndentation - prevLineIndentation) / 2;
 
     //var currentIndentationLevel = (prevLineIndentation - currentIndentationLevel) / 2;
 
     // indent forwards (lightred)
     if(currentLineIndentation > prevLineIndentation) { 
-    	markdown += "<p style='color:red;'>" + value +  "</p>"; // should indent currentLine forward
+    	
+    	markdown += "<p style='color:red;'>" + value + " @should indent: " + indentationLevel + "</p>"; // should indent currentLine forward
     }
     // indent backwards (lightgreen)
     else if(currentLineIndentation < prevLineIndentation) { 
-    	markdown += "<p style='color:green;'>" + value +  "</p>"; // should indent currentLine backwards
+    	markdown += "<p style='color:green;'>" + value + " @should indent: " + indentationLevel +  "</p>"; // should indent currentLine backwards
     }
     // stay (lightblue)
     else {
-    	markdown += "<p style='color:blue;'>" + value +  "</p>"; // ńo indentation
+    	markdown += "<p style='color:blue;'>" + value + " @should indent: 0</p>"; // ńo indentation
     }
     
 

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -192,29 +192,44 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
 	var currentLineIndentation = currentLine.match(/^\s*/)[0].length;
     var prevLineIndentation = prevLine.match(/^\s*/)[0].length;
     var nextLineIndentation = nextLine.match(/^\s*/)[0].length;
-    var indentationLevel = (currentLineIndentation - prevLineIndentation) / 2;
 
     if(!isUnorderdList(prevLine)) {
-    	markdown += "<p>Opening</p>";
+    	markdown += "<hr>";
+    	markdown += "<ul>";
     }
 
     // indent forwards (lightred)
-    if(currentLineIndentation > prevLineIndentation) { 
-    	markdown += "<p style='color:red;'>" + value + " @should indent: " + indentationLevel + "</p>"; // should indent currentLine forward
+    if(currentLineIndentation < nextLineIndentation) { 
+    	markdown += "<li style='color:red;'>";
+    	markdown +=  value;
+
+    	// open sublist
+    	markdown += "<ul>" 
     }
     // indent backwards (lightgreen)
-    else if(currentLineIndentation < prevLineIndentation) { 
-    	markdown += "<p style='color:green;'>" + value + " @should indent: " + indentationLevel +  "</p>"; // should indent currentLine backwards
+    else if(currentLineIndentation > nextLineIndentation) { 
+    	markdown += "<li style='color:green;'>"; 
+    	markdown +=  value + "should close";
+    	markdown += "</li>";
+
+    	//close sublists
+    	var sublistsToClose = (currentLineIndentation - nextLineIndentation) / 2;
+    	for(var i = 0; i < sublistsToClose; i++) {
+    		markdown += "</ul></li>";
+    	}
     	
-    	
+
     }
     // stay (lightblue)
     else {
-    	markdown += "<p style='color:blue;'>" + value + " @should indent: 0</p>"; // ńo indentation
+    	markdown += "<li style='color:blue;'>";
+    	markdown +=  value;
+    	markdown += "</li>";
     }
     
     if(!isUnorderdList(nextLine)) {
-    	markdown += "<p>Closing</p>";
+    	markdown += "</ul>";
+    	markdown += "<hr>";
     }
 
 	return markdown;


### PR DESCRIPTION
fixing issue #2808. 
Markdown is now correct for ordered and unordered lists. critical changes are made in functions handleUnorderedList() and handleOrderedList()