### PR TITLE
G2 c16carbe 5441

### DIFF
--- a/DuggaSys/diagram_figure.js
+++ b/DuggaSys/diagram_figure.js
@@ -450,6 +450,8 @@ function figureSquare() {
         figurePath.addsegment(1, p3, p4);
         figurePath.addsegment(1, p4, p1);
         diagram.push(figurePath);
+        selected_objects.push(figurePath);
+        lastSelectedObject = diagram.length - 1;
         cleanUp();
     }
 }


### PR DESCRIPTION
A square object will now get selected properly when it is created. As such, a square path object will no longer get de-selected when you've resized it.

This is a fix for issue #5441  