### PR TITLE
#4286 DuggaED: CRUD-operations should show a confirmation before executing.

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -8,6 +8,7 @@ var querystring=parseGet();
 var filez;
 var variant = [];
 var submissionRow = 0;
+var decider;
 
 AJAXService("GET",{cid:querystring['cid'],coursevers:querystring['coursevers']},"DUGGA");
 
@@ -244,6 +245,30 @@ function closeEditVariant()
 {
 	$("#editVariant").css("display","none");
 }
+// Displaying and hidding the dynamic comfirmbox for the section edit dialog
+	function confirmBox(temp){	
+		if (temp == 1 || temp == 2 || temp == 3){
+			decider = temp;
+			$("#sectionConfirmBox").css("display","flex");
+		}else if(temp == 4){
+			console.log(decider);
+		    if (decider == 1){
+		    	deleteDugga();
+		    }
+		   	else if (decider == 2){
+		    	createDugga();
+		    }
+		    else if (decider == 3){
+		    	updateDugga();
+		    }
+		    $("#sectionConfirmBox").css("display","none");
+		    decider = 0;
+		}
+		else{
+		   	$("#sectionConfirmBox").css("display","none");
+		   	decider = 0;
+		}
+	}
 
 function createDugga()
 {

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -60,15 +60,32 @@ pdoConnect();
             <div class='inputwrapper'><span>Result Date:</span><input class='textinput datepicker' type='text' id='release' value='None' /></div>
       		</div>
       		<div style='padding:5px;'>
-      			<input style='float:left; 'class='submit-button deleteDugga' type='button' value='Delete' onclick='deleteDugga();' />
-      			<input style='display:none; float:none;' class='submit-button closeDugga' type='button' value='Cancel' onclick='closeEditDugga(); showSaveButton();' /> 
-      			<input style='margin-left:220px; display:none; float:none;' class='submit-button submitDugga' type='button' value='Submit' onclick='createDugga();showSaveButton();' /> 
-      			<input style='float:right; 'class='submit-button updateDugga' type='button' value='Save' onclick='updateDugga();' />
+      			<input style='float:left; 'class='submit-button deleteDugga' type='button' value='Delete' onclick='confirmBox(1);' />
+      			<input style='display:none; float:none;' class='submit-button closeDugga' type='button' value='Cancel' onclick='closeEditDugga();' /> 
+      			<input style='margin-left:220px; display:none; float:none;' class='submit-button submitDugga' type='button' value='Submit' onclick='confirmBox(2);showSaveButton();' /> 
+      			<input style='float:right; 'class='submit-button updateDugga' type='button' value='Save' onclick='confirmBox(3);' />
       		</div>
       </div>
 	</div>
 	<!-- Edit Dugga Dialog END -->
 
+  <!-- Confirm Section Dialog START -->  
+      <div id='sectionConfirmBox' class='loginBoxContainer' style='display:none;'>
+            <div class='loginBox' style='width:460px;'>
+                  <div class='loginBoxheader'>
+                        <h3>Confirm your update</h3>
+                        <div class="cursorPointer" onclick='confirmBox(5);' title="Close window">x</div>
+                  </div>
+                  <div style='text-align: center;'>
+                        <h4>Are you sure you want to make this happen?</h4>
+                  </div>
+                  <div style='display:flex; align-items:center; justify-content: center;'>
+                        <input style='margin-right: 5%;' class='submit-button' type='button' value='Yes' title='Yes' onclick='confirmBox(4);' />
+                        <input style='margin-left: 5%;' class='submit-button' type='button' value='No' title='No' onclick='confirmBox(5);' />
+                  </div>
+            </div>
+      </div>
+  <!-- Confirm Section Dialog START -->  
 	<!-- Edit Variant Dialog START -->
 	<div id='editVariant' class='loginBoxContainer' style='display:none;'>
       <div class='loginBox' style="width:80%;">

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -382,8 +382,7 @@ function changedType()
 }
 
 // Displaying and hidding the dynamic comfirmbox for the section edit dialog
-	function confirmBox(temp)
-	{	
+	function confirmBox(temp){	
 		if (temp == 1 || temp == 2 || temp == 3){
 	        decider = temp;
 	        $("#sectionConfirmBox").css("display","flex");

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -73,7 +73,7 @@ pdoConnect();
 
       <!-- Confirm Section Dialog START -->
       <div id='sectionConfirmBox' class='loginBoxContainer' style='display:none;'>
-             <div class='loginBox' style='width:460px;'>
+            <div class='loginBox' style='width:460px;'>
                   <div class='loginBoxheader'>
                         <h3>Confirm your update</h3>
                         <div class="cursorPointer" onclick='confirmBox(5);' title="Close window">x</div>
@@ -89,7 +89,7 @@ pdoConnect();
       </div>
       <!-- Confirm Edit Section Dialog END -->
 
-  <!-- New Version Dialog START -->
+      <!-- New Version Dialog START -->
 	<div id='newCourseVersion' class='loginBoxContainer' style='display:none;'>
       <div class='loginBox' style='width:464px;'>
       		<div class='loginBoxheader'>


### PR DESCRIPTION
Made dialogbox showup to fix #4286

_"Used the same type and style of fix to the dialogbox as in #4097."_