### PR TITLE
G2-b16andka-c16jonha-5405

### DIFF
--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -237,10 +237,10 @@ function SortableTable(tbl,tableid,filterid,caption,renderCell,renderSortOptions
 		str += "<caption>"+caption+"</caption>";
 
 		// Make headings Clean Contains headings using only A-Z a-z 0-9 ... move to function removes lines of code and removes redundant code/data!?
-	    str += "<thead id='"+tableid+"_tblhead'><tr>";
-	    mhstr += "<thead id='"+tableid+"_tblhead_mh'><tr>";
-	    mhvstr += "<thead id='"+tableid+"_tblhead_mhv'><tr>";
-	    mhfstr += "<thead id='"+tableid+"_tblhead_mhf'><tr>";
+	    str += "<thead class='listHeading' id='"+tableid+"_tblhead'><tr>";
+	    mhstr += "<thead class='listHeading' id='"+tableid+"_tblhead_mh'><tr>";
+	    mhvstr += "<thead class='listHeading' id='"+tableid+"_tblhead_mhv'><tr>";
+	    mhfstr += "<thead class='listHeading' id='"+tableid+"_tblhead_mhf'><tr>";
 
 		//var freezePaneIndex = tbl.tblhead.indexOf(freezePane);
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1791,9 +1791,13 @@ input.large-button {
   width: 100%;
   padding: 1px;
   border-bottom: 2px solid #dbd0d8;
-  border-left: 2px solid #dbd0d8;
   margin-top: 20px;
   font-size: 16px;
+}
+
+.listHeading {
+  border-left: 2px solid #614875;
+  border-right: 2px solid #614875;
 }
 
 .innertable {
@@ -1811,6 +1815,7 @@ input.large-button {
 }
 
 .list td {
+  border-left: 2px solid #dbd0d8;
   border-right: 2px solid #dbd0d8;
   padding: 0 8px 0 8px;
 }
@@ -4413,14 +4418,6 @@ textarea#filecont{
   width: 25px;
 }
 
-#fileLink_tblhead{
-  border-left: 2px solid #614875;
-  border-right: 2px solid #614875;
-}
-#fileLink_tblhead_mh{
-  border-left: 2px solid #614875;
-  border-right: 2px solid #614875;
-}
 
 @media only screen and (max-height: 800px) and (max-width: 1400px) {
   .editFileWindow {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4413,6 +4413,15 @@ textarea#filecont{
   width: 25px;
 }
 
+#fileLink_tblhead{
+  border-left: 2px solid #614875;
+  border-right: 2px solid #614875;
+}
+#fileLink_tblhead_mh{
+  border-left: 2px solid #614875;
+  border-right: 2px solid #614875;
+}
+
 @media only screen and (max-height: 800px) and (max-width: 1400px) {
   .editFileWindow {
     height: 500px;


### PR DESCRIPTION
We solved this by setting the color of the headers borders to the same color as the header. At first we put this styling to the id-match of the header in the fileed-page, but later changed it to a global change as was requested. This is a fix for issue #5405 

![capture](https://user-images.githubusercontent.com/37794047/40306360-abccb1c2-5cfe-11e8-827b-9d5a66b82a43.PNG)

![capture2](https://user-images.githubusercontent.com/37794047/40306362-ae1c739a-5cfe-11e8-854e-5920a4707de7.PNG)
