### PR TITLE
Show sort icon onload - fileed sort

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -298,31 +298,15 @@ function formatBytes(bytes,decimals) {
 function setupSort(){ 
 	/*		Add filter menu		 */
 	var filt ="";	
-	filt+="<td id='select' class='navButt'><span class='dropdown-container' onmouseover='hoverc();' onmouseleave='leavec();'>";
-	filt+="<img class='navButt' src='../Shared/icons/tratt_white.svg'>";
-	filt+="<div id='dropdownc' class='dropdown-list-container'>";
-	filt+="</div>";
-	filt+="</span></td>";
-
 	filt+="<td id='filter' class='navButt'><span class='dropdown-container' onmouseover='hovers();' onmouseleave='leaves();'>";
 	filt+="<img class='navButt' src='../Shared/icons/sort_white.svg'>";
 	filt+="<div id='dropdowns' class='dropdown-list-container'>";
 	filt+="</div>";
 	filt+="</span></td>";
-	//$("#menuHook").before(filt); //menuHook is set between buttons and navName //Not printed since the sorting functionality is not done
-}
-
-function hoverc(){
-    $('#dropdowns').css('display','none');
-  	$('#dropdownc').css('display','block');
-}
-
-function leavec(){
-	$('#dropdownc').css('display','none');  
+	$("#menuHook").before(filt); //menuHook is set between buttons and navName
 }
 
 function hovers(){
-    $('#dropdownc').css('display','none');
   	$('#dropdowns').css('display','block');
 }
 

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -18,7 +18,7 @@ pdoConnect();
 	<script src="../Shared/dugga.js"></script>
 	<script src="fileed.js"></script>
 </head>
-<body>
+<body onload="setupSort();">
 	<?php 
 		$noup="SECTION";
 		include '../Shared/navheader.php';


### PR DESCRIPTION
Removed code that shows icon for filter since customer no longer wants to filter but to search in table (another issue). Also added the function to be executed on load of fileed.php so the icon now shows up. You can view the change in my folder on the testsite.

This is only a partfix for 2775. Do not close the issue.