### PR TITLE
Spacebar works correctly to toggle movearound

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -102,6 +102,10 @@ function keyDownHandler(e){
         eraseSelectedObject();
     } else if(key == 32){
         //Use space for movearound
+        if (e.stopPropagation) {
+            e.stopPropagation();
+            e.preventDefault();
+        }
         if(uimode != "MoveAround"){
             activateMovearound();
         } else{

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -638,6 +638,7 @@ $(document).ready(function(){
         canvas.removeEventListener('mousemove', mousemoveposcanvas, false);
         canvas.removeEventListener('mouseup', mouseupcanvas, false);
         $("#moveButton").removeClass("pressed").addClass("unpressed");
+        $("#moveButton").hide();
         if ($(this).hasClass("pressed")){
             $(".buttonsStyle").removeClass("pressed").addClass("unpressed");
             uimode = "normal";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -638,7 +638,7 @@ $(document).ready(function(){
         canvas.removeEventListener('mousemove', mousemoveposcanvas, false);
         canvas.removeEventListener('mouseup', mouseupcanvas, false);
         $("#moveButton").removeClass("pressed").addClass("unpressed");
-        $("#moveButton").style.visibility = "hidden";
+        $("#moveButton").css("visibility", "hidden");
         if ($(this).hasClass("pressed")){
             $(".buttonsStyle").removeClass("pressed").addClass("unpressed");
             uimode = "normal";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -638,7 +638,7 @@ $(document).ready(function(){
         canvas.removeEventListener('mousemove', mousemoveposcanvas, false);
         canvas.removeEventListener('mouseup', mouseupcanvas, false);
         $("#moveButton").removeClass("pressed").addClass("unpressed");
-        $("#moveButton").hide();
+        $("#moveButton").style.visibility = "hidden";
         if ($(this).hasClass("pressed")){
             $(".buttonsStyle").removeClass("pressed").addClass("unpressed");
             uimode = "normal";

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1427,6 +1427,7 @@ input.submit-button:disabled {
 
 .unpressed{
   background:#614875;
+  visibility:hidden;
 }
 
 .pressed{

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1427,7 +1427,6 @@ input.submit-button:disabled {
 
 .unpressed{
   background:#614875;
-  visibility:hidden;
 }
 
 .pressed{


### PR DESCRIPTION
To toggle movearound with spacebar works as intended. Icon shows only when active and clicking on a createbutton disables the movearound-function and hides the icon.
I have deactivated spacebars default functionality because if a button is marked and you press sapcebar the button is clicked. This causes toggle of movearound to not work.
This is a solution to Issue #4306 