### PR TITLE
Fixed bug when grading a newly submitted dugga

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -695,6 +695,8 @@ function returnedResults(data)
           if (students[t][j].lid == data.duggaid){
             dpos=j;
             students[t][j].grade = parseInt(data.results);
+            students[t][j].gradeExpire = data.duggaexpire;
+            students[t][j].timesGraded = parseInt(data.duggatimesgraded);
             break;
           }
         }

--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -48,7 +48,8 @@ $duggastats="";
 $duggaentry="";
 $duggauser="";
 $duggafeedback="";
-
+$duggaexpire="";
+$duggatimesgraded="";
 $gradeupdated=false;
 
 $entries=array();
@@ -173,6 +174,18 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 					$coursename = $row['coursename'];
 					$results = sendPushNotification($luid, "$listname for $coursename has been graded");
 					// Ignore results of whether the push notification was sent or not, as this notification is only for user convenience
+				}
+			}
+			// Get gradeExpire and timesGraded in order to update the local arrays of resulted.js whenever a grade is updated.
+			$query = $pdo->prepare("SELECT gradeExpire, timesGraded FROM useranswer WHERE uid=:luid AND moment=:moment AND cid=:cid AND vers=:vers LIMIT 1");
+			$query->bindParam(':cid', $cid);
+			$query->bindParam(':vers', $vers);
+			$query->bindParam(':moment', $listentry);
+			$query->bindParam(':luid', $luid);
+			if($query->execute()) {
+				if ($row = $query->fetch(PDO::FETCH_ASSOC)) {
+					$duggaexpire = $row['gradeExpire'];
+					$duggatimesgraded = $row['timesGraded'];
 				}
 			}
 		}
@@ -614,6 +627,8 @@ $array = array(
 	'dugganame' => $dugganame,
 	'duggaparam' => $duggaparam,
 	'duggaanswer' => $duggaanswer,
+	'duggaexpire' => $duggaexpire,
+	'duggatimesgraded' => $duggatimesgraded,
 	'useranswer' => $useranswer,
 	'duggastats' => $duggastats,
 	'duggafeedback' => $duggafeedback,


### PR DESCRIPTION
Issue #4930 
The local value of gradeExpire was not updated whenever a new grade was set. For newly submitted duggas the value of gradeExpire was null, which makes the if statement on row 472 in "resulted.js" fail.

The local value is now updated with the value from the database whenever a grade is updated. While implementing this I made changes to update the local value of timesGraded aswell.

Both gradeExpire and timesGraded should now update correctly.