### PR TITLE
Forms in Edit variant filled in

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -7,6 +7,7 @@ var sessionkind=0;
 var querystring=parseGet();
 var filez;
 var variant = [];
+var submissionRow = 0;
 
 AJAXService("GET",{cid:querystring['cid'],coursevers:querystring['coursevers']},"DUGGA");
 
@@ -151,6 +152,22 @@ function selectDugga(did,name,autograde,gradesys,template,release,deadline)
 	$("#template").html(str);
 }
 
+// Adds a submission row in Edit Variant
+function addSubmissionRow() {
+	$('#submissions').append("<div style='width:100%;display:flex;flex-wrap:wrap;flex-direction:row;'>"+
+					"<select name='type' id='submissionType"+submissionRow+"' style='width:65px;'>"+
+						"<option value='pdf'>PDF</option>"+
+						"<option value='zip'>Zip</option>"+
+						"<option value='link'>Link</option>"+
+						"<option value='text'>Text</option>"+
+					"</select>"+
+					"<input type='text' name='fieldname' id='fieldname"+submissionRow+"' placeholder='Submission name' style='flex:1;margin-left:5px;margin-bottom:3px;height:24.8px;' onkeydown='if (event.keyCode == 13) return false;'/>"+
+					"<input type='text' name='instruction' id='instruction"+submissionRow+"' placeholder='Upload instruction' style='flex:3;margin-left:5px;margin-bottom:3px;height:24.8px;' onkeydown='if (event.keyCode == 13) return false;'/>"+
+					"<input type='button' class='delButton submit-button' value='-' style='width:32px;margin:0px 0px 3px 5px;'></input><br/>"+
+				 "</div>");
+	submissionRow++;
+}
+
 function selectVariant(vid,param,answer,template,dis)
 {
 
@@ -165,6 +182,58 @@ function selectVariant(vid,param,answer,template,dis)
 	} else {
 		$("#toggleVariantButton").val("Disable"); // Set Variant answer
 	}
+	
+	//Parse JSON to add data to forms again
+	var data = $("#parameter").val();
+	if(data == "" || data == "UNK"){}
+	else{
+		var result = JSON.parse(data);
+		//Adds data to forms 
+		if(result["type"]!=undefined){
+			$("#type").val(result["type"]);
+		}
+		
+		if(result["filelink"]!=undefined){
+			$("#filelink").val(result["filelink"]);
+		}
+		
+		if(result["submissions"]!=undefined){
+			//Adds more submission rows if necessary
+			for(i = 0; i < result["submissions"].length; i++){
+				if(i > 0 && i <= submissionRow) {
+					addSubmissionRow();
+				}
+				if(result["submissions"][i]["type"]!=undefined){
+					$("#submissionType"+i).val(result["submissions"][i]["type"]);
+				}
+				if(result["submissions"][i]["fieldname"]!=undefined){
+					$("#fieldname"+i).val(result["submissions"][i]["fieldname"]);
+				}
+				if(result["submissions"][i]["instruction"]!=undefined){
+					$("#instruction"+i).val(result["submissions"][i]["instruction"]);
+				}
+			}
+		}
+	}
+
+}
+
+function closeVariant(){
+	//Removes data from forms, going back to original style
+	$("#type").val("md");
+	$("#filelink").val("");
+	for(i = 0; i < 100; i++){
+		$("#submissionType"+i).val("pdf");
+		$("#fieldname"+i).val("");
+		$("#instruction"+i).val("");
+	}
+	//Removes all submission rows
+	for(i=0; i < submissionRow; i++){
+		$("#submissionType"+i).parent().remove();
+	}
+	submissionRow=0;
+	//Adds one submission row so that one is visible next time it's opened
+	addSubmissionRow();
 }
 
 function isInArray(array, search)
