### PR TITLE
G2 a16rasja 5161

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -56,7 +56,7 @@
     <div id="content" style="padding-top: 40px; padding-bottom: 0px; padding-right: 0px; padding-left: 0px;">
         <div id="buttonDiv">
             <div class="document-settings">
-                <div id="diagram-toolbar" class="application-toolbar-wrap">
+                <div id="diagram-toolbar" class="application-toolbar-wrap" style="display:none">
                     <div class="application-header">
                         <div id="toolbar-minimize"  onclick="toggleToolbarMinimize();">
                             <img id="minimizeArrow" class="toolbarMaximized" src="../Shared/icons/arrow.svg">

--- a/DuggaSys/diagram_toolbox.js
+++ b/DuggaSys/diagram_toolbox.js
@@ -1,11 +1,12 @@
-var val;
+var toolbarState;
 
 function initToolbox(){
     var element = document.getElementById('diagram-toolbar');
     var myCanvas = document.getElementById('myCanvas');
     var bound = myCanvas.getBoundingClientRect();
     element.style.top = (bound.top+"px");
-    val = (localStorage.getItem("toolbarState") != null) ? localStorage.getItem("toolbarState") : 0;
+    toolbarState = (localStorage.getItem("toolbarState") != null) ? localStorage.getItem("toolbarState") : 0;
+    switchToolbar();
     //element.style.height = (bound.bottom-bound.top-200+"px");
     //element.style.height = (400+"px");
 }
@@ -24,26 +25,26 @@ function toggleToolbarMinimize(){
 function switchToolbar(direction){
   var text = ["All", "ER", "UML"];
   if(direction == 'left'){
-    val--;
-    if(val < 0){
-      val = 2;
+    toolbarState--;
+    if(toolbarState < 0){
+      toolbarState = 2;
     }
   }else if(direction == 'right'){
-    val++;
-    if(val > 2){
-      val = 0;
+    toolbarState++;
+    if(toolbarState > 2){
+      toolbarState = 0;
     }
   }
-  document.getElementById('toolbarTypeText').innerHTML = text[val];
-  localStorage.setItem("toolbarState", val)
+  document.getElementById('toolbarTypeText').innerHTML = text[toolbarState];
+  localStorage.setItem("toolbarState", toolbarState);
   //hides irrelevant buttons, and shows relevant buttons
-  if(val == 1){
+  if(toolbarState == 1){
     $(".buttonsStyle").hide();
     $("#linebutton").show();
     $("#attributebutton").show();
     $("#entitybutton").show();
     $("#relationbutton").show();
-  }else if( val == 2){
+  }else if( toolbarState == 2){
     $(".buttonsStyle").hide();
     $("#linebutton").show();
     $("#classbutton").show();
@@ -52,7 +53,7 @@ function switchToolbar(direction){
     $(".buttonsStyle").show();
   }
 
-  document.getElementById('toolbar-switcher').value = val;
+  document.getElementById('toolbar-switcher').value = toolbarState;
 }
 
 

--- a/DuggaSys/diagram_toolbox.js
+++ b/DuggaSys/diagram_toolbox.js
@@ -1,10 +1,11 @@
-var val = (locallocalStorage.getItem("toolbarState") != null) localStorage.getItem("toolbarState") : 0;
+var val;
 
 function initToolbox(){
     var element = document.getElementById('diagram-toolbar');
     var myCanvas = document.getElementById('myCanvas');
     var bound = myCanvas.getBoundingClientRect();
     element.style.top = (bound.top+"px");
+    val = (locallocalStorage.getItem("toolbarState") != null) ? localStorage.getItem("toolbarState") : 0;
     //element.style.height = (bound.bottom-bound.top-200+"px");
     //element.style.height = (400+"px");
 }

--- a/DuggaSys/diagram_toolbox.js
+++ b/DuggaSys/diagram_toolbox.js
@@ -5,7 +5,7 @@ function initToolbox(){
     var myCanvas = document.getElementById('myCanvas');
     var bound = myCanvas.getBoundingClientRect();
     element.style.top = (bound.top+"px");
-    val = (locallocalStorage.getItem("toolbarState") != null) ? localStorage.getItem("toolbarState") : 0;
+    val = (localStorage.getItem("toolbarState") != null) ? localStorage.getItem("toolbarState") : 0;
     //element.style.height = (bound.bottom-bound.top-200+"px");
     //element.style.height = (400+"px");
 }

--- a/DuggaSys/diagram_toolbox.js
+++ b/DuggaSys/diagram_toolbox.js
@@ -7,6 +7,7 @@ function initToolbox(){
     element.style.top = (bound.top+"px");
     toolbarState = (localStorage.getItem("toolbarState") != null) ? localStorage.getItem("toolbarState") : 0;
     switchToolbar();
+    element.style.display = "block";
     //element.style.height = (bound.bottom-bound.top-200+"px");
     //element.style.height = (400+"px");
 }

--- a/DuggaSys/diagram_toolbox.js
+++ b/DuggaSys/diagram_toolbox.js
@@ -1,4 +1,4 @@
-var val = 0;
+var val = (locallocalStorage.getItem("toolbarState") != null) localStorage.getItem("toolbarState") : 0;
 
 function initToolbox(){
     var element = document.getElementById('diagram-toolbar');
@@ -34,7 +34,7 @@ function switchToolbar(direction){
     }
   }
   document.getElementById('toolbarTypeText').innerHTML = text[val];
-
+  localStorage.setItem("toolbarState", val)
   //hides irrelevant buttons, and shows relevant buttons
   if(val == 1){
     $(".buttonsStyle").hide();


### PR DESCRIPTION
When the user has changed the toolbar state and reloads the page it now remembers which toolbar the user have chosen (All, ER, UML) and switches to that toolbar immediately.

This is a soulution for issue #5161 