### PR TITLE
Autodetect extension of file

### DIFF
--- a/DuggaSys/filereceive.php
+++ b/DuggaSys/filereceive.php
@@ -187,7 +187,7 @@ if($ha){
 												//  if returned rows equals 0(the existence of the file is not in the db) add data into the db
 												if($norows==0){
 														if($kind=="LFILE"){
-																$query = $pdo->prepare("INSERT INTO fileLink(filename,kind,cid,fileize) VALUES(:linkval,'4',:cid,:filesize);");
+																$query = $pdo->prepare("INSERT INTO fileLink(filename,kind,cid,filesize) VALUES(:linkval,'4',:cid,:filesize);");
 														}else if($kind=="MFILE"){
 																$query = $pdo->prepare("INSERT INTO fileLink(filename,kind,cid,filesize) VALUES(:linkval,'3',:cid,:filesize);");
 														}else if($kind=="GFILE"){

--- a/DuggaSys/showdoc.php
+++ b/DuggaSys/showdoc.php
@@ -263,7 +263,7 @@
 					
 							if(file_exists ( $file)){
 									$file_extension = strtolower(substr(strrchr($filename,"."),1));									
-									if($file_extension=="html" || $file_extension=="css" || $file_extension=="js"){
+									if($file_extension=="html" || $file_extension=="css" || $file_extension=="js" || $file_extension=="php"){
 											//$bummer=file_get_contents($file);
 										    header('Content-Description: File Transfer');
 										    header('Content-Type: application/octet-stream');
@@ -288,7 +288,7 @@
 												case "gif": $ctype="image/gif"; break;
 												case "png": $ctype="image/png"; break;
 												case "jpg": $ctype="image/jpg"; break;
-												//default: $ctype=mime_content_type($filename); break;
+												default: $ctype=mime_content_type($file); break;
 											}
 											header("Content-Type: ".$ctype);
 											header('Content-Disposition: inline; filename="' .$filename.'"');


### PR DESCRIPTION
Autodetect extension of file if a case has not been implemented yet. This allows certain browsers, e.g Safari, to download these files. 
Also corrected a minor error where "filesize" was misspelled.