### PR TITLE
It is now possible to remove groups in grouped.php

### DIFF
--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -11,6 +11,8 @@ var tablecontent=new Array;
 var feedback=null;
 var typechanged=false;
 var duggaArray = [[]];
+var lidOnLetterGroups=new Array;
+var lidOnNumberGroups=new Array;
 function setup(){
 	
 	var filt = "";
@@ -346,18 +348,20 @@ function selectGroup()
 	for(i=0; i<moments.length; i++){
 		inp+="<option value="+moments[i].lid+">"+moments[i].entryname+"</option>";
 	}
-	document.getElementById("selectMoment").innerHTML=inp;
+	document.getElementById("selectMomentCreate").innerHTML=inp;
+	document.getElementById("selectMomentRemove").innerHTML=inp;
 	
 	//Display pop-up
 	$("#groupSection").css("display","block");
+	$("#removeGroup").css("display","block");
 	$("#overlay").css("display","block");
 }
 
 function createGroup()
 {
-	var chosenMoment=$("#selectMoment").val();
-	var nameType=$("#nameType").val(); 
-	var numberOfGroups=$("#numberOfGroups").val(); 
+	var chosenMoment=$("#selectMomentCreate").val();
+	var nameType=$("#nameTypeCreate").val(); 
+	var numberOfGroups=$("#numberOfGroupsCreate").val(); 
 	var offsetLetter=0;
 	var offsetNumber = 1;
 	var groupError = false;
@@ -429,6 +433,80 @@ function createGroup()
 	}
 	else{
 		$("#numberOfGroupsError").css("display","block");
+	}
+}
+
+function removeGroup()
+{
+	var chosenMomentRemove=$("#selectMomentRemove").val();
+	var nameTypeRemove=$("#nameTypeRemove").val(); 
+	var numberOfGroupsRemove=$("#numberOfGroupsRemove").val(); 
+	var offsetLetter=0;
+	var offsetNumber = 1;
+	var groupError = false;
+	lidOnLetterGroups=new Array;
+	lidOnNumberGroups=new Array;
+	if(numberOfGroupsRemove > 0){
+		if(nameTypeRemove == "a"){
+			for(var lidGroup in availablegroups) {	//get lid of each group
+				for(var groupArray in availablegroups[lidGroup]) { // Get each group, both name and ugid 
+					for(var groupNames in availablegroups[lidGroup][groupArray]) { // Get name of each group
+						for(var a=90;a>=65; a--){  //loop through capital letters
+							var groupLetter = String.fromCharCode(a);
+							if(availablegroups[lidGroup][groupArray][groupNames] == groupLetter && lidGroup==chosenMomentRemove){ //Check if groupname is the same as capital letter and lid is the same as the chosen moment
+								offsetLetter++;
+								lidOnLetterGroups.push(groupNames);
+							}
+							
+						} 
+					}
+				} 
+			}
+			var tmpLetterGroup = lidOnLetterGroups.length-numberOfGroupsRemove;
+			for(tmpLetterGroup;tmpLetterGroup<lidOnLetterGroups.length; tmpLetterGroup++){
+				data = {
+					'chosenMomentRemove':chosenMomentRemove,
+					'ugidGroup':lidOnLetterGroups[tmpLetterGroup]
+				};
+				AJAXService("DELGROUP",data,"GROUP");
+			}	 
+		}
+	
+	else if(nameTypeRemove == "1"){
+			console.log("1");
+			 for(var lidGroup in availablegroups) {	//get lid of each group
+				for(var groupArray in availablegroups[lidGroup]) { // Get each group, both name and ugid 
+					for(var groupNames in availablegroups[lidGroup][groupArray]) { // Get name of each group
+						for(var a=0;a<groupNames; a++){  //loop through capital letters
+							if(availablegroups[lidGroup][groupArray][groupNames] == a && lidGroup==chosenMomentRemove){ //Check if groupname is the same as capital letter and lid is the same as the chosen moment
+								offsetNumber++;
+								lidOnNumberGroups.push(groupNames);
+							}
+						}
+					}
+				}
+			}
+			var tmpNumberGroup = lidOnNumberGroups.length-numberOfGroupsRemove;
+			for(tmpNumberGroup;tmpNumberGroup<lidOnNumberGroups.length; tmpNumberGroup++){
+				data = {
+					'chosenMomentRemove':chosenMomentRemove,
+					'ugidGroup':lidOnNumberGroups[tmpNumberGroup]
+				};
+				AJAXService("DELGROUP",data,"GROUP");
+			}
+		}		
+		$("#numberOfGroups").val('');
+		$("#groupSection").css("display","none");
+		$("#numberOfGroupsError").css("display","none");
+		$("#toManyCreatedGroups").css("display","none");
+		$("#overlay").css("display","none");
+		if(groupError == true){
+			$("#toManyCreatedGroups").css("display","inline-block");
+			$("#overlay").css("display","block");
+		}
+		else{
+			window.location.reload();
+		}
 	}
 }
 function clearGroupWindow(){

--- a/DuggaSys/grouped.js
+++ b/DuggaSys/grouped.js
@@ -11,8 +11,8 @@ var tablecontent=new Array;
 var feedback=null;
 var typechanged=false;
 var duggaArray = [[]];
-var lidOnLetterGroups=new Array;
-var lidOnNumberGroups=new Array;
+var lidOfGroupsWithLettersAsNames=new Array;
+var lidOfGroupsWithNumbersAsNames=new Array;
 function setup(){
 	
 	var filt = "";
@@ -266,7 +266,8 @@ function drawtable(){
 
 	if(tablecontent != null) {
 		str+="<div class='titles' style='padding-bottom:10px;'>";
-		str+="<input style='float:none;flex:1;max-width:125px;' class='submit-button' type='button' value='Manage Groups' onclick='selectGroup();'/>";
+		str+="<input style='float:none;flex:1;max-width:125px;' class='submit-button' type='button' value='New Groups' onclick='showCreateGroupView();'/>";
+		str+="<input style='float:none;flex:1;max-width:125px;' class='submit-button' type='button' value='Remove Groups' onclick='showRemoveGroupView();'/>";
 		str+="</div>";
 		// Init the table string. 
 		// Create the table headers. 
@@ -342,17 +343,28 @@ function drawtable(){
 	document.getElementById("content").innerHTML=str;
 }
 
-function selectGroup()
+function showCreateGroupView()
 {
 	var inp = "";
 	for(i=0; i<moments.length; i++){
 		inp+="<option value="+moments[i].lid+">"+moments[i].entryname+"</option>";
 	}
 	document.getElementById("selectMomentCreate").innerHTML=inp;
-	document.getElementById("selectMomentRemove").innerHTML=inp;
 	
 	//Display pop-up
 	$("#groupSection").css("display","block");
+	$("#overlay").css("display","block");
+}
+
+function showRemoveGroupView()
+{
+	var inp = "";
+	for(i=0; i<moments.length; i++){
+		inp+="<option value="+moments[i].lid+">"+moments[i].entryname+"</option>";
+	}
+	document.getElementById("selectMomentRemove").innerHTML=inp;
+	
+	//Display pop-up
 	$("#removeGroup").css("display","block");
 	$("#overlay").css("display","block");
 }
@@ -418,13 +430,16 @@ function createGroup()
 				AJAXService("NEWGROUP",data,"GROUP");
 			}
 		}		
-		$("#numberOfGroups").val('');
 		$("#groupSection").css("display","none");
 		$("#numberOfGroupsError").css("display","none");
 		$("#toManyCreatedGroups").css("display","none");
 		$("#overlay").css("display","none");
 		if(groupError == true){
 			$("#toManyCreatedGroups").css("display","inline-block");
+			$("#overlay").css("display","block");
+		}
+		else if(numberOfGroups == ''){
+			$("#numberOfGroupsError").css("display","block");
 			$("#overlay").css("display","block");
 		}
 		else{
@@ -443,77 +458,100 @@ function removeGroup()
 	var numberOfGroupsRemove=$("#numberOfGroupsRemove").val(); 
 	var offsetLetter=0;
 	var offsetNumber = 1;
-	var groupError = false;
-	lidOnLetterGroups=new Array;
-	lidOnNumberGroups=new Array;
+	var toManyRemovedGroups = false;
+	lidOfGroupsWithLettersAsNames=new Array; //saves lid of groups with letters as names
+	lidOfGroupsWithNumbersAsNames=new Array; //saves lid of groups with numbers as names
 	if(numberOfGroupsRemove > 0){
 		if(nameTypeRemove == "a"){
 			for(var lidGroup in availablegroups) {	//get lid of each group
 				for(var groupArray in availablegroups[lidGroup]) { // Get each group, both name and ugid 
 					for(var groupNames in availablegroups[lidGroup][groupArray]) { // Get name of each group
-						for(var a=90;a>=65; a--){  //loop through capital letters
+						for(var a=90;a>=65; a--){  //loop through capital letters backwards to be able to remove letters backwards (from Z to A)
 							var groupLetter = String.fromCharCode(a);
 							if(availablegroups[lidGroup][groupArray][groupNames] == groupLetter && lidGroup==chosenMomentRemove){ //Check if groupname is the same as capital letter and lid is the same as the chosen moment
-								offsetLetter++;
-								lidOnLetterGroups.push(groupNames);
+								offsetLetter++; //count on how many groups there are
+								lidOfGroupsWithLettersAsNames.push(groupNames);
 							}
 							
 						} 
 					}
 				} 
 			}
-			var tmpLetterGroup = lidOnLetterGroups.length-numberOfGroupsRemove;
-			for(tmpLetterGroup;tmpLetterGroup<lidOnLetterGroups.length; tmpLetterGroup++){
-				data = {
-					'chosenMomentRemove':chosenMomentRemove,
-					'ugidGroup':lidOnLetterGroups[tmpLetterGroup]
-				};
-				AJAXService("DELGROUP",data,"GROUP");
-			}	 
+			var controlsRemoveGroupsWithLetters = lidOfGroupsWithLettersAsNames.length-numberOfGroupsRemove;
+			if(controlsRemoveGroupsWithLetters >= 0){
+				for(controlsRemoveGroupsWithLetters;controlsRemoveGroupsWithLetters<lidOfGroupsWithLettersAsNames.length; controlsRemoveGroupsWithLetters++){
+					data = {
+						'chosenMomentRemove':chosenMomentRemove,
+						'ugidGroup':lidOfGroupsWithLettersAsNames[controlsRemoveGroupsWithLetters]
+					};
+					AJAXService("DELGROUP",data,"GROUP");
+				}
+			}
+			else{
+				toManyRemovedGroups = true;
+			}
 		}
 	
-	else if(nameTypeRemove == "1"){
-			console.log("1");
+		else if(nameTypeRemove == "1"){
 			 for(var lidGroup in availablegroups) {	//get lid of each group
 				for(var groupArray in availablegroups[lidGroup]) { // Get each group, both name and ugid 
 					for(var groupNames in availablegroups[lidGroup][groupArray]) { // Get name of each group
 						for(var a=0;a<groupNames; a++){  //loop through capital letters
 							if(availablegroups[lidGroup][groupArray][groupNames] == a && lidGroup==chosenMomentRemove){ //Check if groupname is the same as capital letter and lid is the same as the chosen moment
 								offsetNumber++;
-								lidOnNumberGroups.push(groupNames);
+								lidOfGroupsWithNumbersAsNames.push(groupNames);
 							}
 						}
 					}
 				}
 			}
-			var tmpNumberGroup = lidOnNumberGroups.length-numberOfGroupsRemove;
-			for(tmpNumberGroup;tmpNumberGroup<lidOnNumberGroups.length; tmpNumberGroup++){
-				data = {
-					'chosenMomentRemove':chosenMomentRemove,
-					'ugidGroup':lidOnNumberGroups[tmpNumberGroup]
-				};
-				AJAXService("DELGROUP",data,"GROUP");
+			var controlsRemoveGroupsWithNumbers = lidOfGroupsWithNumbersAsNames.length-numberOfGroupsRemove;
+			if(controlsRemoveGroupsWithNumbers >= 0){
+				for(controlsRemoveGroupsWithNumbers;controlsRemoveGroupsWithNumbers<lidOfGroupsWithNumbersAsNames.length; controlsRemoveGroupsWithNumbers++){
+					data = {
+						'chosenMomentRemove':chosenMomentRemove,
+						'ugidGroup':lidOfGroupsWithNumbersAsNames[controlsRemoveGroupsWithNumbers]
+					};
+					AJAXService("DELGROUP",data,"GROUP");
+				}
+			}
+			else{
+				toManyRemovedGroups = true;
+				
 			}
 		}		
 		$("#numberOfGroups").val('');
 		$("#groupSection").css("display","none");
 		$("#numberOfGroupsError").css("display","none");
 		$("#toManyCreatedGroups").css("display","none");
+		$("#numberOfDeletedGroupsError").css("display","none");
 		$("#overlay").css("display","none");
-		if(groupError == true){
-			$("#toManyCreatedGroups").css("display","inline-block");
+		if(toManyRemovedGroups == true){
+			$("#numberOfDeletedGroupsError").css("display","block");
 			$("#overlay").css("display","block");
 		}
 		else{
 			window.location.reload();
 		}
 	}
+	else if(numberOfGroupsRemove == ''){
+		$("#numberOfGroupsToRemoveError").css("display","inline-block");
+		$("#overlay").css("display","block");
+	}
 }
 function clearGroupWindow(){
-	$("#numberOfGroups").val('');
-	$("#nameType").val('a');
-	$("#selectMoment").val(0);
+	$("#numberOfGroupsCreate").val('');
+	$("#nameTypeCreate").val('a');
+	$("#selectMomentCreate").val(0);
 	$("#numberOfGroupsError").css("display","none");
+}
+
+function clearGroupRemoveWindow(){
+	$("#numberOfGroupsRemove").val('');
+	$("#nameTypeRemove").val('a');
+	$("#selectMomentRemove").val(0);
+	$("#numberOfGroupsError").css("display","none");
+	$("#numberOfGroupsToRemoveError").css("display","none");
 }
 
 function closeGroupLimit(){
@@ -568,7 +606,6 @@ function returnedGroup(data) {
 function changegroup(changedElement) {
 	var elementId = changedElement.id; // contains uid_lid_oldUgid (oldUgid if applicable)
 	var value = changedElement.value; // the new ugid (the value of the selected option)
-	
 	var arr = elementId.split("_");
 	var uid = arr[0];
 	var lid = arr[1];

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -43,7 +43,7 @@
 	<!-- Login Dialog END -->
 	
 	<!-- Create Group Dialog START -->
-	<div id='groupSection' class='loginBox newGroups' style='width:285px;display:none;'>
+	<div id='groupSection' class='loginBox' style='width:285px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Create Groups</h3>
 			<div onclick='closeWindows();clearGroupWindow();'>x</div>
@@ -70,10 +70,10 @@
 	<!-- Create Group Dialog END -->
 	
 	<!-- Remove Group Dialog START -->
-	<div id='removeGroup' class='loginBox removeGroups' style='width:285px;display:none;'>
+	<div id='removeGroup' class='loginBox' style='width:285px;display:none;'>
 		<div class='loginBoxheader'>
 			<h3>Remove Groups</h3>
-			<div onclick='closeWindows();clearGroupWindow();'>x</div>
+			<div onclick='closeWindows();clearGroupRemoveWindow();'>x</div>
 		</div>
 		<div style='padding:5px;'>
 			<div id='inputwrapper-name' class='inputwrapper' style='display:inline-block;'>
@@ -87,10 +87,10 @@
 			
 			</div>
 		</div>
-		<p style="display:none; color:red;" id="numberOfGroupsError">You have to assign how many groups should be created.</p> 
-		<p style="display:none; color:red;" id="toManyCreatedGroupsError">You have created a maximum amount of groups.</p> 
+		<p style="display:none; color:red;" id="numberOfGroupsToRemoveError">You have to assign how many groups should be removed.</p> 
+		<p style="display:none; color:red;" id="numberOfDeletedGroupsError">You have tried to remove to many groups</p> 
 		<div style='padding:5px;'>
-			<input style='float:none; display: inline-block;' class='submit-button ' type='button' value='Cancel' onclick='closeWindows();clearGroupWindow();' /> 
+			<input style='float:none; display: inline-block;' class='submit-button' type='button' value='Cancel' onclick='closeWindows();clearGroupRemoveWindow();' /> 
 			<input style='margin-left: 40px; float:none; display: inline-block;' class='submit-button' type='button' value='Remove' onclick='removeGroup();' /> 
 		</div>
 	</div>

--- a/DuggaSys/grouped.php
+++ b/DuggaSys/grouped.php
@@ -43,20 +43,20 @@
 	<!-- Login Dialog END -->
 	
 	<!-- Create Group Dialog START -->
-	<div id='groupSection' class='loginBox' style='width:285px;display:none;'>
+	<div id='groupSection' class='loginBox newGroups' style='width:285px;display:none;'>
 		<div class='loginBoxheader'>
-			<h3>Manage Groups</h3>
+			<h3>Create Groups</h3>
 			<div onclick='closeWindows();clearGroupWindow();'>x</div>
 		</div>
 		<div style='padding:5px;'>
 			<div id='inputwrapper-name' class='inputwrapper' style='display:inline-block;'>
-				<select id='selectMoment' style='float:none; width:100%; margin: 8px 0px;'>
+				<select id='selectMomentCreate' style='float:none; width:100%; margin: 8px 0px;'>
 				</select><br/>
-				<select id="nameType" style='float:none; width:100%;'>
+				<select id="nameTypeCreate" style='float:none; width:100%;'>
 					<option value="a">Letters (A,B,C,...)</option>
 					<option value="1">Numbers (1,2,3,...)</option>
 				</select><br/>
-				<input id="numberOfGroups" type="number" placeholder="  Amount of groups" style='float:none; width:271px; height:24px; margin: 8px 0px;' min="0" max="26"/><br/>
+				<input id="numberOfGroupsCreate" type="number" placeholder="  Amount of groups" style='float:none; width:271px; height:24px; margin: 8px 0px;' min="0" max="26"/><br/>
 				<!-- <span>Name:</span><input style='float:none; margin-left: 5px;' type='text' class='textinput' id='name' placeholder='Name' /> -->
 			</div>
 		</div>
@@ -68,6 +68,33 @@
 		</div>
 	</div>
 	<!-- Create Group Dialog END -->
+	
+	<!-- Remove Group Dialog START -->
+	<div id='removeGroup' class='loginBox removeGroups' style='width:285px;display:none;'>
+		<div class='loginBoxheader'>
+			<h3>Remove Groups</h3>
+			<div onclick='closeWindows();clearGroupWindow();'>x</div>
+		</div>
+		<div style='padding:5px;'>
+			<div id='inputwrapper-name' class='inputwrapper' style='display:inline-block;'>
+				<select id='selectMomentRemove' style='float:none; width:100%; margin: 8px 0px;'>
+				</select><br/>
+				<select id="nameTypeRemove" style='float:none; width:100%;'>
+					<option value="a">Letters (A,B,C,...)</option>
+					<option value="1">Numbers (1,2,3,...)</option>
+				</select><br/>
+				<input id="numberOfGroupsRemove" type="number" placeholder="  Amount of groups" style='float:none; width:271px; height:24px; margin: 8px 0px;' min="0" max="26"/><br/>
+			
+			</div>
+		</div>
+		<p style="display:none; color:red;" id="numberOfGroupsError">You have to assign how many groups should be created.</p> 
+		<p style="display:none; color:red;" id="toManyCreatedGroupsError">You have created a maximum amount of groups.</p> 
+		<div style='padding:5px;'>
+			<input style='float:none; display: inline-block;' class='submit-button ' type='button' value='Cancel' onclick='closeWindows();clearGroupWindow();' /> 
+			<input style='margin-left: 40px; float:none; display: inline-block;' class='submit-button' type='button' value='Remove' onclick='removeGroup();' /> 
+		</div>
+	</div>
+	<!-- Remove Group Dialog END -->
 	<!-- Maximum of Groups Dialog START -->
 	<div id='toManyCreatedGroups' class='loginBox' style='width:285px;display:none;'>
 		<div class='loginBoxheader'>

--- a/DuggaSys/groupedservice.php
+++ b/DuggaSys/groupedservice.php
@@ -32,6 +32,10 @@ $vers = getOP('vers'); // Course version
 $chosenMoment=getOP("chosenMoment"); // Moment (when creating new  groups, lid needs to be connected)
 $groupName=getOP("groupName"); // Name on group (when creating new groups, a name is needed)
 
+// When using opt DELGROUP
+$chosenMomentRemove=getOP("chosenMomentRemove"); // Moment (when creating new  groups, lid needs to be connected)
+$ugidGroup=getOP("ugidGroup"); // Name on group (when creating new groups, a name is needed)
+
 // When using opt UPDATEGROUP
 $uid = getOP('uid'); // User id
 $lid = getOP('lid');
@@ -213,6 +217,15 @@ if(strcmp($opt,"GET")==0){
 				)
 			);
 		}
+	}
+} else if(strcmp($opt,"DELGROUP")==0){
+	$query = $pdo->prepare("DELETE FROM usergroup WHERE ugid = :ugidGroup AND lid = :chosenMomentRemove"); 
+	$query->bindParam(':ugidGroup', $ugidGroup);
+	$query->bindParam(':chosenMomentRemove', $chosenMomentRemove);
+
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error updating entries".$error[2];
 	}
 } else if(strcmp($opt, "UPDATEGROUP") == 0) {
 	

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -688,6 +688,16 @@ header td {
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
 
+.newGroups{
+	top: 20%;
+	left: 60%;
+}
+
+.removeGroups{
+	top: 20%;
+	left: 10%;
+}
+
 #endsessionboxbutton {
   background-color:#614875;
   border:0px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -688,16 +688,6 @@ header td {
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
 
-.newGroups{
-	top: 20%;
-	left: 60%;
-}
-
-.removeGroups{
-	top: 20%;
-	left: 10%;
-}
-
 #endsessionboxbutton {
   background-color:#614875;
   border:0px;


### PR DESCRIPTION
A new button has been added which is called 'Remove Button' where it is possible to remove  groups that have been created. Some changes has also been made to 'Manage Groups' which now is called 'New Groups' instead. It makes more sense to have two different buttons for create and remove groups and therefore don't show create groups and remove groups at the same time. Some functions in the grouped.js have changed names to make it easier to understand what they do. (Fixes issue #4051)