### PR TITLE
column filters not found in localstorage are now shown by default

### DIFF
--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -221,7 +221,7 @@ function SortableTable(tbl,tableid,filterid,caption,renderCell,renderSortOptions
 		var filterstr = "";
 		for (var colname in tbl.tblhead) {
 				var col = tbl.tblhead[colname];
-				if (isFirstVisit) {
+				if (isFirstVisit || typeof columnfilter[colname] == "undefined") {
 					//columnfilter.push(col);
 					columnfilter[colname] = tbl.tblhead[colname];
 				}


### PR DESCRIPTION
Issue #4377 
Fixed issue where new columns were not shown when visiting a a table where there was a record in local storage.