### PR TITLE
Possible to de-select items with ctrl/cmd-key

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -966,7 +966,7 @@ function setRefreshTime() {
 }
 function align(mode){
     for(var i = 0; i < diagram.length; i++){
-        if(diagram[i].targeted == true){
+        if(diagram[i].targeted == true && selected_objects.indexOf(diagram[i]) > -1){
             selected_objects.push(diagram[i]);
         }
     }
@@ -1103,7 +1103,7 @@ function distribute(axis){
     var selected_objects = [];
 
     for(var i = 0; i < diagram.length; i++){
-        if(diagram[i].targeted == true){
+        if(diagram[i].targeted == true  && selected_objects.indexOf(diagram[i]) > -1){
             selected_objects.push(diagram[i]);
         }
     }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -250,10 +250,12 @@ function mousedownevt(ev) {
         md = 4; // Box select or Create mode.
         startMouseCoordinateX = currentMouseCoordinateX;
         startMouseCoordinateY = currentMouseCoordinateY;
-        for (var i = 0; i < selected_objects.length; i++) {
-            selected_objects[i].targeted = false;
+        if(uimode != "MoveAround"){
+            for (var i = 0; i < selected_objects.length; i++) {
+                selected_objects[i].targeted = false;
+            }
+            selected_objects = [];
         }
-        selected_objects = [];
     }
 }
 

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -240,7 +240,7 @@ function mousedownevt(ev) {
                 console.log("Deselect");
                 var index = selected_objects.indexOf(last);
                 if(index > -1){
-                    console.log("index: " index);
+                    console.log("index: " + index);
                     selected_objects = selected_objects.splice(index, 1);
                     last.targeted = false;
                 }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -211,33 +211,31 @@ function mousedownevt(ev) {
         md = 3;
         lastSelectedObject = diagram.itemClicked(currentMouseCoordinateX, currentMouseCoordinateY);
         var last = diagram[lastSelectedObject];
-        if (last.targeted == false) {
+        if (last.targeted == false && uimode != "MoveAround") {
             for (var i = 0; i < diagram.length; i++) {
                 diagram[i].targeted = false;
             }
-            if(uimode != "MoveAround") {
-                // Will add multiple selected diagram objects if the
-                // CTRL/CMD key is currently active
-                if (ctrlIsClicked) {
-                    if(selected_objects.indexOf(last) < 0){
-                        selected_objects.push(last);
-                        last.targeted = true;
-                    }
-                    for (var i = 0; i < selected_objects.length; i++) {
-                        if (selected_objects[i].targeted == false) {
-                            if(selected_objects.indexOf(last) < 0){
-                                selected_objects.push(last);
-                            }
-                            selected_objects[i].targeted = true;
-                        }
-                    }
-                } else {
-                    selected_objects = [];
+            // Will add multiple selected diagram objects if the
+            // CTRL/CMD key is currently active
+            if (ctrlIsClicked) {
+                if(selected_objects.indexOf(last) < 0){
                     selected_objects.push(last);
                     last.targeted = true;
                 }
+                for (var i = 0; i < selected_objects.length; i++) {
+                    if (selected_objects[i].targeted == false) {
+                        if(selected_objects.indexOf(last) < 0){
+                            selected_objects.push(last);
+                        }
+                        selected_objects[i].targeted = true;
+                    }
+                }
+            } else {
+                selected_objects = [];
+                selected_objects.push(last);
+                last.targeted = true;
             }
-        } else{
+        } else if(uimode != "MoveAround"){
             if(ctrlIsClicked){
                 console.log("Deselect len: " + selected_objects.length);
                 var index = selected_objects.indexOf(last);

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -225,7 +225,9 @@ function mousedownevt(ev) {
                     }
                     for (var i = 0; i < selected_objects.length; i++) {
                         if (selected_objects[i].targeted == false) {
-                            selected_objects.push(last);
+                            if(selected_objects.indexOf(last) < 0){
+                                selected_objects.push(last);
+                            }
                             selected_objects[i].targeted = true;
                         }
                     }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -244,6 +244,7 @@ function mousedownevt(ev) {
                 if(index > -1){
                     console.log("index: " + index);
                     selected_objects = selected_objects.splice(index, 1);
+                    console.log("Deselect len after splice: " + selected_objects.length);
                 }
                 last.targeted = false;
             }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -237,10 +237,8 @@ function mousedownevt(ev) {
             }
         } else if(uimode != "MoveAround"){
             if(ctrlIsClicked){
-                console.log("Deselect len: " + selected_objects.length);
                 var index = selected_objects.indexOf(last);
                 if(index > -1){
-                    console.log("index: " + index);
                     selected_objects.splice(index, 1);
                 }
                 last.targeted = false;

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -237,7 +237,7 @@ function mousedownevt(ev) {
             }
         } else{
             if(ctrlIsClicked){
-                console.log("Deselect");
+                console.log("Deselect len: " + selected_objects.length);
                 var index = selected_objects.indexOf(last);
                 if(index > -1){
                     console.log("index: " + index);

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -244,8 +244,8 @@ function mousedownevt(ev) {
                 if(index > -1){
                     console.log("index: " + index);
                     selected_objects = selected_objects.splice(index, 1);
-                    last.targeted = false;
                 }
+                last.targeted = false;
             }
         }
     } else {

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -210,7 +210,8 @@ function mousedownevt(ev) {
     } else if (movobj != -1) {
         md = 3;
         lastSelectedObject = diagram.itemClicked(currentMouseCoordinateX, currentMouseCoordinateY);
-        if (diagram[lastSelectedObject].targeted == false) {
+        var last = diagram[lastSelectedObject];
+        if (last.targeted == false) {
             for (var i = 0; i < diagram.length; i++) {
                 diagram[i].targeted = false;
             }
@@ -218,28 +219,29 @@ function mousedownevt(ev) {
                 // Will add multiple selected diagram objects if the
                 // CTRL/CMD key is currently active
                 if (ctrlIsClicked) {
-                    var last = diagram[lastSelectedObject];
                     if(selected_objects.indexOf(last) < 0){
                         selected_objects.push(last);
                         last.targeted = true;
-                    }else {
-                        console.log("Deselect");
-                        var index = selected_objects.indexOf(last);
-                        if(index > -1){
-                            selected_objects = selected_objects.splice(index, 1);
-                            last.targeted = false;
-                        }
                     }
                     for (var i = 0; i < selected_objects.length; i++) {
                         if (selected_objects[i].targeted == false) {
-                            selected_objects.push(diagram[lastSelectedObject]);
+                            selected_objects.push(last);
                             selected_objects[i].targeted = true;
                         }
                     }
                 } else {
                     selected_objects = [];
-                    selected_objects.push(diagram[lastSelectedObject]);
-                    diagram[lastSelectedObject].targeted = true;
+                    selected_objects.push(last);
+                    last.targeted = true;
+                }
+            }
+        } else{
+            if(ctrlIsClicked){
+                console.log("Deselect");
+                var index = selected_objects.indexOf(last);
+                if(index > -1){
+                    selected_objects = selected_objects.splice(index, 1);
+                    last.targeted = false;
                 }
             }
         }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -218,15 +218,21 @@ function mousedownevt(ev) {
                 // Will add multiple selected diagram objects if the
                 // CTRL/CMD key is currently active
                 if (ctrlIsClicked) {
-                    selected_objects.push(diagram[lastSelectedObject]);
-                    diagram[lastSelectedObject].targeted = true
+                    var last = diagram[lastSelectedObject];
+                    if(!last.targeted){
+                        selected_objects.push(diagram[lastSelectedObject]);
+                        diagram[lastSelectedObject].targeted = true;
+                    }else {
+                        var index = selected_objects.indexOf(last);
+                        if(index > -1){
+                            selected_objects = selected_objects.splice(index, 1);
+                            last.targeted = false;
+                        }
+                    }
                     for (var i = 0; i < selected_objects.length; i++) {
                         if (selected_objects[i].targeted == false) {
                             selected_objects.push(diagram[lastSelectedObject]);
                             selected_objects[i].targeted = true;
-                        }else{
-                            selected_objects[i].targeted = false;
-                            selected_objects = selected_objects.splice(i, 1);
                         }
                     }
                 } else {

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -219,10 +219,11 @@ function mousedownevt(ev) {
                 // CTRL/CMD key is currently active
                 if (ctrlIsClicked) {
                     var last = diagram[lastSelectedObject];
-                    if(!last.targeted){
-                        selected_objects.push(diagram[lastSelectedObject]);
-                        diagram[lastSelectedObject].targeted = true;
+                    if(!selected_objects.contains(last)){
+                        selected_objects.push(last);
+                        last.targeted = true;
                     }else {
+                        console.log("Deselect");
                         var index = selected_objects.indexOf(last);
                         if(index > -1){
                             selected_objects = selected_objects.splice(index, 1);

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -243,8 +243,7 @@ function mousedownevt(ev) {
                 var index = selected_objects.indexOf(last);
                 if(index > -1){
                     console.log("index: " + index);
-                    selected_objects = selected_objects.splice(index, 1);
-                    console.log("Deselect len after splice: " + selected_objects.length);
+                    selected_objects.splice(index, 1);
                 }
                 last.targeted = false;
             }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -219,7 +219,7 @@ function mousedownevt(ev) {
                 // CTRL/CMD key is currently active
                 if (ctrlIsClicked) {
                     var last = diagram[lastSelectedObject];
-                    if(!selected_objects.contains(last)){
+                    if(selected_objects.indexOf(last) < 0){
                         selected_objects.push(last);
                         last.targeted = true;
                     }else {

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -240,6 +240,7 @@ function mousedownevt(ev) {
                 console.log("Deselect");
                 var index = selected_objects.indexOf(last);
                 if(index > -1){
+                    console.log("index: " index);
                     selected_objects = selected_objects.splice(index, 1);
                     last.targeted = false;
                 }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -224,6 +224,9 @@ function mousedownevt(ev) {
                         if (selected_objects[i].targeted == false) {
                             selected_objects.push(diagram[lastSelectedObject]);
                             selected_objects[i].targeted = true;
+                        }else{
+                            selected_objects[i].targeted = false;
+                            selected_objects = selected_objects.splice(i, 1);
                         }
                     }
                 } else {


### PR DESCRIPTION
I enabled that when the flag ctrlIsClicked is active and an item is already selected we de-select it. We had a bug that all functions pushing to selected_objects didn't check if the item already was in selected_objects which made the list contain alot of duplicates, this caused alot of bugs.

This is a solution for Issue #4345 