### PR TITLE
G2-a16rasja-5088

### DIFF
--- a/DuggaSys/forms/attribute_appearance.php
+++ b/DuggaSys/forms/attribute_appearance.php
@@ -1,7 +1,7 @@
 Attribute name:</br>
 <input onkeyup="changeObjectAppearance('attributeType');" id='nametext' type='text'></br>
 Attribute type: </br>
-<select onclick="changeObjectAppearance('attributeType');" id='object_type'>
+<select onchange="changeObjectAppearance('attributeType');" id='object_type'>
     "<option value='Primary key'>Primary key</option>
     "<option value='Partial key'>Partial key</option>
     "<option value='normal' selected="true">Normal</option>
@@ -10,7 +10,7 @@ Attribute type: </br>
     "<option value='Drive'>Derive</option>
 </select></br>
 Background color:<br>
-<select onclick="changeObjectAppearance('attributeType');" id='symbolColor'>
+<select onchange="changeObjectAppearance('attributeType');" id='symbolColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -22,14 +22,14 @@ Background color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Font family:<br>
-<select onclick="changeObjectAppearance('attributeType');" id='font'>
+<select onchange="changeObjectAppearance('attributeType');" id='font'>
     "<option value='Arial' selected="true">Arial</option>
     "<option value='Courier New'>Courier New</option>
     "<option value='Impact'>Impact</option>
     "<option value='Calibri'>Calibri</option>
 </select><br>
 Font color:<br>
-<select onclick="changeObjectAppearance('attributeType');" id='fontColor'>
+<select onchange="changeObjectAppearance('attributeType');" id='fontColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -41,14 +41,14 @@ Font color:<br>
     <option value='#000000' selected="true">Black</option>
 </select><br>
 Text size:<br>
-<select onclick="changeObjectAppearance('attributeType');" id='TextSize'>
+<select onchange="changeObjectAppearance('attributeType');" id='TextSize'>
     "<option value='Tiny' selected="true">Tiny</option>
     "<option value='Small'>Small</option>
     "<option value='Medium'>Medium</option>
     "<option value='Large'>Large</option>
 </select><br>
 Line colors:<br>
-<select onclick="changeObjectAppearance('attributeType');" id='AttributeLineColor'>
+<select onchange="changeObjectAppearance('attributeType');" id='AttributeLineColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>

--- a/DuggaSys/forms/entity_appearance.php
+++ b/DuggaSys/forms/entity_appearance.php
@@ -1,12 +1,12 @@
 Entity name: </br>
 <input onkeyup="changeObjectAppearance('entityType');" id='nametext' type='text'></br>
 Entity type: </br>
-<select onclick="changeObjectAppearance('entityType');" id='object_type'>
+<select onchange="changeObjectAppearance('entityType');" id='object_type'>
     <option value='Weak'>Weak</option>
     <option value='Strong' selected="true">Strong</option>
 </select></br>
 Background color:<br>
-<select onclick="changeObjectAppearance('entityType');" id ='symbolColor'>
+<select onchange="changeObjectAppearance('entityType');" id ='symbolColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -18,14 +18,14 @@ Background color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Font family:<br>
-<select onclick="changeObjectAppearance('entityType');" id ='font'>
+<select onchange="changeObjectAppearance('entityType');" id ='font'>
     <option value='Arial' selected="true">Arial</option>
     <option value='Courier New'>Courier New</option>
     <option value='Impact'>Impact</option>
     <option value='Calibri'>Calibri</option>
 </select><br>
 Font color:<br>
-<select onclick="changeObjectAppearance('entityType');" id ='fontColor'>
+<select onchange="changeObjectAppearance('entityType');" id ='fontColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -37,14 +37,14 @@ Font color:<br>
     <option value='#000000' selected="true">Black</option>
 </select><br>
 Text size:<br>
-<select onclick="changeObjectAppearance('entityType');" id ='TextSize'>
+<select onchange="changeObjectAppearance('entityType');" id ='TextSize'>
     <option value='Tiny' selected="true">Tiny</option>
     <option value='Small'>Small</option>
     <option value='Medium'>Medium</option>
     <option value='Large'>Large</option>
 </select><br>
 Line colors:<br>
-<select onclick="changeObjectAppearance('attributeType');" id='AttributeLineColor'>
+<select onchange="changeObjectAppearance('attributeType');" id='AttributeLineColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>

--- a/DuggaSys/forms/figure_appearance.php
+++ b/DuggaSys/forms/figure_appearance.php
@@ -1,5 +1,5 @@
 Fill color:<br>
-<select onclick="changeObjectAppearance('figureType');" id='figureFillColor'>
+<select onchange="changeObjectAppearance('figureType');" id='figureFillColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -11,7 +11,7 @@ Fill color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Line color:<br>
-<select onclick="changeObjectAppearance('figureType');" id='figureLineColor'>
+<select onchange="changeObjectAppearance('figureType');" id='figureLineColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>

