### PR TITLE
Fix for issue #3576

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1790,7 +1790,7 @@ span.arrow {
   height:50px;
   border-radius:25px;
   box-shadow:0px 0px 15px #888;
-  bottom:55px;
+  top:310px;
   right:50px;
   font-size:24px;
   text-align:center;


### PR DESCRIPTION
The button will now disappear when you zoom in (as for small screens), and it won't block the content.