### PR TITLE
when collapsing tables in fileed now only one icon is showed at a time

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -61,9 +61,14 @@ function makeSortable(table) {
                 }, DELAY);
             } else {
                 clearTimeout(timer);
-                $(this).closest('table').find('tbody').fadeToggle();
-                $('.arrowRight', this).slideToggle();
-                $('.arrowComp', this).slideToggle();  //perform double-click action
+                $(this).closest('table').find('tbody').fadeToggle(500,'linear'); //perform double-click action
+                if($('.arrowRight', this).css('display') == 'none'){
+                	$('.arrowRight', this).delay(200).slideToggle(300,'linear');
+    	            $('.arrowComp', this).slideToggle(300,'linear');	
+				}else{
+					$('.arrowRight', this).slideToggle(300,'linear');
+                	$('.arrowComp', this).delay(200).slideToggle(300,'linear');
+				}
                 clicks = 0;             //after action performed, reset counter
             }
         });


### PR DESCRIPTION
Is #3448 wants only one icon to be showed at one time in the transition when collapsing och compacting the tables. 
Added a jQuery .delay so both icons is not visible at the same time. This would make the table headers hop.

You can see the result at my folder in fileed.
Note that the icon transistion is only runned when you dblclick on the icon. This got strangely changed last week although no code for the toggle whas changed. I think we should add a issue for that.