### PR TITLE
#4308 - On branch #4181, the state of collapsed menus are not always remembered

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1079,6 +1079,9 @@ function returnedSection(data)
 
 	}
 	if(data['debug']!="NONE!") alert(data['debug']);
+
+	getHiddenElements();
+	hideCollapsedMenus();
 }
 
 function showHighscore(did, lid)
@@ -1241,8 +1244,3 @@ $(document).ready(function(){
 		e.stopPropagation();
 	});
 });
-
-window.onload = function() {
-	getHiddenElements();
-	hideCollapsedMenus();
-};


### PR DESCRIPTION
#4308 - Issue has been solved by moving the functions getHiddenElements() and hideCollapsedMenus() so they are not called before the elements that should be hidden have been created.

People who worked on this issue: b16linra, a14oliri.