### PR TITLE
G2-b16petma-4783

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -642,6 +642,7 @@ function eraseObject(object) {
                         || (object.hasConnector(line.topLeft) && object.symbolkind == 3)
                         || (object.hasConnector(line.bottomRight) && object.symbolkind == 3)
             );
+            console.log("Lines to delete: " + objectsToDelete.length);
         }else{
             diagram.filter(symbol => symbol.symbolkind == 3)
                 .filter(entity =>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -635,12 +635,17 @@ function eraseObject(object) {
         if(object.symbolkind != 4){
             var lines = diagram.filter(symbol => symbol.symbolkind == 4);
             console.log("lines " + lines.length);
-            objectsToDelete = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
-                                                    || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint
-                                                    || object.hasConnector(line.topLeft) || object.hasConnector(line.bottomRight));
+            objectsToDelete = lines.filter(
+                line => line.topLeft == object.middleDivider
+                        || line.topLeft == object.centerPoint
+                        || line.bottomRight == object.middleDivider
+                        || line.bottomRight == object.centerPoint
+                        || (object.hasConnector(line.topLeft) && object.symbolkind == 3)
+                        || (object.hasConnector(line.bottomRight) && object.symbolkind == 3)
+            );
             console.log("commonlines " + objectsToDelete.length);
         }else{
-            var entities = diagram.filter(symbol => symbol.symbolkind == 3).forEach(ent => {
+            diagram.filter(symbol => symbol.symbolkind == 3).forEach(ent => {
                 ent.removePointFromConnector(object.topLeft);
                 ent.removePointFromConnector(object.bottomRight);
             });

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -630,19 +630,20 @@ function getConnectedLines(object) {
 
 function eraseObject(object) {
     canvas.style.cursor = "default";
+    var linesWithCommonPoints = [];
     if (object.kind == 2) {
         var lines = diagram.filter(symbol => symbol.symbolkind == 4);
         console.log("lines " + lines.length);
-        var linesWithCommonPoints = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
-                                                      || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint);
+        linesWithCommonPoints = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
+                                                  || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint);
         console.log("commonlines " + linesWithCommonPoints.length);
         object.erase();
         diagram.eraseLines(object, object.getLines());
-        linesWithCommonPoints.forEach(eraseObject);
     } else if (object.kind == 1) {
         object.erase();
     }
     diagram.deleteObject(object);
+    linesWithCommonPoints.forEach(eraseObject);
     updateGraphics();
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -642,7 +642,6 @@ function eraseObject(object) {
                         || (object.hasConnectorFromPoint(line.topLeft) && object.symbolkind == 3)
                         || (object.hasConnectorFromPoint(line.bottomRight) && object.symbolkind == 3)
             );
-            console.log("Lines to delete: " + objectsToDelete.length);
         }else{
             diagram.filter(symbol => symbol.symbolkind == 3)
                 .filter(entity =>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -639,8 +639,8 @@ function eraseObject(object) {
                         || line.topLeft == object.centerPoint
                         || line.bottomRight == object.middleDivider
                         || line.bottomRight == object.centerPoint
-                        || (object.hasConnector(line.topLeft) && object.symbolkind == 3)
-                        || (object.hasConnector(line.bottomRight) && object.symbolkind == 3)
+                        || (object.hasConnectorFromPoint(line.topLeft) && object.symbolkind == 3)
+                        || (object.hasConnectorFromPoint(line.bottomRight) && object.symbolkind == 3)
             );
             console.log("Lines to delete: " + objectsToDelete.length);
         }else{

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -633,10 +633,9 @@ function eraseObject(object) {
     if (object.kind == 2) {
         var lines = diagram.filter(symbol => symbol.symbolkind == 4);
         console.log("lines " + lines.length);
-        var linesWithCommonPoints = lines.filter(line => line.topLeft == object.topLeft
-                                                           || line.topLeft == object.bottomRight
-                                                           || line.bottomRight == object.topLeft
-                                                           || line.bottomRight == object.bottomRight);
+        var linesWithCommonPoints = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
+                                                      || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint
+                                                      || object.hasConnector(line.topLeft) || object.hasConnector || (line.bottomRight));
         console.log("commonlines " + linesWithCommonPoints.length);
         object.erase();
         diagram.eraseLines(object, object.getLines());

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -630,16 +630,19 @@ function getConnectedLines(object) {
 
 function eraseObject(object) {
     canvas.style.cursor = "default";
-    var linesWithCommonPoints = [];
+    var objectsToDelete = [];
     if (object.kind == 2) {
         if(object.symbolkind != 4){
             var lines = diagram.filter(symbol => symbol.symbolkind == 4);
             console.log("lines " + lines.length);
-            linesWithCommonPoints = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
+            objectsToDelete = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
                                                       || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint);
-            console.log("commonlines " + linesWithCommonPoints.length);
+            console.log("commonlines " + objectsToDelete.length);
         }else{
-            
+            var entities = diagram.filter(symbol => symbol.symbolkind == 3).forEach(ent => {
+                ent.removePointFromConnector(object.topLeft);
+                ent.removePointFromConnector(object.bottomRight);
+            });
         }
         object.erase();
         diagram.eraseLines(object, object.getLines());
@@ -647,7 +650,7 @@ function eraseObject(object) {
         object.erase();
     }
     diagram.deleteObject(object);
-    linesWithCommonPoints.forEach(eraseObject);
+    objectsToDelete.forEach(eraseObject);
     updateGraphics();
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -632,11 +632,15 @@ function eraseObject(object) {
     canvas.style.cursor = "default";
     var linesWithCommonPoints = [];
     if (object.kind == 2) {
-        var lines = diagram.filter(symbol => symbol.symbolkind == 4);
-        console.log("lines " + lines.length);
-        linesWithCommonPoints = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
-                                                  || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint);
-        console.log("commonlines " + linesWithCommonPoints.length);
+        if(object.symbolkind != 4){
+            var lines = diagram.filter(symbol => symbol.symbolkind == 4);
+            console.log("lines " + lines.length);
+            linesWithCommonPoints = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
+                                                      || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint);
+            console.log("commonlines " + linesWithCommonPoints.length);
+        }else{
+            
+        }
         object.erase();
         diagram.eraseLines(object, object.getLines());
     } else if (object.kind == 1) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -632,10 +632,12 @@ function eraseObject(object) {
     canvas.style.cursor = "default";
     if (object.kind == 2) {
         var lines = diagram.filter(symbol => symbol.symbolkind == 4);
+        console.log("lines " + lines.length);
         var linesWithCommonPoints = lines.filter(line => line.topLeft == object.topLeft
                                                            || line.topLeft == object.bottomRight
                                                            || line.bottomRight == object.topLeft
                                                            || line.bottomRight == object.bottomRight);
+        console.log("commonlines " + linesWithCommonPoints.length);
         object.erase();
         diagram.eraseLines(object, object.getLines());
         linesWithCommonPoints.forEach(eraseObject);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -634,7 +634,6 @@ function eraseObject(object) {
     if (object.kind == 2) {
         if(object.symbolkind != 4){
             var lines = diagram.filter(symbol => symbol.symbolkind == 4);
-            console.log("lines " + lines.length);
             objectsToDelete = lines.filter(
                 line => line.topLeft == object.middleDivider
                         || line.topLeft == object.centerPoint
@@ -643,7 +642,6 @@ function eraseObject(object) {
                         || (object.hasConnector(line.topLeft) && object.symbolkind == 3)
                         || (object.hasConnector(line.bottomRight) && object.symbolkind == 3)
             );
-            console.log("commonlines " + objectsToDelete.length);
         }else{
             diagram.filter(symbol => symbol.symbolkind == 3)
                 .filter(entity =>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -631,8 +631,14 @@ function getConnectedLines(object) {
 function eraseObject(object) {
     canvas.style.cursor = "default";
     if (object.kind == 2) {
+        var lines = this.prototype.filter(symbol => symbol.symbolkind == 4);
+        var linesWithCommonPoints = lines.prototype.filter(line => line.topLeft == object.topLeft
+                                                           || line.topLeft == object.bottomRight
+                                                           || line.bottomRight == object.topLeft
+                                                           || line.bottomRight == object.bottomRight);
         object.erase();
         diagram.eraseLines(object, object.getLines());
+        linesWithCommonPoints.forEach(eraseObject);
     } else if (object.kind == 1) {
         object.erase();
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -637,7 +637,7 @@ function eraseObject(object) {
             console.log("lines " + lines.length);
             objectsToDelete = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
                                                     || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint
-                                                    || object.hasConnector(line.topLeft) || object.hasConnector(bottomRight));
+                                                    || object.hasConnector(line.topLeft) || object.hasConnector(line.bottomRight));
             console.log("commonlines " + objectsToDelete.length);
         }else{
             var entities = diagram.filter(symbol => symbol.symbolkind == 3).forEach(ent => {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -631,8 +631,8 @@ function getConnectedLines(object) {
 function eraseObject(object) {
     canvas.style.cursor = "default";
     if (object.kind == 2) {
-        var lines = diagram.prototype.filter(symbol => symbol.symbolkind == 4);
-        var linesWithCommonPoints = lines.prototype.filter(line => line.topLeft == object.topLeft
+        var lines = diagram.filter(symbol => symbol.symbolkind == 4);
+        var linesWithCommonPoints = lines.filter(line => line.topLeft == object.topLeft
                                                            || line.topLeft == object.bottomRight
                                                            || line.bottomRight == object.topLeft
                                                            || line.bottomRight == object.bottomRight);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -645,10 +645,14 @@ function eraseObject(object) {
             );
             console.log("commonlines " + objectsToDelete.length);
         }else{
-            diagram.filter(symbol => symbol.symbolkind == 3).forEach(ent => {
-                ent.removePointFromConnector(object.topLeft);
-                ent.removePointFromConnector(object.bottomRight);
-            });
+            diagram.filter(symbol => symbol.symbolkind == 3)
+                .filter(entity =>
+                        entity.hasConnector(object.topLeft)
+                        && entity.hasConnector(object.bottomRight))
+                    .forEach(ent => {
+                        ent.removePointFromConnector(object.topLeft);
+                        ent.removePointFromConnector(object.bottomRight);
+                    });
         }
         object.erase();
         diagram.eraseLines(object, object.getLines());

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -636,7 +636,8 @@ function eraseObject(object) {
             var lines = diagram.filter(symbol => symbol.symbolkind == 4);
             console.log("lines " + lines.length);
             objectsToDelete = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
-                                                      || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint);
+                                                    || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint
+                                                    || object.hasConnector(line.topLeft) || object.hasConnector(bottomRight));
             console.log("commonlines " + objectsToDelete.length);
         }else{
             var entities = diagram.filter(symbol => symbol.symbolkind == 3).forEach(ent => {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -631,7 +631,7 @@ function getConnectedLines(object) {
 function eraseObject(object) {
     canvas.style.cursor = "default";
     if (object.kind == 2) {
-        var lines = this.prototype.filter(symbol => symbol.symbolkind == 4);
+        var lines = diagram.prototype.filter(symbol => symbol.symbolkind == 4);
         var linesWithCommonPoints = lines.prototype.filter(line => line.topLeft == object.topLeft
                                                            || line.topLeft == object.bottomRight
                                                            || line.bottomRight == object.topLeft

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -634,8 +634,7 @@ function eraseObject(object) {
         var lines = diagram.filter(symbol => symbol.symbolkind == 4);
         console.log("lines " + lines.length);
         var linesWithCommonPoints = lines.filter(line => line.topLeft == object.middleDivider || line.topLeft == object.centerPoint
-                                                      || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint
-                                                      || object.hasConnector(line.topLeft) || object.hasConnector || (line.bottomRight));
+                                                      || line.bottomRight == object.middleDivider || line.bottomRight == object.centerPoint);
         console.log("commonlines " + linesWithCommonPoints.length);
         object.erase();
         diagram.eraseLines(object, object.getLines());

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -308,8 +308,13 @@ function mouseupevt(ev) {
                     } else{
                         p2 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);
                     }
-                    diagram[lineStartObj].connectorTop.push({from:p1, to:p2});
-                    diagram[hovobj].connectorTop.push({from:p2, to:p1});
+                    if(diagram[lineStartObj].symbolkind == 3){
+                        diagram[lineStartObj].connectorTop.push({from:p1, to:p2});
+                        diagram[hovobj].connectorTop.push({from:p2, to:p1});
+                    }else{
+                        diagram[lineStartObj].connectorTop.push({from:p2, to:p1});
+                        diagram[hovobj].connectorTop.push({from:p1, to:p2});
+                    }
                 }
             }
         }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -308,7 +308,7 @@ function mouseupevt(ev) {
                     } else{
                         p2 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);
                     }
-                    if(diagram[lineStartObj].symbolkind == 3){
+                    if(diagram[lineStartObj].symbolkind != 3){
                         diagram[lineStartObj].connectorTop.push({from:p1, to:p2});
                         diagram[hovobj].connectorTop.push({from:p2, to:p1});
                     }else{

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -308,13 +308,8 @@ function mouseupevt(ev) {
                     } else{
                         p2 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);
                     }
-                    if(diagram[lineStartObj].symbolkind != 3){
-                        diagram[lineStartObj].connectorTop.push({from:p1, to:p2});
-                        diagram[hovobj].connectorTop.push({from:p2, to:p1});
-                    }else{
-                        diagram[lineStartObj].connectorTop.push({from:p2, to:p1});
-                        diagram[hovobj].connectorTop.push({from:p1, to:p2});
-                    }
+                    diagram[lineStartObj].connectorTop.push({from:p1, to:p2});
+                    diagram[hovobj].connectorTop.push({from:p2, to:p1});
                 }
             }
         }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -455,6 +455,7 @@ function Symbol(kind) {
         var broken = false;
         for(var i = 0; i < this.connectorTop.length; i++){
             if(this.connectorTop[i].to == point || this.connectorTop[i].from == point){
+                points[this.connectorTop[i].from] = "";
                 this.connectorTop.splice(i,1);
                 broken = true;
                 break;
@@ -463,18 +464,21 @@ function Symbol(kind) {
         if(!broken){
             for(var i = 0; i < this.connectorBottom.length; i++){
                 if(this.connectorBottom[i].to == point || this.connectorBottom[i].from == point){
+                    points[this.connectorBottom[i].from] = "";
                     this.connectorBottom.splice(i,1);
                     break;
                 }
             }
             for(var i = 0; i < this.connectorRight.length; i++){
                 if(this.connectorRight[i].to == point || this.connectorRight[i].from == point){
+                    points[this.connectorRight[i].from] = "";
                     this.connectorRight.splice(i,1);
                     break;
                 }
             }
             for(var i = 0; i < this.connectorLeft.length; i++){
                 if(this.connectorLeft[i].to == point || this.connectorLeft[i].from == point){
+                    points[this.connectorLeft[i].from] = "";
                     this.connectorLeft.splice(i,1);
                     break;
                 }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -419,25 +419,25 @@ function Symbol(kind) {
     //--------------------------------------------------------------------
     this.emptyConnectors = function () {
         for (var i = 0; i < this.connectorTop.length; i++) {
-            points[this.connectorTop[i].to] = "";
+            //points[this.connectorTop[i].to] = "";
             points[this.connectorTop[i].from] = "";
             this.connectorTop.splice(i, 1);
             i--;
         }
         for(var i = 0; i < this.connectorRight.length; i++) {
-            points[this.connectorRight[i].to] = "";
+            //points[this.connectorRight[i].to] = "";
             points[this.connectorRight[i].from] = "";
             this.connectorRight.splice(i, 1);
             i--;
         }
         for (var i = 0; i < this.connectorBottom.length; i++) {
-            points[this.connectorBottom[i].to] = "";
+            //points[this.connectorBottom[i].to] = "";
             points[this.connectorBottom[i].from] = "";
             this.connectorBottom.splice(i, 1);
             i--;
         }
         for (var i = 0; i < this.connectorLeft.length; i++) {
-            points[this.connectorLeft[i].to] = "";
+            //points[this.connectorLeft[i].to] = "";
             points[this.connectorLeft[i].from] = "";
             this.connectorLeft.splice(i, 1);
             i--;

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -284,6 +284,29 @@ function Symbol(kind) {
             }
         }
     }
+    
+    this.hasConnectorFromPoint = function(point) {
+        for (var i = 0; i < this.connectorTop.length; i++) {
+            if(this.connectorTop[i].from == point){
+                return true;
+            }
+        }
+        for(var i = 0; i < this.connectorRight.length; i++) {
+            if(this.connectorRight[i].from == point){
+                return true;
+            }
+        }
+        for (var i = 0; i < this.connectorBottom.length; i++) {
+            if(this.connectorBottom[i].from == point){
+                return true;
+            }
+        }
+        for (var i = 0; i < this.connectorLeft.length; i++) {
+            if(this.connectorLeft[i].from == point){
+                return true;
+            }
+        }
+    }
 
 
     //--------------------------------------------------------------------

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -486,7 +486,8 @@ function Symbol(kind) {
         var broken = false;
         for(var i = 0; i < this.connectorTop.length; i++){
             if(this.connectorTop[i].to == point || this.connectorTop[i].from == point){
-                points[this.connectorTop[i].from] = "";
+                if(this.connectorTop[i].to == point) points[this.connectorTop[i].to] = "";
+                else points[this.connectorTop[i].from] = "";
                 this.connectorTop.splice(i,1);
                 broken = true;
                 break;
@@ -495,21 +496,24 @@ function Symbol(kind) {
         if(!broken){
             for(var i = 0; i < this.connectorBottom.length; i++){
                 if(this.connectorBottom[i].to == point || this.connectorBottom[i].from == point){
-                    points[this.connectorBottom[i].from] = "";
+                    if(this.connectorBottom[i].to == point) points[this.connectorBottom[i].to] = "";
+                    else points[this.connectorBottom[i].from] = "";
                     this.connectorBottom.splice(i,1);
                     break;
                 }
             }
             for(var i = 0; i < this.connectorRight.length; i++){
                 if(this.connectorRight[i].to == point || this.connectorRight[i].from == point){
-                    points[this.connectorRight[i].from] = "";
+                    if(this.connectorRight[i].to == point) points[this.connectorRight[i].to] = "";
+                    else points[this.connectorRight[i].from] = "";
                     this.connectorRight.splice(i,1);
                     break;
                 }
             }
             for(var i = 0; i < this.connectorLeft.length; i++){
                 if(this.connectorLeft[i].to == point || this.connectorLeft[i].from == point){
-                    points[this.connectorLeft[i].from] = "";
+                    if(this.connectorLeft[i].to == point) points[this.connectorLeft[i].to] = "";
+                    else points[this.connectorLeft[i].from] = "";
                     this.connectorLeft.splice(i,1);
                     break;
                 }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -419,18 +419,22 @@ function Symbol(kind) {
     //--------------------------------------------------------------------
     this.emptyConnectors = function () {
         for (var i = 0; i < this.connectorTop.length; i++) {
+            points[this.connectorTop[i]] = "";
             this.connectorTop.splice(i, 1);
             i--;
         }
         for(var i = 0; i < this.connectorRight.length; i++) {
+            points[this.connectorRight[i]] = "";
             this.connectorRight.splice(i, 1);
             i--;
         }
         for (var i = 0; i < this.connectorBottom.length; i++) {
+            points[this.connectorBottom[i]] = "";
             this.connectorBottom.splice(i, 1);
             i--;
         }
         for (var i = 0; i < this.connectorLeft.length; i++) {
+            points[this.connectorLeft[i]] = "";
             this.connectorLeft.splice(i, 1);
             i--;
         }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -419,22 +419,26 @@ function Symbol(kind) {
     //--------------------------------------------------------------------
     this.emptyConnectors = function () {
         for (var i = 0; i < this.connectorTop.length; i++) {
-            points[this.connectorTop[i]] = "";
+            points[this.connectorTop[i].to] = "";
+            points[this.connectorTop[i].from] = "";
             this.connectorTop.splice(i, 1);
             i--;
         }
         for(var i = 0; i < this.connectorRight.length; i++) {
-            points[this.connectorRight[i]] = "";
+            points[this.connectorRight[i].to] = "";
+            points[this.connectorRight[i].from] = "";
             this.connectorRight.splice(i, 1);
             i--;
         }
         for (var i = 0; i < this.connectorBottom.length; i++) {
-            points[this.connectorBottom[i]] = "";
+            points[this.connectorBottom[i].to] = "";
+            points[this.connectorBottom[i].from] = "";
             this.connectorBottom.splice(i, 1);
             i--;
         }
         for (var i = 0; i < this.connectorLeft.length; i++) {
-            points[this.connectorLeft[i]] = "";
+            points[this.connectorLeft[i].to] = "";
+            points[this.connectorLeft[i].from] = "";
             this.connectorLeft.splice(i, 1);
             i--;
         }


### PR DESCRIPTION
I have made some filtering for detecting which lines to be removed when a symbol is removed. The problem for the issue was that points where removed that where used by lines and the line wasn't removed so when a new point was created at the index the line referenced the line was again able to be drawn.

Solution for issue #4783 

It also solves that points stays on the canvas when entities with connectors are removed.