### PR TITLE
G2-a16adala-4763

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -145,6 +145,7 @@ function closeAddFile() {
 
 function closePreview() {
 	$(".previewWindow").css("display","none");
+    $(".previewWindowContainer").css("display", "none");
 }
 
 //------------------------------------------------------------------

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -93,6 +93,7 @@ pdoConnect();
 	</div>
 	<!-- Edit File Dialog END -->
     <!-- Markdown-preview functionality START -->
+    <div class="previewWindowContainer"></div>
     <div class="previewWindow">
     	<div class="loginBoxheader">
         	<h3>This is the preview window</h3>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3553,6 +3553,17 @@ ul.hamburgerList button.menuButton {
  *                               Markdown preview                              *
  * --------------================################================-------------- */
 
+.previewWindowContainer {
+  background-color: rgba(0,0,0,0.6);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 8000;
+  display: none;
+}
+
  .previewWindow {
     height: 635px;
     width: 900px;

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -411,13 +411,16 @@ function showPreview() {
 }
 
 function cancelPreview() {
+
     $(".previewWindow").hide();
+    $(".previewWindowContainer").css("display", "none");
 }
 
 function loadPreview(fileUrl) {
     var fileContent = getFIleContents(fileUrl);
     document.getElementById("mrkdwntxt").value = fileContent;
     updatePreview(fileContent);
+    $(".previewWindowContainer").css("display", "block");
     $(".previewWindow").show();
 }
 


### PR DESCRIPTION
The issue is now fixed and works like it should, when the markdown pen is pressed a pop-up window  appears. The page behind the pop-up now has a shadowy background and is a bit darker than the file editor page. This issue was fixed by @a16adala.  

This is a fix for issue #4763 