### PR TITLE
G2-a16timsc-4379

### DIFF
--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -402,10 +402,11 @@ function Symbol(kind) {
     // IMP!: Should not be moved back on canvas after this function is run.
     //--------------------------------------------------------------------
     this.movePoints = function () {
+        if (this.symbolkind == 4) return;
         points[this.topLeft] = waldoPoint;
-        points[this.bottomRight] = waldoPoint;
         points[this.centerPoint] = waldoPoint;
         points[this.middleDivider] = waldoPoint;
+        points[this.bottomRight] = waldoPoint;
     }
     //--------------------------------------------------------------------
     // Moves all relevant points, within the object, off the canvas.

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -404,9 +404,9 @@ function Symbol(kind) {
     this.movePoints = function () {
         if (this.symbolkind == 4) return;
         points[this.topLeft] = waldoPoint;
+        points[this.bottomRight] = waldoPoint;
         points[this.centerPoint] = waldoPoint;
         points[this.middleDivider] = waldoPoint;
-        points[this.bottomRight] = waldoPoint;
     }
     //--------------------------------------------------------------------
     // Moves all relevant points, within the object, off the canvas.


### PR DESCRIPTION
Changed the movePoints function so the line points dosn't get set to empty strings since some sybols share the same points, so that relations doesn't get removed whenever a line connected to it is removed.

This is a fix for Issue #4379 