### PR TITLE
#4971 - DuggaED: Error when closing windows with escape.

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1136,7 +1136,6 @@ $(window).load(function() {
       	if(event.keyCode == 27) {
           closeWindows();
          // closeSelect();
-          showSaveButton();
         }
       });
 });


### PR DESCRIPTION
#4971 - DuggaED: Error when closing windows with escape. 

The only line that needed to be effected was removing the line that called on showSaveButton(). The function showSaveButton is only used in sectioned. Therefore the function call should be inside that file. (In this case there is no need to call showSaveButton when pressing esc.)