### PR TITLE
#4658 SectionEd: Unable to delete certain Headings

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1372,7 +1372,6 @@ function returnedSection(data)
 		showCreateVersion();
 
 	}
-	if(data['debug']!="NONE!") alert(data['debug']);
 	getHiddenElements();
 	hideCollapsedMenus();
 	getArrowElements();

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -76,10 +76,9 @@ if(checklogin()){
 
 			if(!$query->execute()) {
 				$debug=
-					"SQLSTATE error code: ".$query->errorInfo()[0]
-
+					"The item could not be deleted. See information below:"
+					."\n\nSQLSTATE error code: ".$query->errorInfo()[0]
 					."\n\nDriver-specific error code: ".$query->errorInfo()[1]
-
 					."\n\nDriver-specific error message: \n"
 					.$query->errorInfo()[2];
 			}

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -75,7 +75,7 @@ if(checklogin()){
 			$query->bindParam(':lid', $sectid);
 
 			if(!$query->execute()) {
-				$debug="Error updating entries";
+				$debug=$query->errorInfo()[2];
 			}
 		}else if(strcmp($opt,"NEW")===0){
 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -76,12 +76,10 @@ if(checklogin()){
 
 			if(!$query->execute()) {
 				$debug=
-					"SQLSTATE error code: \n"
-					.$query->errorInfo()[0]
+					"SQLSTATE error code: ".$query->errorInfo()[0]
 
-					."\n\nDriver-specific error code: \n"
-					.$query->errorInfo()[1]
-					
+					."\n\nDriver-specific error code: ".$query->errorInfo()[1]
+
 					."\n\nDriver-specific error message: \n"
 					.$query->errorInfo()[2];
 			}

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -75,7 +75,15 @@ if(checklogin()){
 			$query->bindParam(':lid', $sectid);
 
 			if(!$query->execute()) {
-				$debug=$query->errorInfo()[2];
+				$debug=
+					"SQLSTATE error code: \n"
+					.$query->errorInfo()[0]
+
+					."\n\nDriver-specific error code: \n"
+					.$query->errorInfo()[1]
+					
+					."\n\nDriver-specific error message: \n"
+					.$query->errorInfo()[2];
 			}
 		}else if(strcmp($opt,"NEW")===0){
 


### PR DESCRIPTION
#4658 
We removed the second error message and created a new message with the PHP error code and message for this case(the problem was that the key for this moment is used in another table row). So the bug was not that the item couldnt be removed but that the alert was bad and shown twice. 

People who worked on this issue: @b16linra and @d15marwi.