### PR TITLE
Issue#3097

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -621,13 +621,14 @@ function mousemoveevt(ev, t) {
         if (movobj != -1) {
             for (var i = 0; i < diagram.length; i++) {
                 if (diagram[i].targeted == true) {
-                    var obj_topLeft = points[diagram[i].topLeft];
-
-                    var deltatlx = obj_topLeft.x - (Math.round(obj_topLeft.x / gridSize) * gridSize);
-                    var deltatly = obj_topLeft.y - (Math.round(obj_topLeft.y / gridSize) * gridSize);
-
-                    obj_topLeft = Math.round(cy / gridSize) * gridSize;
                     if (snapToGrid) {
+                        var obj_topLeft = points[diagram[i].topLeft];
+                        var tlx = (Math.round(obj_topLeft.x / gridSize) * gridSize);
+                        var tly = (Math.round(obj_topLeft.y / gridSize) * gridSize);
+
+                        var deltatlx = obj_topLeft.x - tlx;
+                        var deltatly = obj_topLeft.y - tly;
+
                         cx = Math.round(cx / gridSize) * gridSize;
                         cy = Math.round(cy / gridSize) * gridSize;
 
@@ -635,7 +636,6 @@ function mousemoveevt(ev, t) {
                         cy -= deltatly;
                     }
                     diagram[i].move(cx - mox, cy - moy);
-
                 }
             }
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -566,7 +566,12 @@ function updateActivePoint() {
         activePoint = null;
     }
 }
+function pointDistance(point1, point2){
+    var width = (point1.x > point2.x)? point1.x - point2.x: point2.x - point1.x;
+    var height = (point1.y > point2.y)? point1.y - point2.y: point2.y - point1.y;
 
+    return [width, height];
+}
 function mousemoveevt(ev, t) {
     xPos = ev.clientX;
     yPos = ev.clientY;
@@ -616,11 +621,21 @@ function mousemoveevt(ev, t) {
         if (movobj != -1) {
             for (var i = 0; i < diagram.length; i++) {
                 if (diagram[i].targeted == true) {
+                    var obj_topLeft = points[diagram[i].topLeft];
+
+                    var deltatlx = obj_topLeft.x - (Math.round(obj_topLeft.x / gridSize) * gridSize);
+                    var deltatly = obj_topLeft.y - (Math.round(obj_topLeft.y / gridSize) * gridSize);
+
+                    obj_topLeft = Math.round(cy / gridSize) * gridSize;
                     if (snapToGrid) {
                         cx = Math.round(cx / gridSize) * gridSize;
                         cy = Math.round(cy / gridSize) * gridSize;
+
+                        cx -= deltatlx;
+                        cy -= deltatly;
                     }
                     diagram[i].move(cx - mox, cy - moy);
+
                 }
             }
         }


### PR DESCRIPTION
Object's top left corner now snap to the grid that is drawn. I attempted comparing the two corners bottom right and top left in order to decide which one to snap to the grid, but it was deemed unsuccessful as it lowered the overall quality.

Suggestion for new issues:
* The grid is not drawn properly (bug)
    - When navigating far outside the start position in the canvas, the grid is no longer drawn
* Snap a group of objects to grid