### PR TITLE
markdown.js now supports styles in tables which are bold, italic and code.

### DIFF
--- a/DuggaSys/templates/PHP_Ex2.txt
+++ b/DuggaSys/templates/PHP_Ex2.txt
@@ -28,9 +28,9 @@ Hello! 3
 
 | Header 1 | Header 2 | Header 3 |
 | -------- | -------: | :------: |
-| Item 1 | ****Item 2**** | Item 3 |
+| Item 1 | Item 2 | Item 3 |
 | Item 4 | Item 5 | Item 6 |
-| Item 7 | Item 8 | Item 9 |
+| Item 7 | **Item 8** | Item 9 |
 
 ****Unordered list****
 * item 1*
@@ -64,6 +64,6 @@ Hello! 3
 
 | Header 1 | Header 2 | Header 3 |
 | -------- | -------: | :------: |
-| Item 1 | ****Item 2**** | Item 3 |
+| Item 1 | *Item 2* | `Item 3`|
 | Item 4 | Item 5 | Item 6 |
 | Item 7 | Item 8 | Item 9 |

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -283,8 +283,16 @@ function handleTable(currentLine, prevLine, nextLine) {
                 if(tableAlignmentConf[i] === 1) alignment = "center";
                 else if(tableAlignmentConf[i] === 2) alignment = "right";
                 else alignment = "left";
+				if(columns[i].trim().match(/^[*].{1}\s*(.*)[*].{1}/gm)){
+                    markdown += "<td style='text-align: " + alignment + ";font-weight:bold;'>" + columns[i].trim().replace(/[*].{1}/gm, '') + "</td>";
+				}else if(columns[i].trim().match(/^[*].{0}\s*(.*)[*].{0}/gm)){
+                    markdown += "<td style='text-align: " + alignment + ";font-style:italic'>" + columns[i].trim().replace(/[*].{0}/gm, '') + "</td>";
+                }else if(columns[i].trim().match(/^[`].{0}\s*(.*)[`].{0}/gm)){
+                    markdown += "<td style='text-align: " + alignment + ";'><code style='border-radius: 3px; display: inline-block; color: white; background: darkgray; padding: 2px;''>" + columns[i].trim().replace(/[`].{0}/gm, '') + "</code></td>";
+                } else{
+                    markdown += "<td style='text-align: " + alignment + ";'>" + columns[i].trim() + "</td>";
+                }
 
-                markdown += "<td style='text-align: " + alignment + ";'>" + columns[i].trim() + "</td>";
             }
             markdown += "</tr>";
 


### PR DESCRIPTION
The markdown.js tables support those styles
<img width="286" alt="skarmavbild 2017-05-22 kl 10 26 49" src="https://cloud.githubusercontent.com/assets/26706764/26298943/52c2fe7c-3ed9-11e7-8d55-c7a1f06e82ab.png">
Please do not close issue! #2648 
