### PR TITLE
Fix for issue #3442

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1296,6 +1296,9 @@ function clearCanvas() {
         diagram[diagram.length - 1].erase();
         diagram.pop();
     }
+    for(var i = 0; i < points.length; i++){
+        points[i]="";
+    }
     updategfx();
 }
 


### PR DESCRIPTION
"Delete All"-button now removes the information about the crosses, but doesn't remove the poistion in the array.