### PR TITLE
Playbutton is grayed out if there's no playlink and also redirects correctly

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1707,8 +1707,16 @@ function Play(event)
 		if(retData['playlink'].indexOf("http")==0){
 				window.location.href=retData['playlink'];
 		}else{
-				navigateTo("/../courses/",retData['playlink']);
-		}
+				var urlText = "";
+				if(retData['public'] === "1") {
+					urlText = "global/" + retData['playlink'];
+                }
+                else{
+					urlText = retData['courseid'] + "/" + retData['playlink'];
+				}
+            	navigateTo("/../courses/", urlText);
+
+        }
 	}
 }
 //-----------------------------------------------------------------------------

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -91,8 +91,8 @@ function returned(data)
 		$("#afterbutton").css("pointer-events","none");	
 	}
 	
-	// Disables the play button if there is no playlink
-	if(typeof retData['playlink'] == 'undefined' || retData['playlink'] == "" || retData['playlink'] == null) {
+	// Disables the play button if there is no playlink or if the file linked does not exist
+	if(!UrlExists()) {
 			$("#playbutton").css("opacity",0.4);
 			$("#playbutton").css("pointer-events","none");
 	}else{
@@ -2676,4 +2676,24 @@ function setResizableToPer(boxValArray)
 //----------------------------------------------------------------------------------
 function addHtmlLineBreak(inString){
 	return inString.replace(/\n/g, '<br>'); 
+}
+
+function UrlExists()
+{
+    var urlText = "";
+    if(retData['public'] === "1") {
+        urlText = "global/" + retData['playlink'];
+    }
+    else{
+        urlText = retData['courseid'] + "/" + retData['playlink'];
+    }
+    var http = new XMLHttpRequest();
+    http.open('HEAD', "../courses/" + urlText, false);
+    http.send();
+    if(http.status == 404 || typeof retData['playlink'] == 'undefined' || retData['playlink'] == "" || retData['playlink'] == null){
+    	return false;
+	}
+	else{
+    	return true;
+	}
 }

--- a/DuggaSys/codeviewerService.php
+++ b/DuggaSys/codeviewerService.php
@@ -466,7 +466,6 @@
 				
 			array_push($box,array($row['boxid'],$boxContent,$content,$row['wordlistid'],$row['boxtitle'],$row['filename'], $row['fontsize']));
 		}
-
 		$array = array(
 			'before' => $backwardExamples,
 			'after' => $forwardExamples,
@@ -485,8 +484,10 @@
 			'wordlists' => $wordLists, 
 			'writeaccess' => $writeAccess,
 			'debug' => $debug,
-			'beforeafter' => $beforeAfters, 
-			'public' => $public
+			'beforeafter' => $beforeAfters,
+			'public' => $public,
+            'courseid' => $courseId,
+            'courseversion' => $courseVersion
 		);
 		echo json_encode($array);
 	}else{


### PR DESCRIPTION
Playbutton will now be grayed out if the playlink is empty or if the file does not exists.
Also fixed the behavior of the playbutton when clicked. The page will now redirect based on if the file is global or not.