### PR TITLE
Added "(No group)" and hover text

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1023,6 +1023,9 @@ function returnedSection(data)
             if('group' in item){
               str+="<td class='moment' style='text-align:right;padding-right:7px;'>("+item['group']['name']+")</td>";
             }
+            else{
+              str+="<td class='moment' style='text-align:right;padding-right:7px;'><span class='tooltip'><span class='tooltiptext'>Contact your teacher</span>(No group)</span></td>";
+            }
           }
         }
         

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -444,6 +444,24 @@ p {
   width: 49%;
 }
 
+.tooltip{
+  line-height: 32px;
+}
+
+.tooltiptext{
+  display: none;
+  width: 160px;
+  background-color: #614875;
+  color: white;
+  text-align: center;
+  border-radius: 6px;
+  margin: 0 5px;
+}
+
+.tooltip:hover .tooltiptext {
+  display: inline-block;
+}
+
 /* --------------================################================-------------- *
  *                                    Header                                    *
  * --------------================################================-------------- */


### PR DESCRIPTION
If student doesn't belong to a group the text "(No group)" should appear instead of the groupname. If you hover over the text a message should appear. Fix for #3974.