### PR TITLE
G2 a16rasja 5474

### DIFF
--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -310,6 +310,8 @@ function handleSelect() {
                 selected_objects.splice(index, 1);
             }
             last.targeted = false;
+            //when deselecting object, set lastSelectedObject to index of last object in selected_objects
+            lastSelectedObject = diagram.indexOf(selected_objects[selected_objects.length-1]);
         }
     }
 }

--- a/DuggaSys/diagram_mouse.js
+++ b/DuggaSys/diagram_mouse.js
@@ -267,6 +267,7 @@ function mousedownevt(ev) {
             for (var i = 0; i < selected_objects.length; i++) {
                 selected_objects[i].targeted = false;
             }
+            lastSelectedObject = -1;
             selected_objects = [];
         }
         if(uimode == "CreateFigure" && figureType == "Square"){


### PR DESCRIPTION
When deselecting objects by pressing an "empty space" in the canvas you will now get the message "no item selected" when pressing the change appearance button.
Also fixed so that when deselecting with ctrl pressed it now opens the appearance menu for one of the selected objects, not the one deselected.

this is a solution for issue #5474 