### PR TITLE
#5027 - SectionED: With FAB, creating link and code items should not be possible when nothing is stored in files

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -355,7 +355,7 @@ function confirmBox(operation, item = null) {
 		$("#sectionConfirmBox").css("display", "none");
 	} else if (operation == "closeConfirmBox") {
 		$("#sectionConfirmBox").css("display", "none");
-		$("#noTestsConfirmBox").css("display", "none");
+		$("#noMaterialConfirmBox").css("display", "none");
 	}
 }
 
@@ -1706,12 +1706,19 @@ function fabValidateType(kind) {
 		selectItem("undefined","New Section","1","undefined","undefined","0","undefined","undefined");
 		newItem();
 	} else if (kind == 2){
-		selectItem("undefined","New Code","2","undefined","undefined","0","undefined","undefined");
-		newItem();
-	} else if (kind == 3){
-		if (retdata['duggor'].length == 0){
+		if(retdata['codeexamples'].length <= 1){ //Index 1 in the array has a hard coded code example.
 			toggleFabButton();
-			$("#noTestsConfirmBox").css("display", "flex");
+			$("#noMaterialText").html("Create a Code example before you can use it for a Code section.");
+			$("#noMaterialConfirmBox").css("display", "flex");
+		} else {
+			selectItem("undefined","New Code","2","undefined","undefined","0","undefined","undefined");
+			newItem();
+		}
+	} else if (kind == 3){
+		if(retdata['duggor'].length == 0){
+			toggleFabButton();
+			$("#noMaterialText").html("Create a Dugga before you can use it for a Test section.");
+			$("#noMaterialConfirmBox").css("display", "flex");
 		} else {
 			selectItem("undefined","New Test","3","undefined","undefined","0","undefined","undefined");
 			newItem();
@@ -1720,8 +1727,14 @@ function fabValidateType(kind) {
 		selectItem("undefined","New Moment","4","undefined","undefined","0","undefined","undefined");
 		newItem();
 	} else if (kind == 5){
-		selectItem("undefined","New Link","5","undefined","undefined","0","undefined","undefined");
-		newItem();
+		if(retdata['links'].length == 0){
+			toggleFabButton();
+			$("#noMaterialText").html("Create a Link before you can use it for a Link section.");
+			$("#noMaterialConfirmBox").css("display", "flex");
+		} else {
+			selectItem("undefined","New Link","5","undefined","undefined","0","undefined","undefined");
+			newItem();
+		}
 	} else if (kind == 6){
 		selectItem("undefined","New Group Activity","6","undefined","undefined","0","undefined","undefined");
 		newItem();
@@ -1772,11 +1785,14 @@ $(window).load(function () {
 			var editSectionDisplay = ($('#editSection').css('display'));
 			var submitButtonDisplay = ($('#submitBtn').css('display'));
 			var deleteButtonDisplay = ($('#sectionConfirmBox').css('display'));
+			var errorMissingMaterialDisplay = ($('#noMaterialConfirmBox').css('display'));
 			if (saveButtonDisplay == 'block' && editSectionDisplay == 'flex' && isNameValid() && isTypeValid()) {
 				updateItem();
 			} else if (submitButtonDisplay == 'block' && editSectionDisplay == 'flex' && isNameValid() && isTypeValid()) {
 				newItem();
 				showSaveButton();
+			} else if (errorMissingMaterialDisplay == 'flex'){
+				closeWindows();
 			}
 
 		}

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -103,22 +103,22 @@
 	</div>
 	<!-- Confirm Edit Section Dialog END -->
 
-	<!-- Confirm No Tests Dialog START -->
-	<div id='noTestsConfirmBox' class='loginBoxContainer' style='display:none;'>
+	<!-- Confirm Missing Material Dialog START -->
+	<div id='noMaterialConfirmBox' class='loginBoxContainer' style='display:none;'>
 		<div class='loginBox' style='width:460px;'>
 			  <div class='loginBoxheader'>
-					<h3>Confirm</h3>
+					<h3>Error: Missing material</h3>
 					<div class="cursorPointer" onclick='confirmBox("closeConfirmBox");' title="Close window">x</div>
 			  </div>
 			  <div style='text-align: center;'>
-					<h4>Create a Dugga before you can use it for a test.</h4>
+					<h4 id="noMaterialText"></h4>
 			  </div>
 			  <div style='display:flex; align-items:center; justify-content: center;'>
 					<input style='margin-right: 5%;' class='submit-button' type='button' value='OK' title='OK' onclick='confirmBox("closeConfirmBox");'/>
 			  </div>
 		</div>
 	</div>
-	<!-- Confirm No Tests Dialog END -->
+	<!-- Confirm Missing Material Dialog END -->
 
 	<!-- New Version Dialog START -->
 	<div id='newCourseVersion' class='loginBoxContainer' style='display:none;'>


### PR DESCRIPTION
#5027 - a16thegu
Generalized the previous "No Test"-dialog window, so the FAB chioces "Code" and "Link" also can use it to display it's error message, by just changing the error message text through an id with jQuery.

Added if-statments for kind 2 and 5 to validate if code examples or links exists in the database for that specific course. Code Examples has a hard codes index, which makes the statment different form the others.

Finally, added code to close the dialog window by pressing "Enter".