### PR TITLE
G2-b16petma-4479 Clear Diagram clears the point array

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -774,11 +774,11 @@ function clearCanvas() {
     while (diagram.length > 0) {
         diagram[diagram.length - 1].erase();
         diagram.pop();
-        c.pop();
     }
     for (var i = 0; i < points.length;) {
         points.pop();
     }
+    Save();
     updateGraphics();
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -774,6 +774,7 @@ function clearCanvas() {
     while (diagram.length > 0) {
         diagram[diagram.length - 1].erase();
         diagram.pop();
+        c.pop();
     }
     for (var i = 0; i < points.length;) {
         points.pop();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -778,7 +778,6 @@ function clearCanvas() {
     for (var i = 0; i < points.length;) {
         points.pop();
     }
-    Save();
     updateGraphics();
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -775,8 +775,8 @@ function clearCanvas() {
         diagram[diagram.length - 1].erase();
         diagram.pop();
     }
-    for (var i = 0; i < points.length; i++) {
-        points[i]="";
+    for (var i = 0; i < points.length;) {
+        points.pop();
     }
     updateGraphics();
 }

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -101,6 +101,7 @@ function getImage() {
 }
 
 function Save() {
+    c = [];
     for (var i = 0; i < diagram.length; i++) {
         c[i] = diagram[i].constructor.name;
         c[i] = c[i].replace(/"/g,"");


### PR DESCRIPTION
When we clear the diagram with clear diagram from the menu, we now clear the points array.
This is a partial fix for issue #4479.
We limit the JSON-files a bit more now.
