### PR TITLE
Enter now works in Linux and Windows

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -256,6 +256,15 @@
                     }
                 };
 
+                $(document).ready(function() {
+                    $(window).keydown(function(event){
+                        if(event.keyCode === 13) {
+                            event.preventDefault();
+                            return false;
+                        }
+                    });
+                });
+
                 /* You want to be able to press enter to continue, this function fixes this. */
                 document.addEventListener("keydown", function(e) {
                     if(e.keyCode === 13){


### PR DESCRIPTION
Pressing enter to move on in installation should now work on different browsers in different operating systems.