### PR TITLE
G2 a16rasja 4831

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -57,10 +57,15 @@
                     <div class="application-header">
                         <div id="toolbar-minimize"  onclick="toggleToolbarMinimize();">
                             <img id="minimizeArrow" class="toolbarMaximized" src="../Shared/icons/arrow.svg">
+                          </div>
+                          <h3>Toolbar</h3>
                         </div>
-                        <h3>Toolbar</h3>
-                    </div>
-                    <div class='application-toolbar'>
+                        <div class='application-toolbar'>
+                          <div id="toolbar-switcher">
+                            <div id="toolbarLeftArrow"> << </div>
+                            <div id="toolbarTypeText"> ALL </div>
+                            <div id="toolbarRightArrow"> >> </div>
+                          </div>
                         <h4 class="label">Tools</h4>
                         <div class="toolbar-drawer">
                             <div class="tooltipdialog">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -61,10 +61,10 @@
                           <h3>Toolbar</h3>
                         </div>
                         <div class='application-toolbar'>
-                          <div id="toolbar-switcher">
-                            <div id="toolbarLeftArrow"> << </div>
+                          <div id="toolbar-switcher" value="0">
+                            <div class="toolbarArrows" id="toolbarLeftArrow" onclick="switchToolbar('left');"> << </div>
                             <div id="toolbarTypeText"> ALL </div>
-                            <div id="toolbarRightArrow"> >> </div>
+                            <div class="toolbarArrows" id="toolbarRightArrow" onclick="switchToolbar('right');"> >> </div>
                           </div>
                         <h4 class="label">Tools</h4>
                         <div class="toolbar-drawer">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -62,9 +62,13 @@
                         </div>
                         <div class='application-toolbar'>
                           <div id="toolbar-switcher">
-                            <div class="toolbarArrows" id="toolbarLeftArrow" onclick="switchToolbar('left');"> << </div>
-                            <div id="toolbarTypeText"> ALL </div>
-                            <div class="toolbarArrows" id="toolbarRightArrow" onclick="switchToolbar('right');"> >> </div>
+                            <div class="toolbarArrows" onclick="switchToolbar('left');">
+                              <img id="toolbarLeftArrow" src="../Shared/icons/arrow.svg">
+                            </div>
+                            <div id="toolbarTypeText">All</div>
+                            <div class="toolbarArrows" onclick="switchToolbar('right');">
+                              <img id="toolbarRightArrow" src="../Shared/icons/arrow.svg">
+                            </div>
                           </div>
                         <h4 class="label">Tools</h4>
                         <div class="toolbar-drawer">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -80,17 +80,14 @@
                                 <button id='attributebutton' onclick='setMode("CreateERAttr");' class='buttonsStyle unpressed' data="Create Attribute">
                                     <img src="../Shared/icons/diagram_create_attribute.svg">
                                 </button>
-                            </div><br>
                             <div class="tooltipdialog">
                                 <button id='entitybutton' onclick='setMode("CreateEREntity");' class='buttonsStyle unpressed' data="Create Entity">
                                     <img src="../Shared/icons/diagram_create_entity.svg">
                                 </button>
-                            </div><br>
                             <div class="tooltipdialog">
                                 <button id='relationbutton' onclick='setMode("CreateERRelation");' class='buttonsStyle unpressed' data="Create Relation">
                                     <img src="../Shared/icons/diagram_create_relation.svg">
                                 </button>
-                            </div><br>
                             <div class="tooltipdialog">
                                 <button id='classbutton' onclick='setMode("CreateClass");' class='buttonsStyle unpressed' data="Create Class">
                                     <img src="../Shared/icons/diagram_create_class.svg">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -61,7 +61,7 @@
                           <h3>Toolbar</h3>
                         </div>
                         <div class='application-toolbar'>
-                          <div id="toolbar-switcher" value="0">
+                          <div id="toolbar-switcher">
                             <div class="toolbarArrows" id="toolbarLeftArrow" onclick="switchToolbar('left');"> << </div>
                             <div id="toolbarTypeText"> ALL </div>
                             <div class="toolbarArrows" id="toolbarRightArrow" onclick="switchToolbar('right');"> >> </div>
@@ -80,14 +80,17 @@
                                 <button id='attributebutton' onclick='setMode("CreateERAttr");' class='buttonsStyle unpressed' data="Create Attribute">
                                     <img src="../Shared/icons/diagram_create_attribute.svg">
                                 </button>
+                            </div>
                             <div class="tooltipdialog">
                                 <button id='entitybutton' onclick='setMode("CreateEREntity");' class='buttonsStyle unpressed' data="Create Entity">
                                     <img src="../Shared/icons/diagram_create_entity.svg">
                                 </button>
