### PR TITLE
G2-b16ponpe-5310

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -49,7 +49,7 @@
 <!-- updateGraphics() must be last -->
 <body onload="initializeCanvas(); Symbol(); canvasSize(); loadDiagram(); debugMode(); initToolbox(); updateGraphics();">
     <?php
-        $noup = "COURSE";
+        $noup = "SECTION";
         include '../Shared/navheader.php';
     ?>
     <!-- content START -->


### PR DESCRIPTION
Changed $noup to section because course showed the swimlane clock. The swimlane clock is now removed.

Solution for #5310 