### PR TITLE
G2 c16carbe 5513

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -865,10 +865,7 @@ function eraseSelectedObject() {
         $(".loginBox").draggable();
     }
     for(var i = 0; i < selected_objects.length; i++){
-        if(selected_objects[i].targeted){
-            selected_objects[i].targeted = false;
-            eraseObject(selected_objects[i]);
-        }
+        eraseObject(selected_objects[i]);
     }
     selected_objects = [];
     lastSelectedObject = -1;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -864,15 +864,14 @@ function eraseSelectedObject() {
         showMenu().innerHTML = "No item selected<type='text'>";
         $(".loginBox").draggable();
     }
-    for (var i = 0; i < diagram.length; i++) {
-        if (diagram[i].targeted == true) {
-            diagram[i].targeted = false;
-            eraseObject(diagram[i]);
-            i = -1;
-            //To avoid removing the same index twice, lastSelectedObject is reset
-            lastSelectedObject = -1;
+    for(var i = 0; i < selected_objects.length; i++){
+        if(selected_objects[i].targeted){
+            selected_objects[i].targeted = false;
+            eraseObject(selected_objects[i]);
         }
     }
+    selected_objects = [];
+    lastSelectedObject = -1;
     updateGraphics();
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -860,7 +860,7 @@ function eraseObject(object) {
 function eraseSelectedObject() {
     canvas.style.cursor = "default";
     //Issue: Need to remove the crosses
-    if(!diagram[lastSelectedObject]){
+    if(selected_objects.length == 0){
         showMenu().innerHTML = "No item selected<type='text'>";
         $(".loginBox").draggable();
     }


### PR DESCRIPTION
The dialog menu telling the user that no item is selected will no longer appear after deleting an item. It will only appear when no item is selected.

The logic for erasing objects was also re-written so that it only loops through selected_objects instead of the entire diagram.

This is a fix for issue #5513 