### PR TITLE
Fixed back button redirection functionality

### DIFF
--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -24,7 +24,7 @@
 <body>
 
 	<?php
-		$noup=true;
+		$noup="SECTION";
 		include '../Shared/navheader.php';
 	?>
 


### PR DESCRIPTION
Changed access editor back button to redirect to section editor instead of course editor. Also checked the other sites with the back button but they seem to work as intended.