### PR TITLE
Swimlane close button - changed pointer when hoover

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2181,12 +2181,16 @@ table {
 
 /* The Close Button */
 .SwimClose {
-  color: #000000;
+  color: white;
   position: absolute;
   top: 7%;
   left: 2%;
   font-size: 28px;
   font-weight: bold;
+  height: 30px;
+  width: 35px;
+  margin-right: 10px;
+  cursor:pointer;
 }
 
 .swimlaneOverlay {


### PR DESCRIPTION
Changed the mouse pointer from a marking  pointer to a "finger"-pointer when hovering over the X to close swimlane.