### PR TITLE
G2 c16linst 4657

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -200,6 +200,8 @@ function renderCell(col,celldata,cellid) {
 			}
 			return "<div>" + listStr + "</div>";
 		}
+	} else if (col == "filesize") {
+		celldata = formatBytes(celldata, 0);
 	} else if (col == "extension") {
 	    return "<div>" + list[list.length - 1] + "</div>";
 	} else if (col == "editor") {


### PR DESCRIPTION
Implemented the already existing suffix "translator" function for the file size cells. It will now look like this:

![skarmavbild 2018-04-19 kl 16 30 49](https://user-images.githubusercontent.com/37794714/38998046-10deaff8-43ef-11e8-8ce5-d13843399d68.png)

This solves issue #4657