### PR TITLE
#4366 - SectionEd/DuggaEd: Explain why a title is invalid

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -306,11 +306,13 @@ function validateName(){
 	var nme=document.getElementById("name");
 	
 	if (nme.value.match(/^[A-Za-zÅÄÖåäö\s\d()]+$/)){
+		$('#tooltipTxt').fadeOut();
 		$('#saveBtn').removeAttr('disabled');
 		$('#submitBtn').removeAttr('disabled');
 		nme.style.backgroundColor = "#fff";
 		retValue = true;
 	}else{
+		$('#tooltipTxt').fadeIn();
 		$('#submitBtn').attr('disabled','disabled');
 		$('#saveBtn').attr('disabled','disabled');
 		nme.style.backgroundColor = "#f57";
@@ -346,6 +348,7 @@ function closeEditDugga()
 	document.getElementById("name").style.backgroundColor = "#fff";  // Resets color for name input
 	$('#submitBtn').removeAttr('disabled');  						 // Resets submit button to its default form
 	$('#saveBtn').removeAttr('disabled');  						 	 // Resets save button to its default form
+	$('#tooltipTxt').css("display","none");							 // Resets tooltip text to its default form
 	//$("#overlay").css("display","none");
 }
 

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -51,7 +51,13 @@ pdoConnect();
       		</div>
       		<div style='padding:5px;'>
       			<input type='hidden' id='did' value='Toddler' /></td>
-      			<div class='inputwrapper'><span>Name:</span><input class='textinput' type='text' id='name' value='New Dugga' onkeyup="validateName();" onchange="validateName();" /></div>
+      			<div class='inputwrapper'>
+	      			<span>Name:</span>
+	      			<div class="tooltipDugga">
+		      			<span id="tooltipTxt" style="display: none;" class="tooltipDuggatext">Illegal characters found in the title!<br>Valid characters: A-Ö, 0-9, ()</span>
+		      		</div>
+		      		<input class='textinput' type='text' id='name' value='New Dugga' onkeyup="validateName();" onchange="validateName();" />
+		      	</div>
       			<div class='inputwrapper'><span>Auto-grade:</span><select id='autograde'><option value='0'>Hidden</option><option value='1'>Public</option></select></div>
       			<div class='inputwrapper'><span>Grade System:</span><select id='gradesys'><option value='1'>U-G-VG</option><option value='2'>U-G</option><option value='3'>U-3-4-5</option></select></div>
       			<div class='inputwrapper'><span>Template:</span><select id='template'><option selected='selected' value=""><option value=""></option></select></div>

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -434,11 +434,13 @@ function validateName(){
 	var nme=document.getElementById("sectionname");
 	
 	if (nme.value.match(/^[A-Za-zÅÄÖåäö\s\d()]+$/)){
+		$('#tooltipTxt').fadeOut();
 		$('#saveBtn').removeAttr('disabled');
 		$('#submitBtn').removeAttr('disabled');
 		nme.style.backgroundColor = "#fff";
 		retValue = true;
 	}else{
+		$('#tooltipTxt').fadeIn();
 		$('#saveBtn').attr('disabled','disabled');
 		$('#submitBtn').attr('disabled','disabled');
 		nme.style.backgroundColor = "#f57";
@@ -505,6 +507,8 @@ function closeSelect()
 	$('#saveBtn').removeAttr('disabled');  							 		// Resets save button to its default form
 	$('#submitBtn').removeAttr('disabled');									// Resets submit button to its default form
 	document.getElementById("sectionname").style.backgroundColor = "#fff";  // Resets color for name input
+	$('#tooltipTxt').css("display","none");							 		// Resets tooltip text to its default form
+
 	
 }
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -49,7 +49,13 @@ pdoConnect();
       		</div>
       		<div style='padding:5px;'>
       			<input type='hidden' id='lid' value='Toddler' />
-      			<div id='inputwrapper-name' class='inputwrapper'><span>Name:</span><input type='text' class='textinput' id='sectionname' value='sectionname' onkeyup="validateName();" onchange="validateName();" /></div>
+      			<div id='inputwrapper-name' class='inputwrapper'>
+	      			<span>Name:</span>
+	      			<div class="tooltipDugga">
+		      			<span id="tooltipTxt" style="display: none;" class="tooltipDuggatext">Illegal characters found in the title!<br>Valid characters: A-Ö, 0-9, ()</span>
+		      		</div>
+	      			<input type='text' class='textinput' id='sectionname' value='sectionname' onkeyup="validateName();" onchange="validateName();" />
+      			</div>
       			<div id='inputwrapper-type' class='inputwrapper'><span>Type:</span><select id='type' onchange='changedType();'></select></div>
       			<div id='inputwrapper-link' class='inputwrapper'><span>Link:</span><select id='link' ></select></div>
       			<div id='inputwrapper-gradesystem' class='inputwrapper'><span>GradeSystem:</span><select id='gradesys' ></select></div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1204,6 +1204,7 @@ input.submit-button-newitem {
   transition:1s background-color;
   float:right;
 }
+
 input.diagram-sidebar-buttons {
    background-color:#7B5A96;
    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
@@ -1284,6 +1285,7 @@ input.submit-button:disabled {
   opacity: 0.3;
 }
 
+
 .buttonsStyle {
   display: flex;
   flex-direction: column;
@@ -1344,6 +1346,40 @@ input.large-button {
   height:48px !important;
   line-height:48px !important;
 }
+
+/* Tooltip */
+
+.tooltipDugga {
+    position: relative;
+    display: inline-block;
+}
+
+.tooltipDugga .tooltipDuggatext {
+    width: 200px;
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 0;
+    position: absolute;
+    z-index: 5;
+    top: -24px;
+	left: -18px;
+    font-size: 12px;
+    line-height: 14px;
+}
+
+.tooltipDugga .tooltipDuggatext::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    margin-top: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent transparent black;
+}
+
 
 /* File upload form */
 


### PR DESCRIPTION
Added a tooltip that pops up next to the "name" input box whenever the user types an invalid character. This design was implemented in both Duggaed and Sectioned.

<img width="494" alt="skarmavbild 2018-04-10 kl 2 05 06 em" src="https://user-images.githubusercontent.com/37795608/38555917-340f530c-3cc8-11e8-8fbb-4a55328de0a2.png">
