### PR TITLE
showdoc.php now supports table styles according to markdown cheatsheet

### DIFF
--- a/DuggaSys/showdoc.php
+++ b/DuggaSys/showdoc.php
@@ -206,8 +206,15 @@
                         if($tableAlignmentConf[$i] === 1) $alignment = "center";
                         else if($tableAlignmentConf[$i] === 2) $alignment = "right";
                         else $alignment = "left";
-
-                        $markdown .= "<td style='text-align: " . $alignment . ";'>" . $columns[$i] . "</td>";
+                        if(preg_match('/^[*].{1}\s*(.*)[*].{1}/',$columns[$i])){
+                            $markdown .= "<td style='text-align: " . $alignment . ";font-weight:bold;'>" . preg_replace('/[*].{1}/', '', $columns[$i]) . "</td>";
+						}else if(preg_match('/^[*].{0}\s*(.*)[*].{0}/',$columns[$i])){
+                            $markdown .= "<td style='text-align: " . $alignment . ";font-style:italic'>" . preg_replace('/[*].{0}/', '', $columns[$i]) . "</td>";
+                		}else if(preg_match('/^[`].{0}\s*(.*)[`].{0}/',$columns[$i])){
+                            $markdown .= "<td style='text-align: " . $alignment . ";'><code style='border-radius: 3px; display: inline-block; color: white; background: darkgray; padding: 2px;''>" . preg_replace('/[`].{0}/', '', $columns[$i]) . "</code></td>";
+                		}else{
+                    		$markdown .= "<td style='text-align: " . $alignment . ";'>" . $columns[$i] . "</td>";
+               			}
                     }
                     $markdown .= "</tr>";
                 }

--- a/lenasys-markdown.txt
+++ b/lenasys-markdown.txt
@@ -74,7 +74,7 @@ Line break
 
 Arrow
  -> 
-(whitespace before and after) prints arrow with double head: “&rarr;”.
+(whitespace before and after) prints arrow with double head: ï¿½&rarr;ï¿½.
 
 Images
 |||src,thumbnail width in px,full size width in px|||
@@ -84,6 +84,7 @@ Tables
 |tr|
 |td|
 ||td in tr||
+| *This is italic* | **This is bold** | `This is code style` |
 
 Ellipsis
 Three or more dots should always be converted to an ellipsis.


### PR DESCRIPTION
showdoc.php now support table styles according to markdown cheatsheet 
<img width="286" alt="skarmavbild 2017-05-23 kl 07 00 03" src="https://cloud.githubusercontent.com/assets/26706764/26339074/7d665de8-3f85-11e7-8235-2e789515880f.png">
Please do not delete issue but you can delete the branch! #3193