### PR TITLE
Added correct closing of span tags in fileed

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -276,7 +276,7 @@ function returnedFile(data)
 			str4+="<table class='list' style='margin-bottom:8px;' >";
 
 		  str4+="<thead style='cursor:pointer;'>" + 
-		  "<tr><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><span>ID<span>" +
+		  "<tr><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><span>ID</span>" +
 		  "<img src='../Shared/icons/desc_complement.svg' class='arrowComp'><img src='../Shared/icons/right_complement.svg' class='arrowRight' style='display:none;'></div></th>" +
     //  str4+="<tr onclick='toggleTableVisibility(\"local\");'><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><img id='local_icon' src='../Shared/icons/desc_complement.svg'/><span>ID<span></div></th><th>Course Local File</th>" +
 		  "<th>Course Local File</th>" +

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -244,7 +244,7 @@ function returnedFile(data)
       str3+="<thead style='cursor:pointer;'>";
       //str3+="<tr onclick='toggleTableVisibility(\"course\");'><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><span>ID<span></div></th><th>Course File</th>" +
 	
-      str3+="<tr><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><span>ID<span>" +
+      str3+="<tr><th style='width:30px;'><div style='display:flex;justify-content:flex-start;align-items:center;' /><span>ID</span>" +
       "<img src='../Shared/icons/desc_complement.svg' class='arrowComp'><img src='../Shared/icons/right_complement.svg' class='arrowRight' style='display:none;'></div></th>" +
       "<th>Course File</th>" +
 	  "<th>File extension</th>" +


### PR DESCRIPTION
In fileed, the 2 last tables there was an incorrect closing of span tags. I added a "/" to 2 spans tags. 

Previously there was a strange transistion, issue #3351, in the tables when collapsing but is now fixed.

Issue is fixed if your review is ok. You can see the result at my testfolder.