### PR TITLE
Added function to check if user is on HTTPS

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -588,6 +588,12 @@ function addSecurityQuestionProfile(username) {
 	});
 }
 
+function checkHTTPS() { 
+  if (location.protocol != 'https:') { 
+    /* do something */ 
+  } 
+} 
+
 function processResetPasswordCheckUsername() {
 
 	/*This function is supposed to get the security question from the database*/


### PR DESCRIPTION
This will be used for issue #2638. The function checks if the user is on HTTPS and by doing that we can allow certain functionality only for users on HTTPS (such as changing password).