### PR TITLE
Move button is unselected when object button is selected

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -707,6 +707,10 @@ function relationMode() {
 
 $(document).ready(function(){
     $("#linebutton, #attributebutton, #entitybutton, #relationbutton, #squarebutton, #drawfreebutton").click(function(){
+        canvas.removeEventListener('mousedown', getMousePos, false);
+        canvas.removeEventListener('mousemove', mousemoveposcanvas, false);
+        canvas.removeEventListener('mouseup', mouseupcanvas, false);
+        $("#moveButton").removeClass("pressed").addClass("unpressed");
         if ($(this).hasClass("pressed")){
             $(".buttonsStyle").removeClass("pressed").addClass("unpressed");
         } else {

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -420,7 +420,7 @@ function resize() {
 //---------------------------------------
 // MOVING AROUND IN THE CANVAS
 //---------------------------------------
-function movemode(e, t) {
+function movemode() {
     uimode = "MoveAround";
 	$(".buttonsStyle").removeClass("pressed").addClass("unpressed");
     var button = document.getElementById("moveButton").className;


### PR DESCRIPTION
The issue is solved. The move button will now be unselected when an object button is pressed, and the functionality will switch from moving the drawing area to drawing the selected object. 

Also removed some unnecessary parameters. 