### PR TITLE
Fix for issues #3365 and  #3270

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -869,16 +869,21 @@ function zoomOutMode(e){
 }
 
 function zoomInClick(){
-	zv+=0.1;
+	ctx.restore();
+	ctx.scale(1,1);
+	zv=1.25;
 	reWrite();
-	ctx.scale(1.1,1.1);
+	ctx.scale(zv,zv);
 }
 
 function zoomOutClick(){
-	zv-=0.1;
+	ctx.restore();
+	ctx.scale(1,1);
+	zv=0.75;
 	reWrite();
-	ctx.scale(0.9,0.9);
+	ctx.scale(zv,zv);
 }
+
 function getUploads() {
     document.getElementById('buttonid').addEventListener('click', openDialog);
     function openDialog() {
@@ -1927,7 +1932,7 @@ function hashfunction()
 			};
 		a = JSON.stringify(obj);
 		
-		localStorage.setItem('localdiagram', a);
+		localStorage.setItem('localdiagram'+numberStorage, a);
 		
 		
 		console.log(hash.toString(16));
@@ -1936,9 +1941,13 @@ function hashfunction()
 
 // retrive an old diagram if it exist.
 function loadDiagram(){
-	
+	var checkLocalStorage = localStorage.getItem('localdiagram');
 	//loacal storage and hash
-	var localDiagram = JSON.parse(localStorage.getItem('localdiagram'));
+	if(checkLocalStorage == "" || checkLocalStorage == null) {
+		console.log("Hej");
+	} else {
+		var localDiagram = JSON.parse(localStorage.getItem('localdiagram'));
+	}
 	var localhexHash = localStorage.getItem('localhash');
 	
 	console.log("local hash: ", localhexHash);
@@ -2002,7 +2011,7 @@ function loadDiagram(){
 
 //remove localstorage
 function removeLocal(){
-    localStorage.setItem('localhash', "");
+    localStorage.setItem('localdiagram', "");
 }
 
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -804,12 +804,10 @@ function initcanvas()
 		makegfx();
 
 	updategfx();
-
 	document.getElementById("moveButton").addEventListener('click', movemode, false);
 	document.getElementById("zoomInButton").addEventListener('click', zoomInMode, false);
 	document.getElementById("zoomOutButton").addEventListener('click', zoomOutMode, false);
 	canvas.addEventListener('dblclick', doubleclick, false);
-
 }
 // Function to enable and disable the grid, functionality is related to cx and cy
 
@@ -869,19 +867,21 @@ function zoomOutMode(e){
 }
 
 function zoomInClick(){
-	ctx.restore();
-	ctx.scale(1,1);
-	zv=1.25;
+	var oldZV = zv;
+	zv+=0.1;
 	reWrite();
-	ctx.scale(zv,zv);
+	// To be able to use the 10% increase och decrease, we need to use this calcuation.
+	var inScale = ((1/oldZV)*zv);
+	ctx.scale(inScale,inScale);
 }
 
 function zoomOutClick(){
-	ctx.restore();
-	ctx.scale(1,1);
-	zv=0.75;
+	var oldZV = zv;
+	zv-=0.1;
 	reWrite();
-	ctx.scale(zv,zv);
+	// To be able to use the 10% increase och decrease, we need to use this calcuation.
+	var outScale = ((1/oldZV)*zv);
+	ctx.scale(outScale,outScale);
 }
 
 function getUploads() {
@@ -983,14 +983,14 @@ function mousemoveevt(ev, t) {
 	moy = cy;
 	hovobj = diagram.inside(cx, cy);
 	if (ev.pageX || ev.pageY == 0) { // Chrome
-		cx = ev.pageX - acanvas.offsetLeft;
-		cy = ev.pageY - acanvas.offsetTop;
+		cx = (ev.pageX - acanvas.offsetLeft)*(1/zv);
+		cy = (ev.pageY - acanvas.offsetTop)*(1/zv);
 	} else if (ev.layerX || ev.layerX == 0) { // Firefox
-		cx = ev.layerX - acanvas.offsetLeft;
-		cy = ev.layerY - acanvas.offsetTop;
+		cx = (ev.layerX - acanvas.offsetLeft)*(1/zv);
+		cy = (ev.layerY - acanvas.offsetTop)*(1/zv);
 	} else if (ev.offsetX || ev.offsetX == 0) { // Opera
-		cx = ev.offsetX - acanvas.offsetLeft;
-		cy = ev.offsetY - acanvas.offsetTop;
+		cx = (ev.offsetX - acanvas.offsetLeft)*(1/zv);
+		cy = (ev.offsetY - acanvas.offsetTop)*(1/zv);
 	}
 	if(md == 1 || md == 2 || md == 0 && uimode != " ") {
 		if(snapToGrid) {
@@ -1932,7 +1932,7 @@ function hashfunction()
 			};
 		a = JSON.stringify(obj);
 		
-		localStorage.setItem('localdiagram'+numberStorage, a);
+		localStorage.setItem('localdiagram', a);
 		
 		
 		console.log(hash.toString(16));


### PR DESCRIPTION
The zoom function is now fixed, and the mouse point is also fixed. You can now zoom in and out without any problems. When zoomed in, you can press and move any figure or symbol that you want.