### PR TITLE
Fix for loginbox

### DIFF
--- a/Shared/loginbox.php
+++ b/Shared/loginbox.php
@@ -47,7 +47,7 @@
 		<div id='newpassword' class='newpassword' style="display:none">
 			<div class='loginBoxheader'>
 				<h3> Reset Password</h3>
-				<div class="cursorPointer" onclick="closeWindows()" title="Close window">x</div>
+				<div class="cursorPointer" onclick="closeWindows(); resetLoginStatus();" title="Close window">x</div>
 			</div>
 			<div style='padding: 20px;'>
 				<table class="loginBoxTable">


### PR DESCRIPTION
The forgot-password page now reverts back to the regular login page after you close the window.