### PR TITLE
G2 c16carbe 4778

### DIFF
--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -418,15 +418,16 @@ function doubleclick(ev) {
 
 function resize() {
     if (uimode == "CreateClass" && md == 4) {
-        if (currentMouseCoordinateX >= startMouseCoordinateX && (currentMouseCoordinateX - startMouseCoordinateX) < classTemplate.width) {
-            currentMouseCoordinateX = startMouseCoordinateX + classTemplate.width;
-        } else if (currentMouseCoordinateX < startMouseCoordinateX && (startMouseCoordinateX - currentMouseCoordinateX) < classTemplate.width) {
-            currentMouseCoordinateX = startMouseCoordinateX - classTemplate.width;
+        if (currentMouseCoordinateX < startMouseCoordinateX) {
+            var tempX = currentMouseCoordinateX;
+            currentMouseCoordinateX = startMouseCoordinateX;
+            startMouseCoordinateX = tempX;
+
         }
-        if (currentMouseCoordinateY >= startMouseCoordinateY && (currentMouseCoordinateY - startMouseCoordinateY) < classTemplate.width) {
-            currentMouseCoordinateY = startMouseCoordinateY + classTemplate.height;
-        } else if (currentMouseCoordinateY < startMouseCoordinateY && (startMouseCoordinateY - currentMouseCoordinateY) < classTemplate.height) {
-            currentMouseCoordinateY = startMouseCoordinateY - classTemplate.height;
+        if (currentMouseCoordinateY < startMouseCoordinateY) {
+            var tempY = currentMouseCoordinateY;
+            currentMouseCoordinateY = startMouseCoordinateY;
+            startMouseCoordinateY = tempY;
         }
     } else if (uimode == "CreateERAttr" && md == 4) {
         if (currentMouseCoordinateX >= startMouseCoordinateX && (currentMouseCoordinateX - startMouseCoordinateX) < attributeTemplate.width) {

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -192,26 +192,26 @@ function Symbol(kind) {
         } else if (this.symbolkind == 1) {
             // Place middle divider point in middle between x1 and y1
             points[this.middleDivider].x = x1 + hw;
-            // If middle divider is below y2 set y2 to middle divider
-            if (points[this.middleDivider].y > points[this.bottomRight].y) {
-                points[this.bottomRight].y = points[this.middleDivider].y;
+
+            if(points[this.bottomRight].y-points[this.topLeft].y < classTemplate.height){
+                points[this.topLeft].y = points[this.middleDivider].y - (classTemplate.height/2);
+                points[this.bottomRight].y = points[this.middleDivider].y + (classTemplate.height/2);
             }
-            // If bottom right is below 0 set bottom right to top left
-            if (hw < 0) {
-                points[this.bottomRight].x = points[this.topLeft].x + 150;
+            if(points[this.bottomRight].y < points[this.middleDivider].y || points[this.topLeft].y > points[this.middleDivider].y){
+                points[this.middleDivider].y = points[this.topLeft].y + (classTemplate.height/2);
             }
-            // If top left is below middle divider set top left to middle divider
-            if (points[this.topLeft].y > points[this.middleDivider].y) {
-                points[this.topLeft].y = points[this.middleDivider].y;
+            if(points[this.bottomRight].x-points[this.topLeft].x < classTemplate.width){
+                points[this.topLeft].x = points[this.middleDivider].x - (classTemplate.width/2);
+                points[this.bottomRight].x = points[this.middleDivider].x + (classTemplate.width/2);
             }
         } else if (this.symbolkind == 5){
-            // Static size of relation. Makes resizing of relation impossible.
-            points[this.topLeft].x = points[this.middleDivider].x-relationTemplate.width/2;
-            points[this.topLeft].y = points[this.middleDivider].y-relationTemplate.height/2;
-            points[this.bottomRight].x = points[this.middleDivider].x+relationTemplate.width/2;
-            points[this.bottomRight].y = points[this.middleDivider].y+relationTemplate.height/2;
+                // Static size of relation. Makes resizing of relation impossible.
+                points[this.topLeft].x = points[this.middleDivider].x-relationTemplate.width/2;
+                points[this.topLeft].y = points[this.middleDivider].y-relationTemplate.height/2;
+                points[this.bottomRight].x = points[this.middleDivider].x+relationTemplate.width/2;
+                points[this.bottomRight].y = points[this.middleDivider].y+relationTemplate.height/2;
+            }
         }
-    }
 
     //--------------------------------------------------------------------
     // Sorts the connector


### PR DESCRIPTION
Fixed the parts of resize() and adjust() functions that are for the UML object. 
The resize() function was altered in such a way that it can have a custom size (because the changes in adjust() affected initial custom sizes in such a way that it couldn't be done)
The adjust() function was altered so that no point can exceed its neighbors x and y coordinates.

It should be noted that this solution can be improved upon and probably should be heavily tested.

This is a solution for #4778 