### PR TITLE
Updated code standard - avoid let, use var when declaring variables

### DIFF
--- a/code_standard.md
+++ b/code_standard.md
@@ -1,6 +1,6 @@
 # Review considerations of importance
 
-* Small code is impprtant - a small solution is better, reuse important
+* Small code is important - a small solution is better, reuse important
 * Minimize use of libraries such as jquery
 * Innerhtml better than dom .addchild etc
 * Static code better than dynamic.
@@ -68,6 +68,7 @@ function setup()
 function returned(data) <-- Returned function should exist and work the same in most files
 {	 <-- brackets on same level as function keyword but on the next line
 		test=2; <-- wrong since variable test is not declared using var
+		let test2 = ""; <-- wrong since let is not supported by older browsers, should use var when declaring variables
 		if(retdata['debug']!="NONE!") alert(retdata['debug']); <-- only for very short code we allow single line if-statements and never allow else with single line if-statements
 		
 		// User can choose template if no template has been choosen and the user has write access.


### PR DESCRIPTION
#5340 
The code standard is updated because older browsers does not support "let" when declaring varibables. Therefore variables should be declared using var.