### PR TITLE
Fix for issue 3144 - changed cursor in all popup windows to 'pointer' on the closing button

### DIFF
--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -49,7 +49,7 @@
 	<div id='createUsers' class='loginBox' style='width:464px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Create Users</h3>
-			<div onclick='closeWindows();'>x</div>
+			<div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 		<div class='note'>
             <p>Users must be separated with a linebreak and the format required for each user is as follows:</p>
@@ -70,7 +70,7 @@
 	<div id='editUsers' class='loginBox' style='width:464px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Edit Users</h3>
-			<div onclick='closeWindows();'>x</div>
+			<div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 					
 		<div style='padding:5px;'>

--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -230,7 +230,7 @@ Testing Link:
 		<div id='editExample' class='loginBox' style='width:650px;display:none;'>
 			<div class='loginBoxheader'>
 				<h3>Edit Example</h3>
-				<div onclick='closeEditExample();'>x</div>
+				<div class='cursorPointer' onclick='closeEditExample();'>x</div>
 			</div>
 			<fieldset>
 				<legend>Example Info</legend>
@@ -260,7 +260,7 @@ Testing Link:
 		<div id='chooseTemplate' class='loginBox' style='width:464px;display:none;'>
 			<div class='loginBoxheader'>
 				<h3>Edit Example</h3>
-				<div onclick='closeTemplateWindow();'>x</div>
+				<div class='cursorPointer' onclick='closeTemplateWindow();'>x</div>
 			</div>
 			<table width="100%">
 				<tr>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -85,7 +85,7 @@ pdoConnect();
 	<div id="appearance" class='loginBox' style='display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Apperance</h3>
-			<div onclick='closeAppearanceDialogMenu()'>x</div>
+			<div class='cursorPointer' onclick='closeAppearanceDialogMenu()'>x</div>
 		</div>
 		<div class='table-wrap'>
 			<div id="f01">

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -44,7 +44,7 @@ pdoConnect();
 	<div id='editDugga' class='loginBox' style='width:464px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Edit Dugga</h3>
-			<div onclick='closeEditDugga();'>x</div>
+			<div class='cursorPointer' onclick='closeEditDugga();'>x</div>
 		</div>
 		<div style='padding:5px;'>
 			<input type='hidden' id='did' value='Toddler' /></td>
@@ -66,7 +66,7 @@ pdoConnect();
 	<div id='editVariant' class='loginBox' style='width:80%; left:20%; display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Edit Variant</h3>
-			<div onclick='closeWindows();closeVariant();'>x</div>
+			<div class='cursorPointer' onclick='closeWindows();closeVariant();'>x</div>
 		</div>
 		<div style='padding:5px;display:flex;'>
 			<input type='hidden' id='vid' value='Toddler' />
@@ -116,7 +116,7 @@ pdoConnect();
 	<!-- Result Dialog START -->
 	<div id='resultpopover' class='resultPopover' style='display:none'>
 		<div class='loginBoxheader'>
-			<div onclick="closePreview();">x</div>
+			<div class='cursorPointer' onclick="closePreview();">x</div>
 		</div>
 		<div id="MarkCont" style="position:absolute; left:4px; right:4px; top:34px; bottom:4px; border:2px inset #aaa;background:#bbb"></div>
 	</div>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -82,7 +82,7 @@ pdoConnect();
 	<div id='editFile' class='loginBox' style='width:464px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Edit File/Link</h3>
-			<div onclick='closeEditFile();'>x</div>
+			<div class='cursorPointer' onclick='closeEditFile();'>x</div>
 		</div>
 		<form enctype="multipart/form-data" action="filereceive.php" onsubmit="return validateForm()" method="POST">
 			<div style='padding:5px;'>

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -48,7 +48,7 @@ pdoConnect();
 	
 	<div id='resultpopover' class='resultPopover' style='display:none'>
 		<div class='loginBoxheader'>
-			<h3 style='width:100%;' id='Nameof'>Show Results</h3><div onclick='closeWindows();'>x</div>
+			<h3 style='width:100%;' id='Nameof'>Show Results</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 		<div id="MarkCont" style="position:absolute; left:4px; right:204px; top:34px; bottom:4px; border:2px inset #aaa;background:#bbb; overflow:scroll;"> </div>
 		<div style="position:absolute; right:2px; top:34px; background:#bbb; width:200px;"><div id='markMenuPlaceholder'></div><div id="teacherFeedbackTable"></div></div>
