### PR TITLE
Fix for issue #3355

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1070,6 +1070,11 @@ function dialogForm() {
         form.innerHTML =
             "Relation name:</br>" +
             "<input id='nametext' type='text'></br>" +
+            "Relation type: </br>" +
+            "<select id ='relationType'>" +
+                "<option value='weak'>weak</option>" +
+                "<option value='strong' selected>strong</option>" +
+            "</select></br>" +
             "Font family:<br>" +
             "<select id ='font'>" +
                 "<option value='arial' selected>Arial</option>" +
@@ -1135,7 +1140,7 @@ function changeNameRelation() {
     diagram[selobj].fontColor = document.getElementById('fontColor').value;
     diagram[selobj].font = document.getElementById('font').value;
     diagram[selobj].sizeOftext = document.getElementById('TextSize').value;
-    diagram[selobj].entityType = document.getElementById('entityType').value;
+    diagram[selobj].relationType = document.getElementById('relationType').value;
     updategfx();
     $("#appearance").hide();
 }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -658,6 +658,13 @@ function Symbol(kind) {
             var midx = points[this.middleDivider].x;
             var midy = points[this.middleDivider].y;
             ctx.beginPath();
+            if (this.relationType == 'weak') {
+            	ctx.moveTo(midx + 0, y1 + 5);
+                ctx.lineTo(x2 - 5, midy + 0);
+                ctx.lineTo(midx + 0, y2 - 5);
+                ctx.lineTo(x1 + 5, midy + 0);
+                ctx.lineTo(midx + 0, y1 + 5);
+        }
             ctx.moveTo(midx, y1);
             ctx.lineTo(x2, midy);
             ctx.lineTo(midx, y2);


### PR DESCRIPTION
When weak is selected, an extra border appears around the figure to signify the weakness of the relation.