### PR TITLE
#5159 DuggaED: New button in variants

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -305,7 +305,8 @@ function validateDuggaName() {
 // VARIANT FUNCTIONS start
 function newVariant() {
 	showVariantDisableButton();
-	showVariantSubmitButton();
+	$("#submitVariant").css("display", "block");
+	$("#saveVariant").css("display", "none");
 	document.getElementById('filelink').value = '';
 	document.getElementById('filelink').placeholder = 'File link';
 	document.getElementById('extraparam').value = '';
@@ -341,7 +342,7 @@ function selectVariant(vid) {
 		});
 	});
 
-	showVariantSaveButton();
+	$("#saveVariant").css("display", "block");
 
 	$("#vid").val(target_variant['vid']); // Set Variant ID
 	$("#variantparameterText").val(target_variant['param']); // Set Variant ID
@@ -819,16 +820,6 @@ function showDuggaSaveButton() {
 	$("#saveDugga").css("display", "block");
 }
 
-function showVariantSubmitButton() {
-	$("#submitVariant").css("display", "block");
-	$("#saveVariant").css("display", "none");
-}
-
-function showVariantSaveButton() {
-	$("#submitVariant").css("display", "none");
-	$("#saveVariant").css("display", "block");
-}
-
 function showVariantEnableButton() {
 	$("#enableVariant").css("display", "block");
 	$("#disableVariant").css("display", "none");
@@ -838,6 +829,7 @@ function showVariantDisableButton() {
 	$("#enableVariant").css("display", "none");
 	$("#disableVariant").css("display", "block");
 }
+
 
 //END OF closers and openers
 

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -175,8 +175,8 @@ pdoConnect();
             </div>
             <div id='buttonVariantDiv' style='padding:5px;'>
               <input id='closeVariant' class='submit-button' style='display:block; float:left;' type='button' value='Close' onclick='closeWindows();'>
-              <input id='submitVariant' class='submit-button' style='display:none; float:right;' type='button' value='Submit' onclick='createVariant();'>
-              <input id='saveVariant' class='submit-button' style='display:none; float:right;' type='button' value='Save' onclick='updateVariant(); showVariantSubmitButton();'>
+              <input id='submitVariant' class='submit-button' style='display:none; float:right;' type='button' value='Create' onclick='createVariant();'>
+              <input id='saveVariant' class='submit-button' style='display:none; float:right;' type='button' value='Update' onclick='updateVariant();'>
               <input id='disableVariant' class='submit-button disableEnable' style='display:none; float:right;' type='button' value='Disable' onclick='showVariantEnableButton();'>
               <input id='enableVariant' class='submit-button disableEnable' style='display:none; float:right;' type='button' value='Enable' onclick='showVariantDisableButton();'>
               <input id='cancelVariant' class='submit-button' style='display:block; float:right;' type='button' value='Cancel' onclick='newVariant(); removeVariantTableHighlights();'>


### PR DESCRIPTION
**#5159**

Changed the buttons so that the "Send" button says "create" to make it clear that it creates a new variant. The "save" button also has a changed name to "update" to clarify that it updates a variation.

To duplicate a variation it is necessary to click edit on a variant and then press the "create" button. Making multiple duplicates at once does not work well because the table will be updated between each individual insertion.

This solution is no doubt enough workable when the maximum number of variants for a dugga is 36.