### PR TITLE
The breakline issue in markdown.js and showdoc.php is now fixed

### DIFF
--- a/DuggaSys/showdoc.php
+++ b/DuggaSys/showdoc.php
@@ -88,6 +88,10 @@
                     $markdown .= "<br>";
                 }
             }
+            // close table
+            if(!isTable($currentLine) && !isTable($nextLine)){
+                $markdown .= "</tbody></table>";
+            }
 			return $markdown;
 		}
         // Check if its an ordered list
@@ -207,11 +211,6 @@
                     }
                     $markdown .= "</tr>";
                 }
-            }
-
-            // close table
-            if(!isTable($nextLine)) {
-                $markdown .= "</tbody></table>";
             }
             return $markdown;
         }

--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -26,6 +26,11 @@ Hello! 3
 Hello! 3
 ~~~
 
+| Header 1 | Header 2 | Header 3 |
+| -------- | -------: | :------: |
+| Item 1 | ****Item 2**** | Item 3 |
+| Item 4 | Item 5 | Item 6 |
+| Item 7 | Item 8 | Item 9 |
 
 ****Unordered list****
 * item 1*
@@ -56,3 +61,9 @@ Hello! 3
     3. item 1.
   3. item 1.
 * item 6*
+
+| Header 1 | Header 2 | Header 3 |
+| -------- | -------: | :------: |
+| Item 1 | ****Item 2**** | Item 3 |
+| Item 4 | Item 5 | Item 6 |
+| Item 7 | Item 8 | Item 9 |

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -161,13 +161,16 @@ function identifier(prevLine, currentLine, markdown, nextLine){
     }
     // handle tables
     else if(isTable(currentLine)) {
-    	markdown += handleTable(currentLine, prevLine, nextLine);
+        markdown += handleTable(currentLine, prevLine, nextLine);
     }
     // If its ordinary text then show it directly
     else {
         markdown += markdownBlock(currentLine);
     }
-
+    // close table
+    if(!isTable(currentLine) && !isTable(nextLine)){
+        markdown += "</tbody></table>";
+    }
     return markdown;
 }
 // Check if its an unordered list
@@ -235,8 +238,8 @@ function handleLists(currentLine, prevLine, nextLine) {
         }
     }
     // Close list
-    if(!isOrderdList(nextLine) && isOrderdList(currentLine) && !isUnorderdList(nextLine)) markdown += "</ol>"; // Close ordered list
-    if(!isUnorderdList(nextLine) && isUnorderdList(currentLine) && !isOrderdList(nextLine)) markdown += "</ul>"; // Close unordered list
+    if(!isOrderdList(nextLine) && isOrderdList(currentLine) && !isUnorderdList(nextLine) && !isTable(nextLine)) markdown += "</ol>"; // Close ordered list
+    if(!isUnorderdList(nextLine) && isUnorderdList(currentLine) && !isOrderdList(nextLine) && !isTable(nextLine)) markdown += "</ul>"; // Close unordered list
     return markdown;
 }
 function handleTable(currentLine, prevLine, nextLine) {
@@ -290,10 +293,6 @@ function handleTable(currentLine, prevLine, nextLine) {
                 markdown += "</thead><tbody>";
             }
         }
-    }
-    // close table
-    if(!isTable(nextLine)) {
-        markdown += "</tbody></table>";
     }
     return markdown;
 }


### PR DESCRIPTION
Changed syntax for tables to eliminate the breakline issue from tables. #3964