### PR TITLE
Remaining "group functionality"

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -797,6 +797,7 @@ function returnedSection(data)
 
 		str+="<div id='Sectionlistc' >";
 
+		//group-related variable
 		var groupitems = 0;
 
 		// For now we only have two kinds of sections


### PR DESCRIPTION
Found one variabel that seems to be linked with the group functionality that was previously removed.