### PR TITLE
Fixed event counter on contribution page

### DIFF
--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -112,7 +112,7 @@ foreach($rows as $row){
 $eventrankno="NOT FOUND";
 $eventrank="NOT FOUND";
 $i=1;
-$query = $log_db->prepare('SELECT count(*) as rowk, author FROM event where eventtime>"2018-03-25" AND  eventtime<"2019-01-01" and eventtime!="undefined" group by author order by rowk desc;');
+$query = $log_db->prepare('SELECT count(*) as rowk, author FROM event where eventtime>"2018-03-25" AND  eventtime<"2019-01-01" and eventtime!="undefined" AND kind != "comment" group by author order by rowk desc;');
 if(!$query->execute()) {
     $error=$query->errorInfo();
     $debug="Error reading entries".$error[2];


### PR DESCRIPTION
#5107 

> It seems that "Events Performed" under project statistics for a user takes "Comment Creation" into account.
>
>Using the provided testdata we can see that created comments amounts to 138. Looking at the total amount of performed evens in the contribution list below we can see that 7 events have been performed. If we now look back to the table at the top we can see that "Events Performed" is at 145.

To test this navigate to a course and change the URL ending from "DuggaSys/*" to "DuggaSys/contribution.php" to navigate to the contribution page.
![image](https://user-images.githubusercontent.com/37804205/40166457-dc2807ec-59be-11e8-9f89-300fca4f4055.png)
