### PR TITLE
G2 c16carbe 5222

### DIFF
--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -220,7 +220,7 @@ function Symbol(kind) {
             this.minHeight = attrHeight + opHeight;
 
             //Finding the longest string
-            var longestStr = "";
+            var longestStr = this.name;
             for(var i = 0; i < this.operations.length; i++){
                 if(this.operations[i].text.length > longestStr.length)
                     longestStr = this.operations[i].text;


### PR DESCRIPTION
Fixed so that UML will resize according to the name of the class if no operations/attributes exist (or if they are shorter than the classname)

This fixes issue #5222 