### PR TITLE
G2 a16rasja 5245

### DIFF
--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -24,7 +24,8 @@ function closeAppearanceDialogMenu() {
      */
      //if the X
      if(globalAppearanceValue == 1){
-
+       var tmpDiagram = localStorage.getItem("diagram" + diagramNumberHistory);
+       if (tmpDiagram != null) LoadImport(tmpDiagram);
      }
     appearanceMenuOpen = false;
     classAppearanceOpen = false;

--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -1,5 +1,3 @@
-var tempDiagram;
-
 //--------------------------------------------------------------------
 // Basic functionality
 // The building blocks for creating the menu
@@ -26,7 +24,8 @@ function closeAppearanceDialogMenu() {
      */
      //if the X is pressed on the global appearance menu rollback the changes
      if(globalAppearanceValue == 1){
-       diagram = tempDiagram;
+       var tmpDiagram = localStorage.getItem("diagram" + diagramNumberHistory);
+       if (tmpDiagram != null) LoadImport(tmpDiagram);
      }
     appearanceMenuOpen = false;
     classAppearanceOpen = false;
@@ -35,6 +34,7 @@ function closeAppearanceDialogMenu() {
     $("#appearance").hide();
     dimDialogMenu(false);
     document.removeEventListener("click", clickOutsideDialogMenu);
+    SaveState();
 }
 
 function clickOutsideDialogMenu(ev) {
@@ -169,7 +169,6 @@ function setSelectedOption(type, value){
 
 function globalAppearanceMenu(){
     globalAppearanceValue = 1;
-    tempDiagram = diagram;
 
     //open a menu to change appearance on all entities.
     var form = showMenu();

--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -1,3 +1,5 @@
+var tempDiagram;
+
 //--------------------------------------------------------------------
 // Basic functionality
 // The building blocks for creating the menu
@@ -22,6 +24,10 @@ function closeAppearanceDialogMenu() {
     /*
      * Closes the dialog menu for appearance.
      */
+     //if the X is pressed on the global appearance menu rollback the changes
+     if(globalAppearanceValue == 1){
+       diagram = tempDiagram;
+     }
     appearanceMenuOpen = false;
     classAppearanceOpen = false;
     globalAppearanceValue = 0;
@@ -163,6 +169,8 @@ function setSelectedOption(type, value){
 
 function globalAppearanceMenu(){
     globalAppearanceValue = 1;
+    tempDiagram = diagram;
+
     //open a menu to change appearance on all entities.
     var form = showMenu();
     //AJAX

--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -171,7 +171,7 @@ function globalAppearanceMenu(){
     //open a menu to change appearance on all entities.
     var form = showMenu();
     //AJAX
-    loadFormIntoElement(form,'forms/global_appearance.php');
+    //loadFormIntoElement(form,'forms/global_appearance.php');
 }
 
 function objectAppearanceMenu(form) {

--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -22,10 +22,9 @@ function closeAppearanceDialogMenu() {
     /*
      * Closes the dialog menu for appearance.
      */
-     //if the X is pressed on the global appearance menu rollback the changes
+     //if the X
      if(globalAppearanceValue == 1){
-       var tmpDiagram = localStorage.getItem("diagram" + diagramNumberHistory);
-       if (tmpDiagram != null) LoadImport(tmpDiagram);
+
      }
     appearanceMenuOpen = false;
     classAppearanceOpen = false;
@@ -34,7 +33,6 @@ function closeAppearanceDialogMenu() {
     $("#appearance").hide();
     dimDialogMenu(false);
     document.removeEventListener("click", clickOutsideDialogMenu);
-    SaveState();
 }
 
 function clickOutsideDialogMenu(ev) {
@@ -169,7 +167,6 @@ function setSelectedOption(type, value){
 
 function globalAppearanceMenu(){
     globalAppearanceValue = 1;
-
     //open a menu to change appearance on all entities.
     var form = showMenu();
     //AJAX

--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -171,7 +171,7 @@ function globalAppearanceMenu(){
     //open a menu to change appearance on all entities.
     var form = showMenu();
     //AJAX
-    //loadFormIntoElement(form,'forms/global_appearance.php');
+    loadFormIntoElement(form,'forms/global_appearance.php');
 }
 
 function objectAppearanceMenu(form) {

--- a/DuggaSys/forms/global_appearance.php
+++ b/DuggaSys/forms/global_appearance.php
@@ -1,13 +1,14 @@
 Font family:<br>
 <select id='font' onchange='globalFont(); hashFunction(); updateGraphics();'>
+    <option value='' selected>Choose font</option>
     <option value='Arial' selected>Arial</option>
     <option value='Courier New'>Courier New</option>
     <option value='Impact'>Impact</option>
     <option value='Calibri'>Calibri</option>
 </select><br>
-
 Font color:<br>
 <select id ='fontColor' onchange='globalFontColor(); hashFunction(); updateGraphics();'>
+    <option value='' selected>Choose text color</option>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -20,6 +21,7 @@ Font color:<br>
 </select><br>
 Text size:<br>
 <select id='TextSize' onchange='globalTextSize(); hashFunction(); updateGraphics();'>
+    <option value='' selected>Choose text size</option>
     <option value='Tiny' selected>Tiny</option>
     <option value='Small'>Small</option>
     <option value='Medium'>Medium</option>
@@ -27,6 +29,7 @@ Text size:<br>
 </select><br>
 Fill color:<br>
 <select onchange="globalFillColor(); hashFunction(); updateGraphics();" id='FillColor'>
+    <option value='' selected>Choose symbol color</option>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -39,6 +42,7 @@ Fill color:<br>
 </select><br>
 Stroke color:<br>
 <select onchange="globalStrokeColor(); hashFunction(); updateGraphics();" id='StrokeColor'>
+    <option value='' selected>Choose line color</option>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>

--- a/DuggaSys/forms/global_appearance.php
+++ b/DuggaSys/forms/global_appearance.php
@@ -52,4 +52,4 @@ Stroke color:<br>
 Line thickness:<br>
 <input id="line-thickness" onclick='globalLineThickness(); hashFunction(); updateGraphics();' style="width:100%; margin: -2px; padding: 0px;" type="range" min="1" max="5" value="2">
 
-<button type='submit' class='submit-button' onclick="closeAppearanceDialogMenu(); setType(form);" style='float: none; display: block; margin: 0px auto;'>OK</button>
+<button type='submit' class='submit-button' onclick="SaveState(); closeAppearanceDialogMenu(); setType(form);" style='float: none; display: block; margin: 0px auto;'>OK</button>

--- a/DuggaSys/forms/global_appearance.php
+++ b/DuggaSys/forms/global_appearance.php
@@ -1,7 +1,7 @@
 Font family:<br>
 <select id='font' onchange='globalFont(); hashFunction(); updateGraphics();'>
     <option value='' selected> - Choose font - </option>
-    <option value='Arial' selected>Arial</option>
+    <option value='Arial'>Arial</option>
     <option value='Courier New'>Courier New</option>
     <option value='Impact'>Impact</option>
     <option value='Calibri'>Calibri</option>
@@ -22,7 +22,7 @@ Font color:<br>
 Text size:<br>
 <select id='TextSize' onchange='globalTextSize(); hashFunction(); updateGraphics();'>
     <option value='' selected> - Choose text size - </option>
-    <option value='Tiny' selected>Tiny</option>
+    <option value='Tiny' >Tiny</option>
     <option value='Small'>Small</option>
     <option value='Medium'>Medium</option>
     <option value='Large'>Large</option>

--- a/DuggaSys/forms/global_appearance.php
+++ b/DuggaSys/forms/global_appearance.php
@@ -7,7 +7,7 @@ Font family:<br>
 </select><br>
 
 Font color:<br>
-<select id ='fontColor' onchange='globalFontColor(); hashfunction(); updategfx();'>
+<select id ='fontColor' onchange='globalFontColor(); hashFunction(); updateGraphics();'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -19,14 +19,14 @@ Font color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Text size:<br>
-<select id='TextSize' onchange='globalTextSize(); hashfunction(); updategfx();'>
+<select id='TextSize' onchange='globalTextSize(); hashFunction(); updateGraphics();'>
     <option value='Tiny' selected>Tiny</option>
     <option value='Small'>Small</option>
     <option value='Medium'>Medium</option>
     <option value='Large'>Large</option>
 </select><br>
 Fill color:<br>
-<select onchange="globalFillColor(); hashfunction(); updategfx();" id='FillColor'>
+<select onchange="globalFillColor(); hashFunction(); updateGraphics();" id='FillColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -38,7 +38,7 @@ Fill color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Stroke color:<br>
-<select onchange="globalStrokeColor(); hashfunction(); updategfx();" id='StrokeColor'>
+<select onchange="globalStrokeColor(); hashFunction(); updateGraphics();" id='StrokeColor'>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -50,6 +50,6 @@ Stroke color:<br>
     <option value='#000000'>Black</option>
 </select><br>
 Line thickness:<br>
-<input id="line-thickness" onclick='globalLineThickness(); hashfunction(); updategfx();' style="width:100%; margin: -2px; padding: 0px;" type="range" min="1" max="5" value="2">
+<input id="line-thickness" onclick='globalLineThickness(); hashFunction(); updateGraphics();' style="width:100%; margin: -2px; padding: 0px;" type="range" min="1" max="5" value="2">
 
 <button type='submit' class='submit-button' onclick="closeAppearanceDialogMenu(); changeObjectAppearance(); setType(form);" style='float: none; display: block; margin: 0px auto;'>OK</button>

--- a/DuggaSys/forms/global_appearance.php
+++ b/DuggaSys/forms/global_appearance.php
@@ -1,6 +1,6 @@
 Font family:<br>
 <select id='font' onchange='globalFont(); hashFunction(); updateGraphics();'>
-    <option value='' selected>Choose font</option>
+    <option value='' selected> - Choose font - </option>
     <option value='Arial' selected>Arial</option>
     <option value='Courier New'>Courier New</option>
     <option value='Impact'>Impact</option>
@@ -8,7 +8,7 @@ Font family:<br>
 </select><br>
 Font color:<br>
 <select id ='fontColor' onchange='globalFontColor(); hashFunction(); updateGraphics();'>
-    <option value='' selected>Choose text color</option>
+    <option value='' selected> - Choose text color - </option>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -21,7 +21,7 @@ Font color:<br>
 </select><br>
 Text size:<br>
 <select id='TextSize' onchange='globalTextSize(); hashFunction(); updateGraphics();'>
-    <option value='' selected>Choose text size</option>
+    <option value='' selected> - Choose text size - </option>
     <option value='Tiny' selected>Tiny</option>
     <option value='Small'>Small</option>
     <option value='Medium'>Medium</option>
@@ -29,7 +29,7 @@ Text size:<br>
 </select><br>
 Fill color:<br>
 <select onchange="globalFillColor(); hashFunction(); updateGraphics();" id='FillColor'>
-    <option value='' selected>Choose symbol color</option>
+    <option value='' selected> - Choose symbol color - </option>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>
@@ -42,7 +42,7 @@ Fill color:<br>
 </select><br>
 Stroke color:<br>
 <select onchange="globalStrokeColor(); hashFunction(); updateGraphics();" id='StrokeColor'>
-    <option value='' selected>Choose line color</option>
+    <option value='' selected> - Choose line color - </option>
     <option value='#ccefff'>Blue</option>
     <option value='#ddffee'>Green</option>
     <option value='#e6e6e6'>Grey</option>

--- a/DuggaSys/forms/global_appearance.php
+++ b/DuggaSys/forms/global_appearance.php
@@ -1,5 +1,5 @@
 Font family:<br>
-<select id='font' onchange='globalFont(); hashfunction(); updategfx();'>
+<select id='font' onchange='globalFont(); hashFunction(); updateGraphics();'>
     <option value='Arial' selected>Arial</option>
     <option value='Courier New'>Courier New</option>
     <option value='Impact'>Impact</option>
@@ -52,4 +52,4 @@ Stroke color:<br>
 Line thickness:<br>
 <input id="line-thickness" onclick='globalLineThickness(); hashFunction(); updateGraphics();' style="width:100%; margin: -2px; padding: 0px;" type="range" min="1" max="5" value="2">
 
-<button type='submit' class='submit-button' onclick="closeAppearanceDialogMenu(); changeObjectAppearance(); setType(form);" style='float: none; display: block; margin: 0px auto;'>OK</button>
+<button type='submit' class='submit-button' onclick="SaveState(); closeAppearanceDialogMenu(); setType(form);" style='float: none; display: block; margin: 0px auto;'>OK</button>

--- a/DuggaSys/forms/global_appearance.php
+++ b/DuggaSys/forms/global_appearance.php
@@ -52,4 +52,4 @@ Stroke color:<br>
 Line thickness:<br>
 <input id="line-thickness" onclick='globalLineThickness(); hashFunction(); updateGraphics();' style="width:100%; margin: -2px; padding: 0px;" type="range" min="1" max="5" value="2">
 
-<button type='submit' class='submit-button' onclick="SaveState(); closeAppearanceDialogMenu(); setType(form);" style='float: none; display: block; margin: 0px auto;'>OK</button>
+<button type='submit' class='submit-button' onclick="closeAppearanceDialogMenu(); setType(form);" style='float: none; display: block; margin: 0px auto;'>OK</button>


### PR DESCRIPTION
The select boxes for global appearance has new default values. 
When a styling option is selected it changes the object immediately. 
When the user closes the appearance menu with the 'X' in the upper right it doesn't save the styling. 

![chrome_2018-05-15_15-10-57](https://user-images.githubusercontent.com/37794628/40058672-3446224c-5852-11e8-8f21-1de26796b64c.png)

This is a solution for issue #5245, and seems like issue #5140 is solved as well.