### PR TITLE
Manage groups moments update automatically

### DIFF
--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -68,29 +68,6 @@ function sorttype(t){
 		typechanged=true;
 }
 
-function selectGroup()
-{
-	//Display pop-up
-	$("#groupSection").css("display","block");
-	$("#overlay").css("display","block");
-}
-
-function createGroup()
-{
-	name=$("#name").val(); 
-	if(name){
-		AJAXService("NEWGROUP",{name:name},"GROUP"); 
-		$("#groupSection").css("display","none");
-		$("#groupNameError").css("display","none");
-		$("#overlay").css("display","none");
-		$("#name").val('');
-		window.location.reload();	
-	}
-	else{
-		$("#groupNameError").css("display","block");
-	}
-}
-
 function process()
 {			
 		// Read dropdown from local storage
@@ -216,6 +193,35 @@ function drawtable(){
 	str+="</table>";
 	
 	document.getElementById("content").innerHTML=str;
+}
+
+function selectGroup()
+{
+	var inp = "";
+	for(i=0; i<moments.length; i++){
+		inp+="<option value='i'>"+moments[i].entryname+"</option>";
+	}
+	document.getElementById("selectMoment").innerHTML=inp;
+	
+	//Display pop-up
+	$("#groupSection").css("display","block");
+	$("#overlay").css("display","block");
+}
+
+function createGroup()
+{
+	name=$("#name").val(); 
+	if(name){
+		AJAXService("NEWGROUP",{name:name},"GROUP"); 
+		$("#groupSection").css("display","none");
+		$("#groupNameError").css("display","none");
+		$("#overlay").css("display","none");
+		$("#name").val('');
+		window.location.reload();	
+	}
+	else{
+		$("#groupNameError").css("display","block");
+	}
 }
 
 function returnedGroup(data)

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -50,9 +50,7 @@
 		</div>
 		<div style='padding:5px;'>
 			<div id='inputwrapper-name' class='inputwrapper' style='display:inline-block;'>
-				<select style='float:none; width:100%; margin: 8px 0px;'>
-					<option>Biträkningsduggor 1HP</option>
-					<option>Frågeduggor 1HP</option>
+				<select id='selectMoment' style='float:none; width:100%; margin: 8px 0px;'>
 				</select><br/>
 				<select style='float:none; width:100%;'>
 					<option value="a">a-z</option>


### PR DESCRIPTION
The moments in the dropdown in Manage Groups on the Groups page is now getting the names dynamically. Fix for issue #3786.