### PR TITLE
G2 c16carbe 4528

### DIFF
--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -243,6 +243,16 @@ function mousedownevt(ev) {
                 }
                 last.targeted = false;
             }
+            else{
+                //Unselects every object.
+                for(var i = 0; i < diagram.length; i++){
+                    diagram[i].targeted = false;
+                }
+                //Sets the clicked object as targeted
+                selected_objects = [];
+                selected_objects.push(last);
+                last.targeted = true;
+            }
         }
     } else {
         md = 4; // Box select or Create mode.


### PR DESCRIPTION
Fixed selection so that when several objects are selected, the last one clicked (without CTRL held in) will be selected and remove the selection from the other objects.

This is a fix for Issue #4528