+                            </div>
                             <div class="tooltipdialog">
                                 <button id='relationbutton' onclick='setMode("CreateERRelation");' class='buttonsStyle unpressed' data="Create Relation">
                                     <img src="../Shared/icons/diagram_create_relation.svg">
                                 </button>
+                            </div>
                             <div class="tooltipdialog">
                                 <button id='classbutton' onclick='setMode("CreateClass");' class='buttonsStyle unpressed' data="Create Class">
                                     <img src="../Shared/icons/diagram_create_class.svg">

--- a/DuggaSys/diagram_toolbox.js
+++ b/DuggaSys/diagram_toolbox.js
@@ -17,6 +17,26 @@ function toggleToolbarMinimize(){
     }
 }
 
+//function for switching the toolbar state (All, ER, UML)
+function switchToolbar(direction){
+  var val = document.getElementById('toolbar-switcher').value;
+  var text = ["All", "ER", "UML"];
+  if(direction == 'left'){
+    val = val <= 2 ? 2 : val--;
+  }else if(direction == 'right'){
+    val = val >= 2 ? 0 : val++;
+  }
+  document.getElementById('toolbarTypeText').innerHTML = text[val];
+
+  //hides irrelevant buttons, and shows relevant buttons
+  if(val == 1){
+    $(".tooltipDialog").hide();
+  }else{
+    $(".tooltipDialog").show();
+  }
+}
+
+
 $( function() {
     $( "#diagram-toolbar" ).draggable();
 } );

