### PR TITLE
G2-c16jonha-b16andka-5413

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4374,6 +4374,10 @@ textarea#mrkdwntxt {
   margin-top:20px;
 }
 
+.fileLink-editor, .fileLink-trashcan{
+  text-align: center;
+}
+
 textarea#filecont{
   width: 99%;
   height: 100%;


### PR DESCRIPTION
We managed to align the icons correctly by setting the text-align in their respective classes to center.

![centerplopp](https://user-images.githubusercontent.com/37794047/40307502-113f0a88-5d03-11e8-92bf-dbb5935a8a43.PNG)

This is a fix for issue #5413