### PR TITLE
#5165 - SectionED: Toggle and hide new swimlande view

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -898,17 +898,19 @@ function returnedSection(data) {
 		str += "<div id='courseList'>";
 		str += "<!-- Statistics List -->"
 		+ "<div id='statisticsList'>"
-			+ "<div id='statistics' style='display: inline-block; cursor: pointer;'>"
-				+ "<div style='margin: 10px;'>"
-					+ "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + menuState.idCounter++ + data.coursecode + "class='arrowComp' style='display: none;'>"
-					+ "<img src='../Shared/icons/right_complement.svg' id='arrowRight" + menuState.idCounter++ + data.coursecode + "class='arrowRight' style='display: inline;'>"
-				+ "</div>"
-				+ "<div class='nowrap' style='padding-left:5px' title='statistics'>"
-						+ "<span class='listentries-span' style='writing-mode: vertical-rl; text-orientation: upright;'>Statistics</span>"
-				+ "</div>"
-			+ "</div>"
-			+ "<div id='statistics" + menuState.idCounter + data.coursecode + "' class='statisticsContent' style='display: inline-block;'></div>"
-		+ "</div>";
+		+ "<div id='statistics' class='statistics' style='display: inline-block; cursor: pointer;'>"
+		+ "<div style='margin: 10px;'>"
+		+ "<img src='../Shared/icons/desc_complement.svg' id='arrowComp"
+		+ menuState.idCounter++ + data.coursecode + "' class='arrowComp' style='display: inline-block;'>"
+		+ "<img src='../Shared/icons/right_complement.svg' id='arrowRight"
+		+ menuState.idCounter++ + data.coursecode + "' class='arrowRight' style='display: none;'>"
+		+ "</div>"
+		+ "<div class='nowrap' style='padding-left:5px' title='statistics'>"
+		+ "<span class='listentries-span' style='writing-mode: vertical-rl; text-orientation: upright;'>Statistics</span>"
+		+ "</div></div>"
+		+ "<div id='statistics" + menuState.idCounter + data.coursecode
+		+ "' class='statisticsContent' style='display: inline-block;'>"
+		+ "</div></div>";
 
 		str += "<div id='Sectionlistc'>";
 
@@ -1589,7 +1591,7 @@ function returnedHighscore(data) {
 }
 
 // Toggle content for each moment
-$(document).on('click', '.moment, .section', function () {
+$(document).on('click', '.moment, .section, .statistics', function () {
 	/* The event handler returns two elements. The following two if statements
 	   gets the element of interest. */
 	if (this.id.length > 0) {
@@ -1598,9 +1600,11 @@ $(document).on('click', '.moment, .section', function () {
 	if (this.id.length > 0) {
 		saveArrowIds(this.id);
 	}
+
 	hideCollapsedMenus();
 	toggleArrows();
 });
+
 
 // Save ids of all elements, whose state needs to be remembered, in local storage.
 function saveHiddenElementIDs(clickedElement) {
@@ -1622,15 +1626,19 @@ function saveArrowIds(clickedElement) {
 /* Hide all child elements to the moment and section elements in the
    hiddenElements array. */
 function hideCollapsedMenus() {
-	$('.header, .section, .code, .test, .link, .group').show();
+	$('.header, .section, .code, .test, .link, .group, .statisticsContent').show();
 	for (var i = 0; i < menuState.hiddenElements.length; i++) {
 		var ancestor = findAncestor($("#" + menuState.hiddenElements[i])[0], "moment");
 		if ((ancestor != undefined || ancestor != null) && ancestor.classList.contains('moment')) {
+			console.log("Moment!"); // Remove later
 			jQuery(ancestor).nextUntil('.moment').hide();
 		}
 		ancestor = findAncestor($("#" + menuState.hiddenElements[i])[0], "section");
 		if ((ancestor != undefined || ancestor != null) && ancestor.classList.contains('section')) {
 			jQuery(ancestor).nextUntil('.section').hide();
+		}
+		if(menuState.hiddenElements[i] == "statistics"){
+			$("#statistics").nextAll().hide();
 		}
 	}
 }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -900,16 +900,13 @@ function returnedSection(data) {
 		+ "<div id='statisticsList'>"
 		+ "<div id='statistics' class='statistics' style='display: inline-block; cursor: pointer;'>"
 		+ "<div style='margin: 10px;'>"
-		+ "<img src='../Shared/icons/desc_complement.svg' id='arrowComp"
-		+ menuState.idCounter++ + data.coursecode + "' class='arrowComp' style='display: inline-block;'>"
-		+ "<img src='../Shared/icons/right_complement.svg' id='arrowRight"
-		+ menuState.idCounter++ + data.coursecode + "' class='arrowRight' style='display: none;'>"
+		+ "<img src='../Shared/icons/right_complement.svg' id='arrowRightStatistics' style='display: inline-block;'>"
+		+ "<img src='../Shared/icons/desc_complement.svg' id='arrowCompStatistics' style='display: none;'>"
 		+ "</div>"
 		+ "<div class='nowrap' style='padding-left:5px' title='statistics'>"
 		+ "<span class='listentries-span' style='writing-mode: vertical-rl; text-orientation: upright;'>Statistics</span>"
 		+ "</div></div>"
-		+ "<div id='statistics" + menuState.idCounter + data.coursecode
-		+ "' class='statisticsContent' style='display: inline-block;'>"
+		+ "<div class='statisticsContent' style='display: inline-block;'>"
 		+ "</div></div>";
 
 		str += "<div id='Sectionlistc'>";
@@ -1630,25 +1627,36 @@ function hideCollapsedMenus() {
 	for (var i = 0; i < menuState.hiddenElements.length; i++) {
 		var ancestor = findAncestor($("#" + menuState.hiddenElements[i])[0], "moment");
 		if ((ancestor != undefined || ancestor != null) && ancestor.classList.contains('moment')) {
-			console.log("Moment!"); // Remove later
 			jQuery(ancestor).nextUntil('.moment').hide();
 		}
 		ancestor = findAncestor($("#" + menuState.hiddenElements[i])[0], "section");
 		if ((ancestor != undefined || ancestor != null) && ancestor.classList.contains('section')) {
 			jQuery(ancestor).nextUntil('.section').hide();
 		}
+
 		if(menuState.hiddenElements[i] == "statistics"){
-			$("#statistics").nextAll().hide();
+			$(".statistics").nextAll().hide();
 		}
 	}
 }
 
 /* Show down arrow by default and then hide this arrow and show the right
-   arrow if it is in the arrowIcons array. */
+   arrow if it is in the arrowIcons array.
+	 The other way around for the statistics section. */
 function toggleArrows() {
+	$('#arrowRightStatistics').show();
+	$('#arrowCompStatistics').hide();
+	for (var i = 0; i < menuState.hiddenElements.length; i++){
+		console.log("Hej!");
+		if (menuState.hiddenElements[i] == "statistics"){
+			console.log("Hej! if");
+			$('#arrowRightStatistics').hide();
+			$('#arrowCompStatistics').show();
+		}
+	}
+
 	$('.arrowComp').show();
 	$('.arrowRight').hide();
-
 	for (var i = 0; i < menuState.arrowIcons.length; i++) {
 		/* If the string 'arrowComp' is a part of the string on the current
 		   index of the arrowIcons array, hide down arrow and show right arrow. */

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -895,7 +895,22 @@ function returnedSection(data) {
 
 		str += "</div>";
 
-		str += "<div id='Sectionlistc' >";
+		str += "<div id='courseList'>";
+		str += "<!-- Statistics List -->"
+		+ "<div id='statisticsList'>"
+			+ "<div id='statistics' style='display: inline-block; cursor: pointer;'>"
+				+ "<div style='margin: 10px;'>"
+					+ "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + menuState.idCounter++ + data.coursecode + "class='arrowComp' style='display: none;'>"
+					+ "<img src='../Shared/icons/right_complement.svg' id='arrowRight" + menuState.idCounter++ + data.coursecode + "class='arrowRight' style='display: inline;'>"
+				+ "</div>"
+				+ "<div class='nowrap' style='padding-left:5px' title='statistics'>"
+						+ "<span class='listentries-span' style='writing-mode: vertical-rl; text-orientation: upright;'>Statistics</span>"
+				+ "</div>"
+			+ "</div>"
+			+ "<div id='statistics" + menuState.idCounter + data.coursecode + "' class='statisticsContent' style='display: inline-block;'></div>"
+		+ "</div>";
+
+		str += "<div id='Sectionlistc'>";
 
 		// For now we only have two kinds of sections
 		if (data['entries'].length > 0) {
@@ -1459,7 +1474,7 @@ function returnedSection(data) {
 			str += "</div>";
 		}
 
-		str += "</div>";
+		str += "</div></div>";
 		var slist = document.getElementById('Sectionlist');
 		slist.innerHTML = str;
 		if (resave == true) {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -511,13 +511,14 @@ p {
   display: flex;
  }
 
- #statistics {
+ .statistics {
    background-color: #927b9e;
    color: white;
    width: 36px;
    height: 100%;
    box-shadow: 3px 0px 0px #aaa;
    margin-right: 3px;
+   font-size: 14pt;
  }
 
  .statisticsContent {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -497,6 +497,35 @@ p {
   display: inline-block;
 }
 
+/*  Statistics List */
+
+#courseList { /* Move up later*/
+    display: flex;
+}
+
+#Sectionlistc { /* Move up later*/
+  display: inline-block;
+}
+
+ #statisticsList {
+  display: flex;
+ }
+
+ #statistics {
+   background-color: #927b9e;
+   color: white;
+   width: 36px;
+   height: 100%;
+   box-shadow: 3px 0px 0px #aaa;
+   margin-right: 3px;
+ }
+
+ .statisticsContent {
+   width: 100px;
+   height: 100%;
+   background-color: #d8d7da;
+ }
+
 /* --------------================################================-------------- *
  *                                    Header                                    *
  * --------------================################================-------------- */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1961,13 +1961,13 @@ span.arrow {
   /* ie 6/7 */
 }
 
-.arrowComp {
+.arrowComp, #arrowCompStatistics{
   vertical-align: text-top;
   position: relative;
   cursor: pointer;
 }
 
-.arrowRight {
+.arrowRight, #arrowRightStatistics{
   vertical-align: text-top;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
#5165 - @a16thegu
Created a statistics section that is collapsable, just like moment or section, to the left in sectionEd.

Bug with the arrows, that are changing bepending on if the section is collapsed or not.
Arrow down should show when the section is collapsed and arrow right when the section is showing.
This bug will be soled in issue #5233 .