### PR TITLE
First column is now shown in courses without tests

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -619,13 +619,13 @@ function buildDynamicHeaders() {
 function buildStudentInfo() {
   var i = 0;
 	students.forEach(function(entry) {
+		var row = {"FnameLnameSSN":entry[0]};
 		if(entry.length > 1) {
-			var row = {"FnameLnameSSN":entry[0]};
 			for(var j = 1; j < entry.length; j++) {
 				row["lid:"+entry[j]['lid']] = entry[j];
 			}
-			studentInfo[i++] = row;
 		}
+		studentInfo[i++] = row;
 	});
 	return studentInfo;
 }


### PR DESCRIPTION
Issue #5220 
Data for first column was not added if there was no gradeable moments in a course, hence there was nothing to display.

The "Fname/Lname/SSN" column should now show data for each student/teacher even if the course has no gradeble moments.