### PR TITLE
Download button instead of P-button in showDugga

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1173,7 +1173,7 @@ function findfilevers(filez,cfield,ctype,displaystate)
 		var foundfile=null;
 		var oldfile="";
 		var tab="<table class='previewTable'>";
-		tab+="<thead><tr><th>Preview</th><th>Filename</th><th>Upload date</th><th colspan=2>Teacher feedback</th></tr></thead>"
+		tab+="<thead><tr><th></th><th>Filename</th><th>Upload date</th><th colspan=2>Teacher feedback</th></tr></thead>"
 		tab +="<tbody>";
 		if (typeof filez !== "undefined"){
 			for (var i=filez.length-1;i>=0;i--){
@@ -1184,9 +1184,9 @@ function findfilevers(filez,cfield,ctype,displaystate)
 							tab+="<td>";
 							// Button for making / viewing feedback - note - only button for given feedback to students.
 							if (ctype == "link"){
-									tab+="<a href='"+filez[i].content+"' ><button>P</button></a>";
+									tab+="<a href='"+filez[i].content+"' ><img src='../Shared/icons/file_download.svg' /></a>";
 							} else {
-									tab+="<a href='"+filelink+"' ><button>P</button></a>";
+									tab+="<a href='"+filelink+"' ><img src='../Shared/icons/file_download.svg' /></a>";
 							}
 							tab+="</td>";
 							tab+="<td>";

--- a/Shared/icons/file_download.svg
+++ b/Shared/icons/file_download.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>


### PR DESCRIPTION
#3602 Changed P-button to a download button in showDugga. 
To test log in as someone who's submited "Rapport inlämning" in the course "Webbutveckling - datorgrafik" (example a99marjo) and look at the button to the left of filename. See image.

![mockup](https://user-images.githubusercontent.com/36665559/38993008-abb4efa4-43e2-11e8-8b96-fc2fb4ea3834.png)
. 