### PR TITLE
G2-a16rasja-4905

### DIFF
--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -313,6 +313,8 @@ function mouseupevt(ev) {
                     if(diagram[lineStartObj].connectorCountFromSymbol(diagram[hovobj]) >= 2) okToMakeLine = false;
                 } else if(symbolEndKind == 5 && symbolStartKind == 5){
                     okToMakeLine = false;
+                } else if((symbolEndKind == 1 && symbolStartKind != 1) || (symbolEndKind != 1 && symbolStartKind == 1)){
+                    okToMakeLine = false;
                 }
                 if(okToMakeLine){
                     if(createNewPoint) p1 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);


### PR DESCRIPTION
You are not able to draw a line between ER objects and UML objects anymore.

This is a soulution for issue #4905 