### PR TITLE
Week19 #3059 support for mixing nested sublists in markdown.js

### DIFF
--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -15,6 +15,17 @@
       * item 5*
 * item 4*
 * item 5*
+  1. item 1.
+  2. item 1.
+    1. item 1.
+    2. item 1.
+      * item 1*
+        * item 1*
+          1. item 1.
+          2. item 1.
+          3. item 1.
+    3. item 1.
+  3. item 1.
 * item 6*
 
 

--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -1,18 +1,11 @@
-****Unordered list with nested ordered list****
-* item
-* item
-* item
-  * item
-  * item
-  * item
-    * item
-      * item
-      * item (next ordered list item)
-        1. item
-        2. item
-        3. item (last ordered)
-* item
-* item
-* item
-
-
+****Unordered list****
+* item 1*
+* item 2*
+* item 3*
+* item 4*
+* item 5*
+* item 6*
+1. item 1.
+2. item 2.
+3. item 3.
+4. item 4.

--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -1,40 +1,18 @@
-### **Overview**
-The difference between this example and the previous example is that in this case the base html tags are written using echo. 
-
-From the standpoint of the browser the result is identical. 
-
-**Web Page Output:**
-~~~
-Hello!
-~~~
-
-****Table****
-| Heading | Heading | Heading |
-| :----: | ---: | ---- |
-| item | item | item |
-| item | item | item |
-| item | item | item |
-
-****Unordered list****
+****Unordered list with nested ordered list****
 * item
 * item
 * item
   * item
   * item
+  * item
+    * item
+      * item
+      * item (next ordered list item)
+        1. item
+        2. item
+        3. item (last ordered)
+* item
+* item
 * item
 
-****Unordered list with dashes****
-- item
-- item
-- item
-  - item
-  - item
-- item
 
-****Ordered list****
-1. item
-2. item
-3. item
-  1. item
-  2. item
-4. item

--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -2,10 +2,23 @@
 * item 1*
 * item 2*
 * item 3*
+	1. item 1.
+	2. item 2.
+	3. item 3.
+	4. item 4.
 * item 4*
 * item 5*
 * item 6*
+
+****Ordered list****
 1. item 1.
 2. item 2.
 3. item 3.
+	* item 1*
+	* item 2*
+	* item 3*
 4. item 4.
+5. item 5.
+6. item 6.
+
+

--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -2,23 +2,19 @@
 * item 1*
 * item 2*
 * item 3*
-	1. item 1.
-	2. item 2.
-	3. item 3.
-	4. item 4.
+  1. item 1.
+  2. item 2.
+    1. item 1.
+    2. item 2.
+      * item 1*
+      * item 2*
+      * item 3*
+        1. item 1.
+        2. item 2.
+      * item 4*
+      * item 5*
 * item 4*
 * item 5*
 * item 6*
-
-****Ordered list****
-1. item 1.
-2. item 2.
-3. item 3.
-	* item 1*
-	* item 2*
-	* item 3*
-4. item 4.
-5. item 5.
-6. item 6.
 
 

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -12,6 +12,7 @@ Markdown support javascript
 */
 // GLOBALS
 var tableAlignmentConf = [];
+var openedSublists = [];
 
 
 //Functions for gif image