--- a/DuggaSys/diagram_toolbox.js
+++ b/DuggaSys/diagram_toolbox.js
@@ -1,3 +1,5 @@
+var val = 0;
+
 function initToolbox(){
     var element = document.getElementById('diagram-toolbar');
     var myCanvas = document.getElementById('myCanvas');
@@ -19,7 +21,6 @@ function toggleToolbarMinimize(){
 
 //function for switching the toolbar state (All, ER, UML)
 function switchToolbar(direction){
-  var val = document.getElementById('toolbar-switcher').value;
   var text = ["All", "ER", "UML"];
   if(direction == 'left'){
     val = val <= 2 ? 2 : val--;
@@ -34,6 +35,8 @@ function switchToolbar(direction){
   }else{
     $(".tooltipDialog").show();
   }
+
+  document.getElementById('toolbar-switcher').value = val;
 }
 
 

--- a/DuggaSys/diagram_toolbox.js
+++ b/DuggaSys/diagram_toolbox.js
@@ -23,17 +23,32 @@ function toggleToolbarMinimize(){
 function switchToolbar(direction){
   var text = ["All", "ER", "UML"];
   if(direction == 'left'){
-    val = val <= 2 ? 2 : val--;
+    val--;
+    if(val < 0){
+      val = 2;
+    }
   }else if(direction == 'right'){
-    val = val >= 2 ? 0 : val++;
+    val++;
+    if(val > 2){
+      val = 0;
+    }
   }
   document.getElementById('toolbarTypeText').innerHTML = text[val];
 
   //hides irrelevant buttons, and shows relevant buttons
   if(val == 1){
-    $(".tooltipDialog").hide();
-  }else{
-    $(".tooltipDialog").show();
+    $(".buttonsStyle").hide();
+    $("#linebutton").show();
+    $("#attributebutton").show();
+    $("#entitybutton").show();
+    $("#relationbutton").show();
+  }else if( val == 2){
+    $(".buttonsStyle").hide();
+    $("#linebutton").show();
+    $("#classbutton").show();
+  }
+  else{
+    $(".buttonsStyle").show();
   }
 
   document.getElementById('toolbar-switcher').value = val;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1136,20 +1136,17 @@ input {
   display: flex;
   text-align: center;
 }
-#toolbarLeftArrow{
-  width:20%;
+.toolbarArrows{
   background: #614875;
-  border-radius: 8px;
-  cursor:pointer;
+  border-radius: 5px;
+  cursor: pointer;
+  font-weight: bold;
+  color: white;
 }
 #toolbarTypeText{
   width:60%;
-}
-#toolbarRightArrow{
-  width:20%;
-  background: #614875;
-  border-radius: 8px;
-  cursor:pointer;
+  background-color: #f1f1f1;
+  border: 1px solid #eaeaea;
 }
 
 /* --------------================################================-------------- *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1131,6 +1131,26 @@ input {
 .toolbarMaximized{
     transform: rotate(180deg);
 }
+#toolbar-switcher{
+  height:20px;
+  display: flex;
+  text-align: center;
+}
+#toolbarLeftArrow{
+  width:20%;
+  background: #614875;
+  border-radius: 8px;
+  cursor:pointer;
+}
+#toolbarTypeText{
+  width:60%;
+}
+#toolbarRightArrow{
+  width:20%;
+  background: #614875;
+  border-radius: 8px;
+  cursor:pointer;
+}
 
 /* --------------================################================-------------- *
  *                            END TOOLBOX/APPLICATION                           *
@@ -3387,7 +3407,7 @@ li:nth-last-child(2) a:hover {
 li:nth-last-child(3) a {
 	background-color: #e9a901;
   color: white;
-  
+
 }
 
 li:nth-last-child(3) a:hover {
@@ -3410,7 +3430,7 @@ li:nth-last-child(4) a:hover {
 li:nth-last-child(5) a {
 	background-color: #d14d58;
   color: white;
-  
+
 }
 
 li:nth-last-child(5) a:hover {
@@ -3422,7 +3442,7 @@ li:nth-last-child(5) a:hover {
 li:nth-last-child(6) a {
 	background-color: #cb438d;
   color: white;
-  
+
 }
 
 li:nth-last-child(6) a:hover {
@@ -3434,7 +3454,7 @@ li:nth-last-child(6) a:hover {
 li:nth-last-child(7) a {
 	background-color: #a844cc;
   color: white;
-  
+
 }
 
 li:nth-last-child(7) a:hover {
@@ -3446,7 +3466,7 @@ li:nth-last-child(7) a:hover {
 li:nth-last-child(8) a {
 	background-color: #6f34dc;
   color: white;
-  
+
 }
 
 li:nth-last-child(8) a:hover {
@@ -3458,7 +3478,7 @@ li:nth-last-child(8) a:hover {
 li:nth-last-child(9) a {
 	background-color: #1f65cd;
   color: white;
-  
+
 }
 
 li:nth-last-child(9) a:hover {
@@ -3470,13 +3490,13 @@ li:nth-last-child(9) a:hover {
 li:nth-last-child(10) a {
 	background-color: blue;
   color: white;
-  
+
 }
 
 li:nth-last-child(10) a:hover {
 	background-color: pink;
   color: white;
-  
+
 }
 
 /* --------------================################================-------------- *
@@ -3507,8 +3527,8 @@ li:nth-last-child(10) a:hover {
     right: 0;
     top: 220px;
     position: absolute;
-     
-     
+
+
 }
 .markdown {
     border: solid rgb(200,200,200);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1135,8 +1135,10 @@ input {
   height:20px;
   display: flex;
   text-align: center;
+  padding:0 3px;
 }
 .toolbarArrows{
+  width:20%;
   background: #614875;
   border-radius: 5px;
   cursor: pointer;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1151,6 +1151,12 @@ input {
   background-color: #f1f1f1;
   border: 1px solid #eaeaea;
 }
+#toolbarLeftArrow{
+  style="transform: rotate(-90deg);
+}
+#toolbarRightArrow{
+  style="transform: rotate(90deg);
+}
 
 /* --------------================################================-------------- *
  *                            END TOOLBOX/APPLICATION                           *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1136,6 +1136,7 @@ input {
   display: flex;
   text-align: center;
   padding:0 3px;
+  line-height: 20px;
 }
 .toolbarArrows{
   width:20%;
@@ -1474,6 +1475,7 @@ div.submit-button:disabled {
   justify-content: center;
   align-items: center;
   border-radius: 8px;
+  margin: 5px 0;
 }
 
 .buttonsStyle img,

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1483,7 +1483,7 @@ div.submit-button:disabled {
   justify-content: center;
   align-items: center;
   border-radius: 8px;
-  margin: 5px 0;
+  margin: 5px auto;
 }
 
 .buttonsStyle img,

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1153,9 +1153,13 @@ input {
 }
 #toolbarLeftArrow{
   style="transform: rotate(-90deg);
+  width: 50%;
+  filter:invert(100%);
 }
 #toolbarRightArrow{
-  style="transform: rotate(90deg);
+  transform: rotate(90deg);
+  width: 50%;
+  filter:invert(100%);
 }
 
 /* --------------================################================-------------- *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1143,8 +1143,6 @@ input {
   background: #614875;
   border-radius: 5px;
   cursor: pointer;
-  font-weight: bold;
-  color: white;
 }
 #toolbarTypeText{
   width:60%;
@@ -1152,7 +1150,7 @@ input {
   border: 1px solid #eaeaea;
 }
 #toolbarLeftArrow{
-  style="transform: rotate(-90deg);
+  transform: rotate(-90deg);
   width: 50%;
   filter:invert(100%);
 }


### PR DESCRIPTION
Added an option in the toolbar to switch between different modes to only see the buttons that belongs to that diagram type. You can choose between all symbols, ER symbols and UML symbols. 
Also centered all the buttons.

![chrome_2018-04-26_14-05-43](https://user-images.githubusercontent.com/37794628/39304770-1bfe6330-495b-11e8-8323-df01983cc34a.png)

This is a fix for Issue #4831 