### PR TITLE
#5029 - SectionED: With Add button, creating link and code items should not be possible when nothing is stored in files

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -405,6 +405,10 @@ function isTypeValid(){
 	var nme = document.getElementById("type");
 	if(retdata['duggor'].length == 0 && kind == 3){
 		return false;
+	} else if (retdata['codeexamples'].length >= 1 && kind == 2){
+		return false;
+	} else if (retdata['links'].length == 0 && kind == 5){
+		return false;
 	}
 	return true;
 }
@@ -416,17 +420,24 @@ function validateType() {
 		$('#saveBtn').removeAttr('disabled');
 		$('#submitBtn').removeAttr('disabled');
 		type.style.backgroundColor = "#fff";
-	}else{
+	} else {
 		$('#saveBtn').attr('disabled', 'disabled');
 		$('#submitBtn').attr('disabled', 'disabled');
-		if(!isTypeValid()){
+		if (!isTypeValid()){
+			if (type.value == 2){ //Code
+				$("#tooltipType").html("Create a Code example before you can use it for a Code section.");
+			} else if (type.value == 3){ //Test
+				$("#tooltipType").html("Create a Dugga before you can use it for a Test section.");
+			} else if (type.value == 5){ // Link
+				$("#tooltipType").html("Create a Link before you can use it for a Link section.");
+			}
+
 			$('#tooltipType').fadeIn();
 			for (i = 0; i < type.options.length; i++) {
 				type.options[i].style.backgroundColor = "#fff";
 			}
 			type.style.backgroundColor = "#f57";
-
-		}else if(!isNameValid()){
+		} else if (!isNameValid()){
 			$('#tooltipType').fadeOut();
 			type.style.backgroundColor = "#FFF";
 		}
@@ -1229,8 +1240,8 @@ function returnedSection(data) {
 
 				str += "</td>";
 
-				
-				
+
+
 
 				// Add generic td for deadlines if one exists
 				if ((itemKind === 3) && (deadline !== null || deadline === "undefined")) {
@@ -1256,7 +1267,7 @@ function returnedSection(data) {
 
 					str += "</div></td>";
 				}
-				
+
 				// Due to date and time format problems slice is used to make the variable submitted the same format as variable deadline
 				if (submitted) {
 					var dateSubmitted = submitted.toJSON().slice(0, 10).replace(/-/g, '-');
@@ -1268,7 +1279,7 @@ function returnedSection(data) {
 						str += "<td style='width:25px;'><img style='width:25px; padding-top:3px'"
 							+ "title='This dugga is not guaranteed to be marked due to submition after deadline.'"
 							+ "src='../Shared/icons/warningTriangle.svg'/></td>";
-					} 
+					}
 				}
 
 				// Cog Wheel

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -405,7 +405,7 @@ function isTypeValid(){
 	var nme = document.getElementById("type");
 	if(retdata['duggor'].length == 0 && kind == 3){
 		return false;
-	} else if (retdata['codeexamples'].length >= 1 && kind == 2){
+	} else if (retdata['codeexamples'].length <= 1 && kind == 2){
 		return false;
 	} else if (retdata['links'].length == 0 && kind == 5){
 		return false;

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -60,9 +60,8 @@
 				<div id='inputwrapper-type' class='inputwrapper'>
 					<span>Type:</span>
 					<div class="tooltipDuggaType">
-						<span id="tooltipType" style="display: none;" class="tooltipDuggaTypeTxt">Create a Dugga before you can use it for a test.</span>
+						<span id="tooltipType" style="display: none;" class="tooltipDuggaTypeTxt"></span>
 				</div> <!-- If you want to change the names of the spans, make sure that they fit with the dropdown box.
-
 							If they don't, change the width of loginbox select in the CSS file -->
 				  <select id='type' value='type' onchange='changedType(document.getElementById("type").value);validateType();'></select>
         </div>


### PR DESCRIPTION
#5029 - @a16thegu
Removed the hard coded tooltip message in sectioned.php, so it can be added via jQuery instead - depending on what kind is validated.

Added else-statments to the isTypeValid() function so it can check if any links or code examples exist under Files. If not, a message will be displayd using jQuery for that specific kind/type.

Additional, I removed some breaklines and added spaces where it was needed where I was adding my functionality.