### PR TITLE
Add cursorPointer class to remaining popup boxes

### DIFF
--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -179,7 +179,7 @@ Testing Link:
 		<div id='editContent' class='loginBox' style='width:510px;display:none;'>
 			<div class='loginBoxheader'>
 				<h3>Edit Content</h3>
-				<div onclick='closeEditContent();'>x</div>
+				<div class='cursorPointer' onclick='closeEditContent();'>x</div>
 			</div>	
 			<table width="100%" style="table-layout:fixed;">
 				<tr>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -161,7 +161,7 @@
 
 	<!-- LoginBox (receiptbox) Start! -->
 	<div id='receiptBox' class="loginBox" style="display:none">
-		<div class='loginBoxheader'><h3>Kvitto - Duggasvar</h3><div onclick="hideReceiptPopup()">x</div></div>
+		<div class='loginBoxheader'><h3>Kvitto - Duggasvar</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
 		<div id='receiptInfo'></div>
 		<textarea id="receipt" autofocus readonly></textarea>
 		<div class="button-row">

--- a/DuggaSys/templates/dugga3.html
+++ b/DuggaSys/templates/dugga3.html
@@ -30,7 +30,7 @@
   <div>
         <div class='loginBoxheader'>
             <h3>Dugga 3 - Geometri</h3>
-            <div onclick="hideReceiptPopup()">x</div>
+            <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
         </div>
           <div class="table-wrap">
             <table>

--- a/DuggaSys/templates/shapes-dugga.html
+++ b/DuggaSys/templates/shapes-dugga.html
@@ -2,7 +2,7 @@
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Dugga Stats</h3>
-        <div onclick="hideDuggaStatsPopup()">x</div>
+        <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>
     <div class="table-wrap">
         <table>

--- a/DuggaSys/testDugga.php
+++ b/DuggaSys/testDugga.php
@@ -97,7 +97,7 @@
 
 	<!-- LoginBox (receiptbox) Start! -->
 	<div id='receiptBox' class="loginBox" style="display:none">
-		<div class='loginBoxheader'><h3>Kvitto - Duggasvar</h3><div onclick="hideReceiptPopup()">x</div></div>
+		<div class='loginBoxheader'><h3>Kvitto - Duggasvar</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
 		<div id='receiptInfo'></div>
 		<textarea id="receipt" autofocus readonly></textarea>
 		<div class="button-row">


### PR DESCRIPTION
All popup boxes should now have the correct cursor when the close button is hovered over. Fixes #3452 