### PR TITLE
Changed the default color and line width

### DIFF
--- a/DuggaSys/diagram_figure.js
+++ b/DuggaSys/diagram_figure.js
@@ -11,10 +11,10 @@ function Path() {
     this.intarr = Array();          // Intersection list (one list per segment)
     this.tmplist = Array();         // Temporary list for testing of intersections
     this.auxlist = Array();         // Auxillary temp list for testing of intersections
-    this.fillColor = "#48B";        // Fill color (default is blueish)
-    this.strokeColor = "#246";      // Stroke color (default is dark blue)
-    this.Opacity = 0.5;             // Opacity (default is 50%)
-    this.linewidth = 3;             // Line Width (stroke width - default is 3 pixels)
+    this.fillColor = "#fff";        // Fill color (default is white)
+    this.strokeColor = "#000";      // Stroke color (default is black)
+    this.Opacity = 1;               // Opacity (default is 100%)
+    this.linewidth = 2;             // Line Width (stroke width - default is 2 pixels)
     this.isorganized = true;        // This is true if segments are organized e.g. can be filled using a single command since segments follow a path 1,2-2,5-5,9 etc
                                     // An organized path can contain several sub-path, each of which must be organized
 
@@ -319,7 +319,7 @@ function Path() {
     //--------------------------------------------------------------------
     this.drawsegments = function (segmentlist, color) {
         // Draw aux set
-        canvasContext.lineWidth = 1;
+        canvasContext.lineWidth = this.lineWidth;
         canvasContext.strokeStyle = "#46f";
         for (var i = 0; i < segmentlist.length; i++) {
             var line = segmentlist[i];

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -115,7 +115,7 @@ function mousemoveevt(ev, t) {
             canvasContext.lineTo(currentMouseCoordinateX, currentMouseCoordinateY);
             canvasContext.lineTo(startMouseCoordinateX, currentMouseCoordinateY);
             canvasContext.lineTo(startMouseCoordinateX, startMouseCoordinateY);
-            canvasContext.strokeStyle = "#d51";
+            canvasContext.strokeStyle = "#000";
             canvasContext.stroke();
             canvasContext.setLineDash([]);
             canvasContext.closePath(1);
@@ -134,7 +134,7 @@ function mousemoveevt(ev, t) {
             canvasContext.lineTo(midx, currentMouseCoordinateY);
             canvasContext.lineTo(startMouseCoordinateX, midy);
             canvasContext.lineTo(midx, startMouseCoordinateY);
-            canvasContext.strokeStyle = "#d51";
+            canvasContext.strokeStyle = "#000";
             canvasContext.stroke();
             canvasContext.setLineDash([]);
             canvasContext.closePath(1);
@@ -146,7 +146,7 @@ function mousemoveevt(ev, t) {
         } else if(uimode == "CreateERAttr"){
             canvasContext.setLineDash([3, 3]);
             drawOval(startMouseCoordinateX, startMouseCoordinateY, currentMouseCoordinateX, currentMouseCoordinateY);
-            canvasContext.strokeStyle = "#d51";
+            canvasContext.strokeStyle = "#000";
             canvasContext.stroke();
             canvasContext.setLineDash([]);
             if (ghostingCrosses == true) {
@@ -159,7 +159,7 @@ function mousemoveevt(ev, t) {
             canvasContext.beginPath();
             canvasContext.moveTo(startMouseCoordinateX, startMouseCoordinateY);
             canvasContext.lineTo(currentMouseCoordinateX, currentMouseCoordinateY);
-            canvasContext.strokeStyle = "#d51";
+            canvasContext.strokeStyle = "#000";
             canvasContext.stroke();
             canvasContext.setLineDash([]);
             if (ghostingCrosses == true) {
@@ -175,7 +175,7 @@ function mousemoveevt(ev, t) {
             canvasContext.lineTo(currentMouseCoordinateX, currentMouseCoordinateY);
             canvasContext.lineTo(startMouseCoordinateX, currentMouseCoordinateY);
             canvasContext.lineTo(startMouseCoordinateX, startMouseCoordinateY);
-            canvasContext.strokeStyle = "#d51";
+            canvasContext.strokeStyle = "#000";
             canvasContext.stroke();
             canvasContext.setLineDash([]);
             canvasContext.closePath(1);
@@ -295,7 +295,7 @@ function mouseupevt(ev) {
 
         erAttributeA.centerPoint = p3;
         erAttributeA.object_type = "";
-        erAttributeA.fontColor = "#253";
+        erAttributeA.fontColor = "#000";
         erAttributeA.font = "Arial";
         diagram.push(erAttributeA);
         //selecting the newly created attribute and open the dialogmenu.
@@ -310,7 +310,7 @@ function mouseupevt(ev) {
         erEnityA.centerPoint = p3;
         erEnityA.arity = [];
         erEnityA.object_type = "";
-        erEnityA.fontColor = "#253";
+        erEnityA.fontColor = "#000";
         erEnityA.font = "Arial";
         diagram.push(erEnityA);
         //selecting the newly created enitity and open the dialogmenu.

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -13,9 +13,9 @@ function Symbol(kind) {
     this.operations = [];           // Operations array
     this.attributes = [];           // Attributes array
     this.textsize = 14;             // 14 pixels text size is default
-    this.symbolColor = '#dfe';      // change background colors on entities
-    this.strokeColor = '#253';          // change standard line color
-    this.lineWidth = 1;
+    this.symbolColor = '#fff';      // change background colors on entities
+    this.strokeColor = '#000';      // change standard line color
+    this.lineWidth = 2;
     var textscale = 10;
     this.name = "New Class";        // Default name is new class
     this.key_type = "none"          // Defult key tyoe for a class.
@@ -551,7 +551,7 @@ function Symbol(kind) {
     //     canvasContext.setLineDash(segments);
     //--------------------------------------------------------------------
     this.draw = function () {
-        canvasContext.lineWidth = this.lineWidth;
+        canvasContext.lineWidth = this.lineWidth * 2;
         if (this.sizeOftext == 'Tiny') {
             textsize = 14;
         } else if (this.sizeOftext == 'Small') {
@@ -573,7 +573,7 @@ function Symbol(kind) {
             // Clear Class Box
             canvasContext.fillStyle = "#fff";
             canvasContext.fillRect(x1, y1, x2 - x1, y2 - y1);
-            canvasContext.fillStyle = "#246";
+            canvasContext.fillStyle = "#fff";
             if (this.targeted) {
                 canvasContext.strokeStyle = "#F82";
             } else {
@@ -582,7 +582,7 @@ function Symbol(kind) {
             // Write Class Name
             canvasContext.textAlign = "center";
             canvasContext.textBaseline = "middle";
-            canvasContext.fillStyle = "#F0F";
+            canvasContext.fillStyle = "#000";
             canvasContext.fillText(this.name, x1 + ((x2 - x1) * 0.5), y1 + (0.85 * this.textsize));
             if (this.key_type == 'Primary key') {
                 var linelenght = canvasContext.measureText(this.name).width;
@@ -641,7 +641,7 @@ function Symbol(kind) {
             canvasContext.stroke();
         } else if (this.symbolkind == 2) {
             //drawing a multivalue attribute
-            canvasContext.lineWidth = this.lineWidth/2;
+            canvasContext.lineWidth = this.lineWidth;
             if (this.key_type == 'Multivalue') {
                 drawOval(x1 - 10, y1 - 10, x2 + 10, y2 + 10);
                 canvasContext.fillStyle = this.symbolColor;
@@ -679,7 +679,7 @@ function Symbol(kind) {
                 canvasContext.strokeStyle = this.strokeColor;
             }
             canvasContext.stroke();
-            canvasContext.fillStyle = "#253";
+            canvasContext.fillStyle = "#fff";
             canvasContext.fillStyle = this.fontColor;
             canvasContext.closePath();
             canvasContext.save();
@@ -730,12 +730,12 @@ function Symbol(kind) {
                 canvasContext.strokeStyle = this.strokeColor;
             }
             canvasContext.stroke();
-            canvasContext.fillStyle = "#253";
+            canvasContext.fillStyle = "#fff";
             canvasContext.fillStyle = this.fontColor;
             canvasContext.fillText(this.name, x1 + ((x2 - x1) * 0.5), (y1 + ((y2 - y1) * 0.5)));
             canvasContext.restore();
             canvasContext.font = parseInt(textsize) + "px " + this.font;
-            canvasContext.fillStyle = "#000";
+            canvasContext.fillStyle = "#fff";
             for (var i = 0; i < this.arity.length; i++) {
                 for (var j = 0; j < this.arity[i].length; j++) {
                     var arity = this.arity[i][j];
@@ -748,7 +748,7 @@ function Symbol(kind) {
         } else if (this.symbolkind == 4) {
             // ER Attribute relationship is a single line
             if (this.key_type == "Forced") {
-                canvasContext.lineWidth = this.lineWidth * 3;
+                canvasContext.lineWidth = this.lineWidth;
                 if (this.isHovered || this.targeted) {
                     canvasContext.strokeStyle = "#F82";
                 } else {
@@ -759,7 +759,7 @@ function Symbol(kind) {
                 canvasContext.lineTo(x2, y2);
                 canvasContext.stroke();
                 canvasContext.lineWidth = this.lineWidth;
-                canvasContext.strokeStyle = "#FFF";
+                canvasContext.strokeStyle = "#000";
                 canvasContext.beginPath();
                 canvasContext.moveTo(x1, y1);
                 canvasContext.lineTo(x2, y2);
@@ -823,7 +823,7 @@ function Symbol(kind) {
                 canvasContext.strokeStyle = this.strokeColor;
             }
             canvasContext.stroke();
-            canvasContext.fillStyle = "#253";
+            canvasContext.fillStyle = "#fff";
             canvasContext.fillStyle = this.fontColor;
             canvasContext.fillText(this.name, x1 + ((x2 - x1) * 0.5), (y1 + ((y2 - y1) * 0.5)));
             canvasContext.restore();


### PR DESCRIPTION
The issue is solved. Changed the default color for the symbols and figures. The default background color is now white, and the line color is black. Also changed the line width for all objects to 2.

On line 554, the lineWidth is multiplied by 2. This is because some objects automatically get half the line width otherwise.