### PR TITLE
G2 a16rasja 5173

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1255,15 +1255,6 @@ input {
   padding: 8px 0px 8px 8px;
 }
 
-.drop-down-item>a::before,
-.export-drop-down-item>a::before {
-  /*PLACEHOLDER FOR ICON*/
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  content: "I";
-}
-
 .drop-down-item:hover,
 .export-drop-down-item:hover {
   background-color: rgb(240, 240, 240);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1270,14 +1270,6 @@ input {
   padding: 8px 0px 8px 8px;
 }
 
-.drop-down-text>a::before {
-  /*PLACEHOLDER FOR ICON*/
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  content: "I";
-}
-
 .drop-down-text:hover {
   background-color: rgb(240, 240, 240);
   cursor: default !important;


### PR DESCRIPTION
There are no longer lines beside the menu items in the diagram menu.

![chrome_2018-05-08_16-25-02](https://user-images.githubusercontent.com/37794628/39763211-ce045406-52dc-11e8-9aee-31b583f58e75.png)

This is a soulution for issue #5173 