### PR TITLE
Fix for issue #3498

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -160,7 +160,6 @@ points.drawpoints = function ()
             ctx.restore();
         }
     }
-    ctx.lineWidth = 1;
 }
 
 //--------------------------------------------------------------------
@@ -906,9 +905,15 @@ function getConnectedLines(object) {
 
 function eraseObject(object) {
     document.getElementById("myCanvas").style.cursor = "default";
-    var private_lines = object.getLines();
-    object.erase();
-    diagram.eraseObjectLines(object, private_lines);
+    if(object.kind==2){
+      var private_lines = object.getLines();
+      object.erase();
+      diagram.eraseObjectLines(object, private_lines);
+    }
+    else if(object.kind==1){
+      object.erase();
+    }
+
     diagram.delete(object);
     updategfx();
 }
@@ -920,7 +925,7 @@ function eraseSelectedObject() {
         if (diagram[i].targeted == true) {
             diagram[i].targeted = false;
             eraseObject(diagram[i]);
-            i = 0;
+            i = -1;
             //To avoid removing the same index twice, selobj is reset
             selobj = -1;
         }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -441,6 +441,7 @@ function Symbol(kind) {
     //     ctx.setLineDash(segments);
     //--------------------------------------------------------------------
     this.draw = function () {
+        ctx.lineWidth = 2;
         if (this.sizeOftext == 'Tiny') {
             textsize = 14;
         } else if (this.sizeOftext == 'Small') {


### PR DESCRIPTION
Created a difference betwen how a figure and a symbol is erase, which solves the bug when using the delete object function to delete figures.

Also added a global standard line-width for all drawn objects, the result is a bit cleaner diagram.