### PR TITLE
#3027 Properly display dropdown icon in the dugga editor

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -187,6 +187,7 @@ function showVariant(param){
         if($(duggaId).hasClass("selectedtr")){ // Add a class to dugga if it is not already set and hide/show variant based on class.
             $(variantId).hide();
             $(duggaId).removeClass("selectedtr");
+            $(arrowId).html("&#x25BC;");
             if (index > -1) {
                variant.splice(index, 1);
             }
@@ -194,6 +195,7 @@ function showVariant(param){
         } else {
             $(duggaId).addClass("selectedtr");
             $(variantId).slideDown(); 
+            $(arrowId).html("&#9658;");
         }
         
         $(variantId).css("border-bottom", "1px solid gray");
@@ -346,6 +348,13 @@ function returnedDugga(data)
     var length = variant.length;
     for(index = 0;  index < length; index++){
         showVariant(variant[index]);
+    }
+    
+    var variantLength = data['entries'].length;
+    for(idx = 0; idx < variantLength; idx++) {
+        if (!document.getElementById("variantInfo"+idx) && document.getElementById("dugga"+idx)) {
+            $("#arrow"+idx).hide();
+        }
     }
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1168,6 +1168,10 @@ input.large-button {
     box-shadow: -1px 5px 5px 0px rgba(0,0,0,0.21);
 }
 
+.list#testTable tr:nth-child(odd), .list#testTable tr:nth-child(even){
+    background-color:#eae8eb;
+}
+
 .list#testTable tr{
     line-height:45px; 
     border-bottom:1px solid gray;
@@ -1212,7 +1216,7 @@ input.large-button {
 
 #testinnertable tr {
     border-bottom: none !important;
-    background-color:white;
+    background-color:white !important;
 }
 
 span.arrow {


### PR DESCRIPTION
Dropdown icon should now only be displayed on the rows that have a variant to show in the dugga editor. Icon now also changes when clicked upon to give feedback. 