### PR TITLE
Dropdownlist will be hidden if mouse hover Back-button in grouped.php

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -19,7 +19,7 @@
 			// this file navheader file. The switch case uses ternary operators to
 			// determine the href attribute value. (if(this) ? dothis : elsethis)
 			//---------------------------------------------------------------------
-			echo "<td class='navButt' id='back' title='Back' onclick='window.history.back()'>";
+			echo "<td class='navButt' id='back' title='Back' onmouseover='hoverBack();' onclick='window.history.back()'>";
 
             echo "<img src='../Shared/icons/Up.svg'></a></td>";
 			
@@ -88,5 +88,8 @@
 	function cookieMessage(){
 		localStorage.setItem("cookieMessage", "off");
 		$("#cookiemsg").css("display", "none");
+	}
+	function hoverBack(){
+		$(".dropdown-list-container").css("display", "none");
 	}
 </script>


### PR DESCRIPTION
The dropdownlist that appears when mouse hover over Funnel icon will now disappear when the mouse hover over Back-button in navheader. This does mean that the dropdownlist will not be shown incorrectly anymore. The same issue was also present in resulted.php but it will also be solved with this change.(Fixes issue #4063)