### PR TITLE
Added overflow-y scroll to body

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -65,6 +65,7 @@ html, body {
 body {
   font-family: 'Roboto', sans-serif,"Helvetica Neue",Helvetica,Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
+  overflow-y:scroll;
 }
 
 .listbar{


### PR DESCRIPTION
Now the scrollbar will always be there so the tables won't hop when collapsing. 
I added overflow-y:scroll to body.
This solves is #3704 .