### PR TITLE
Fix for issue #4581

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -261,7 +261,16 @@ function renderCell(col,celldata,cellid) {
 		if (link[0] == "https" || link[0] == "http") {
 			return "<a href='" + celldata + "' target='_blank'>" + celldata + "</a>";
 		} else {
-			return "<div>" + list[0] + "</div>";
+			// Goes through the previously split parts of the file name
+			// and adds dots to keep the actual file name correct
+			var listStr = "";
+			for (var i = 0; i < list.length - 1; i++) {
+				listStr += list[i];
+				if (i != list.length - 2) {
+					listStr += ".";
+				}
+			}
+			return "<div>" + listStr + "</div>";
 		}
 	} else if (col == "extension") {
 	    return "<div>" + list[list.length - 1] + "</div>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -264,7 +264,7 @@ function renderCell(col,celldata,cellid) {
 			return "<div>" + list[0] + "</div>";
 		}
 	} else if (col == "extension") {
-	    return "<div>" + list[1] + "</div>";
+	    return "<div>" + list[list.length - 1] + "</div>";
 	} else if (col == "editor") {
 		if(link[0] == "https" || link[0] == "http"){
 			str = "";


### PR DESCRIPTION
Fixed the problem with the extensions. Previously, the extension was received from the file name by splitting the name at ".", but this became a problem when a file name was containing more than one dot.

An example of this is a PNG file we uploaded, with a time in the name: "kl.05.27.35". Because there was a dot before the "05", it believed that "05" was the extension (see screenshot below).

![skarmavbild 2018-04-19 kl 10 56 30](https://user-images.githubusercontent.com/37794714/38981837-9d615eb4-43c0-11e8-849f-c34caf1b3920.png)

Now, name can contain many dots. The extension will only be received from the last split.

![skarmavbild 2018-04-19 kl 10 59 59](https://user-images.githubusercontent.com/37794714/38981940-dc15a994-43c0-11e8-843e-94c075662268.png)

This is a fix for issue #4581