### PR TITLE
Fix for misplaced info window and console refrence crash

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -83,10 +83,9 @@ function showInfoText(object, displayText){
   var text = document.getElementById("infoText");
   text.style.display = "inline";
   text.innerHTML = displayText;
-
-  if(object.width!=null){
-    text.style.left = (document.documentElement.scrollLeft + object.getBoundingClientRect()["x"] + object.width["baseVal"]["value"] + 2) + "px";
-    text.style.top = (document.documentElement.scrollTop + object.getBoundingClientRect()["y"] + (object.height.baseVal.value / 2) - (text.offsetHeight / 2)) + "px";
+  if(typeof object.attributes.width !== 'undefined'){
+    text.style.left = (document.documentElement.scrollLeft + object.getBoundingClientRect()["x"] + object.getBoundingClientRect().width + 2) + "px";
+    text.style.top = (document.documentElement.scrollTop + object.getBoundingClientRect()["y"] + (object.getBoundingClientRect().height / 2) - (text.offsetHeight / 2)) + "px";
   }
   else{
     text.style.left = (document.documentElement.scrollLeft + object.getBoundingClientRect()["x"] + object.r["baseVal"]["value"] + 2) + "px";


### PR DESCRIPTION
#5315 

> When hovering over a bar in the bar diagram the code tries to find an attribute that does not exists, and this leads to the window that displays the information about that day is misplaces and there is an error in the console.

Fixed the attribute references, which solved the misplaced info window