### PR TITLE
Minimode now renders students in a single line mode

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -30,6 +30,7 @@ var clist;
 var onlyPending=false;
 var timeZero=new Date(0);
 var showTeachers = false;
+var showMini = false;
 var duggaArray = [[]];
 
 function setup(){
@@ -184,8 +185,9 @@ function process()
 	dstr+="><label class='headerlabel' for='pending'>Only pending</label></div>";
 
 	// Filter for mini mode
-	dstr+="<div class='checkbox-dugga checkmoment'><input type='checkbox' disabled class='headercheck' name='minimode' value='0' id='minimode' onchange='miniMode()'>";
-	dstr+="<label class='headerlabel' for='minimode'>Mini mode</label></div>";
+	dstr+="<div class='checkbox-dugga checkmoment'><input type='checkbox' class='headercheck' name='minimode' value='0' id='minimode' onclick='toggleMiniMode()'";
+	if (showMini){ dstr+=" checked"; }
+	dstr+="><label class='headerlabel' for='minimode'>Mini mode</label></div>";
 
 	dstr+="<div style='display:flex;justify-content:flex-end;border-top:1px solid #888'><button onclick='leavec()'>Filter</button></div>";
 
@@ -641,11 +643,11 @@ function returnedResults(data)
   }
 }
 
-function miniMode(){
+function toggleMiniMode(){
   if (document.getElementById('minimode').checked){
-    $(".gradeImg").css("display", "none");
+    showMini = true;
   } else {
-    $(".gradeImg").css("display", "block");
+    showMini = false;
   }
 }
 
@@ -714,6 +716,16 @@ function createSortableTable(data){
 }
 
 function renderCell(col,celldata,cellid) {
+	if (showMini) {
+		if (col == "FnameLnameSSN"){
+			str = "<div class='dugga-result-div'>";
+    	str += celldata.firstname + " " + celldata.lastname;
+    	str += "</div>"
+    	return str;
+  	} else {
+  		return "";
+  	}
+	}
 	// First column (Fname/Lname/SSN)
   if (col == "FnameLnameSSN"){
     str = celldata.grade;
@@ -721,7 +733,7 @@ function renderCell(col,celldata,cellid) {
 
   } else {
     // color based on pass,fail,pending,assigned,unassigned
-    str = "<div style='height:100%;' class='";
+    str = "<div style='height:80px;' class='";
       if(celldata.kind==4) { str += "dugga-moment "; }
       if (celldata.grade === 1) {str += "dugga-fail";}
       else if (celldata.grade > 1) {str += "dugga-pass";}

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2063,7 +2063,7 @@ span.arrow {
 }
 
 #resultTable td {
-  height: 80px;
+  height: 1px;
   padding: 0px;
 }
 


### PR DESCRIPTION
Issue #4229 

Remade the checkbox functionality and hiding of grading buttons from issue #4227 and #4228 now that sortabletable has been implemented.

Minimode now renders students in a single line mode where only the name of the student is shown. The change of height made in styles.css (to make the table work in firefox) was moved to an inline style in renderCell() to make it possible to change the height of cells when entering minimode.