### PR TITLE
Changed styling of profile page

### DIFF
--- a/DuggaSys/profile.php
+++ b/DuggaSys/profile.php
@@ -31,39 +31,45 @@ pdoConnect();
 		include '../Shared/loginbox.php';
 	?>
 
-	<div id="content">
-		<button class="profile-element" type="button" id="activate_notifications">Activate notifications</button>
-		<script>
-var push_notifications_vapid_public_key = "<?php echo PUSH_NOTIFICATIONS_VAPID_PUBLIC_KEY; ?>";
-		</script>
-	
-		<form class="profile-element" method="POST" action="">
- 			Challenge question
- 			<br>
- 			<?php
- 				/*change loginname to security question when we are able to get that from session*/
-				echo "<textarea id='challengeQuestion' value='' onkeyup='checkScroll(this)' style='height:1.25em; width:16em; overflow:auto; font-family:sans-serif;'>".$_SESSION['loginname']."</textarea>"
-			?>
-		 	<br>
-		 	<input type="button" name="Save" id="Save" value="Save" />
-
-		</form>
+	<div id="content" style="display:flex">
+		<div style="display:inline-flex;margin:0 auto 0 auto;">
+			<div id="changeChallengeQuestion" style="margin-right:30px">
+				<h3>Change challenge question</h3>
+				<form method="post">
+					<label for="currentPassword">Current password</label><br/>
+					<input type="password" id="currentPassword" placeholder="Current password" /><br/><br/>
+					<label for="challengeQuestion">Challenge question</label><br/>
+					<?php
+						/*change loginname to security question when we are able to get that from session*/
+						echo "<textarea id='challengeQuestion' value='' onkeyup='checkScroll(this)' style='height:1.25em; max-height:110px; width:16em; overflow:auto; font-family:sans-serif;'>".$_SESSION['loginname']."</textarea><br/>"
+					?>
+					<label for="challengeAnswer">Challenge question</label><br/>
+					<input type="password" id="challengeAnswer" placeholder="Answer to question" /><br/><br/>
+				 	<button type="button" id="saveChallenge">Save</button>
+				</form>
+			</div>
 		
-		<form class="profile-element" method="POST" action="">
- 			New password 
- 			<br>
- 			<input type="text" id="newPassword" value="" style="width:16em;" placeholder="Enter new password" />
- 			<br>
-		 	<input type="button" name="Save" id="Save" value="Save" />
-		</form>
+			<div id="changePassword" style="margin:0 30px 0 30px;">
+				<h3>Change password</h3>
+				<form method="post">
+					<label for="currentPassword2">Current password</label><br/>
+					<input type="password" id="currentPassword2" placeholder="Current password" /><br/><br/>
+					<label for="newPassword">New password</label><br/>
+					<input type="password" id="newPassword" placeholder="New password" /><br/>
+					<label for="newPassword2">New password again</label><br/>
+					<input type="password" id="newPassword2" placeholder="New password again" /><br/><br/>
+					<button type="button" id="savePassword">Save</button>
+				</form>
+			</div>
 		
-		<form class="profile-element" method="POST" action="">
-			Enter password to make changes 
-			<br>
-			<input type="text" id="passwordConfirmation" value="" style="width:16em;" placeholder="Enter password" /> 
-			<br>
-			<button type="button" id="saveProfile">Save changes</button>
-		</form>
+			<div id="notificationsOnOff" style="margin-left:30px">
+				<h3>Activate notifications</h3>
+				<button type="button" class="profile-element" id="activate_notifications">Activate notifications</button>
+				<script>
+					var push_notifications_vapid_public_key = "<?php echo PUSH_NOTIFICATIONS_VAPID_PUBLIC_KEY; ?>";
+				</script>
+			</div>
+		</div>
 	</div>
 
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -196,10 +196,6 @@ p {
     margin-right:2px;
 }
 
-.profile-element {
-	margin-top: 25px;
-}
-
 .sys{
     border-radius:6px;
     color:#775886;


### PR DESCRIPTION
The styling of the profile page has been changed. A field has been added where you can enter an answer to the challenge question. A field for entering a new password again has also been added.

To be able to change either the challenge question or the password a field has been added where you have to enter the current password.

This commit only contain styling/design fixes so no functionality has been added. (Partially related to issue #2638)