### PR TITLE
Created a limit on how many new groups can be added with letters as name

### DIFF
--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -353,13 +353,14 @@ function createGroup()
 	var numberOfGroups=$("#numberOfGroups").val(); 
 	var offsetLetter=0;
 	var offsetNumber = 1;
+	var groupError = false;
 	
 	if(numberOfGroups > 0){
 		if(nameType == "a"){
 			for(var lidGroup in availablegroups) {	//get lid of each group
 				for(var groupArray in availablegroups[lidGroup]) { // Get each group, both name and ugid 
 					for(var groupNames in availablegroups[lidGroup][groupArray]) { // Get name of each group
-						for(var a=65;a<90; a++){  //loop through capital letters
+						for(var a=65;a<=90; a++){  //loop through capital letters
 							var groupLetter = String.fromCharCode(a);
 							if(availablegroups[lidGroup][groupArray][groupNames] == groupLetter && lidGroup==chosenMoment){ //Check if groupname is the same as capital letter and lid is the same as the chosen moment
 								offsetLetter++;
@@ -371,12 +372,18 @@ function createGroup()
 			var startLetter = +offsetLetter+65;
 			var numbersOfLetters = +numberOfGroups+startLetter;
 			for(startLetter;startLetter<numbersOfLetters; startLetter++){
-				var groupLetter = String.fromCharCode(startLetter);
-				data = {
-					'chosenMoment':chosenMoment,
-					'groupName':groupLetter
-				};
-				AJAXService("NEWGROUP",data,"GROUP");
+				if(startLetter<= 90){
+					var groupLetter = String.fromCharCode(startLetter);
+					data = {
+						'chosenMoment':chosenMoment,
+						'groupName':groupLetter
+					};
+					AJAXService("NEWGROUP",data,"GROUP");
+					groupError=false;
+				}
+				else{
+					groupError=true;
+				}
 			}
 		}
 		else{
@@ -403,8 +410,15 @@ function createGroup()
 		$("#numberOfGroups").val('');
 		$("#groupSection").css("display","none");
 		$("#numberOfGroupsError").css("display","none");
+		$("#toManyCreatedGroups").css("display","none");
 		$("#overlay").css("display","none");
-		window.location.reload();
+		if(groupError == true){
+			$("#toManyCreatedGroups").css("display","inline-block");
+			$("#overlay").css("display","block");
+		}
+		else{
+			window.location.reload();
+		}
 	}
 	else{
 		$("#numberOfGroupsError").css("display","block");
@@ -415,7 +429,12 @@ function clearGroupWindow(){
 	$("#nameType").val('a');
 	$("#selectMoment").val(0);
 	$("#numberOfGroupsError").css("display","none");
-	
+}
+
+function closeGroupLimit(){
+	$("#toManyCreatedGroups").css("display","none");
+	$("#overlay").css("display","none");
+	window.location.reload();
 }
 function returnedGroup(data)
 {

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -61,12 +61,24 @@
 			</div>
 		</div>
 		<p style="display:none; color:red;" id="numberOfGroupsError">You have to assign how many groups should be created.</p> 
+		<p style="display:none; color:red;" id="toManyCreatedGroupsError">You have created a maximum amount of groups.</p> 
 		<div style='padding:5px;'>
 			<input style='float:none; display: inline-block;' class='submit-button ' type='button' value='Cancel' onclick='closeWindows();clearGroupWindow();' /> 
 			<input style='margin-left: 40px; float:none; display: inline-block;' class='submit-button' type='button' value='Submit' onclick='createGroup();' /> 
 		</div>
 	</div>
 	<!-- Create Group Dialog END -->
-
+	<!-- Maximum of Groups Dialog START -->
+	<div id='toManyCreatedGroups' class='loginBox' style='width:285px;display:none;'>
+		<div class='loginBoxheader'>
+			<h3>Manage Groups</h3>
+			<div onclick='closeGroupLimit();'>x</div>
+		</div>
+		<p style="display:inline-block; color:red;">You have created a maximum amount of groups.</p> 
+		<div style='padding:5px;'>
+			<input style='margin-left: 40px; float:none; display: inline-block;' class='submit-button' type='button' value='OK' onclick='closeGroupLimit();' /> 
+		</div>
+	</div>
+	<!-- Maximum of Groups Dialog END -->
 </body>
 </html>


### PR DESCRIPTION
Added a check to see if the user tries to add more groups than there are capital letters. If a user tries to add more groups a pop-up will appear. This makes it not create groups with weird names like "[" or "/". (Fixes issue #4037)