### PR TITLE
Highlighting points when targeted, makes it easier to resize

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -204,6 +204,7 @@ points.drawPoints = function() {
     }
 }
 
+
 //--------------------------------------------------------------------
 // closestPoint - Returns the distance and index of the point closest
 // to the coordinates passed as parameters.
@@ -802,6 +803,8 @@ var consloe = {};
 consloe.log = function(gobBluth) {
     document.getElementById("consloe").innerHTML = ((JSON.stringify(gobBluth) + "<br>") + document.getElementById("consloe").innerHTML);
 }
+
+
 
 //debugMode this function show and hides crosses and the consol.
 var ghostingCrosses = false; // used to repressent a switch for whenever the debugMode is enabled or not.

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -296,6 +296,8 @@ function Symbol(kind) {
         return pointToLineDistance(points[this.topLeft], points[this.bottomRight], mx, my) < 11;
     }
 
+    
+    
     this.entityhover = function(mx,my){
         //we have correct points in the four corners of a square.
         if(mx > tl.x && mx < tr.x){
@@ -318,8 +320,8 @@ function Symbol(kind) {
                 br = {x:p2.x, y:p2.y};
                 tr = {x:br.x, y:tl.y};
                 bl = {x:tl.x, y:br.y};
-            }else{
-                //we are in the buttomleft
+            }else{ 
+                //we are in the bottomleft
                 tr = {x:p2.x, y:p2.y};
                 bl = {x:p1.x, y:p1.y};
                 tl = {x:bl.x, y:tr.y};
@@ -333,7 +335,7 @@ function Symbol(kind) {
                 tl = {x:bl.x, y:tr.y};
                 br = {x:tr.x, y:bl.y};
             }else{
-                //we are in the buttomright
+                //we are in the bottomright
                 br = {x:p1.x, y:p1.y};
                 tl = {x:p2.x, y:p2.y};
                 bl = {x:tl.x, y:br.y};
@@ -528,10 +530,14 @@ function Symbol(kind) {
 
         ctx.strokeStyle = (this.targeted || this.isHovered) ? "#F82" : this.strokeColor;
 
+     
+        
         var x1 = points[this.topLeft].x;
         var y1 = points[this.topLeft].y;
         var x2 = points[this.bottomRight].x;
         var y2 = points[this.bottomRight].y;
+        
+        
 
         ctx.save();
         if(this.symbolkind == 1){
@@ -707,7 +713,23 @@ function Symbol(kind) {
 
 
         ctx.restore();
-        ctx.setLineDash([]);
+        ctx.setLineDash([]);  
+        
+        
+        //Highlighting points when targeted, makes it easier to resize
+        if(this.targeted){
+            ctx.beginPath();
+            ctx.arc(x1,y1,5,0,2*Math.PI,false);
+            ctx.fillStyle = '#F82';
+            ctx.fill();
+               
+            ctx.beginPath();
+            ctx.arc(x2,y2,5,0,2*Math.PI,false);
+            ctx.fillStyle = '#F82';
+            ctx.fill();
+        }
+        
+        
     }
 /*
     this.drawUML = function(x1, y1, x2, y2)


### PR DESCRIPTION
Added code in function draw in diagram_symbol.js. 
Created filled circle where you are able to resize the symbol. 
Solution for issue #4201 