### PR TITLE
Fix for issue #3564

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -749,6 +749,9 @@ function doubleclick(ev) {
         if (document.getElementById('attributeType') != null) {
             document.getElementById('attributeType').value = diagram[selobj].attributeType;
         }
+        if (document.getElementById('relationType') != null) {
+            document.getElementById('relationType').value = diagram[selobj].relationType;
+        }
     }
 }
 function resize() {


### PR DESCRIPTION
Settings are saved when the user doubleclick the relation symbol to re-open dialogue box.