### PR TITLE
G2 c16linst 3825

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -79,6 +79,7 @@ var classTemplate = {
   height: 7 * gridSize
 };
 var a = [], b = [], c = [];
+var selected_objects = [];              // Is used to store multiple selected objects
 var mousedownX = 0, mousedownY = 0;     // Is used to save the exact coordinants when pressing mousedown while in the "Move Around"-mode
 var mousemoveX = 0, mousemoveY = 0;     // Is used to save the exact coordinants when moving aorund while in the "Move Around"-mode
 var mouseDiffX = 0, mouseDiffY = 0;     // Saves to diff between mousedown and mousemove to know how much to translate the diagram
@@ -317,6 +318,25 @@ diagram.targetItemsInsideSelectionBox = function (endX, endY, startX, startY) {
                 this[i].targeted = false;
             }
         }
+    }
+}
+
+
+//--------------------------------------------------------------------
+// Keeps track of if the CTRL or CMD key is active or not
+//--------------------------------------------------------------------
+var ctrlIsClicked = false;
+//var selectedItems = [];
+
+window.onkeydown = function(event) {
+    if(event.which == 17 || event.which == 91) {
+        ctrlIsClicked = true;
+    }
+}
+
+window.onkeyup = function(event) {
+    if(event.which == 17 || event.which == 91) {
+        ctrlIsClicked = false;
     }
 }
 
@@ -1092,8 +1112,6 @@ function setRefreshTime() {
     }
 }
 function align(mode){
-    var selected_objects = [];
-
     for(var i = 0; i < diagram.length; i++){
         if(diagram[i].targeted == true){
             selected_objects.push(diagram[i]);

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -233,19 +233,37 @@ function mousedownevt(ev) {
             for (var i = 0; i < diagram.length; i++) {
                 diagram[i].targeted = false;
             }
+
+
+/****************** HÄR ÄR JAGGGG *******************************************************/
+
             if(uimode != "MoveAround") {
-                diagram[lastSelectedObject].targeted = true;
+                // Will add multiple selected diagram objects if the
+                // CTRL/CMD key is currently active
+                if (ctrlIsClicked) {
+                    selected_objects.push(diagram[lastSelectedObject]);
+                    diagram[lastSelectedObject].targeted = true
+                    for (var i = 0; i < selected_objects.length; i++) {
+                        if (selected_objects[i].targeted == false) {
+                            selected_objects.push(diagram[lastSelectedObject]);
+                            selected_objects[i].targeted = true;
+                        }
+                    }
+                } else {
+                    selected_objects = [];
+                    selected_objects.push(diagram[lastSelectedObject]);
+                    diagram[lastSelectedObject].targeted = true;
+                }
             }
         }
     } else {
         md = 4;            // Box select or Create mode.
         startMouseCoordinateX = currentMouseCoordinateX;
         startMouseCoordinateY = currentMouseCoordinateY;
-    }
-    if (lastSelectedObject >= 0) {
-        if(uimode != "MoveAround") {
-            diagram[lastSelectedObject].targeted = true;
+        for (var i = 0; i < selected_objects.length; i++) {
+            selected_objects[i].targeted = false;
         }
+        selected_objects = [];
     }
     if(uimode == "CreateFigure" && figureType == "Square"){
         createFigure();

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -233,10 +233,6 @@ function mousedownevt(ev) {
             for (var i = 0; i < diagram.length; i++) {
                 diagram[i].targeted = false;
             }
-
-
-/****************** HÄR ÄR JAGGGG *******************************************************/
-
             if(uimode != "MoveAround") {
                 // Will add multiple selected diagram objects if the
                 // CTRL/CMD key is currently active


### PR DESCRIPTION
It works to select multiple objects with CTRL/CMD, but not together with the 'dotted selector'. When a selection has been made with the 'dotted selector' and another object is selected with CTRL/CMD, the previously selected objects are deselected. Working on a solution.

It isn't possible to deselect an object with the CTRL/CMD button pressed either. It seems that clicks on already selected objects aren't recognized.

Some new issues could be:
- Integrating 'dotted selector' selection with CTRL/CMD selection
- Making it possible to deselect single objects with CTRL/CMD