### PR TITLE
Celldata for inline editing now works as celldata in rendercell

### DIFF
--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -67,12 +67,12 @@ function updateCellInternal() {
 function clickedInternal(event,clickdobj) {
 	if (sortableTable.currentTable.showEditCell != null) {
 		let cellelement = event.target.closest("td");
-		let arr = cellelement.className.split("-");
+		let arr = cellelement.id.split("_");
 		let rowelement = event.target.closest("tr");
 		let barr = rowelement.id.split("_");
-
-		var columnname = arr[1];
-		var columnno = arr[2];
+    arr[0] = arr[0].split("r")[1];
+		var columnname = arr[2];
+		var columnno = arr[0];
 		var rowno = parseInt(barr[1]);
 		var tableid = barr[0];
 		var str = "";
@@ -82,7 +82,7 @@ function clickedInternal(event,clickdobj) {
 		sortableTable.edit_tableid = tableid;
 
 		var rowdata = sortableTable.currentTable.getRow(rowno);
-		var coldata = rowdata[columnno];
+		var coldata = rowdata[columnname];
 
 		str += "<div id='input-container' style='flex-grow:1'>";
 		str += sortableTable.currentTable.showEditCell(coldata,rowno,rowelement,cellelement,columnname,columnno,rowdata,coldata,tableid);
@@ -297,7 +297,7 @@ function SortableTable(tbl,tableid,filterid,caption,renderCell,renderSortOptions
 		// Render table body
 		str += "<tbody id='"+tableid+"_body'>";
 		mhvstr += "<tbody id='"+tableid+"_mhvbody'>";
-		
+
 		for (var i = 0; i < tbl.tblbody.length; i++) {
 			var row = tbl.tblbody[i];
 


### PR DESCRIPTION
Issue #5174 

Ask me if you need help with testing

I noticed the columnno variable is also not working as intended as arr doesn't get the column number. I believe group 2 might have worked on a fix for this that comes in the next merge. (It didn't work before my fix, its ok, i didn't break it)also the variable is named coldata, but looking at the examples its used as celldata.