### PR TITLE
Added numbers to the left of students in grouped.php

### DIFF
--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -31,6 +31,7 @@ function returnedGroup(data)
 	str+="<thead>";
 	str+="<tr class='markinglist-header'>";
 	
+	str += "<th id='header' class='grouprow' ><span>#<span></th>";
 	str+="<th colspan='1' id='subheading' class='result-header'>";
 	str+="Studenter";
 	str+="</th>";
@@ -71,8 +72,11 @@ function returnedGroup(data)
 	str+="</thead>";
 	// Iterate the tableContent. 
 	str += "<tbody>";
+	var row=0;
 	for(var i = 0; i < tableContent.length; i++) { // create table rows. 
+		row++;
 		str+="<tr>";
+		str+="<td id='row"+row+"' class='grouprow'><div>"+row+"</div></td>";
 		for(var j = 1; j < tableContent[i].length; j++) {
 			str+="<td>"+tableContent[i][j]+"</td>";
 		}

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2023,6 +2023,14 @@ span.arrow {
   line-height: 47px;
 }
 
+.grouprow > div {
+  text-align: center;
+  font-size: 20px;
+  color:#614875 !important;
+  min-height: 47px;
+  line-height: 47px;
+}
+
 /*styling for contribution.php*/
 /*this was inline-CSS before, only moved it to the right file*/
 .fumho th {


### PR DESCRIPTION
Numbers are now displayed to the left of the students. It will make it easier for teachers to know how many groups there are.