### PR TITLE
Magic heading now stays visible after filter

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -688,6 +688,7 @@ function leavec()
     localStorage.setItem("lena_"+querystring['cid']+"-"+querystring['coursevers']+"-pending", onlyPending);
 
 	if(str!=old || onlyPending==opend) process();
+  magicHeading();
 }
 
 // Function to select and unselect all duggas 
@@ -772,7 +773,8 @@ function leaves()
 	if (!(ocol==col && odir==dir) || typechanged) {
     typechanged=false;
     resort();
-}
+  }
+  magicHeading();
 }
 
 function sorttype(t){
@@ -790,6 +792,7 @@ function sorttype(t){
 				}
 		}
 		typechanged=true;
+    magicHeading();
 }
 
 function magicHeading()


### PR DESCRIPTION
The magic heading now stays visible after the content has been filtered
in the result-view.
Solves issue #3655