### PR TITLE
#5324 - SectionED: Hide the statistics tab on mobile

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3175,6 +3175,10 @@ only screen and (max-device-width: 800px) {
     display: block;
     height: 13px;
   }
+
+  #statisticsList {
+    display: none;
+  }
 }
 
 @media only screen and (max-width: 768px),
@@ -3198,6 +3202,10 @@ only screen and (max-device-width: 768px) {
   }
   #Sectionlist .course {
     font-size: 20px;
+  }
+
+  #statisticsList {
+    display: none;
   }
 }
 
@@ -3229,6 +3237,10 @@ only screen and (max-device-width: 710px) {
     height: 26px;
     opacity: 1.0;
   }
+
+  #statisticsList {
+    display: none;
+  }
 }
 
 @media only screen and (max-width: 590px),
@@ -3252,6 +3264,10 @@ only screen and (max-device-width: 590px) {
     display: block;
     height: 26px;
     opacity: 1.0;
+  }
+
+  #statisticsList {
+    display: none;
   }
 }
 
@@ -3280,6 +3296,10 @@ only screen and (max-device-width: 530px) {
   }
   #Sectionlist .course {
     font-size: 16px;
+  }
+
+  #statisticsList {
+    display: none;
   }
 }
 
@@ -3324,12 +3344,20 @@ only screen and (max-device-width: 480px) {
     margin-top: 0px;
     margin-left: 0px;
   }
+
+  #statisticsList {
+    display: none;
+  }
 }
 
 @media only screen and (max-width: 320px),
 only screen and (max-device-width: 320px) {
   #Sectionlist .course {
     font-size: 14px;
+  }
+
+  #statisticsList {
+    display: none;
   }
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3523,6 +3523,10 @@ only screen and (max-device-width: 320px) {
     width: 95%;
     margin: 1rem auto;
   }
+
+  #statisticsList {
+    display: none;
+  }
 }
 
 /* --------------================################================-------------- *


### PR DESCRIPTION
#5324 - @a16thegu
Added "display: none;" on @media screens from 800px and under in the style.css, which hide the statistics-section on displays under 800px in width (like smartphones).