### PR TITLE
G2-b16petma-5037

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -607,7 +607,7 @@ diagram.sortConnectors = function() {
 diagram.updateQuadrants = function() {
     for (var i = 0; i < diagram.length; i++) {
         if (diagram[i].symbolkind == 3 || diagram[i].symbolkind == 5 || diagram[i].symbolkind == 1) {
-            diagram[i].quadrants();
+            if(diagram[i].quadrants()) break;
         }
     }
 }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -100,96 +100,96 @@ function Symbol(kind) {
     //--------------------------------------------------------------------
     this.quadrants = function () {
         // Fix right connector box (1)
-        var changed = true;
+        var changed = false;
         var anyChanged = false;
         var i = 0;
         while (i < this.connectorRight.length) {
-            changed = true;
             var xk = points[this.connectorRight[i].to].x;
             var yk = points[this.connectorRight[i].to].y;
             var bb = this.getquadrant(xk, yk);
             if (bb == 3) {
+                changed = true;
                 conn = this.connectorRight.splice(i, 1);
                 this.connectorLeft.push(conn[0]);
             } else if (bb == 0) {
+                changed = true;
                 conn = this.connectorRight.splice(i, 1);
                 this.connectorTop.push(conn[0]);
             } else if (bb == 2) {
+                changed = true;
                 conn = this.connectorRight.splice(i, 1);
                 this.connectorBottom.push(conn[0]);
             } else {
                 i++;
-                changed = false;
             }
         }
-        anyChanged = changed ? true : anyChanged;
         // Fix left connector box (3)
         var i = 0;
         while (i < this.connectorLeft.length) {
-            changed = true;
             var xk = points[this.connectorLeft[i].to].x;
             var yk = points[this.connectorLeft[i].to].y;
             var bb = this.getquadrant(xk, yk);
             if (bb == 1) {
+                changed = true;
                 conn = this.connectorLeft.splice(i, 1);
                 this.connectorRight.push(conn[0]);
             } else if (bb == 0) {
+                changed = true;
                 conn = this.connectorLeft.splice(i, 1);
                 this.connectorTop.push(conn[0]);
             } else if (bb == 2) {
+                changed = true;
                 conn = this.connectorLeft.splice(i, 1);
                 this.connectorBottom.push(conn[0]);
             } else {
-                changed = false;
                 i++;
             }
         }
-        anyChanged = changed ? true : anyChanged;
         // Fix top connector box (0)
         var i = 0;
         while (i < this.connectorTop.length) {
-            changed = true;
             var xk = points[this.connectorTop[i].to].x;
             var yk = points[this.connectorTop[i].to].y;
             var bb = this.getquadrant(xk, yk);
             if (bb == 1) {
+                changed = true;
                 conn = this.connectorTop.splice(i, 1);
                 this.connectorRight.push(conn[0]);
             } else if (bb == 3) {
+                changed = true;
                 conn = this.connectorTop.splice(i, 1);
                 this.connectorLeft.push(conn[0]);
             } else if (bb == 2) {
+                changed = true;
                 conn = this.connectorTop.splice(i, 1);
                 this.connectorBottom.push(conn[0]);
             } else {
-                changed = false;
                 i++;
             }
         }
-        anyChanged = changed ? true : anyChanged;
         // Fix bottom connector box (2)
         var i = 0;
         while (i < this.connectorBottom.length) {
-            changed = true;
             var xk = points[this.connectorBottom[i].to].x;
             var yk = points[this.connectorBottom[i].to].y;
             var bb = this.getquadrant(xk, yk);
             if (bb == 1) {
+                changed = true;
                 conn = this.connectorBottom.splice(i, 1);
                 this.connectorRight.push(conn[0]);
             } else if (bb == 3) {
+                changed = true;
                 conn = this.connectorBottom.splice(i, 1);
                 this.connectorLeft.push(conn[0]);
             } else if (bb == 0) {
+                changed = true;
                 conn = this.connectorBottom.splice(i, 1);
                 this.connectorTop.push(conn[0]);
             } else {
-                changed = false;
                 i++;
             }
         }
-        anyChanged = changed ? true : anyChanged;
-        return anyChanged;
+        return changed;
     }
 
     //--------------------------------------------------------------------

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -101,7 +101,6 @@ function Symbol(kind) {
     this.quadrants = function () {
         // Fix right connector box (1)
         var changed = false;
-        var anyChanged = false;
         var i = 0;
         while (i < this.connectorRight.length) {
             var xk = points[this.connectorRight[i].to].x;

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -100,8 +100,11 @@ function Symbol(kind) {
     //--------------------------------------------------------------------
     this.quadrants = function () {
         // Fix right connector box (1)
+        var changed = true;
+        var anyChanged = false;
         var i = 0;
         while (i < this.connectorRight.length) {
+            changed = true;
             var xk = points[this.connectorRight[i].to].x;
             var yk = points[this.connectorRight[i].to].y;
             var bb = this.getquadrant(xk, yk);
@@ -116,11 +119,14 @@ function Symbol(kind) {
                 this.connectorBottom.push(conn[0]);
             } else {
                 i++;
+                changed = false;
             }
         }
+        anyChanged = changed ? true : anyChanged;
         // Fix left connector box (3)
         var i = 0;
         while (i < this.connectorLeft.length) {
+            changed = true;
             var xk = points[this.connectorLeft[i].to].x;
             var yk = points[this.connectorLeft[i].to].y;
             var bb = this.getquadrant(xk, yk);
@@ -134,12 +140,15 @@ function Symbol(kind) {
                 conn = this.connectorLeft.splice(i, 1);
                 this.connectorBottom.push(conn[0]);
             } else {
+                changed = false;
                 i++;
             }
         }
+        anyChanged = changed ? true : anyChanged;
         // Fix top connector box (0)
         var i = 0;
         while (i < this.connectorTop.length) {
+            changed = true;
             var xk = points[this.connectorTop[i].to].x;
             var yk = points[this.connectorTop[i].to].y;
             var bb = this.getquadrant(xk, yk);
@@ -153,12 +162,15 @@ function Symbol(kind) {
                 conn = this.connectorTop.splice(i, 1);
                 this.connectorBottom.push(conn[0]);
             } else {
+                changed = false;
                 i++;
             }
         }
+        anyChanged = changed ? true : anyChanged;
         // Fix bottom connector box (2)
         var i = 0;
         while (i < this.connectorBottom.length) {
+            changed = true;
             var xk = points[this.connectorBottom[i].to].x;
             var yk = points[this.connectorBottom[i].to].y;
             var bb = this.getquadrant(xk, yk);
@@ -172,9 +184,12 @@ function Symbol(kind) {
                 conn = this.connectorBottom.splice(i, 1);
                 this.connectorTop.push(conn[0]);
             } else {
+                changed = false;
                 i++;
             }
         }
+        anyChanged = changed ? true : anyChanged;
+        return anyChanged;
     }
 
     //--------------------------------------------------------------------


### PR DESCRIPTION
Made that we only change one connector when we iterate over the symbols.
The solution was tested with a diagram that was bugged on previous version and changed to my branch and the flickering disappeared.
Solution for issue #5037 