### PR TITLE
#2931(repulling) Added functionality to show/hide a variant 

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -6,6 +6,8 @@
 var sessionkind=0;
 var querystring=parseGet();
 var filez;
+var variant = [];
+
 AJAXService("GET",{cid:querystring['cid'],coursevers:querystring['coursevers']},"DUGGA");
 
 $(function() {
@@ -165,23 +167,43 @@ function selectVariant(vid,param,answer,template,dis)
 	}
 }
 
+function isInArray(array, search)
+{
+    return array.indexOf(search) >= 0;
+}
+
 function showVariant(param){
-    if (document.getElementById("variantInfo"+param) && document.getElementById("dugga"+param)) {
-        $(".fumo").removeClass("selectedtr");
-        $(".variantInfo").hide();
-        var variantId="#variantInfo" + param;
-        var duggaId="#dugga" + param;
-        /*
-        var arrowId="#arrow" + param;
-        $(arrowId).show(400);
-        /*
-        console.log(variantId);
-        console.log(duggaId);*/
-        $(variantId).slideDown(400);
+    var variantId="#variantInfo" + param;
+    var duggaId="#dugga" + param;
+    var arrowId="#arrow" + param;
+    var index = variant.indexOf(param);
+    
+    
+    if (document.getElementById("variantInfo"+param) && document.getElementById("dugga"+param)) {// Check if dugga row and corresponding variant
+        if(!isInArray(variant, param)){
+             variant.push(param);
+        }
         
-        $(duggaId).addClass("selectedtr");
-        $(variantId).css("border-bottom", "2px solid gray");
-       
+        if($(duggaId).hasClass("selectedtr")){ // Add a class to dugga if it is not already set and hide/show variant based on class.
+            $(variantId).hide();
+            $(duggaId).removeClass("selectedtr");
+            if (index > -1) {
+               variant.splice(index, 1);
+            }
+            
+        } else {
+            $(duggaId).addClass("selectedtr");
+            $(variantId).slideDown(); 
+        }
+        
+        $(variantId).css("border-bottom", "1px solid gray");
+    }
+}
+
+function showVariantz(param){
+    var index = variant.indexOf(param);
+    if(!isInArray(variant, param)){
+         variant.push(param);
     }
 }
 //----------------------------------------
@@ -208,10 +230,10 @@ function returnedDugga(data)
 
 			var item=data['entries'][i];
       
-			str+="<tr class='fumo' id='dugga" +i+ "' onClick='showVariant("+i+")'>";
+			str+="<tr class='fumo' id='dugga" +i+ "'>";
 
 			result++;
-            str+="<td><span class='arrow' id='arrow"+i+"'>&#x25BC;</span></td>";
+            str+="<td id='arrowz' onClick='showVariant("+i+")'><span class='arrow' id='arrow"+i+"'>&#x25BC;</span></td>";
 			str+="<td><label>Name: </label><input type='text' id='duggav"+result+"' style='font-size:1em;border: 0;border-width:0px;' onchange='changename("+item['did']+","+result+")' placeholder='"+item['name']+"' /></td>";
 			if(item['autograde']=="1"){
 				result++;
@@ -264,7 +286,7 @@ function returnedDugga(data)
 
 			str+="<td style='padding:4px;'>";
 			str+="<img id='plorf' style='float:left;margin-right:4px;' src='../Shared/icons/PlusU.svg' ";
-			str+=" onclick='addVariant(\""+querystring['cid']+"\",\""+item['did']+"\");' >";
+			str+=" onclick=' showVariantz("+i+"); addVariant(\""+querystring['cid']+"\",\""+item['did']+"\");'>";
 			str+="</td>";
 
 
@@ -320,6 +342,11 @@ function returnedDugga(data)
 	var slist=document.getElementById("content");
 	slist.innerHTML=str;
 	if(data['debug']!="NONE!") alert(data['debug']);
+    
+    var length = variant.length;
+    for(index = 0;  index < length; index++){
+        showVariant(variant[index]);
+    }
 }
 
 function parseParameters(str){

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1157,31 +1157,68 @@ input.large-button {
   width:110px;
 }
 
-.list#testTable td {
-  padding:8px; 
-  text-align:center;
-  border:none;
+
+.list#testTable td{
+    padding:8px; 
+    text-align:center;border:none;
 }
 
-.list#testTable th {
-  line-height:45px; 
-  box-shadow: -1px 5px 5px 0px rgba(0,0,0,0.21);
+.list#testTable th{
+    line-height:45px;
+    box-shadow: -1px 5px 5px 0px rgba(0,0,0,0.21);
 }
 
-.list#testTable tr {
-  line-height:45px;
+.list#testTable tr{
+    line-height:45px; 
+    border-bottom:1px solid gray;
+}
+.list#testTable tr>tr{
+    line-height:45px; 
+    border-bottom:none;
 }
 
 .list#testTable .variantInfo {
-  display:none;
+    display:none;
+}
+
+.list#testTable #plorf:hover,  .list#testTable #dorf:hover {
+    cursor:pointer;
+}
+
+.list#testTable #plorf, .list#testTable #dorf {
+    box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.2); 
+    padding:10px;
 }
 
 .list#testTable input, .list#testTable select, .list#testTable label {
-  padding:5px;
+    padding:5px;
 }
 
-.selectedtr { 
-  border-bottom:none !important;
+.selectedtr {
+    border-bottom:none !important;
+}
+
+.list#testTable input {
+    border-width: 2px !important; 
+    border-style: inset !important;
+}
+
+#testinnertable {
+    background:#fff;
+    box-shadow:none;
+    border-top: none;
+    border-bottom: none;
+}
+
+#testinnertable tr {
+    border-bottom: none !important;
+    background-color:white;
+}
+
+span.arrow {
+    padding:10px; 
+    cursor:pointer; 
+    box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.2);
 }
 
 .list#testTable input { 


### PR DESCRIPTION
Since there was some problems during the previous merge I'm doing another pull request.

The user should now be able to show/hide variants when the arrow button is clicked in the dugga editor. New variants and deleted variants should now also cause the the corresponding dugga to give feedback to the user by showing that a variant has been added or deleted in the table.