### PR TITLE
G2 a16juleh c16linst 4738

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -47,7 +47,6 @@ function returnedFile(data) {
 
     var tabledata = {
     	tblhead:{
-    		fileid:"File ID",
     		filename:"File name",
     		extension:"Extension",
     		kind:"Kind",

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -80,7 +80,6 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid))) {
         }
 
       $entry = array(
-    			'fileid' => $row['fileid'],
     			'filename' => $row['filename'],
           'extension' => $row['filename'],
           'kind' => $row['kind'],

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -562,10 +562,19 @@ function SortableTable(tbl,tableid,filterid,caption,renderCell,renderSortOptions
 	        childrenTR = th.children[0],
 	        childrenTH = childrenTR.children[col],
 	        imgDesc = childrenTH.children[0],
-	        imgAsc = childrenTH.children[1];
+	        imgAsc = childrenTH.children[1],
+	        reg = /^\d+$/;
 
 	    reverse = -((+reverse) || -1);
 	    tr = tr.sort(function (a, b) { // sort rows
+	    	// Checks if the text content is a single number
+	    	if (a.cells[col].textContent.match(reg)) {
+	    		if (a.cells[col].textContent.length < 2) {
+	    			// Adds a 0 to the beginning of the number so that the
+	    			// sorting can work properly
+					a.cells[col].textContent = "0" + a.cells[col].textContent;
+	    		}
+	    	}
 			return reverse // `-1 *` if want opposite order
 			* (a.cells[col].textContent.trim() // using `.textContent.trim()` for test
 	            .localeCompare(b.cells[col].textContent.trim())
@@ -587,7 +596,15 @@ function SortableTable(tbl,tableid,filterid,caption,renderCell,renderSortOptions
 	    	imgAsc.classList.remove("hideTableArrow");
 	    }
 
-	    for(var i = 0; i < tr.length; ++i) tb.appendChild(tr[i]); // append each row in order
+	    for (var i = 0; i < tr.length; i++) {
+	    	// Removes the 0 that is previously added for the proper sorting
+	    	for (var x = 0; x < tr[i].children.length; x++) {
+		    	if (tr[i].children[x].textContent.charAt(0) == "0" && tr[i].children[x].textContent.length == 2) {
+		    		tr[i].children[x].textContent = tr[i].children[x].textContent.substr(1);
+		    	}
+	    	}
+	    	tb.appendChild(tr[i]); // append each row in order
+	    }
 	}
 }
 


### PR DESCRIPTION
Fixed sort functionality for cells with numbers. Added a zero to the beginning of the number (so that 2 becomes 02, 5 becomes 05 and so on) before sorting so that the sorting could work properly. Previously, it sorted like this: 1 12 17 18 2 20 24 etc. Removed it before rendering the cell so that it shows the original value to the user. This functionality exists in sortabletable. 

<img width="120" alt="skarmavbild 2018-04-23 kl 14 15 48" src="https://user-images.githubusercontent.com/37794632/39126044-56db2ca6-4701-11e8-970e-698429834e01.png">


Removed column "File ID" as requested in the issue. 

<img width="1262" alt="skarmavbild 2018-04-23 kl 14 01 24" src="https://user-images.githubusercontent.com/37794632/39125326-da2e1ae4-46fe-11e8-9bb3-f413f516dcdd.png">

This solves issue #4738 
