### PR TITLE
Renamed deltaX and DeltaY to dx and dy

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -212,9 +212,9 @@ points.closestPoint = function(xCoordinate, yCoordinate) {
     var distance = 50000000;
     var index = -1;
     for (var i = 0; i < this.length; i++) {
-        var deltaX = xCoordinate - this[i].x;
-        var deltaY = yCoordinate - this[i].y;
-        var hypotenuseElevatedBy2 = (deltaX * deltaX) + (deltaY * deltaY);
+        var dx = xCoordinate - this[i].x;
+        var dy = yCoordinate - this[i].y;
+        var hypotenuseElevatedBy2 = (dx * dx) + (dy * dy);
         if (hypotenuseElevatedBy2 < distance) {
             distance = hypotenuseElevatedBy2;
             index = i;


### PR DESCRIPTION
As the title says, I just renamed deltaX and deltaY to dx and dy. I have also created each figure and removed it to see if it still works, and it does.

This is a commit for Issue #4325