### PR TITLE
G2 a16adala 5488

### DIFF
--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -986,7 +986,7 @@ function Symbol(kind) {
         ctx.beginPath();
         if (this.targeted || this.isHovered) {
             ctx.lineWidth = 2;
-            ctx.strokeColor = "F82";
+            ctx.lineDash = "F82";
             ctx.rect(x1, y1, x2-x1, y2-y1);
             ctx.setLineDash([5, 4]);
         }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -988,7 +988,7 @@ function Symbol(kind) {
             ctx.lineWidth = 2;
             ctx.strokeColor = "F82";
             ctx.rect(x1, y1, x2-x1, y2-y1);
-            ctx.stroke();
+            ctx.setLineDash([5, 4]);
         }
 
         ctx.fillStyle = this.fontColor;

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -986,7 +986,6 @@ function Symbol(kind) {
         ctx.beginPath();
         if (this.targeted || this.isHovered) {
             ctx.lineWidth = 2;
-            ctx.lineDash = "F82";
             ctx.rect(x1, y1, x2-x1, y2-y1);
             ctx.setLineDash([5, 4]);
         }

--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -986,8 +986,10 @@ function Symbol(kind) {
         ctx.beginPath();
         if (this.targeted || this.isHovered) {
             ctx.lineWidth = 2;
-            ctx.rect(x1, y1, x2-x1, y2-y1);
             ctx.setLineDash([5, 4]);
+            ctx.strokeColor = "F82";
+            ctx.rect(x1, y1, x2-x1, y2-y1);
+            ctx.stroke();
         }
 
         ctx.fillStyle = this.fontColor;


### PR DESCRIPTION
There is no longer a solid border around the text so that it better represents just simply where the text is rather than that you are typing inside a box.
This is a fix for #5488 
![image](https://user-images.githubusercontent.com/37834994/40365100-26bb4558-5dd4-11e8-9fe9-ccf5ec83da4f.png)
