### PR TITLE
#4667 - SectionEd: FAB-button opacity issue

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3218,6 +3218,7 @@ ul.hamburgerList button.menuButton {
   bottom: 45px;
   right: 24px;
   height: 70px;
+  z-index: 500;
 }
 
 .zoom-fab {


### PR DESCRIPTION
#4667

Fixed an issue where the FAB button was hiding underneath a new hidden item.