### PR TITLE
3384 mime_content_type

### DIFF
--- a/DuggaSys/filereceive.php
+++ b/DuggaSys/filereceive.php
@@ -152,7 +152,8 @@ if($ha){
 							
 								$temp = explode(".", $filea["name"]);
 								$extension = end($temp); //stores the file type
-								if(in_array($extension, $allowedX)&&in_array($filea['type'], $allowedT)){ 
+								$filetype = mime_content_type($filea["tmp_name"]);
+								if(in_array($extension, $allowedX)&&in_array($filetype, $allowedT)){ 
 										//  if file type is allowed, continue the uploading process.
 				
 										$fname=$filea['name'];
@@ -211,7 +212,7 @@ if($ha){
 								}else{ 
 									//if the file extension is not allowed
 									if(!in_array($extension, $allowedX)) echo "Extension ".$extension." not allowed.\n";
-									if(!in_array($filea['type'], $allowedT)) echo "Type ".$filea['type']." not allowed.\n";
+									if(!in_array($filetype, $allowedT)) echo "Type ".$filetype." not allowed.\n";
 									$error=true;
 								}
 						}

--- a/DuggaSys/filereceive.php
+++ b/DuggaSys/filereceive.php
@@ -102,7 +102,7 @@ if($ha){
 
 		if($storefile){
 				//  if the file is of type "GFILE"(global) or "MFILE"(course local) and it doesn't exists in the db, add a row into the db
-				$allowedT = array("application/pdf", "image/gif", "image/jpeg", "image/jpg","image/png","image/x-png","application/x-rar-compressed","application/zip","text/html","text/plain", "application/octet-stream", "text/xml", "application/x-javascript", "text/css", "text/php","text/markdown", "application/postscript", "application/octet-stream","image/svg+xml", "application/octet-stream", "application/octet-stream", "application/msword", "application/octet-stream", "application/octet-stream", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/vnd.oasis.opendocument.text", "text/xml", "text/xml","application/octetstream","application/x-pdf", "application/download" , "application/x-download");
+				$allowedT = array("application/pdf", "image/gif", "image/jpeg", "image/jpg","image/png","image/x-png","application/x-rar-compressed","application/zip","text/html","text/plain", "application/octet-stream", "text/xml", "application/x-javascript", "text/css", "text/php","text/markdown", "application/postscript", "application/octet-stream","image/svg+xml", "application/octet-stream", "application/octet-stream", "application/msword", "application/octet-stream", "application/octet-stream", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/vnd.oasis.opendocument.text", "text/xml", "text/xml","application/octetstream","application/x-pdf", "application/download" , "application/x-download", "application/x-dosexec", "application/x-sharedlib", "text/x-php");
 				$allowedX = array("pdf","gif", "jpeg", "jpg", "png","zip","rar","html","txt", "java", "xml", "js", "css", "php","md","ai", "psd","svg", "sql", "sr", "doc", "sl", "glsl", "docx", "odt", "xslt", "xsl");
 				
 				$swizzled = swizzleArray($_FILES['uploadedfile']);
@@ -152,6 +152,7 @@ if($ha){
 							
 								$temp = explode(".", $filea["name"]);
 								$extension = end($temp); //stores the file type
+								// Determine file MIME-type
 								$filetype = mime_content_type($filea["tmp_name"]);
 								if(in_array($extension, $allowedX)&&in_array($filetype, $allowedT)){ 
 										//  if file type is allowed, continue the uploading process.


### PR DESCRIPTION
DuggaSys/filereceived.php now uses mime_content_type function instead of file['type'] to determine MIME type of uploaded files. A few new types were added to whitelist. File changed is used when uploading files to LenaSYS.