@@ -58,7 +58,7 @@ pdoConnect();
 	
 	<div id='previewpopover' class='previewPopover' style='display:none;'>
 		<div class='loginBoxheader'>
-			<h3 style='width:100%;' id='Nameof'>Document Preview</h3><div onclick='closeWindows();'>x</div>
+			<h3 style='width:100%;' id='Nameof'>Document Preview</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 		<div style="position:absolute;left:0px;top:34px;bottom:0px;right:0px;">
 			<table width="100%" height="100%">
@@ -99,7 +99,7 @@ pdoConnect();
 	
 	<div id='statisticspopover' class='previewpopover' style='display:none;'>
 		<div class='loginBoxheader'>
-			<h3 style='width:100%;' id='Nameof'>Collective results</h3><div onclick='closeWindows();'>x</div>
+			<h3 style='width:100%;' id='Nameof'>Collective results</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 	</div>
 </body>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -44,7 +44,7 @@ pdoConnect();
 	<div id='editSection' class='loginBox' style='width:460px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Edit Item</h3>
-			<div onclick='closeWindows(); closeSelect();showSaveButton();'>x</div>
+			<div class='cursorPointer' onclick='closeWindows(); closeSelect();showSaveButton();'>x</div>
 		</div>
 		<div style='padding:5px;'>
 			<input type='hidden' id='lid' value='Toddler' />
@@ -76,7 +76,7 @@ pdoConnect();
 	<div id='newCourseVersion' class='loginBox' style='width:464px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>New Course Version</h3>
-			<div onclick='closeWindows();'>x</div>
+			<div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 		<div style='padding:5px;'>
 			<input type='hidden' id='cid' value='Toddler' />
@@ -97,7 +97,7 @@ pdoConnect();
 	<div id='editCourseVersion' class='loginBox' style='width:464px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Edit Course Version</h3>
-			<div onclick='closeWindows();'>x</div>
+			<div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 		<div style='padding:5px;'>
 			<input type='hidden' id='cid' value='Toddler' />
@@ -117,7 +117,7 @@ pdoConnect();
 	<div id='HighscoreBox' class='loginBox' style='width:500px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Highscore</h3>
-			<div onclick='closeWindows();'>x</div>
+			<div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 		<table id ='HighscoreTable' width='100%'>
 			<tr>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -179,7 +179,7 @@
 
 	<div id='previewpopover' class='previewPopover' style='display:none;'>
 		<div class='loginBoxheader'>
-			<h3 style='width:100%;' id='Nameof'>Submission and feedback view</h3><div onclick='closeWindows();'>x</div>
+			<h3 style='width:100%;' id='Nameof'>Submission and feedback view</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 		<div style="position:absolute;left:0px;top:34px;bottom:0px;right:0px;">
 			<table width="100%" height="100%">

--- a/DuggaSys/templates/3d-dugga.html
+++ b/DuggaSys/templates/3d-dugga.html
@@ -100,7 +100,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
       <div class="table-wrap">
         <table>
@@ -114,7 +114,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/XMLAPI_report1.html
+++ b/DuggaSys/templates/XMLAPI_report1.html
@@ -48,7 +48,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>

--- a/DuggaSys/templates/bit-dugga.html
+++ b/DuggaSys/templates/bit-dugga.html
@@ -86,7 +86,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
       <div class="table-wrap">
         <table>
@@ -100,7 +100,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/boxmodell.html
+++ b/DuggaSys/templates/boxmodell.html
@@ -12,7 +12,7 @@
   <div>
         <div class='loginBoxheader'>
             <h3 style="width: 75%;">Dugga - Boxmodellen</h3>
-            <div onclick="hideDuggaInfoPopup()">x</div>
+            <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
         </div>
           <div class="table-wrap">
             <table>
@@ -35,7 +35,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -49,7 +49,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/color-dugga.html
+++ b/DuggaSys/templates/color-dugga.html
@@ -70,7 +70,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -84,7 +84,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/curve-dugga.html
+++ b/DuggaSys/templates/curve-dugga.html
@@ -41,7 +41,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -55,7 +55,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/dugga1.html
+++ b/DuggaSys/templates/dugga1.html
@@ -86,7 +86,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
       <div class="table-wrap">
         <table>
