### PR TITLE
Made it possible to create new groups with 'Manage groups'

### DIFF
--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -261,7 +261,7 @@ function drawtable(){
 	
 	str+="<div class='titles' style='padding-bottom:10px;'>";
 	str+="<h1 style='flex:10;text-align:center;'>Groups</h1>";
-	str+="<input style='float:none;flex:1;max-width:85px;' class='submit-button' type='button' value='New Group' onclick='selectGroup();'/>";
+	str+="<input style='float:none;flex:1;max-width:125px;' class='submit-button' type='button' value='Manage Groups' onclick='selectGroup();'/>";
 	str+="</div>";
 
 	// Create the table headers. 
@@ -339,7 +339,7 @@ function selectGroup()
 {
 	var inp = "";
 	for(i=0; i<moments.length; i++){
-		inp+="<option value='i'>"+moments[i].entryname+"</option>";
+		inp+="<option value="+moments[i].lid+">"+moments[i].entryname+"</option>";
 	}
 	document.getElementById("selectMoment").innerHTML=inp;
 	
@@ -350,17 +350,32 @@ function selectGroup()
 
 function createGroup()
 {
-	name=$("#name").val(); 
-	if(name){
-		AJAXService("NEWGROUP",{name:name},"GROUP"); 
+	var chosenMoment=$("#selectMoment").val();
+	var nameType=$("#nameType").val(); 
+	var numberOfGroups=$("#numberOfGroups").val(); 
+		
+	if(numberOfGroups > 0){
+		if(nameType == "a"){
+			//lägg till möjlighet att lägga in bokstäver istället för siffror i databasen
+			alert("Work in progress");
+		}
+		else{
+			for(var groupName=1;groupName<= numberOfGroups;groupName++){
+				data = {
+					'chosenMoment':chosenMoment,
+					'groupName':groupName
+				};
+				AJAXService("NEWGROUP",data,"GROUP");
+			}
+		}		
 		$("#groupSection").css("display","none");
-		$("#groupNameError").css("display","none");
+		$("#numberOfGroupsError").css("display","none");
 		$("#overlay").css("display","none");
-		$("#name").val('');
-		window.location.reload();	
+		//$("#name").val('');
+		window.location.reload();
 	}
 	else{
-		$("#groupNameError").css("display","block");
+		$("#numberOfGroupsError").css("display","block");
 	}
 }
 

--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -351,13 +351,26 @@ function createGroup()
 	var chosenMoment=$("#selectMoment").val();
 	var nameType=$("#nameType").val(); 
 	var numberOfGroups=$("#numberOfGroups").val(); 
-	var beginOfLettersUnicode = 65;
+	var offsetLetter=0;
 	
 	if(numberOfGroups > 0){
 		if(nameType == "a"){
-			var numbersOfLetters = +numberOfGroups+beginOfLettersUnicode;
-			for(var i=65;i<numbersOfLetters; i++){
-				var groupLetter = String.fromCharCode(i);
+			for(var lidGroup in availablegroups) {	//get lid of each group
+				for(var groupArray in availablegroups[lidGroup]) { // Get each group, both name and ugid 
+					for(var groupNames in availablegroups[lidGroup][groupArray]) { // Get name of each group
+						for(var a=65;a<90; a++){  //loop through capital letters
+							var groupLetter = String.fromCharCode(a);
+							if(availablegroups[lidGroup][groupArray][groupNames] == groupLetter && lidGroup==chosenMoment){ //Check if groupname is the same as capital letter and lid is the same as the chosen moment
+								offsetLetter++;
+							}
+						}
+					}
+				}
+			}
+			var startLetter = +offsetLetter+65;
+			var numbersOfLetters = +numberOfGroups+startLetter;
+			for(startLetter;startLetter<numbersOfLetters; startLetter++){
+				var groupLetter = String.fromCharCode(startLetter);
 				data = {
 					'chosenMoment':chosenMoment,
 					'groupName':groupLetter
@@ -377,7 +390,6 @@ function createGroup()
 		$("#groupSection").css("display","none");
 		$("#numberOfGroupsError").css("display","none");
 		$("#overlay").css("display","none");
-		//$("#name").val('');
 		window.location.reload();
 	}
 	else{

--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -353,11 +353,19 @@ function createGroup()
 	var chosenMoment=$("#selectMoment").val();
 	var nameType=$("#nameType").val(); 
 	var numberOfGroups=$("#numberOfGroups").val(); 
-		
+	var beginOfLettersUnicode = 65;
+	
 	if(numberOfGroups > 0){
 		if(nameType == "a"){
-			//lägg till möjlighet att lägga in bokstäver istället för siffror i databasen
-			alert("Work in progress");
+			var numbersOfLetters = +numberOfGroups+beginOfLettersUnicode;
+			for(var i=65;i<numbersOfLetters; i++){
+				var groupLetter = String.fromCharCode(i);
+				data = {
+					'chosenMoment':chosenMoment,
+					'groupName':groupLetter
+				};
+				AJAXService("NEWGROUP",data,"GROUP");
+			}
 		}
 		else{
 			for(var groupName=1;groupName<= numberOfGroups;groupName++){

--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -383,7 +383,6 @@ function createGroup()
 			for(var lidGroup in availablegroups) {	//get lid of each group
 				for(var groupArray in availablegroups[lidGroup]) { // Get each group, both name and ugid 
 					for(var groupNames in availablegroups[lidGroup][groupArray]) { // Get name of each group
-						//console.log(availablegroups[lidGroup][groupArray].length);
 						for(var a=0;a<groupNames; a++){  //loop through capital letters
 							if(availablegroups[lidGroup][groupArray][groupNames] == a && lidGroup==chosenMoment){ //Check if groupname is the same as capital letter and lid is the same as the chosen moment
 								offsetNumber++;
@@ -401,6 +400,7 @@ function createGroup()
 				AJAXService("NEWGROUP",data,"GROUP");
 			}
 		}		
+		$("#numberOfGroups").val('');
 		$("#groupSection").css("display","none");
 		$("#numberOfGroupsError").css("display","none");
 		$("#overlay").css("display","none");
@@ -410,7 +410,13 @@ function createGroup()
 		$("#numberOfGroupsError").css("display","block");
 	}
 }
-
+function clearGroupWindow(){
+	$("#numberOfGroups").val('');
+	$("#nameType").val('a');
+	$("#selectMoment").val(0);
+	$("#numberOfGroupsError").css("display","none");
+	
+}
 function returnedGroup(data)
 {
 	var headings = data.headings;

--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -352,6 +352,7 @@ function createGroup()
 	var nameType=$("#nameType").val(); 
 	var numberOfGroups=$("#numberOfGroups").val(); 
 	var offsetLetter=0;
+	var offsetNumber = 1;
 	
 	if(numberOfGroups > 0){
 		if(nameType == "a"){
@@ -379,10 +380,23 @@ function createGroup()
 			}
 		}
 		else{
-			for(var groupName=1;groupName<= numberOfGroups;groupName++){
+			for(var lidGroup in availablegroups) {	//get lid of each group
+				for(var groupArray in availablegroups[lidGroup]) { // Get each group, both name and ugid 
+					for(var groupNames in availablegroups[lidGroup][groupArray]) { // Get name of each group
+						//console.log(availablegroups[lidGroup][groupArray].length);
+						for(var a=0;a<groupNames; a++){  //loop through capital letters
+							if(availablegroups[lidGroup][groupArray][groupNames] == a && lidGroup==chosenMoment){ //Check if groupname is the same as capital letter and lid is the same as the chosen moment
+								offsetNumber++;
+							}
+						}
+					}
+				}
+			}
+			var totalNumberOfGroups = parseInt(offsetNumber)+parseInt(numberOfGroups);
+			for(offsetNumber;offsetNumber< totalNumberOfGroups;offsetNumber++){
 				data = {
 					'chosenMoment':chosenMoment,
-					'groupName':groupName
+					'groupName':offsetNumber
 				};
 				AJAXService("NEWGROUP",data,"GROUP");
 			}

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -62,7 +62,7 @@
 		</div>
 		<p style="display:none; color:red;" id="numberOfGroupsError">You have to assign how many groups should be created.</p> 
 		<div style='padding:5px;'>
-			<input style='float:none; display: inline-block;' class='submit-button ' type='button' value='Cancel' onclick='closeWindows();' /> 
+			<input style='float:none; display: inline-block;' class='submit-button ' type='button' value='Cancel' onclick='closeWindows();clearGroupWindow();' /> 
 			<input style='margin-left: 40px; float:none; display: inline-block;' class='submit-button' type='button' value='Submit' onclick='createGroup();' /> 
 		</div>
 	</div>

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -53,7 +53,7 @@
 				<select id='selectMoment' style='float:none; width:100%; margin: 8px 0px;'>
 				</select><br/>
 				<select id="nameType" style='float:none; width:100%;'>
-					<option value="a">Letters (a,b,c,...)</option>
+					<option value="a">Letters (A,B,C,...)</option>
 					<option value="1">Numbers (1,2,3,...)</option>
 				</select><br/>
 				<input id="numberOfGroups" type="number" placeholder="  Amount of groups" style='float:none; width:271px; height:24px; margin: 8px 0px;' min="0" max="26"/><br/>

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -46,7 +46,7 @@
 	<div id='groupSection' class='loginBox' style='width:285px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Manage Groups</h3>
-			<div onclick='closeWindows();'>x</div>
+			<div onclick='closeWindows();clearGroupWindow();'>x</div>
 		</div>
 		<div style='padding:5px;'>
 			<div id='inputwrapper-name' class='inputwrapper' style='display:inline-block;'>

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -52,15 +52,15 @@
 			<div id='inputwrapper-name' class='inputwrapper' style='display:inline-block;'>
 				<select id='selectMoment' style='float:none; width:100%; margin: 8px 0px;'>
 				</select><br/>
-				<select style='float:none; width:100%;'>
+				<select id="nameType" style='float:none; width:100%;'>
 					<option value="a">a-z</option>
 					<option value="1">1-</option>
 				</select><br/>
-				<input type="number" placeholder="  Amount of groups" style='float:none; width:271px; height:24px; margin: 8px 0px;'/><br/>
+				<input id="numberOfGroups" type="number" placeholder="  Amount of groups" style='float:none; width:271px; height:24px; margin: 8px 0px;' min="0"/><br/>
 				<!-- <span>Name:</span><input style='float:none; margin-left: 5px;' type='text' class='textinput' id='name' placeholder='Name' /> -->
 			</div>
 		</div>
-		<p style="display:none; color:red;" id="groupNameError">Du måste ange ett namn för att skapa en grupp.</p>
+		<p style="display:none; color:red;" id="numberOfGroupsError">Du måste hur många grupper du vill skapa.</p> 
 		<div style='padding:5px;'>
 			<input style='float:none; display: inline-block;' class='submit-button ' type='button' value='Cancel' onclick='closeWindows();' /> 
 			<input style='margin-left: 40px; float:none; display: inline-block;' class='submit-button' type='button' value='Submit' onclick='createGroup();' /> 

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -60,7 +60,7 @@
 				<!-- <span>Name:</span><input style='float:none; margin-left: 5px;' type='text' class='textinput' id='name' placeholder='Name' /> -->
 			</div>
 		</div>
-		<p style="display:none; color:red;" id="numberOfGroupsError">Du måste hur många grupper du vill skapa.</p> 
+		<p style="display:none; color:red;" id="numberOfGroupsError">You have to assign how many groups should be created.</p> 
 		<div style='padding:5px;'>
 			<input style='float:none; display: inline-block;' class='submit-button ' type='button' value='Cancel' onclick='closeWindows();' /> 
 			<input style='margin-left: 40px; float:none; display: inline-block;' class='submit-button' type='button' value='Submit' onclick='createGroup();' /> 

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -53,10 +53,10 @@
 				<select id='selectMoment' style='float:none; width:100%; margin: 8px 0px;'>
 				</select><br/>
 				<select id="nameType" style='float:none; width:100%;'>
-					<option value="a">a-z</option>
-					<option value="1">1-</option>
+					<option value="a">Letters (a,b,c,...)</option>
+					<option value="1">Numbers (1,2,3,...)</option>
 				</select><br/>
-				<input id="numberOfGroups" type="number" placeholder="  Amount of groups" style='float:none; width:271px; height:24px; margin: 8px 0px;' min="0"/><br/>
+				<input id="numberOfGroups" type="number" placeholder="  Amount of groups" style='float:none; width:271px; height:24px; margin: 8px 0px;' min="0" max="26"/><br/>
 				<!-- <span>Name:</span><input style='float:none; margin-left: 5px;' type='text' class='textinput' id='name' placeholder='Name' /> -->
 			</div>
 		</div>

--- a/DuggaSys/groupedservice.php
+++ b/DuggaSys/groupedservice.php
@@ -29,7 +29,8 @@ $cid = getOP('cid'); // Course id
 $vers = getOP('vers'); // Course version
 
 // When using opt NEWGROUP
-$name=getOP("name"); // Name (when creating a new group)
+$chosenMoment=getOP("chosenMoment"); // Moment (when creating new  groups, lid needs to be connected)
+$groupName=getOP("groupName"); // Name on group (when creating new groups, a name is needed)
 
 // When using opt UPDATEGROUP
 $uid = getOP('uid'); // User id
@@ -45,7 +46,7 @@ $debug="NONE!";
 
 // Create arguments for log
 $log_uuid = getOP('log_uuid'); // Cookie id or something.. 
-$info=$opt." ".$cid." ".$vers." ".$name." ".$uid." ".$lid." ".$oldUgid." ".$newUgid;
+$info=$opt." ".$cid." ".$vers." ".$groupName." ".$uid." ".$lid." ".$oldUgid." ".$newUgid;
 
 // Log the start event of this service query. This is logged in log.db (not MySQL)
 logServiceEvent($log_uuid, EventTypes::ServiceServerStart, __FILE__, $userid, $info);
@@ -168,8 +169,9 @@ if(strcmp($opt,"GET")==0){
 
  	}
 } else if(strcmp($opt,"NEWGROUP")==0){
-	$query = $pdo->prepare("INSERT INTO `usergroup` (`ugid`, `name`, `created`, `lastupdated`) VALUES (DEFAULT, :name, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"); 
-	$query->bindParam(':name', $name);
+	$query = $pdo->prepare("INSERT INTO usergroup (ugid,name,lid,created,lastupdated) VALUES (DEFAULT, :groupName,:chosenMoment,CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"); 
+	$query->bindParam(':chosenMoment', $chosenMoment);
+	$query->bindParam(':groupName', $groupName);
 
 	if(!$query->execute()) {
 		$error=$query->errorInfo();
@@ -180,8 +182,9 @@ if(strcmp($opt,"GET")==0){
 				$codeexamples,
 				array(
 					'ugid' => (int)$row['ugid'],
-					'name' => $row['name'],
+					'name' => $row['groupName'],
 					'created' => $row['created'],
+					'lid' => (int)$row['chosenMoment'],
 					'lastupdated' => $row['lastupdated']
 				)
 			);


### PR DESCRIPTION
New groups are now able to be created with 'Manage Groups'. The groups can either have capital letters or numbers as names. The teacher that makes groups will not have to name all groups, the names will be created automatically.(Fixes issue #3675 )