### PR TITLE
Fix for issue #3601 - switched link to preview of uploaded file from preview button to file link and vice versa

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1034,9 +1034,9 @@ function findfilevers(filez,cfield,ctype,displaystate)
 							tab+="</td>";
 							tab+="<td style='padding:4px;'>";
                             if (ctype == "link"){
-                                    tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);'>"+filez[i].content+"</span>";
+                                    tab+="<span style='cursor: pointer;text-decoration:underline;'  onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);'>"+filez[i].content+"</span>";
 							} else {
-                                    tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);'>"+filez[i].filename+"."+filez[i].extension+"</span>";
+                                    tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);' style='cursor: pointer;text-decoration:underline;'>"+filez[i].filename+"."+filez[i].extension+"</span>";
 							}
 							tab+="</td><td style='padding:4px;'>";
 							tab+=filez[i].updtime;+"</td>";

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1025,15 +1025,18 @@ function findfilevers(filez,cfield,ctype,displaystate)
 							tab+="<tr'>"
 
 							tab+="<td style='padding:4px'>";
-							// Button for making / viewing feedback - note - only button for given feedback to students.
-							tab+="<button onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);'>P</button>";
-							tab+="</td>";
-
-							tab+="<td style='padding:4px;'>";
+							// Button for making / viewing feedback - note - only button for given feedback to students.			
 							if (ctype == "link"){
-									tab+="<a href='"+filez[i].content+"' >"+filez[i].content+"</a>";
+									tab+="<a href='"+filez[i].content+"' ><button>P</button></a>";
 							} else {
-									tab+="<a href='"+filelink+"' >"+filez[i].filename+"."+filez[i].extension+"</a>";
+									tab+="<a href='"+filelink+"' ><button>P</button></a>";
+							}
+							tab+="</td>";
+							tab+="<td style='padding:4px;'>";
+                            if (ctype == "link"){
+                                    tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);'>"+filez[i].content+"</span>";
+							} else {
+                                    tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);'>"+filez[i].filename+"."+filez[i].extension+"</span>";
 							}
 							tab+="</td><td style='padding:4px;'>";
 							tab+=filez[i].updtime;+"</td>";


### PR DESCRIPTION
Previously the preview has used the preview button to preview the uploaded file and clicking on the name of the uploaded file would give a link to the file in a separate window. A switch between these links was suggested and have been implemented in this pull request.