--- a/DuggaSys/forms/global_appearance.php
+++ b/DuggaSys/forms/global_appearance.php
@@ -1,5 +1,5 @@
 Font family:<br>
-<select id='font' onclick='globalFont(); hashfunction(); updategfx();'>
+<select id='font' onchange='globalFont(); hashfunction(); updategfx();'>
     <option value='Arial' selected>Arial</option>
     <option value='Courier New'>Courier New</option>
     <option value='Impact'>Impact</option>
@@ -7,7 +7,7 @@ Font family:<br>
 </select><br>
 
 Font color:<br>
-<select id ='fontColor' onclick='globalFontColor(); hashfunction(); updategfx();'>
+<select id ='fontColor' onchange='globalFontColor(); hashfunction(); updategfx();'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -19,14 +19,14 @@ Font color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Text size:<br>
-<select id='TextSize' onclick='globalTextSize(); hashfunction(); updategfx();'>
+<select id='TextSize' onchange='globalTextSize(); hashfunction(); updategfx();'>
     <option value='Tiny' selected>Tiny</option>
     <option value='Small'>Small</option>
     <option value='Medium'>Medium</option>
     <option value='Large'>Large</option>
 </select><br>
 Fill color:<br>
-<select onclick="globalFillColor(); hashfunction(); updategfx();" id='FillColor'>
+<select onchange="globalFillColor(); hashfunction(); updategfx();" id='FillColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -38,7 +38,7 @@ Fill color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Stroke color:<br>
-<select onclick="globalStrokeColor(); hashfunction(); updategfx();" id='StrokeColor'>
+<select onchange="globalStrokeColor(); hashfunction(); updategfx();" id='StrokeColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>

--- a/DuggaSys/forms/line_appearance.php
+++ b/DuggaSys/forms/line_appearance.php
@@ -1,5 +1,5 @@
 Line type: </br>
-<select onclick="changeObjectAppearance('lineType');" id='object_type'>
+<select onchange="changeObjectAppearance('lineType');" id='object_type'>
     <option value='normal'>Normal</option>
     <option value='Forced'>Forced</option>
     <option value='Derived'>Derived</option>
@@ -12,7 +12,7 @@ Cardinality: <br/>
   <option value="M">M</option>
 </select><br/>
 <!--Line colors:<br>
-<select onclick="changeObjectAppearance('attributeType');" id='AttributeLineColor'>
+<select onchange="changeObjectAppearance('attributeType');" id='AttributeLineColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>

--- a/DuggaSys/forms/relation_appearance.php
+++ b/DuggaSys/forms/relation_appearance.php
@@ -1,12 +1,12 @@
 Relation name:</br>
 <input onkeyup="changeObjectAppearance('relationType');" id='nametext' type='text'></br>
 Relation type: </br>
-<select onclick="changeObjectAppearance('relationType');" id='object_type'>
+<select onchange="changeObjectAppearance('relationType');" id='object_type'>
     <option value='Weak'>Weak</option>
     <option value='Strong' selected>Strong</option>
 </select></br>
 Background color:<br>
-<select onclick="changeObjectAppearance('relationType');" id='symbolColor'>
+<select onchange="changeObjectAppearance('relationType');" id='symbolColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -18,14 +18,14 @@ Background color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Font family:<br>
-<select onclick="changeObjectAppearance('relationType');" id='font'>
+<select onchange="changeObjectAppearance('relationType');" id='font'>
     <option value='Arial' selected>Arial</option>
     <option value='Courier New'>Courier New</option>
     <option value='Impact'>Impact</option>
     <option value='Calibri'>Calibri</option>
 </select><br>
 Font color:<br>
-<select onclick="changeObjectAppearance('relationType');" id='fontColor'>
+<select onchange="changeObjectAppearance('relationType');" id='fontColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -37,14 +37,14 @@ Font color:<br>
     <option value='#000000' selected="true">Black</option>
 </select><br>
 Text size:<br>
-<select onclick="changeObjectAppearance('relationType');" id='TextSize'>
+<select onchange="changeObjectAppearance('relationType');" id='TextSize'>
     <option value='Tiny' selected="true">Tiny</option>
     <option value='Small'>Small</option>
     <option value='Medium'>Medium</option>
     <option value='Large'>Large</option>
 </select><br>
 Line colors:<br>
-<select onclick="changeObjectAppearance('attributeType');" id='AttributeLineColor'>
+<select onchange="changeObjectAppearance('attributeType');" id='AttributeLineColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>


### PR DESCRIPTION
Changed calling type for selectboxes from onclick to onchange. Onchange makes the changes appear immediately when selecting an option. Onclick didn't work on mac computers.

This is a soulution for issue #5088.
