### PR TITLE
Fix for removeLocal()

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1560,7 +1560,7 @@ function loadDiagram() {
 //remove localstorage
 function removeLocal() {
     for (var i = 0; i < localStorage.length; i++){
-        localStorage.removeItem("localdiagram"+i);
+        localStorage.removeItem("localdiagram");
     }
 }
 


### PR DESCRIPTION
Currently we only store localdiagram without any numbers, that's why "localdiagram" + i did not work. If we however start storing localdiagrams with numbers we would have to revert this change.