### PR TITLE
A bugg fix that solves incorrect sorting of duggas on the result page

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -889,16 +889,16 @@ function compare(a,b) {
 			tempB += 10;
 		}
 
-		if(a['submitted'] > b['submitted']) {
+		if(a['submitted'] < b['submitted']) {
 			tempA += 1;
-		} else if(a['submitted'] < b['submitted']) {
+		} else if(a['submitted'] > b['submitted']) {
 			tempB += 1;
 		}
 	}
 
-	if (tempA > tempB) {
+	if (tempA < tempB) {
 		return 1;
-	} else if (tempA < tempB) {
+	} else if (tempA > tempB) {
 		return -1;
 	} else {
 		return 0;

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -850,6 +850,14 @@ function compare(a,b) {
 		tempB += " " + b['lastname'].toUpperCase();
 		tempB += " " + b['ssn'].toUpperCase();
 
+		if (tempA > tempB) {
+			return 1;
+		} else if (tempA < tempB) {
+			return -1;
+		} else {
+			return 0;
+		}
+
 	//Columns that contains duggor
 	} else {
 		/* The sorting in a column needs to follow the following priority order:
@@ -894,14 +902,14 @@ function compare(a,b) {
 		} else if(a['submitted'] > b['submitted']) {
 			tempB += 1;
 		}
-	}
 
-	if (tempA < tempB) {
-		return 1;
-	} else if (tempA > tempB) {
-		return -1;
-	} else {
-		return 0;
+		if (tempA < tempB) {
+			return 1;
+		} else if (tempA > tempB) {
+			return -1;
+		} else {
+			return 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Issue #5200 

A couple of bugs have been found:

- It seems like the entire table is being sorted backwards. When the table is supposed to be sorted in ascending order it is actually sorted in descended order (and vice versa).

- It also seems like the different sections is being sorted backwards. In the first section for example; On-time, ungraded duggas is being sorted. Duggas here should be sorted from oldest to newest. Though, a newly submitted dugga is being sorted before older duggas. This should not happen.

**Solution:**
The sorting on duggas on the result page should be:

1. Ungraded duggas within deadline (Yellow)
2. Ungraded duggas that have been submitted to late (Orange)
3. Passed duggas (Green)
4. Failed duggas (Red)
5. Students that has only viewed the dugga but not submitted anything (light purple background)
6. All other students that has not even visited the dugga (grey panel without buttons)

The sorting on Fname/Lname/SSN should be:
1. First name
2. Last name
3. SSN

To be able to test this I refer to merge #5187

> Duggas submitted after the deadline should be separated from the duggas submitted before the deadline by using two distinct background colours.
>
>The solution affects the table on the result page.
I had to change the test data to be able to test this, since all deadlines where prior to the submissions.
So i used the following MySql query to change the deadline so i could have both duggas before and after the deadline.
>
>update quiz set deadline = '2017-01-01 23:59:59' where id = 10;
>
>This will change the deadline for "Rapport" in the course "Webbutveckling - datorgrafik".
Then I also had to make a new submission for one of the students who had NOT done the "Rapport" dugga yet to be able to see the difference on submitted duggas. (yellow/oranage)