### PR TITLE
Small fix where an reverted grade still had a timestamp for the grade

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1031,7 +1031,7 @@ function gradeDugga(e, gradesys, cid, vers, moment, uid, mark, ukind, qversion, 
                     var newGradeExpirePlusOneDay = newDateObj.getTime();
 
 					// Compair the gradeExpire value to the current time, if no grade is set, we can always set it no matter the last change
-					if(newGradeExpirePlusOneDay > currentTimeGetTime || (($(e.target ).hasClass("Gc"))  || ($(e.target ).hasClass("VGc")) || ($(e.target ).hasClass("Uh")))){
+					if(newGradeExpirePlusOneDay > currentTimeGetTime){
 						//The user must press the ctrl-key to activate if-statement
 						if(event.ctrlKey || event.metaKey){
 							changeGrade(1, gradesys, cid, vers, moment, uid, mark, ukind, qversion, qid);

--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -70,7 +70,12 @@ logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "resultedservice.php"
 if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESSION['uid']))) {
 	if(strcmp($opt,"CHGR")==0){
 		if($ukind=="U"){
-			$query = $pdo->prepare("UPDATE userAnswer SET grade=:mark,creator=:cuser,marked=NOW(),timesGraded=timesGraded + 1,gradeExpire=CURRENT_TIMESTAMP WHERE cid=:cid AND moment=:moment AND vers=:vers AND uid=:uid");
+			if ($mark == "UNK"){
+				$mark = null;
+				$query = $pdo->prepare("UPDATE userAnswer SET grade=:mark,creator=:cuser,marked=NULL,timesGraded=timesGraded + 1,gradeExpire=CURRENT_TIMESTAMP WHERE cid=:cid AND moment=:moment AND vers=:vers AND uid=:uid");
+			} else {
+				$query = $pdo->prepare("UPDATE userAnswer SET grade=:mark,creator=:cuser,marked=NOW(),timesGraded=timesGraded + 1,gradeExpire=CURRENT_TIMESTAMP WHERE cid=:cid AND moment=:moment AND vers=:vers AND uid=:uid");
+			}
 			$query->bindParam(':mark', $mark);
 			$query->bindParam(':cuser', $userid);
 
@@ -79,9 +84,7 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 			$query->bindParam(':vers', $vers);
 			$query->bindParam(':uid', $luid);
 
-			if ($mark == "UNK"){
-				$mark = null;
-			}
+
 
 			if(!$query->execute()) {
 				$error=$query->errorInfo();


### PR DESCRIPTION
issue #4220 and issue #4179 

Changed the parse to parse null as the timestamp if the grade also is null