### PR TITLE
#4388 - DuggaEd: Dialogue-box says "Edit" when creating new

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -427,7 +427,7 @@ function selectDugga(qid){
 	$("#template").html(str);
 }
 
-function editSectionDialogTitle(title){
+function editDialogTitle(title){
 	// Change title of the edit section dialog
 	if(title == "newItem"){
 		document.getElementById("editDialogTitle").innerHTML = "New Item";

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -430,9 +430,9 @@ function selectDugga(qid){
 function editSectionDialogTitle(title){
 	// Change title of the edit section dialog
 	if(title == "newItem"){
-		document.getElementById("editSectionDialogTitle").innerHTML = "New Item";
+		document.getElementById("editDialogTitle").innerHTML = "New Item";
 	}else if(title == "editItem"){
-		document.getElementById("editSectionDialogTitle").innerHTML = "Edit Item";
+		document.getElementById("editDialogTitle").innerHTML = "Edit Item";
 	}
 }
 
@@ -645,7 +645,7 @@ function returnedDugga(data) {
     		modified:"Last modified",
     		cogwheel:"*",
     		trashcan:"<input type='button' value='+' class='submit-button-newitem'"
-				+"onclick='showSubmitButton(); editSectionDialogTitle(\"newItem\"); newDugga();'>"
+				+"onclick='showSubmitButton(); editDialogTitle(\"newItem\"); newDugga();'>"
     	},
     	tblbody: data['entries'],
     	tblfoot:[]
@@ -718,7 +718,7 @@ function renderCell(col,celldata,cellid) {
 		object=JSON.parse(celldata);
 	    str=
 					"<img id='dorf' class='trashcanIcon' src='../Shared/icons/Cogwheel.svg' "
-					+ " onclick='showSaveButton(); editSectionDialogTitle(\"editItem\"); "
+					+ " onclick='showSaveButton(); editDialogTitle(\"editItem\"); "
 					+ "	selectDugga(\""+object+"\");' >";
 		return str;
 	}

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -427,6 +427,15 @@ function selectDugga(qid){
 	$("#template").html(str);
 }
 
+function editSectionDialogTitle(title){
+	// Change title of the edit section dialog
+	if(title == "newItem"){
+		document.getElementById("editSectionDialogTitle").innerHTML = "New Item";
+	}else if(title == "editItem"){
+		document.getElementById("editSectionDialogTitle").innerHTML = "Edit Item";
+	}
+}
+
 
 function newDugga()
 {
@@ -635,7 +644,8 @@ function returnedDugga(data) {
     		qrelease:"Result date",
     		modified:"Last modified",
     		cogwheel:"*",
-    		trashcan:"<input type='button' value='+' class='submit-button-newitem' onclick='showSubmitButton(); newDugga()'>"
+    		trashcan:"<input type='button' value='+' class='submit-button-newitem'"
+				+"onclick='showSubmitButton(); editSectionDialogTitle(\"newItem\"); newDugga();'>"
     	},
     	tblbody: data['entries'],
     	tblfoot:[]
@@ -676,7 +686,7 @@ function returnedDugga(data) {
 // Rendring specific cells
 function renderCell(col,celldata,cellid) {
 	list+= celldata + " ";
-	
+
 	// Translating autograding from integers to show the data like yes/no.
 	if (col == "autograde"){
 		if(celldata == "0"){
@@ -702,12 +712,14 @@ function renderCell(col,celldata,cellid) {
 			celldata = "Undefined";
 		}
 	}
-	
+
 	// Placing a clickable cogwheel in its designated column that opens a window for editing the row.
 	else if (col == "cogwheel"){
 		object=JSON.parse(celldata);
-	    str="<img id='dorf' class='trashcanIcon' src='../Shared/icons/Cogwheel.svg' ";
-		str+=" onclick='showSaveButton(); selectDugga(\""+object+"\");' >";
+	    str=
+					"<img id='dorf' class='trashcanIcon' src='../Shared/icons/Cogwheel.svg' "
+					+ " onclick='showSaveButton(); editSectionDialogTitle(\"editItem\"); "
+					+ "	selectDugga(\""+object+"\");' >";
 		return str;
 	}
 

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -48,7 +48,7 @@ pdoConnect();
 	<div id='editDugga' class='loginBoxContainer' style='display:none;'>
       <div class='loginBox' style='width:464px;'>
       		<div class='loginBoxheader'>
-      			<h3>Edit Dugga</h3>
+      			<h3 id="editSectionDialogTitle">Edit Dugga</h3>
       			<div class='cursorPointer' onclick='closeEditDugga();'>x</div>
       		</div>
       		<div style='padding:5px;'>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -48,7 +48,7 @@ pdoConnect();
 	<div id='editDugga' class='loginBoxContainer' style='display:none;'>
       <div class='loginBox' style='width:464px;'>
       		<div class='loginBoxheader'>
-      			<h3 id="editSectionDialogTitle">Edit Dugga</h3>
+      			<h3 id="editDialogTitle">Edit Dugga</h3>
       			<div class='cursorPointer' onclick='closeEditDugga();'>x</div>
       		</div>
       		<div style='padding:5px;'>


### PR DESCRIPTION
#4388 

Fixed by adding an ID to the dialogue-title and changing it depending on if you click to add a new or click to edit. 