@@ -521,22 +590,8 @@ $(document).ready(function(){
 		jsonStr += ']'; // The end of the submissions array.
 		// Here, the freetext field handling should be added as it comes after the submissions array.
 		jsonStr += '}'; // The end of the JSON-string.
-
+		
 		return jsonStr;
-	}
-
-	function addSubmissionRow() {
-		$('#submissions').append("<div style='width:100%;display:flex;flex-wrap:wrap;flex-direction:row;'>"+
-					 	"<select name='type' id='submissionType' style='width:65px;'>"+
-					 		"<option value='pdf'>PDF</option>"+
-					 		"<option value='zip'>Zip</option>"+
-					 		"<option value='link'>Link</option>"+
-					 		"<option value='text'>Text</option>"+
-					 	"</select>"+
-					 	"<input type='text' name='fieldname' id='fieldname' placeholder='Submission name' style='flex:1;margin-left:5px;margin-bottom:3px;height:24.8px;' onkeydown='if (event.keyCode == 13) return false;'/>"+
-					 	"<input type='text' name='instruction' id='instruction' placeholder='Upload instruction' style='flex:3;margin-left:5px;margin-bottom:3px;height:24.8px;' onkeydown='if (event.keyCode == 13) return false;'/>"+
-					 	"<input type='button' class='delButton submit-button' value='-' style='width:32px;margin:0px 0px 3px 5px;'></input><br/>"+
-					 "</div>");
 	}
 
 	$(document).on('click','.delButton', function(){
@@ -551,7 +606,6 @@ $(document).ready(function(){
 	});
 
 	$('#createjson').click(function(){
-		// console.log("asdasd");
 		$('#parameter').val(createJSONString($('#jsonform').serializeArray()));
 	});
 });

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -56,7 +56,7 @@ pdoConnect();
 			<div class='inputwrapper'><span>Deadline Date:</span><input class='textinput datepicker' type='text' id='deadline' value='None' /></div>
 		</div>
 		<div style='padding:5px;'>
-            <input style='float:left; 'class='submit-button' type='button' value='Delete' onclick='deleteDugga();' />
+			<input style='float:left; 'class='submit-button' type='button' value='Delete' onclick='deleteDugga();' />
 			<input style='float:right; 'class='submit-button' type='button' value='Save' onclick='updateDugga();' />
 		</div>
 	</div>
@@ -66,7 +66,7 @@ pdoConnect();
 	<div id='editVariant' class='loginBox' style='width:80%; left:20%; display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Edit Variant</h3>
-			<div onclick='closeWindows();'>x</div>
+			<div onclick='closeWindows();closeVariant();'>x</div>
 		</div>
 		<div style='padding:5px;display:flex;'>
 			<input type='hidden' id='vid' value='Toddler' />
@@ -78,12 +78,11 @@ pdoConnect();
 							<legend>Instruction file</legend>
 							<div style="display:flex;flex-wrap:nowrap;flex-direction:row;">
 								<select name="type" id="type" style="flex:1">
-									<option value="pick"> Pick filetype </option>
 									<option value="md">Markdown</option>
 									<option value="pdf">PDF</option>
 									<option value="html">HTML</option>
 								</select><br/>
-								<input type="text" name="filelink" placeholder="File link" style="flex:2;margin-left:5px;" onkeydown="if (event.keyCode == 13) return false;"><br/>
+								<input type="text" name="filelink" id="filelink" placeholder="File link" style="flex:2;margin-left:5px;" onkeydown="if (event.keyCode == 13) return false;"><br/>
 							</div>
 						</fieldset>
 					</div>
@@ -109,7 +108,7 @@ pdoConnect();
 		<div style='padding:5px;'>
 			<input style='float:left;' class='submit-button' type='button' value='Delete' onclick='deleteVariant();' />
 			<input id="toggleVariantButton" style='float:left;' class='submit-button' type='button' value='Disable' onclick='toggleVariant();' />
-			<input style='float:right;' class='submit-button' type='button' value='Save' onclick='updateVariant();' />
+			<input style='float:right;' class='submit-button' type='button' value='Save' onclick='updateVariant();closeVariant();' />
 		</div>
 	</div>
 	<!-- Edit Variant Dialog END -->


### PR DESCRIPTION
The forms in Edit variant is now filled in (if you have a JSON-string) when the box is opened so that you don't have to fill it all in again. Fix for issue #3266.