### PR TITLE
Changed offset value to make the magic headings appear earlier.

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -866,7 +866,7 @@ function sorttype(t){
 function magicHeading()
 {
     // Display Magic Headings when scrolling
-    if(window.pageYOffset-10>$("#subheading").offset().top){
+    if(window.pageYOffset+15>$("#subheading").offset().top){
         $("#upperDecker").css("display","block");
     }else{
         $("#upperDecker").css("display","none");            


### PR DESCRIPTION
Change offset to +15 instead of -10 making the magic heading appear as
soon as the header text dissapears on the screen.