### PR TITLE
#4350 Part 4 - Check of code standard in HGustavs/LenaSYS/DuggaSYS/sectioned.js

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -259,11 +259,6 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
 
 }
 
-function participationList() {
-	alert("ParticipationList");
-}
-
-
 function changedType(value)
 {
 	kind=value;


### PR DESCRIPTION
#4350 
@a15magkn

Removed the function participationList().
This is most likely a remnant of the old GroupEd that was removed in the issue #4188