### PR TITLE
#4381 - SectionEd: Duplicating items when going from hidden to public 

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -70,7 +70,7 @@ pdoConnect();
       		<div style='padding:5px;'>
       			<input style='display:none; float:left;' class='submit-button deleteDugga' type='button' value='Delete' onclick='deleteItem();' />
       			<input style='display:block; float:left;' class='submit-button closeDugga' type='button' value='Cancel' onclick='closeWindows();' />
-      			<input id="submitBtn" style='margin-left:220px; display:none; float:none;' class='submit-button submitDugga' type='button' value='Submit' onclick='newItem();' />
+      			<input id="submitBtn" style='margin-left:220px; display:none; float:none;' class='submit-button submitDugga' type='button' value='Submit' onclick='newItem(); showSaveButton();' />
       			<input id="saveBtn" style='float:right;' class='submit-button updateDugga' type='button' value='Save' onclick='updateItem();' />
           </div>
       </div>

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1046,7 +1046,10 @@ function getCookie(cname) {
 $(window).load(function() {
 	//There is an issue with using this code, it generates errors that stop execution
       $(window).keyup(function(event){
-      	if(event.keyCode == 27) closeWindows();
+      	if(event.keyCode == 27) {
+          closeWindows();
+          showSaveButton();
+        }
       });
 });
 


### PR DESCRIPTION
#4381 - The fault was that the save-button was hidden and never shown again. This was fixed by adding the showButton() function to escape-press-event and also after creating a new item.

This issue was solved by @a14oliri and @b16linra.

