### PR TITLE
G2 a16adala 5192

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -122,7 +122,7 @@ pdoConnect();
                     <span id="codeBlockText" onclick="codeBlockText()" title="CodeBlock">&#10065;</span>
                     <span id="lists" onclick="lists()" title="lists">&#9711;</span>
                     <span id="quoteText" onclick="quoteText()" title="quote">&#10078;</span>
-                    <span id="linkz" onclick="linkText()" title="link"><img id="linkFabBtnImg" class="fab-icon"
+                    <span id="linkz" onclick="linkText()" title="link"><img id="linkFabBtnImgPrev" class="fab-icon"
                                                                             src="../Shared/icons/link-icon.svg"></span>
                     <span id="img" onclick="externalImg()" title="Img"><img id="insert-photo" class="fab-icon"
                                                                             src="../Shared/icons/insert-photo.svg"></span>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3870,7 +3870,7 @@ textarea#mrkdwntxt {
     margin-left: 14%;
 }
 
-#linkFabBtnImg {
+#linkFabBtnImgPrev {
     position: absolute;
     margin-left: 10px;
 }


### PR DESCRIPTION
Changed the ID that controlled the css for the fab-button Link and the link button inside the preview-window. Now they have seperate id's and will no longer be a problem for eachother
This is a fix for issue #5192 