### PR TITLE
Lines connect on the closest side at all times.

### DIFF
--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -43,7 +43,7 @@ function Symbol(kind) {
     //--------------------------------------------------------------------
     this.getquadrant = function (xk, yk) {
         // Read cardinal points
-        var c = corners();
+        var c = this.corners();
         var x1 = c.tl.x;
         var y1 = c.tl.y;
         var x2 = c.br.x;
@@ -245,10 +245,11 @@ function Symbol(kind) {
     // Sorts all connectors
     //--------------------------------------------------------------------
     this.sortAllConnectors = function () {
-        var x1 = points[this.topLeft].x;
-        var y1 = points[this.topLeft].y;
-        var x2 = points[this.bottomRight].x;
-        var y2 = points[this.bottomRight].y;
+        var c = this.corners();
+        var x1 = c.tl.x;
+        var y1 = c.tl.y;
+        var x2 = c.br.x;
+        var y2 = c.br.y;
         this.sortConnector(this.connectorRight, 1, y1, y2, x2);
         this.sortConnector(this.connectorLeft, 1, y1, y2, x1);
         this.sortConnector(this.connectorTop, 2, x1, x2, y1);


### PR DESCRIPTION
Solution for issue #4496 
An inverted object make topleft point and bottomright point incorrect and we need to sort points to generate correct points for calculating quadrants and for the sorting of connectors.