### PR TITLE
Made the grey background show when the security question pop up is shown

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -856,6 +856,7 @@ function sendReceiptEmail(){
 function showSecurityPopup()
 {
    $("#securitynotification").css("display","block");
+   $("#overlay").css("display","block");
 }
 
 function showDuggaInfoPopup()


### PR DESCRIPTION
The underlayer(grey background) will now be shown when the pop-up window that makes the user to set a security question on login is shown. The underlayer will disappear when the pop-up window is closed.