### PR TITLE
#4588 - SectionEd: Allow "," and "." in the Name

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -407,7 +407,7 @@ function validateName(){
 
 	var nme=document.getElementById("sectionname");
 
-	if (nme.value.match(/^[A-Za-zÅÄÖåäö\s\d()]+$/)){
+	if (nme.value.match(/^[A-Za-zÅÄÖåäö\s\d(),.]+$/)){
 		$('#tooltipTxt').fadeOut();
 		$('#saveBtn').removeAttr('disabled');
 		$('#submitBtn').removeAttr('disabled');


### PR DESCRIPTION
#4588

Fixed an issue where the "," and "." characters weren't allowed when typing a title on some moments, dugga etc.