### PR TITLE
Adjusted '+' to the center of FAB

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1738,7 +1738,6 @@ span.arrow {
   width:50px;
   height:50px;
   border-radius:25px;
-  line-height:50px;
   box-shadow:0px 0px 15px #888;
   bottom:55px;
   right:50px;
@@ -1749,6 +1748,8 @@ span.arrow {
   z-index:4000;
   border:none;
   cursor: pointer;
+  padding-left: 7px;
+  padding-top: 1px;
 }
 
 .dugga-pass {


### PR DESCRIPTION
Added padding to the FAB to get '+' aligned in the center. (Fix for issue #3296)