### PR TITLE
#5166 - DuggaED: Remove answer column in variants

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -590,7 +590,6 @@ function renderVariant(clickedElement) {
 		tblhead: {
 			vid: "",
 			param: "Parameter",
-			variantanswer: "Answer",
 			modified: "Modified",
 			disabled: "Status",
 			arrowVariant: "",


### PR DESCRIPTION
#5166 - Removed the answer column from the variants editor.

According to the customer, it is a little uncertain where the answer related data is used, so the code has not been modified more than removing the column from the editor.