### PR TITLE
Changed css for fileLink_counter

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -335,8 +335,8 @@ p {
 }
 
 .fileLink_counter {
-  font-size: 20px;
-  color: #614875;
+  font-size: 16px;
+  color: #000;
 }
 
 #Sectionlist .example {


### PR DESCRIPTION
The css is now changed so its no longer purple or bigger than the rest of the text to maintain a more consistent styling.