### PR TITLE
Use PHP's password_hash and related function instead of MYSQL password

### DIFF
--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -75,9 +75,9 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 			$debug="Error updating user".$error[2];
 		}
 	}else if(strcmp($opt,"CHPWD")==0){
-		$query = $pdo->prepare("UPDATE user set password=password(:pwd), requestedpasswordchange=0 where uid=:uid;");
+		$query = $pdo->prepare("UPDATE user set password=:pwd, requestedpasswordchange=0 where uid=:uid;");
 		$query->bindParam(':uid', $uid);
-		$query->bindParam(':pwd', $pw);
+		$query->bindParam(':pwd', standardPasswordHash($pw));
 
 		if(!$query->execute()) {
 			$error=$query->errorInfo();
@@ -120,14 +120,14 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 					// assigned password which can be printed later.
 					if ($userquery->execute() && $userquery->rowCount() <= 0 && !empty($username)) {
 							$rnd=makeRandomString(9);
-							$querystring='INSERT INTO user (username, email, firstname, lastname, ssn, password,addedtime, class) VALUES(:username,:email,:firstname,:lastname,:ssn,password(:password),now(),:className);';	
+							$querystring='INSERT INTO user (username, email, firstname, lastname, ssn, password,addedtime, class) VALUES(:username,:email,:firstname,:lastname,:ssn,:password,now(),:className);';	
 							$stmt = $pdo->prepare($querystring);
 							$stmt->bindParam(':username', $username);
 							$stmt->bindParam(':email', $saveemail);
 							$stmt->bindParam(':firstname', $firstname);
 							$stmt->bindParam(':lastname', $lastname);
 							$stmt->bindParam(':ssn', $ssn);
-							$stmt->bindParam(':password', $rnd);
+							$stmt->bindParam(':password', standardPasswordHash($rnd));
 							$stmt->bindParam(':className', $className);
 							
 							if(!$stmt->execute()) {

--- a/Shared/sessions.php
+++ b/Shared/sessions.php
@@ -169,6 +169,17 @@ function requestChange($username)
 }
 
 /**
+ * Hash a password with the global LenaSys settings, this will make any future changes simpler as
+ * only this function and needs_rehash in login needs to be changed to accomodate future settings
+ * @param string $password Password to hash
+ * @return string Hashed password
+ */
+function standardPasswordHash($password)
+{
+	return password_hash($password, PASSWORD_BCRYPT);
+}
+
+/**
  * Log in the user with the specified username and password and
  * optionally set cookies for the user to be remembered until next
  * time they visit the site.
@@ -197,7 +208,7 @@ function login($username, $password, $savelogin)
 
 		if ($row['password'] == $row['mysql_pwd_input']) {
 			// User still has a mysql password, update to better
-			$row['password'] = password_hash($password, PASSWORD_BCRYPT);
+			$row['password'] = standardPasswordHash($password);
 			$query = $pdo->prepare("UPDATE user SET password = :pwd WHERE uid=:uid");
 			$query->bindParam(':uid', $row['uid']);
 			$query->bindParam(':pwd', $row['password']);
@@ -206,7 +217,7 @@ function login($username, $password, $savelogin)
 			// User has a php password
 			if (password_needs_rehash($row['password'], PASSWORD_BCRYPT)) {
 				// The php password is not up to date, update it to be even safer (the cost may have changed, or another algoritm than bcrypt is used)
-				$row['password'] = password_hash($password, PASSWORD_BCRYPT);
+				$row['password'] = standardPasswordHash($password);
 				$query = $pdo->prepare("UPDATE user SET password = :pwd WHERE uid=:uid");
 				$query->bindParam(':uid', $row['uid']);
 				$query->bindParam(':pwd', $row['password']);

--- a/Shared/sessions.php
+++ b/Shared/sessions.php
@@ -163,10 +163,7 @@ function login($username, $password, $savelogin)
 	if($pdo == null) {
 		pdoConnect();
 	}
-
-//echo "SELECT uid,username,password,superuser FROM user WHERE username=:username and password=password(':pwd') LIMIT 1";
-
-	$query = $pdo->prepare("SELECT uid,username,password,superuser,lastname,firstname FROM user WHERE username=:username and password=password(:pwd) LIMIT 1");
+	$query = $pdo->prepare("SELECT uid,username,password,superuser,lastname,firstname,password(:pwd) as mysql_pwd_input FROM user WHERE username=:username LIMIT 1");
 
 	$query->bindParam(':username', $username);
 	$query->bindParam(':pwd', $password);
@@ -176,6 +173,29 @@ function login($username, $password, $savelogin)
 	if($query->rowCount() > 0) {
 		// Fetch the result
 		$row = $query->fetch(PDO::FETCH_ASSOC);
+
+		if ($row['password'] == $row['mysql_pwd_input']) {
+			// User still has a mysql password, update to better
+			$row['password'] = password_hash($password, PASSWORD_BCRYPT);
+			$query = $pdo->prepare("UPDATE user SET password = :pwd WHERE uid=:uid");
+			$query->bindParam(':uid', $row['uid']);
+			$query->bindParam(':pwd', $row['password']);
+			$query->execute();
+		} else if (password_verify($password, $row['password'])) {
+			// User has a php password
+			if (password_needs_rehash($row['password'], PASSWORD_BCRYPT)) {
+				// The php password is not up to date, update it to be even safer (the cost may have changed, or another algoritm than bcrypt is used)
+				$row['password'] = password_hash($password, PASSWORD_BCRYPT);
+				$query = $pdo->prepare("UPDATE user SET password = :pwd WHERE uid=:uid");
+				$query->bindParam(':uid', $row['uid']);
+				$query->bindParam(':pwd', $row['password']);
+				$query->execute();
+			}
+		} else {
+			// Wrong password entered
+			return false;
+		}
+
 		$_SESSION['uid'] = $row['uid'];
 		$_SESSION["loginname"]=$row['username'];
 		$_SESSION["passwd"]=$row['password'];
@@ -184,10 +204,12 @@ function login($username, $password, $savelogin)
 		$_SESSION["firstname"]=$row['firstname'];
 
 		// Save some login details in cookies.
-		if($savelogin) {
+		// The current try at a solution solution is unsafe as anyone with access to the computer can check the cookie and get the full password
+		// Therefore the solution has been commented away
+		/*if($savelogin) {
 			setcookie('username', $row['username'], time()+60*60*24*30, '/');
 			setcookie('password', $password, time()+60*60*24*30, '/');
-		}
+		}*/
 		return true;
 
 	} else {

--- a/Shared/sessions.php
+++ b/Shared/sessions.php
@@ -169,14 +169,24 @@ function requestChange($username)
 }
 
 /**
- * Hash a password with the global LenaSys settings, this will make any future changes simpler as
- * only this function and needs_rehash in login needs to be changed to accomodate future settings
- * @param string $password Password to hash
- * @return string Hashed password
+ * Hash a string with the global LenaSys settings.
+ * By having this function encapsulated it enables simpler change in the future.
+ * @param string $text Text to hash
+ * @return string Hashed text
  */
-function standardPasswordHash($password)
+function standardPasswordHash($text)
 {
-	return password_hash($password, PASSWORD_BCRYPT);
+	return password_hash($text, PASSWORD_BCRYPT);
+}
+
+/**
+ * Test if a hashed string meets the global LenaSys settings. 
+ * @param string $text Text to check
+ * @return boolean
+ */
+function standardPasswordNeedsRehash($text)
+{
+	return password_needs_rehash($text, PASSWORD_BCRYPT);
 }
 
 /**
@@ -215,7 +225,7 @@ function login($username, $password, $savelogin)
 			$query->execute();
 		} else if (password_verify($password, $row['password'])) {
 			// User has a php password
-			if (password_needs_rehash($row['password'], PASSWORD_BCRYPT)) {
+			if (standardPasswordNeedsRehash($row['password'], PASSWORD_BCRYPT)) {
 				// The php password is not up to date, update it to be even safer (the cost may have changed, or another algoritm than bcrypt is used)
 				$row['password'] = standardPasswordHash($password);
 				$query = $pdo->prepare("UPDATE user SET password = :pwd WHERE uid=:uid");

--- a/install/SQL/init_db.sql
+++ b/install/SQL/init_db.sql
@@ -26,8 +26,8 @@ CREATE TABLE user(
 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 
 INSERT INTO user(username,password,newpassword,creator,superuser) values ("Grimling","$2y$12$stG4CWU//NCdnbAQi.KTHO2V0UVDVi89Lx5ShDvIh/d8.J4vO8o8m",0,1,1);
-INSERT INTO user(username,password,newpassword,creator) values ("Toddler","$2y$12$IHb86c8/PFyI5fa9r8B0But7rugtGKtogyp/2X0OuB3GJl9l0iJ.q",0,1);
-INSERT INTO user(username,password,newpassword,creator,ssn) values ("Tester", "$2y$12$IHb86c8/PFyI5fa9r8B0But7rugtGKtogyp/2X0OuB3GJl9l0iJ.q",1,1,"111111-1111");
+INSERT INTO user(username,password,newpassword,creator) values ("Toddler","$2y$12$IHb86c8/PFyI5fa9r8B0But7rugtGKtogyp/2X0OuB3GJl9l0iJ.q",0,1); /* Password is Kong */
+INSERT INTO user(username,password,newpassword,creator,ssn) values ("Tester", "$2y$12$IHb86c8/PFyI5fa9r8B0But7rugtGKtogyp/2X0OuB3GJl9l0iJ.q",1,1,"111111-1111"); /* Password is Kong */
 
 
 /**
@@ -555,7 +555,6 @@ UPDATE user SET firstname="Toddler", lastname="Kong" WHERE username="Toddler";
 UPDATE user SET firstname="Johan", lastname="Grimling" WHERE username="Grimling";
 UPDATE user SET ssn="810101-5567" WHERE username="Grimling";
 UPDATE user SET ssn="444444-5447" WHERE username="Toddler";
-UPDATE user SET password=password("Kong") WHERE username="Toddler";
 UPDATE user SET superuser=1 WHERE username="Toddler";
 
 /* Templates for codeexamples */


### PR DESCRIPTION
Fixes issue #1964 .
Will improve security of the system by replacing outdated functions.
The fix will slowly update any old passwords when people log in to be in the new standard.