### PR TITLE
Enter closes dialog menus

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -99,6 +99,9 @@ function keyDownHandler(e){
     if(key == 46){
         eraseSelectedObject();
     }
+    else if (key == 13) {
+        closeAppearanceDialogMenu();
+    }
 }
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
Enter now has the same function as the OK button in dialog menus in diagram editor. Fixes #3962 