### PR TITLE
#4428 remove the shadow around the cogwheel and trashcan icon

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1618,8 +1618,11 @@ input.large-button {
 }
 
 #plorf, #dorf {
-    box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.2);
     padding:4px;
+}
+
+#plorf {
+    box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.2);
 }
 
 .list#testTable input, .list#testTable select, .list#testTable label {


### PR DESCRIPTION
Issue discription:
When an admin is logged in at the courseed site the cogwheel for a course has a shadow, this should be removed.

Solution:
removed the box shadow for the trashcan and cogwheel icons