### PR TITLE
Refresh page after adding an item

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -457,6 +457,7 @@ function newItem()
   if (kind==0||kind==1||kind==2||kind==5) gradesys=tabs; 
   AJAXService("NEW",{lid:lid,kind:kind,link:link,sectname:sectionname,visibility:visibility,moment:moment,gradesys:gradesys,highscoremode:highscoremode,comment:comment,rowcolor:rowcolor,grouptype:grouptype},"SECTION"); 
   $("#editSection").css("display","none"); 
+  window.location.reload();		// Refreshes page to make it able to update items
 }
 
 function closeSelect()


### PR DESCRIPTION
The page now refreshes when an item is added. It makes it able to update
an item directly after adding it, instead of after refreshing
the page manually. Solution for issue #3168