### PR TITLE
#4515 -  SectionEd: Yellow border not removed when pressing escape 

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1101,6 +1101,7 @@ $(window).load(function() {
       $(window).keyup(function(event){
       	if(event.keyCode == 27) {
           closeWindows();
+          closeSelect();
           showSaveButton();
         }
       });


### PR DESCRIPTION
#4515 

Issue fixed by adding a function to escape-press-event-handler.

People who worked on this issue @a14oliri and @b16linra 