### PR TITLE
G2-b16andka-5196

### DIFF
--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -373,6 +373,7 @@ function SortableTable(tbl,tableid,filterid,caption,renderCell,renderSortOptions
 		mhvstr+= "</table>";
 
 		this.magicHeader();
+		freezePaneHandler();
 	}
 
 	this.toggleColumn = function(colname,col) {


### PR DESCRIPTION
The magicheader in sortableTable is no longer flickering when rendering the table.

Solution for #5196 