@@ -100,7 +100,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/dugga2.html
+++ b/DuggaSys/templates/dugga2.html
@@ -70,7 +70,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -84,7 +84,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/dugga3.html
+++ b/DuggaSys/templates/dugga3.html
@@ -61,7 +61,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -75,7 +75,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/dugga4.html
+++ b/DuggaSys/templates/dugga4.html
@@ -82,7 +82,7 @@
   <div>
         <div class='loginBoxheader'>
             <h3 style="width: 75%;">Dugga 4 - Transformationer</h3>
-            <div onclick="hideDuggaInfoPopup()">x</div>
+            <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
         </div>
           <div class="table-wrap">
             <table>
@@ -106,7 +106,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -120,7 +120,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/dugga5.html
+++ b/DuggaSys/templates/dugga5.html
@@ -88,7 +88,7 @@
   <div>
         <div class='loginBoxheader'>
             <h3>3D-dugga</h3>
-            <div onclick="hideDuggaInfoPopup();">x</div>
+            <div class='cursorPointer' onclick="hideDuggaInfoPopup();">x</div>
         </div>
           <div class="table-wrap">
             <table>
@@ -112,7 +112,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
       <div class="table-wrap">
         <table>
@@ -126,7 +126,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/feedback_dugga.html
+++ b/DuggaSys/templates/feedback_dugga.html
@@ -13,7 +13,7 @@
 			<div id="feedbackBoxy" class="loginBox" style="display:none;">
 	    <div class='loginBoxheader'>
 	        <h3>Feedback Log</h3>
-	        <div onclick="hideReceiptPopup()">x</div>
+	        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
 	    </div>
 	    <div class="table-wrap" id="feedbackTable">
 	        <table>
@@ -33,7 +33,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>

--- a/DuggaSys/templates/generic_dugga_file_receive.html
+++ b/DuggaSys/templates/generic_dugga_file_receive.html
@@ -14,7 +14,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>

--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -37,7 +37,7 @@
   <div>
     <div class='loginBoxheader'>
         <h3 style="width: 75%;">Dugga - HTML/CSS</h3>
-        <div onclick="hideDuggaInfoPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -60,7 +60,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -74,7 +74,7 @@
 <div id="feedbackBox" class="loginBox">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/html_css_dugga_light.html
+++ b/DuggaSys/templates/html_css_dugga_light.html
@@ -34,7 +34,7 @@
   <div>
     <div class='loginBoxheader'>
         <h3 style="width: 75%;">Dugga - HTML/CSS</h3>
-        <div onclick="hideDuggaInfoPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -57,7 +57,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>
@@ -71,7 +71,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/shapes-dugga.html
+++ b/DuggaSys/templates/shapes-dugga.html
@@ -24,7 +24,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/Shared/loginbox.php
+++ b/Shared/loginbox.php
@@ -126,7 +126,7 @@
 		<div id='resetcomplete' style="display:none">
 			<div class='loginBoxheader' id="completeid">
 				<h3>Request complete</h3>
-				<div onclick="closeWindows()">x</div>
+				<div class='cursorPointer' onclick="closeWindows()">x</div>
 			</div>
 			  <div class="table-wrap">
 				<table>
@@ -151,7 +151,7 @@
     <div class="loginBox" id="securitynotification" style="display:none;">
          <div class='loginBoxheader'>
           <h3>Choose a challenge question</h3>
-          <div onclick="closeWindows(); setSecurityNotifaction('off');">x</div>
+          <div class='cursorPointer' onclick="closeWindows(); setSecurityNotifaction('off');">x</div>
         </div>  
         <p id="securitynotificationmessage">You need to choose a challenge question. You can do this by visiting your profile page(clicking your username) or by clicking <a onclick="closeWindows(); setSecurityNotifaction('off');" href='profile.php'>here</a> </p>
     </div>
@@ -160,7 +160,7 @@
   <div class="expiremessagebox" style="display:none">
     <div class='loginBoxheader'>
       <h3>Alert</h3>
-      <div onclick="closeWindows()">x</div>
+      <div class='cursorPointer' onclick="closeWindows()">x</div>
     </div>
     <p id="expiremessage">Your session will expire in about 30 minutes.</p>
   </div>


### PR DESCRIPTION
All popup windows should now have the cursor 'pointer' on the x, when closing the popup. I added a generic CSS class in style.css called cursorPointer and added class='cursorPointer' to all popup windows closing button.