### PR TITLE
Added all groups in grouped.php

### DIFF
--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -9,6 +9,7 @@ var courselist;
 
 function setup(){  	
 	AJAXService("GET", { cid : querystring['cid'],vers : querystring['coursevers'] }, "GROUP");
+	
 }
 
 function returnedGroup(data)
@@ -20,7 +21,7 @@ function returnedGroup(data)
 		
 		allData = data; // used by dugga.js
 				
-				
+		
 		str="";
 
 		// Redraw main result table    
@@ -28,6 +29,10 @@ function returnedGroup(data)
 		str+="<table class='markinglist' id='markinglist'>";
 		str+="<thead>";
 		str+="<tr class='markinglist-header'>";
+		
+		str+="<th colspan='1' id='subheading' class='result-header'>";
+		str+="Grupper";
+		str+="</th>";
 
 		str+="<th colspan='1' id='subheading' class='result-header'>";
 		str+="Studenter";
@@ -56,22 +61,32 @@ function returnedGroup(data)
 					
 					if (moments[l].kind===4){
 							momname = moments[l].entryname;
-							str+="<th  class='result-header' colspan='"+(colsp)+"'>"+momname+"</th>"	
+							str+="<th  class='result-header' colspan='"+(colsp)+"'>"+momname+"</th>";	
 							colpos=l;
 							colsp=-1;
 					}
+					/* else{
+						var groupname = moments[l].name;
+ 						
+						str+="<td class='result-header dugga-result-subheader' colspan='"+(colsp)+"'>"+groupname+"</td>"
+						str+="</tr>"
+					} */ 
 															
 			}
-			str+="</tr><tr class='markinglist-header'>";
+			
+			
+			
+			/* str+="</th><th colspan='1' class='result-header dugga-result-subheader' id='header0'><div class='dugga-result-subheader-div' title='Grupper'>Grupper</div></th>"	
 			str+="</th><th colspan='1' class='result-header dugga-result-subheader' id='header0'><div class='dugga-result-subheader-div' title='Uppgifter'>Uppgifter</div></th>"	
 			str+="</th><th colspan='1' class='result-header dugga-result-subheader' id='header0'><div class='dugga-result-subheader-div' title='Aktiv'>Aktiv i kursen</div></th>"	
-			for(var l=0;l<moments.length;l++){
-				if(moments[l].kind==3){
-						str+="<th class='result-header dugga-result-subheader' id='header"+(l+1)+"'><div class='dugga-result-subheader-div' title='"+moments[l].entryname+"'>"+moments[l].entryname+"</div></th>"	
-						
+		*/	for(var l=0;l<moments.length;l++){
+				if(moments[l].name){
+					str+="</tr><tr class='markinglist-header'>";
+					str+="<th class='result-header dugga-result-subheader' id='header"+(l+1)+"'><div class='dugga-result-subheader-div' title='"+moments[l].name+"'>"+moments[l].name+"</div></th>";	
+					str+="</tr>";
 				}
 			}
-			str+="</tr></thead></table>";
+			str+="</thead></table>";
 			document.getElementById("content").innerHTML=str;
 		
 }

--- a/DuggaSys/groupedservice.php
+++ b/DuggaSys/groupedservice.php
@@ -28,12 +28,15 @@ $listentry = getOP('moment');
 $qvariant=getOP("qvariant");
 $gentries=array();
 
+
+
 $debug="NONE!";
 
 // Don't retreive all results if request was for a single dugga or a grade update
 if(strcmp($opt,"GET")==0){
 	if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESSION['uid']))) {
 		
+		//$query = $pdo->prepare("SELECT usergroup.name FROM `usergroup` INNER JOIN user_usergroup ON user_usergroup.ugid=usergroup.ugid;");
 		$query = $pdo->prepare("SELECT listentries.*,quizFile,COUNT(variant.vid) as qvariant FROM listentries LEFT JOIN quiz ON  listentries.link=quiz.id LEFT JOIN variant ON quiz.id=variant.quizID WHERE listentries.cid=:cid and listentries.vers=:vers and (listentries.kind=3 or listentries.kind=4) GROUP BY lid ORDER BY pos;");
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':vers', $vers);
@@ -56,8 +59,27 @@ if(strcmp($opt,"GET")==0){
 				)
 			);
 		}
+		
+		$query = $pdo->prepare("SELECT name FROM `usergroup`;");
+
+		if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error retreiving moments and duggas. (row ".__LINE__.") ".$query->rowCount()." row(s) were found. Error code: ".$error[2];
+		}
+
+		$currentMoment=null;
+		foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
+			array_push(
+				$gentries,
+				array(
+					'name' =>$row['name']
+				)
+			);
+		}
 	}
 }
+
+
 
 if(isset($_SERVER["REQUEST_TIME_FLOAT"])){
 		$serviceTime = microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"];	


### PR DESCRIPTION
All groups that exists are now shown on grouped.php. It is better to show groups instead of all students. The students will be shown beside the groupname which makes it easy to see which student is placed in the groups. Show the students together with the groups will be a later issue.