### PR TITLE
G2 a16rasja 5448

### DIFF
--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -187,6 +187,9 @@ function objectAppearanceMenu(form) {
     */
 
     form.innerHTML = "No item selected<type='text'>";
+    //if no item has been selected
+    if(!diagram[lastSelectedObject]){ return;}
+
     if (diagram[lastSelectedObject].symbolkind == 1) {
         classAppearanceOpen = true;
         loadUMLForm(form, 'forms/class_appearance.php?');

--- a/DuggaSys/diagram_dialog.js
+++ b/DuggaSys/diagram_dialog.js
@@ -14,6 +14,8 @@ function openAppearanceDialogMenu() {
     /*
      * Opens the dialog menu for appearance.
      */
+
+    $(".loginBox").draggable();
     var form = showMenu();
     appearanceMenuOpen = true;
     objectAppearanceMenu(form);

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -489,7 +489,6 @@ function doubleclick(ev) {
     var posistionY = (sy + yPos);
     if (lastSelectedObject != -1 && diagram[lastSelectedObject].targeted == true) {
         openAppearanceDialogMenu();
-        $(".loginBox").draggable();
         //console.log("Error:\nFollowing error is prompted because the element has not successfully been loaded\ninto the document before trying to find it by ID. These dialogs are loaded into\nthe diagram dynamically as of Issue #3733");
     }
 }


### PR DESCRIPTION
You are now able to close the appearance menu when opening it with the change appearance button. 
Also fixed so that no exception is generated when opening the appearance menu without any object selected.

This is a solution for issue #5448.