### PR TITLE
Makes 'name' in usergroup not UNIQUE

### DIFF
--- a/install/SQL/changes.txt
+++ b/install/SQL/changes.txt
@@ -77,3 +77,7 @@ Added rows to 'vers' to have a start date and end date to a version of a course
 /* Updated courseexample to match the current version of the course */
 INSERT INTO codeexample ... (1,'PHP Example 1',"PHP Startup","PHP_Ex1.php",1,2013,'2','1',1,1); # Old version
 INSERT INTO codeexample ... (1,'PHP Example 1',"PHP Startup","PHP_Ex1.php",1,45656,'2','1',1,1); # New version
+
+Made ´name´ in usergroup not unique
+	´name´ varchar(255) NOT NULL UNIQUE #Old version
+	´name´ varchar(255) NOT NULL #New version

--- a/install/SQL/init_db.sql
+++ b/install/SQL/init_db.sql
@@ -490,7 +490,7 @@ CREATE TABLE user_push_registration (
 CREATE TABLE `usergroup` (
   `ugid` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   `lid` int(10) UNSIGNED NOT NULL,
-  `name` varchar(255) NOT NULL UNIQUE,
+  `name` varchar(255) NOT NULL,
   `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `lastupdated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`ugid`,`lid`),


### PR DESCRIPTION
Changed 'name' in 'usergroup' table to be not unique anymore. The reason is because usergroups are connected to lid(listentry id)  and therefore it should be possible to have the same name on groups, but the groups still need to have different lid to be able to have the same name. If 'name' would be unique it would not be possible to have 2 groups with the name 'A' for example. It is not needed to change PRIMARY KEY in 'usergroup' table. (Fixes issue #3963)