### PR TITLE
Fix for issue #2983 regarding breakline after ending lists

### DIFF
--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -8,10 +8,25 @@ From the standpoint of the browser the result is identical.
 Hello!
 ~~~
 
-| head0 | head1 | head2 | head3 |
-| ----- | :----: | ---- | ---- |
-| dsa1 | dsa1 | dsa1 | dsa1 |
-| dsa2 | dsa2 | dsa2 | dsa2 |
-| ----- | ----: | ---- | :----: |
-| dsa3 | dsa3 | dsa3 | dsa3 |
-| dsa4 | dsa4 | dsa4 | dsa3 |
+1. asd
+2. awed
+  1. asd
+  2. asd
+  3. asd
+    1. asd
+      1. asd
+    2. asd
+      1. asd
+3. asd
+4. asd
+* asd
+* awed
+  * asd
+  * asd
+  * asd
+    * asd
+      * asd
+    * asd
+      * asd
+* asd
+* asd

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -228,7 +228,7 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     	markdown += "</li>";
     }
     // Close the list
-    if(!isUnorderdList(nextLine)) {
+    if(!isUnorderdList(currentLine)) {
     	markdown += "</ul>";
     }
 
@@ -269,7 +269,7 @@ function handleOrderedList(currentLine, prevLine, nextLine) {
     	markdown += "</li>";
     }
     // Close the ordered list
-    if(!isOrderdList(nextLine)) {
+    if(!isOrderdList(currentLine)) {
     	markdown += "</ol>";
     }
 


### PR DESCRIPTION
Solution for the bug and now its working properly now and a breakline is not needed at the end of lists.