### PR TITLE
G2-a15setno-5149

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -138,8 +138,7 @@ pdoConnect();
                     </div>
                 </div>
                 <div class="markText">
-                <textarea id="mrkdwntxt" oninput="updatePreview(this.value)" name="markdowntext" rows="32"
-                          cols="40"></textarea>
+                <textarea id="mrkdwntxt" oninput="updatePreview(this.value)" name="markdowntext"></textarea>
                 </div>
             </div>
             <div class="markdownPrev">

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3950,23 +3950,38 @@ textarea#mrkdwntxt {
 
 }
 
-@media only screen and (max-height: 800px) and (max-width: 1400px) {
-    .previewWindow {
-        height: 500px;
-     }
-     .markdown {
-         height: 400px;
-     }
-     .markdownPrev {
-         height: 400px;
-     }
-    #mrkdwntxt {
-        height: 350px;
-    }
-    .optionButtons {
-        top: 436px;
-    }
- }
+
+@media only screen and (max-height: 2560px) and (max-width: 1400px) {
+  .previewWindow {
+    height: 750px;
+    position: fixed;
+  }
+
+  .markdown {
+    height: 350px;
+    width: 97%;
+    position: relative;
+    float: left;
+  }
+
+  .markdownPrev {
+    height: 250px;
+    width: 92%;
+    float: left;
+    position: fixed;
+    margin: 400px auto auto 8px;
+  }
+
+  #mrkdwntxt {
+    height: 300px;
+    width: 100%;
+  }
+
+  .optionButtons {
+    top: 686px;
+  }
+}
+
 
 /* Import diagram */
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3696,6 +3696,10 @@ li:nth-last-child(10) a:hover {
     position: fixed;
 }
 
+.markdownPart{
+  height: 100%;
+}
+
 .markdown {
   border: solid rgb(200, 200, 200);
   background-color: #FFFFFF;
@@ -3717,6 +3721,11 @@ li:nth-last-child(10) a:hover {
   margin: 20px 1% 10px 8px;
   float: right;
 }
+
+#editForm {
+  height:100%;
+}
+
 .markdownPrev pre{
   font-family: Hack, MyWebFont,Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
   font-size: 10px;
@@ -3730,6 +3739,7 @@ li:nth-last-child(10) a:hover {
   border: 1px solid #bebab0;
   box-shadow: 1px 1px 2px #666;
 }
+
 .optionButtons {
   top: 585px;
   position: relative;
@@ -3951,32 +3961,33 @@ textarea#mrkdwntxt {
 }
 
 
-@media only screen and (max-height: 2560px) and (max-width: 1400px) {
+@media only screen and (max-height: 2560px) and (max-width: 1440px) {
   .previewWindow {
-    height: 750px;
-    position: fixed;
+    height: 80%;
   }
-
   .markdown {
-    height: 350px;
+    height: 35%;
     width: 97%;
     position: relative;
     float: left;
   }
-
   .markdownPrev {
-    height: 250px;
-    width: 92%;
+    height: 35%;
+    width: 97%;
     float: left;
-    position: fixed;
-    margin: 400px auto auto 8px;
+    margin: auto auto auto 8px;
   }
-
+  .markText {
+    height:75%;
+    width:90%;
+  }
   #mrkdwntxt {
-    height: 300px;
-    width: 100%;
+    border-radius: 8px;
+    resize: none;
+    width:100%;
+    height:100%;
+    margin:12px;
   }
-
   .optionButtons {
     top: 686px;
   }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3966,8 +3966,6 @@ textarea#mrkdwntxt {
     width:90%;
   }
   #mrkdwntxt {
-    border-radius: 8px;
-    resize: none;
     width:100%;
     height:100%;
     margin:5px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3726,20 +3726,6 @@ li:nth-last-child(10) a:hover {
   height:100%;
 }
 
-.markdownPrev pre{
-  font-family: Hack, MyWebFont,Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
-  font-size: 10px;
-  line-height: 12px;
-  white-space: pre;
-  white-space: pre-wrap;
-  background: #ffffff;
-  display: inline-block;
-  padding: 1em;
-  margin: 0.5em 0px;
-  border: 1px solid #bebab0;
-  box-shadow: 1px 1px 2px #666;
-}
-
 .optionButtons {
   top: 585px;
   position: relative;
@@ -3957,11 +3943,9 @@ textarea#mrkdwntxt {
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);
 }
 #inputSave {
-
 }
 
-
-@media only screen and (max-height: 2560px) and (max-width: 1440px) {
+@media only screen and (max-height: 800px) and (max-width: 1350px) {
   .previewWindow {
     height: 80%;
   }
@@ -3978,7 +3962,7 @@ textarea#mrkdwntxt {
     margin: auto auto auto 8px;
   }
   .markText {
-    height:75%;
+    height:70%;
     width:90%;
   }
   #mrkdwntxt {
@@ -3986,7 +3970,7 @@ textarea#mrkdwntxt {
     resize: none;
     width:100%;
     height:100%;
-    margin:12px;
+    margin:5px;
   }
   .optionButtons {
     top: 686px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3945,7 +3945,7 @@ textarea#mrkdwntxt {
 #inputSave {
 }
 
-@media only screen and (max-height: 800px) and (max-width: 1350px) {
+@media only screen and (max-height: 1440px) and (max-width: 1350px) {
   .previewWindow {
     height: 80%;
   }


### PR DESCRIPTION
The layout for the mobile view is changed. 
The codeblock is also fixed, if you want to create a codeblock you only get one box around the code, instead of two boxes.

---
![mobil 2 0](https://user-images.githubusercontent.com/37832730/40000038-0558ef9a-578b-11e8-96c5-4a7755436525.PNG)

This is a fix for issue #5149 