### PR TITLE
Cookie message only shown once

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -86,12 +86,20 @@
 	?>
 </header>
 <script type="text/javascript">
+		if(localStorage.getItem("cookieMessage")=="off"){
+			$("#cookiemsg").css("display", "none");
+		}
+		else{
+			$("#cookiemsg").css("display", "flex");
+		}
+
 	setupLoginLogoutButton('<?PHP echo json_encode(checklogin()) ?>');
   function displaySwimlane(){
     $("#swimlane").css("display", "block");
   }
 	
 	function cookieMessage(){
+		localStorage.setItem("cookieMessage", "off");
 		$("#cookiemsg").css("display", "none");
 	}
 </script>


### PR DESCRIPTION
The cookie message is now only shown once after you press the OK-button. (Fix for issue #2769)