### PR TITLE
#5055 - Font weight is different in Firefox on macOS

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -59,6 +59,7 @@ body {
 body {
   font-family: 'Roboto', sans-serif, "Helvetica Neue", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
#5055 - Fixed by adding a row of styling in styles.css that disables anti-aliasing in Firefox on macOS.