### PR TITLE
Fixed issue 4730 and a bug

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1022,6 +1022,11 @@ input {
   border-collapse: collapse;
   font-family: Roboto, Arial Narrow;
   margin-left: -2px;
+  background-color: transparent;
+}
+
+.loginboxTr{
+  background-color: inherit !important;;
 }
 
 #loginBoxTitle{

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -877,7 +877,7 @@ function processLogin(result) {
 
 
 function displayAlertText(selector, text){
-  $(selector).html("<div class='alert danger' style='color: rgb(199, 80, 80); margin-top: 10px; text-align: center;'>"+text+"</div>");
+  $(selector).html("<div class='alert' style='color: rgb(199, 80, 80); margin-top: 10px; text-align: center;'>"+text+"</div>");
 }
 
 function processLogout() {

--- a/Shared/loginbox.php
+++ b/Shared/loginbox.php
@@ -12,32 +12,32 @@
 			</div>
 			<form action="" id="loginForm" method="post">
 				<table class="loginBoxTable">
-					<tr>
+					<tr class="loginboxTr">
 						<td>
 							<label id="loginBoxTitle">Sign in</label>
 						</td>
 					</tr>
-					<tr>
+					<tr  class="loginboxTr">
 						<td>
 							<input id="username" placeholder="Username" class='form-control textinput' type='text' autofocus  style='width: 260px; height: 35px; margin: 8px 0; border: 1px solid #a3a3a3;'>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<td>
 							<input id="password" placeholder="Password" class='form-control textinput' type='password' style='width: 260px; height: 35px; margin: 8px 0; border: 1px solid #a3a3a3;'>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<td class="nowrap">
 							<label class='text forgotPw' onclick='toggleloginnewpass();' title='Retrieve a new password'>Forgot Password?</label>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<td>
 							<input type='button' class='buttonLoginBox' onclick="loginBarrier();" value='Login' title='Login'>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<!-- Message displayed when using wrong password or username -->
 						<td id="message";></td>
 					</tr>
@@ -56,17 +56,17 @@
 							<label id="loginBoxTitle">Enter your username to reset the password</label>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<td>
 							<input id="usernamereset" placeholder="Username" class='form-control textinput' type='text' autofocus  style='width: 260px; height: 35px; margin: 8px 0; border: 1px solid #a3a3a3;'>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<td>
 							<input type='button' class='buttonLoginBox' onclick="resetPasswordBarrier();" value='Continue' style='margin-top: 10px;' title='Continue'>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<!-- Message displayed when using wrong password or username -->
 						<td id="message2";></td>
 					</tr>
@@ -90,7 +90,7 @@
 							<label id="loginBoxTitle">Please answer your security question</label>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<td style='padding-top: 14px;'>
 							<label style='font-size: 14px;'> Question: </label>
 							<label id="displaysecurityquestion" class="text">Placeholder question</label>
@@ -101,7 +101,7 @@
 							<input id="answer" class='form-control textinput' type='password' placeholder="Answer" autofocus  style='width: 260px; height: 35px; margin: 8px 0; border: 1px solid #a3a3a3;'>
 						</td>
 					</tr>
-					<tr>
+					<tr class="loginboxTr">
 						<td>
 							<input type='button' class='buttonLoginBox' onclick="enterSecurityQuestionBarrier();" value='Check answer' style='margin-top: 10px;' title='Check answer'>
 						</td>


### PR DESCRIPTION
#4730 Removed pink/red background behind alert messages in loginbox. Also removed lightgrey background behind several objects when opening loginbox on specific sites for example showDugga. See images.

Before changes:
![beforealert](https://user-images.githubusercontent.com/36665559/39125188-6e3447b4-46fe-11e8-8ccd-03fbaa3ec83a.JPG)
![beforedugga](https://user-images.githubusercontent.com/36665559/39125190-70c0e4b0-46fe-11e8-8b16-f760b7884c1e.JPG)

After changes:
![afteralert](https://user-images.githubusercontent.com/36665559/39125201-79e99adc-46fe-11e8-866b-eb4936684115.JPG)
![afterdugga](https://user-images.githubusercontent.com/36665559/39125206-80474f82-46fe-11e8-9e49-f5c9a176c144.JPG)
