### PR TITLE
The top object is now selected when objects are stacked

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -347,7 +347,7 @@ diagram.itemClicked = function() {
     if(uimode == "MoveAround"){
         return -1;
     }
-    for (var i = 0; i < this.length; i++) {
+    for (var i = this.length - 1; i >= 0; i--) {
         if (this[i].isClicked(currentMouseCoordinateX, currentMouseCoordinateY)) {
             return i;
         }


### PR DESCRIPTION
This is a fix for the issue #4364.

The fix is done by looping through the objects backwards when checking if an object is being clicked.