### PR TITLE
Removed the static height of input element of 26px

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -795,7 +795,6 @@ header td {
 
 input {
   border-radius: 2px;
-  height: 26px;
   border: 2px solid #ccc;
   border-radius: 4px;
   font-size: 16px;


### PR DESCRIPTION
There was a set height for ALL inputs in the LenaSYS. Removed this hardcoded input height enforcement.
There were none set for input tags at start of the project. This made the filter menu in resulted and grouped look bad, but i fixed it!