@@ -295,25 +296,44 @@ function handleLists(currentLine, prevLine, nextLine) {
     
      // Open a new sublist
     if(currentLineIndentation < nextLineIndentation) { 
-    	console.log("open a new sublist");
+    	markdown += "<li>";
+    	markdown +=  value;
+
+    	// begin open sublist
+    	if(isOrderdList(nextLine)) {
+			markdown += "<ol>";
+            openedSublists.push(0);
+		} else {
+			markdown += "<ul>";
+            openedSublists.push(1);
+		}
     }
     // Stay in current list or sublist
-    if(currentLineIndentation === prevLineIndentation || currentLineIndentation === nextLineIndentation) {
+    if(currentLineIndentation === nextLineIndentation) {
     	markdown += "<li>";
     	markdown +=  value;
     	markdown += "</li>";
     }
     // Close sublists
     if(currentLineIndentation > nextLineIndentation) { 
-    	console.log("closing sublists");
-    	var sublistsToClose = (currentLineIndentation - nextLineIndentation) / 2;
-    	console.log(sublistsToClose);
-    	for(var i = 0; i < sublistsToClose; i++) {
-    		
-    	}
+    	markdown += "<li>";
+    	markdown +=  value;
+    	markdown += "</li>";
+
+        var sublistsToClose = (currentLineIndentation - nextLineIndentation) / 2;
+        for(var i = 0; i < sublistsToClose; i++) {
+            var whatSublistToClose = openedSublists[openedSublists.length - 1];
+            openedSublists.pop();
+
+            if(whatSublistToClose === 0) { // close ordered list
+                markdown += "</ol>";
+            } else { // close unordered list
+                markdown += "</ul>";
+            }
+            markdown += "</li>";
+        }
+
     }
-    
-    
 
     // Close list
     if(!isOrderdList(nextLine) && isOrderdList(currentLine) && !isUnorderdList(nextLine)) markdown += "</ol>"; // Close ordered list

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -156,13 +156,9 @@ function parseLineByLine(inString) {
 }
 // This function detect the text type
 function identifier(prevLine, currentLine, markdown, nextLine){
-    // handle unordered lists <ul></ul>
-    if(isUnorderdList(currentLine)) {
-        markdown += handleUnorderedList(currentLine, prevLine, nextLine);
-    }
-    // handle ordered lists <ol></ol>
-    else if(isOrderdList(currentLine)) {
-        markdown += handleOrderedList(currentLine, prevLine, nextLine);
+    // handle lists
+    if(isUnorderdList(currentLine) || isOrderdList(currentLine)) {
+        markdown += handleLists(currentLine, prevLine, nextLine);
     }
     // handle tables
     else if(isTable(currentLine)) {
@@ -283,13 +279,18 @@ function handleOrderedList(currentLine, prevLine, nextLine) {
 }
 function handleLists(currentLine, prevLine, nextLine) {
 	var markdown = "";
-	var value = currentLine.substr(currentLine.match(/^\s*\d*\.\s*/)[0].length, currentLine.length);
-	var currentLineIndentation = currentLine.match(/^\s*\d*/)[0].length;
-    var nextLineIndentation = nextLine.match(/^\s*\d*/)[0].length;
-    
-    // Open a new list
-    if(!isOrderdList(prevLine)) markdown += "<ol>"; // Open a new ordered list
-    if(!isUnorderdList(prevLine)) markdown += "<ul>"; //Open a new unordered list
+
+	var value = "";
+	currentLineIndentation = currentLine.match(/^\s*/)[0].length;
+	nextLineIndentation = nextLine.match(/^\s*/)[0].length;	
+	prevLineIndentation = prevLine.match(/^\s*/)[0].length;
+
+    // decide value
+    if(isOrderdList(currentLine)) value = currentLine.substr(currentLine.match(/^\s*\d*\.\s*/)[0].length, currentLine.length);
+	if(isUnorderdList(currentLine)) value = currentLine.substr(currentLine.match(/^\s*[\-\*]\s*/gm)[0].length, currentLine.length);
+
+    if(!isOrderdList(prevLine) && isOrderdList(currentLine)) markdown += "<ol>"; // Open a new ordered list
+    if(!isUnorderdList(prevLine) && isUnorderdList(currentLine)) markdown += "<ul>"; //Open a new unordered list
     
      // Open a new sublist
     if(currentLineIndentation < nextLineIndentation) { 
@@ -297,7 +298,9 @@ function handleLists(currentLine, prevLine, nextLine) {
     }
     // Close sublists
     else if(currentLineIndentation > nextLineIndentation) { 
- 
+ 		console.log("prev", prevLineIndentation);
+ 		console.log("curr", currentLineIndentation);
+ 		console.log("next", nextLineIndentation);
     }
     // Stay in current list or sublist
     else {
@@ -307,8 +310,8 @@ function handleLists(currentLine, prevLine, nextLine) {
     }
 
     // close list
-    if(!isOrderdList(nextLine)) markdown += "</ol>"; // Close ordered list
-    if(!isUnorderdList(nextLine)) markdown += "</ul>"; // Close unordered list
+    if(!isOrderdList(nextLine) && isOrderdList(currentLine)) markdown += "</ol>"; // Close ordered list
+    if(!isUnorderdList(nextLine) && isUnorderdList(currentLine)) markdown += "</ul>"; // Close unordered list
 
     return markdown;
     

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -281,37 +281,41 @@ function handleLists(currentLine, prevLine, nextLine) {
 	var markdown = "";
 
 	var value = "";
-	currentLineIndentation = currentLine.match(/^\s*/)[0].length;
-	nextLineIndentation = nextLine.match(/^\s*/)[0].length;	
-	prevLineIndentation = prevLine.match(/^\s*/)[0].length;
+	var currentLineIndentation = currentLine.match(/^\s*/)[0].length;
+	var nextLineIndentation = nextLine.match(/^\s*/)[0].length;	
+	var prevLineIndentation = prevLine.match(/^\s*/)[0].length;
 
     // decide value
     if(isOrderdList(currentLine)) value = currentLine.substr(currentLine.match(/^\s*\d*\.\s*/)[0].length, currentLine.length);
 	if(isUnorderdList(currentLine)) value = currentLine.substr(currentLine.match(/^\s*[\-\*]\s*/gm)[0].length, currentLine.length);
 
-    if(!isOrderdList(prevLine) && isOrderdList(currentLine)) markdown += "<ol>"; // Open a new ordered list
-    if(!isUnorderdList(prevLine) && isUnorderdList(currentLine)) markdown += "<ul>"; //Open a new unordered list
+	// Open new list
+    if(!isOrderdList(prevLine) && isOrderdList(currentLine) && !isUnorderdList(prevLine)) markdown += "<ol>"; // Open a new ordered list
+    if(!isUnorderdList(prevLine) && isUnorderdList(currentLine) && !isOrderdList(prevLine)) markdown += "<ul>"; //Open a new unordered list
     
-     // Open a new sublist
-    if(currentLineIndentation < nextLineIndentation) { 
-
-    }
-    // Close sublists
-    else if(currentLineIndentation > nextLineIndentation) { 
- 		console.log("prev", prevLineIndentation);
- 		console.log("curr", currentLineIndentation);
- 		console.log("next", nextLineIndentation);
-    }
     // Stay in current list or sublist
-    else {
+    if (currentLineIndentation === prevLineIndentation || currentLineIndentation === nextLineIndentation) {
     	markdown += "<li>";
     	markdown +=  value;
     	markdown += "</li>";
     }
+     // Open a new sublist
+    else if(currentLineIndentation < nextLineIndentation) { 
 
-    // close list
-    if(!isOrderdList(nextLine) && isOrderdList(currentLine)) markdown += "</ol>"; // Close ordered list
-    if(!isUnorderdList(nextLine) && isUnorderdList(currentLine)) markdown += "</ul>"; // Close unordered list
+    }
+    // Close sublists
+    else if(currentLineIndentation > nextLineIndentation) { 
+    	console.log(currentLine);
+ 		console.log("prev", prevLineIndentation);
+ 		console.log("curr", currentLineIndentation);
+ 		console.log("next", nextLineIndentation);
+    }
+    
+   
+
+    // Close list
+    if(!isOrderdList(nextLine) && isOrderdList(currentLine) && !isUnorderdList(nextLine)) markdown += "</ol>"; // Close ordered list
+    if(!isUnorderdList(nextLine) && isUnorderdList(currentLine) && !isOrderdList(nextLine)) markdown += "</ul>"; // Close unordered list
 
     return markdown;
     

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -209,7 +209,8 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     if(currentLineIndentation < nextLineIndentation) { 
     	markdown += "<li>";
     	markdown +=  value;
-    	markdown += "<ul>" 
+
+    	markdown += "<ul> <!-- HAHAHA -->";
     }
     // Close sublists
     else if(currentLineIndentation > nextLineIndentation) { 
@@ -217,6 +218,11 @@ function handleUnorderedList(currentLine, prevLine, nextLine) {
     	markdown +=  value;
     	markdown += "</li>";
     	var sublistsToClose = (currentLineIndentation - nextLineIndentation) / 2;
+
+    	if(!isOrderdList(prevLine)) {
+    		console.log(currentLine);
+    	}
+
     	for(var i = 0; i < sublistsToClose; i++) {
     		markdown += "</ul></li>";
     	}
@@ -274,6 +280,38 @@ function handleOrderedList(currentLine, prevLine, nextLine) {
     }
 
 	return markdown;
+}
+function handleLists(currentLine, prevLine, nextLine) {
+	var markdown = "";
+	var value = currentLine.substr(currentLine.match(/^\s*\d*\.\s*/)[0].length, currentLine.length);
+	var currentLineIndentation = currentLine.match(/^\s*\d*/)[0].length;
+    var nextLineIndentation = nextLine.match(/^\s*\d*/)[0].length;
+    
+    // Open a new list
+    if(!isOrderdList(prevLine)) markdown += "<ol>"; // Open a new ordered list
+    if(!isUnorderdList(prevLine)) markdown += "<ul>"; //Open a new unordered list
+    
+     // Open a new sublist
+    if(currentLineIndentation < nextLineIndentation) { 
+
+    }
+    // Close sublists
+    else if(currentLineIndentation > nextLineIndentation) { 
+ 
+    }
+    // Stay in current list or sublist
+    else {
+    	markdown += "<li>";
+    	markdown +=  value;
+    	markdown += "</li>";
+    }
+
+    // close list
+    if(!isOrderdList(nextLine)) markdown += "</ol>"; // Close ordered list
+    if(!isUnorderdList(nextLine)) markdown += "</ul>"; // Close unordered list
+
+    return markdown;
+    
 }
 function handleTable(currentLine, prevLine, nextLine) {
     var markdown = "";

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -293,25 +293,27 @@ function handleLists(currentLine, prevLine, nextLine) {
     if(!isOrderdList(prevLine) && isOrderdList(currentLine) && !isUnorderdList(prevLine)) markdown += "<ol>"; // Open a new ordered list
     if(!isUnorderdList(prevLine) && isUnorderdList(currentLine) && !isOrderdList(prevLine)) markdown += "<ul>"; //Open a new unordered list
     
+     // Open a new sublist
+    if(currentLineIndentation < nextLineIndentation) { 
+    	console.log("open a new sublist");
+    }
     // Stay in current list or sublist
-    if (currentLineIndentation === prevLineIndentation || currentLineIndentation === nextLineIndentation) {
+    if(currentLineIndentation === prevLineIndentation || currentLineIndentation === nextLineIndentation) {
     	markdown += "<li>";
     	markdown +=  value;
     	markdown += "</li>";
     }
-     // Open a new sublist
-    else if(currentLineIndentation < nextLineIndentation) { 
-
-    }
     // Close sublists
-    else if(currentLineIndentation > nextLineIndentation) { 
-    	console.log(currentLine);
- 		console.log("prev", prevLineIndentation);
- 		console.log("curr", currentLineIndentation);
- 		console.log("next", nextLineIndentation);
+    if(currentLineIndentation > nextLineIndentation) { 
+    	console.log("closing sublists");
+    	var sublistsToClose = (currentLineIndentation - nextLineIndentation) / 2;
+    	console.log(sublistsToClose);
+    	for(var i = 0; i < sublistsToClose; i++) {
+    		
+    	}
     }
     
-   
+    
 
     // Close list
     if(!isOrderdList(nextLine) && isOrderdList(currentLine) && !isUnorderdList(nextLine)) markdown += "</ol>"; // Close ordered list


### PR DESCRIPTION
Issue #3059 

Implementing support for nesting unordered and ordered lists in markdown.js. 

Do not close this branch or issue after merging since it's only partially fixed. Same logic will be implemented in showdoc.php