### PR TITLE
#5320 SectionED: Make the text on the statistics tab unselectable

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -966,7 +966,7 @@ function returnedSection(data) {
 		str += "<div id='courseList'>";
 		str += "<!-- Statistics List -->"
 		+ "<div id='statisticsList'>"
-		+ "<div id='statistics' class='statistics' style='display: inline-block; cursor: pointer;'>"
+		+ "<div id='statistics' class='statistics noselect' style='display: inline-block; cursor: pointer;'>"
 		+ "<div style='margin: 10px;'>"
 		+ "<img src='../Shared/icons/right_complement.svg' id='arrowStatisticsOpen'>"
 		+ "<img src='../Shared/icons/desc_complement.svg' id='arrowStatisticsClosed'>"


### PR DESCRIPTION
#5320 
@a15magkn
Made so that the Statistics-text to the left of the screen is unselectable