### PR TITLE
Changed the AJAXSERVICE and name on function in grouped.js

### DIFF
--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -8,10 +8,10 @@ var versions;
 var courselist;
 
 function setup(){  	
-	AJAXService("GET", { cid : querystring['cid'],vers : querystring['coursevers'] }, "RESULT");
+	AJAXService("GET", { cid : querystring['cid'],vers : querystring['coursevers'] }, "GROUP");
 }
 
-function returnedResults(data)
+function returnedGroup(data)
 {
 		entries=data.entries;
 		moments=data.moments;


### PR DESCRIPTION
The change were made to make the grouped.js work after the changes in Pull Request #3082 were made. The grouped.js is now using grouedservice.php instead of resultedservice.php