### PR TITLE
Showdoc now produces a return link to the active course version

### DIFF
--- a/DuggaSys/showdoc.php
+++ b/DuggaSys/showdoc.php
@@ -485,7 +485,7 @@
 				if($hdrs=="none"){
 					
 				}else if($readfile == false){
-					$noup="SECTION";
+					$noup="SHOWDOC";
 					include '../Shared/navheader.php';
 				}
 								

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -32,8 +32,22 @@
 					echo ($cid != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$cid."&coursevers=".$coursevers : "../DuggaSys/courseed.php");
 					echo "'>";
 					echo "<img src='../Shared/icons/Up.svg'></a></td>";
-			}
-        
+			}else if($noup=='SHOWDOC'){
+    			$cid=getOPG('cid');
+    			if($cid=="UNK") $cid=getOPG('courseid');
+    				$coursevers=getOPG('coursevers');
+    			if($coursevers=="UNK"){
+    				$coursevers=getOP('coursevers');
+    				$query = $pdo->prepare("SELECT activeversion from course where cid=:cid limit 1;");
+					$query->bindParam(':cid', $cid);
+					$result = $query->execute();
+				if($row = $query->fetch(PDO::FETCH_ASSOC)) $coursevers = $row['activeversion'];
+				}
+    		echo "<a href='";
+    		echo ($cid != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$cid."&coursevers=".$coursevers : "../DuggaSys/courseed.php");
+    		echo "'>";
+    		echo "<img src='../Shared/icons/Up.svg'></a></td>";
+    		}
 			if($noup=='COURSE'){
                     $cid=getOPG('cid');
                     if($cid=="UNK") $cid=getOPG('courseid');


### PR DESCRIPTION
Issue #1783 
If no course version is provided when navigating to showdoc the return link now links to the active version of the course instead of UNK.

@HGustavs 
Is it OK to make a query in navheader.php to solve this, since there is no suitable service file?