### PR TITLE
Arrows now toggle correctly in sectioned

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1183,37 +1183,37 @@ $(document).on('click', '.section', function () {
 // Function for hiding content for all moments
 $(document).on('click', '.hideAll', function () {
     $('.moment').nextUntil('.moment').hide(400);
-    $('.moment').children('.arrowRight').slideToggle();
-    $('.moment').children('.arrowComp').slideToggle();
     $('.hideAll').hide();
     $('.showAll').show().css('display', 'flex');
+    $('.arrowRight').show(400);
+    $('.arrowComp').hide();
 });
 
 // Function for hiding content for all sections
 $(document).on('click', '.hideAll', function () {
     $('.section').nextUntil('.section').hide(400);
-    $('.section').children('.arrowRight').slideToggle();
-    $('.section').children('.arrowComp').slideToggle();
     $('.hideAll').hide();
     $('.showAll').show().css('display', 'flex');
+    $('.arrowRight').show(400);
+    $('.arrowComp').hide();
 });
 
 // Function for showing content for all moments
 $(document).on('click', '.showAll', function () {
     $('.moment').nextUntil('.moment').show(400);
-    $('.moment').children('.arrowRight').slideToggle();
-    $('.moment').children('.arrowComp').slideToggle();
     $('.hideAll').show();
     $('.showAll').hide();
+    $('.arrowRight').hide(400);
+    $('.arrowComp').show();
 });
 
 // Function for showing content for all sections
 $(document).on('click', '.showAll', function () {
     $('.section').nextUntil('.section').show(400);
-    $('.section').children('.arrowRight').slideToggle();
-    $('.section').children('.arrowComp').slideToggle();
     $('.hideAll').show();
     $('.showAll').hide();
+    $('.arrowRight').hide();
+    $('.arrowComp').show(400);
 });
 
 // Function to prevent collapsing when clicking icons


### PR DESCRIPTION
The arrows now toggle correctly in sectioned. If a section is already
hidden when you collapse all content the arrow stays to show it's
hidden.
Solves issue #3836