### PR TITLE
Stop light logic is not correct for moment that has duggas

### DIFF
--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -276,8 +276,8 @@ foreach($query->fetchAll() as $row) {
 					$markedy=null;
 			}
 	}else{
-			$resulty=-1;
-			$markedy=null;	
+        	$resulty=$row['grade'];
+        	$markedy=$row['marked'];
 	}
 	array_push(
 		$resulties,


### PR DESCRIPTION
Stop lights now displays correct for duggas. If grade is pass - green, if fail - red. If not marked - yellow.