### PR TITLE
#2826 Force users to set a security question

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -14,6 +14,18 @@ var inParams = "UNK";;
 var MAX_SUBMIT_LENGTH = 5000;
 var querystring=parseGet();
 
+//show or hide securitynotification based on localstorage variables
+$( document ).ready(function() {
+    if (localStorage.getItem("securityquestion") === null && localStorage.getItem("securitynotification") == "on"){
+        showSecurityPopup();
+    }
+});
+
+// Set the localstorage item securitynotifaction to on or off.
+function setSecurityNotifaction(param){
+    localStorage.setItem("securitynotification", param);
+}
+
 function toggleloginnewpass(){
 	resetFields();
 	if(status == 0){
@@ -687,6 +699,12 @@ function processLogin() {
 			success:function(data) {
 				var result = JSON.	parse(data);
 				if(result['login'] == "success") {
+                    if(result['securityquestion'] != null) {
+                        localStorage.setItem("securityquestion", "set");
+                    } else {
+                        setSecurityNotifaction("on"); 
+                    }
+                    
 					setExpireCookie();
 					setExpireCookieLogOut();
 					
@@ -714,6 +732,8 @@ function processLogout() {
 		type:"POST",
 		url: "../Shared/loginlogout.php",
 		success:function(data) {
+            localStorage.removeItem("securityquestion");
+            localStorage.removeItem("securitynotification");
 			var urlDivided = window.location.href.split("/");
 			urlDivided.pop();
 			urlDivided.pop();
@@ -831,6 +851,11 @@ function sendReceiptEmail(){
 			window.location="mailto:"+email+"?Subject=LENASys%20Dugga%20Receipt&body=This%20is%20your%20receipt%20:%20"+receipt+"%0A%0A/LENASys Administrators";
 			hideReceiptPopup();
 	}
+}
+
+function showSecurityPopup()
+{
+   $("#securitynotification").css("display","block");
 }
 
 function showDuggaInfoPopup()

--- a/Shared/loginbox.php
+++ b/Shared/loginbox.php
@@ -146,7 +146,15 @@
 	</div>
 	
 	<!-- Login Box End! -->
-  
+  <!-- security question notifaction -->
+
+    <div class="loginBox" id="securitynotification" style="display:none;">
+         <div class='loginBoxheader'>
+          <h3>Choose a challenge question</h3>
+          <div onclick="closeWindows(); setSecurityNotifaction('off');">x</div>
+        </div>  
+        <p id="securitynotificationmessage">You need to choose a challenge question. You can do this by visiting your profile page(clicking your username) or by clicking <a onclick="closeWindows(); setSecurityNotifaction('off');" href='profile.php'>here</a> </p>
+    </div>
   <!-- dialogbox -->
   
   <div class="expiremessagebox" style="display:none">

--- a/Shared/loginlogout.php
+++ b/Shared/loginlogout.php
@@ -34,6 +34,9 @@ if($opt=="LOGIN"){
 			// Successfully logged in, return user name
 			$res["login"] = "success";
 			$res["username"] = $username;
+            if(isset($_SESSION["securityquestion"])) {
+                $res["securityquestion"] = "set";
+            }
 
 			// Log USERID for Dugga Access
 			logUserEvent($username,EventTypes::LoginSuccess,"");

--- a/Shared/sessions.php
+++ b/Shared/sessions.php
@@ -224,7 +224,7 @@ function login($username, $password, $savelogin)
 	if($pdo == null) {
 		pdoConnect();
 	}
-	$query = $pdo->prepare("SELECT uid,username,password,superuser,lastname,firstname,password(:pwd) as mysql_pwd_input FROM user WHERE username=:username LIMIT 1");
+	$query = $pdo->prepare("SELECT uid,username,password,superuser,lastname,firstname,securityquestion,password(:pwd) as mysql_pwd_input FROM user WHERE username=:username LIMIT 1");
 
 	$query->bindParam(':username', $username);
 	$query->bindParam(':pwd', $password);
@@ -263,6 +263,10 @@ function login($username, $password, $savelogin)
 		$_SESSION["superuser"]=$row['superuser'];
 		$_SESSION["lastname"]=$row['lastname'];
 		$_SESSION["firstname"]=$row['firstname'];
+        
+        if($row['securityquestion'] != null) {
+            $_SESSION["securityquestion"]="set";
+        }
 
 		// Save some login details in cookies.
 		// The current try at a solution solution is unsafe as anyone with access to the computer can check the cookie and get the full password


### PR DESCRIPTION
A notification window is now displayed whicn prompts the user to set a challenge question if it's not set. If it is already set no window will appear.

Solves the issue #2826 