### PR TITLE
Added error message to the profile page for security question

### DIFF
--- a/DuggaSys/profile.php
+++ b/DuggaSys/profile.php
@@ -40,6 +40,7 @@ pdoConnect();
 						<label for="currentPassword">Current password</label><br/>
 						<input type="password" id="currentPassword" placeholder="Current password" /><br/><br/>
 						<label for="challengeQuestion">Challenge question</label><br/>
+						<label id="securityQuestionError"></label>
 						<?php echo "<textarea id='challengeQuestion' value='' onkeyup='checkScroll(this)' style='height:1.25em; max-height:110px; width:16em; overflow:auto; font-family:sans-serif;'></textarea><br/>" ?>
 						<script>addSecurityQuestionProfile('<?php echo $_SESSION['loginname'] ?>')</script>
 						<label for="challengeAnswer">Challenge question</label><br/>

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -576,7 +576,13 @@ function addSecurityQuestionProfile(username) {
 				if(result['getname'] == "success") {
 					$("#challengeQuestion").html(result['securityquestion']);
 				}else{
-					console.log("Username was not found OR User does not have a question OR User might be a teacher");
+					if(typeof result.reason != "undefined") {
+						$("#changeChallengeQuestion #securityQuestionError").html("<div class='alert danger'>" + result.reason + "</div>");
+					} else {
+						$("#changeChallengeQuestion #securityQuestionError").html("<div class='alert danger'>" + result['getname']  + "</div>");
+					}
+					$("#changeChallengeQuestion #challengeQuestion").css("background-color", "rgba(255, 0, 6, 0.2)");
+					$("#changeChallengeQuestion #securityQuestionError").css("color", "rgba(255, 0, 6, 0.8)");
 			}
 		}
 	});


### PR DESCRIPTION
If for example a security question is not found, a error message will be displayed and red color will highlight the error.