### PR TITLE
G2 a16rasja 5295

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -875,37 +875,6 @@ function setType() {
     updateGraphics();
 }
 
-/*
- * Closes the dialog menu for appearance.
- */
-function closeAppearanceDialogMenu() {
-    $("#appearance").hide();
-    dimDialogMenu(false);
-    document.removeEventListener("click", clickOutsideDialogMenu);
-}
-
-/*
- * Closes the dialog menu when click is done outside box.
- */
-function clickOutsideDialogMenu(event) {
-    $(document).mousedown(function (event) {
-        var container = $("#appearance");
-        if (!container.is(event.target) && container.has(event.target).length === 0) {
-            container.hide();
-            dimDialogMenu(false);
-            document.removeEventListener("click", clickOutsideDialogMenu);
-        }
-    });
-}
-
-function dimDialogMenu(dim) {
-    if (dim) {
-        $("#appearance").css("display", "flex");
-    } else {
-        $("#appearance").css("display", "none");
-    }
-}
-
 function connectedObjects(line) {
     var privateObjects = [];
     for (var i = 0; i < diagram.length; i++) {

--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -27,6 +27,7 @@ function closeAppearanceDialogMenu() {
        var tmpDiagram = localStorage.getItem("diagram" + diagramNumberHistory);
        if (tmpDiagram != null) LoadImport(tmpDiagram);
      }
+     $(".loginBox").draggable('destroy');
     appearanceMenuOpen = false;
     classAppearanceOpen = false;
     globalAppearanceValue = 0;
@@ -169,6 +170,7 @@ function setSelectedOption(type, value){
 function globalAppearanceMenu(){
     globalAppearanceValue = 1;
     //open a menu to change appearance on all entities.
+    $(".loginBox").draggable();
     var form = showMenu();
     //AJAX
     loadFormIntoElement(form,'forms/global_appearance.php');


### PR DESCRIPTION
The global appearance menu is now draggable from the beginning.
Also removed so that login box isn't draggable when closing any of the appearance menus

This is a solution for issue #5295 