### PR TITLE
Now Show/hide all transforms properly

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -717,14 +717,14 @@ function returnedSection(data)
 
         	str+="</div>";
 
-        	str+="<div class='hideAll' id='course-showhide-text' style='position:absolute; cursor: pointer; left:25px; margin-top: 10px; display: flex;' >";
+        	str+="<div class='hideAll' id='course-showhide-text' style='position:absolute; cursor: pointer; margin-top: 10px; display: flex;' >";
 			str+="<text class='showhidetext' >"+showhideall+"</text>";
         	str+="</div>";
 
         	str+="<div class='showhide' id='course-showhide' value='Show/Hide all' style='display:none; position:absolute;  cursor: pointer; left:10px; margin-top: 10px;' ><img src='../Shared/icons/right_complement.svg' class='arrowRight'><img src='../Shared/icons/desc_complement.svg' class='arrowComp' style='display:none'>";
         	str+="</div>";
 
-        	str+="<div class='showAll' id='course-showhide-text' style='display:none; position:absolute;  cursor: pointer; left:25px; margin-top: 10px;' >";
+        	str+="<div class='showAll' id='course-showhide-text' style='display:none; position:absolute;  cursor: pointer; margin-top: 10px;' >";
         	str+="<text class='showhidetext' >"+showhideall+"</text>";
 
         	str+="</div>";


### PR DESCRIPTION
When window is re-sized down it transforms and still keep a position to the left. Solves issue #3938