### PR TITLE
Remove remeber me from loginbox

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -884,7 +884,6 @@ input {
 .loginBox .forgotPw {
   cursor: pointer;
   text-decoration: underline;
-  margin-left: 46px;
 }
 
 .loginBox .form-control {

--- a/Shared/loginbox.php
+++ b/Shared/loginbox.php
@@ -28,9 +28,6 @@
 					</tr>
 					<tr>
 						<td class="nowrap">
-							<input id='saveuserlogin' type='checkbox' value="on">
-							<label class="text">Remember me</label>
-							
 							<label class='text forgotPw' onclick='toggleloginnewpass();'>Forgot Password?</label>
 						</td>
 					</tr>


### PR DESCRIPTION
The remember me function is now removed. This is replaced by #1846 so the browser is remembering the login. So the remember me function is not needed. 

Solves issue: #920 
