### PR TITLE
404-text updated

### DIFF
--- a/errorpages/404.php
+++ b/errorpages/404.php
@@ -18,7 +18,7 @@ setcookie("loginvar", $loginvar);
         <meta name="viewport" content="width=device-width, initial-scale=1 maximum-scale=1">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title><h1>404 Filez not found.</h1></title>
+        <title> File not found</title>
 
         <link type="text/css" href="../Shared/css/style.css" rel="stylesheet">
         <link type="text/css" href="../Shared/css/jquery-ui-1.10.4.min.css" rel="stylesheet">
@@ -28,6 +28,7 @@ setcookie("loginvar", $loginvar);
         <script src="../Shared/dugga.js"></script>
 </head>
 <body>
+<h1>404 - File not found</h1>
 
 </body>
 </html>


### PR DESCRIPTION
The 404-page now has an error message. The error message is displayed in the header as before but without "h1" tags. 