### PR TITLE
Made it possible to change a group assignment dropdown twice

### DIFF
--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -427,6 +427,9 @@ function changegroup(changedElement) {
 	
 	// This AJAXService will map uid to ugid in user_usergroup
 	AJAXService("UPDATEGROUP", data, "GROUP");
+
+	// Update the ID of the element 
+	changedElement.id = (value > 0) ? uid+"_"+lid+"_"+value : uid+"_"+lid; 
 }
 
 function resort()


### PR DESCRIPTION
This allows the user to change the group assignment one more time after the first time, without
having to refreshing the page. This is achieved by updating the ID of the changed element (and those are later thrown into the service file for database update)