### PR TITLE
G2-b16petma-5183

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -135,7 +135,8 @@ function keyDownHandler(e){
         for(var i = 0; i < cloneTempArray.length; i++){
             //Display cloned objects except lines
             if(cloneTempArray[i].symbolkind != 4){
-                temp.push(diagram[copySymbol(cloneTempArray[i]) - 1]);
+                const cloneIndex = copySymbol(cloneTempArray[i]) - 1; 
+                temp.push(diagram[cloneIndex]);
             }
         }
         cloneTempArray = temp;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -133,11 +133,12 @@ function keyDownHandler(e){
         //Ctrl + v
         for(var i = 0; i < cloneTempArray.length; i++){
             //Display cloned objects except lines
+            var temp = [];
             if(cloneTempArray[i].symbolkind != 4){
-                copySymbol(cloneTempArray[i]);
+                temp.push(diagram[copySymbol(cloneTempArray[i]) - 1]);
             }
+            cloneTempArray = temp;
         }
-        fillCloneArray();
         updateGraphics();
         SaveState();
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -140,6 +140,7 @@ function keyDownHandler(e){
             }
         }
         cloneTempArray = temp;
+        selected_objects = temp;
         updateGraphics();
         SaveState();
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -128,10 +128,7 @@ function keyDownHandler(e){
         ctrlIsClicked = true;
     } else if(ctrlIsClicked && key == 67){
         //Ctrl + c
-        cloneTempArray = [];
-        for(var i = 0; i < selected_objects.length; i++){
-            cloneTempArray.push(selected_objects[i]);
-        }
+        fillCloneArray();
     } else if(ctrlIsClicked && key == 86 ){
         //Ctrl + v
         for(var i = 0; i < cloneTempArray.length; i++){
@@ -140,6 +137,7 @@ function keyDownHandler(e){
                 copySymbol(cloneTempArray[i]);
             }
         }
+        fillCloneArray();
         updateGraphics();
         SaveState();
     }
@@ -151,6 +149,13 @@ function keyDownHandler(e){
       ctrlIsClicked = true;
     }
 
+}
+
+function fillCloneArray(){
+    cloneTempArray = [];
+    for(var i = 0; i < selected_objects.length; i++){
+        cloneTempArray.push(selected_objects[i]);
+    }
 }
 
 //--------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -131,14 +131,14 @@ function keyDownHandler(e){
         fillCloneArray();
     } else if(ctrlIsClicked && key == 86 ){
         //Ctrl + v
+        var temp = [];
         for(var i = 0; i < cloneTempArray.length; i++){
             //Display cloned objects except lines
-            var temp = [];
             if(cloneTempArray[i].symbolkind != 4){
                 temp.push(diagram[copySymbol(cloneTempArray[i]) - 1]);
             }
-            cloneTempArray = temp;
         }
+        cloneTempArray = temp;
         updateGraphics();
         SaveState();
     }


### PR DESCRIPTION
We use the newly copied symbols for the next ctrl-v. This fixes that the symbols stacks.
Solution for issue #5183 