### PR TITLE
#4445 - SectionEd: Change the FAB "+"-buttons position

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -31,7 +31,7 @@ pdoConnect();
 	?>
 
 	<!-- content START -->
-	<div id="content">
+	<div id="content" style="padding-bottom: 125px;">
 		<!-- Section List -->
 		<div id='Sectionlist'></div>
 	</div>


### PR DESCRIPTION
#4445

Fixed an issue where the FAB button was covering the edit and delete buttons on some duggas.