### PR TITLE
G2-a15setno-5456

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -161,8 +161,8 @@ pdoConnect();
                     </div>
                     </fieldset>
                 </div>
-                <button class="save-close-button" type="submit" onclick="saveMarkdown()">Save</button>
-                <button class="save-close-button" onclick="cancelPreview()">Close</button>
+                <button class="save-close-button-md" type="submit" onclick="saveMarkdown()">Save</button>
+                <button class="save-close-button-md" onclick="cancelPreview()">Close</button>
             </div>
             <div class="editFilePart">
                 <div class="editFileWindow">
@@ -172,8 +172,8 @@ pdoConnect();
                         </div>
                     </div>
 
-                    <button class="save-close-button" type="submit" onclick="saveTextToFile()"> Save </button>
-                    <button class="save-close-button" onclick="cancelPreview()">Close</button>
+                    <button class="save-close-button-fe" type="submit" onclick="saveTextToFile()"> Save </button>
+                    <button class="save-close-button-fe" onclick="cancelPreview()">Close</button>
                     <div class="optionButtons">
 
                     </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3986,7 +3986,7 @@ li:nth-last-child(10) a:hover {
   width: 38%;
   height: 80%;
   position: relative;
-  margin: 20px 1% 10px 1%;
+  margin: 2% 1% 1% 1%;
   float: left;
 }
 #markset {
@@ -4000,7 +4000,7 @@ li:nth-last-child(10) a:hover {
   width: 56%;
   height: 80%;
   position: relative;
-  margin: 20px 1% 10px 1%;
+  margin: 2% 1% 1% 1%;
   float: right;
 }
 
@@ -4008,7 +4008,7 @@ li:nth-last-child(10) a:hover {
   height:100%;
 }
 
-.save-close-button {
+.save-close-button-md {
   border-radius: 4px;
   background-color: #614875;
   border: 0px;
@@ -4016,8 +4016,8 @@ li:nth-last-child(10) a:hover {
   height: 30px;
   color: #fff;
   cursor: pointer;
-  margin-top: 19px;
-  margin-bottom: 2px;
+  margin-top: 3px;
+  margin-bottom: 30px;
   margin-right: 3%;
   font-size: 14px;
   transition: 1s background-color;
@@ -4231,7 +4231,6 @@ textarea#mrkdwntxt {
     height: 38%;
     width: 97%;
     float: left;
-    margin: auto auto auto 8px;
   }
   .markText {
     height:100%;
@@ -4239,8 +4238,8 @@ textarea#mrkdwntxt {
   .optionButtons {
     top: 686px;
   }
-  .save-close-button{
-    margin-top: 29px;
+  .save-close-button-md{
+    margin-top: 15px;
   }
 }
 
@@ -4380,6 +4379,26 @@ textarea#mrkdwntxt {
   width: 355px;
 }
 
+.save-close-button-fe{
+  border-radius: 4px;
+  background-color: #614875;
+  border: 0px;
+  width: 110px;
+  height: 30px;
+  color: #fff;
+  cursor: pointer;
+  margin-top: 20px;
+  margin-bottom: 2px;
+  margin-right: 3%;
+  font-size: 14px;
+  transition: 1s background-color;
+  float: right;
+  line-height: 30px;
+  text-align: center;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+}
+
+
 #filecont {
   resize: none;
   margin: 10px auto;
@@ -4394,6 +4413,20 @@ textarea#filecont{
   height: 100%;
   display: block;
   padding: 10px
+}
+
+@media only screen and (max-width: 900px) {
+  .editFileWindow {
+    height: 80%;
+  }
+
+  #filecont {
+    height: 70%;
+  }
+
+  .optionButtons {
+    top: 436px;
+  }
 }
 
 /* --------------================################================-------------- *
@@ -4431,27 +4464,6 @@ textarea#filecont{
 /* Preview, Edit and Delete columns */
 .variant-arrowVariant, .variant-cogwheelVariant, .variant-trashcanVariant {
   width: 25px;
-}
-
-
-@media only screen and (max-height: 800px) and (max-width: 1400px) {
-  .editFileWindow {
-    height: 500px;
-  }
-
-  .editFileCode {
-    height: 400px;
-  }
-
-  #filecont {
-    height: 350px;
-  }
-}
-
-@media only screen and (max-width: 900px) {
-  .optionButtons {
-    top: 436px;
-  }
 }
 
 /* styling for the search bar in duggaed.php */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4016,8 +4016,7 @@ li:nth-last-child(10) a:hover {
   height: 30px;
   color: #fff;
   cursor: pointer;
-  margin-top: 3px;
-  margin-bottom: 30px;
+  margin-top: auto;
   margin-right: 3%;
   font-size: 14px;
   transition: 1s background-color;
@@ -4117,7 +4116,7 @@ textarea#mrkdwntxt {
   margin-left: 9.75%;
   font-size: 12px;
   position: absolute;
-  margin-top: -3px;
+  margin-top: -0.3%;
 }
 #codeBlockText {
     cursor: pointer;


### PR DESCRIPTION
The margins for the save and close buttons are changed. They do not have the same top and bottom margin because of the rest of the layout, but they are now more centered. About the textarea in the markdown preview, @b16nicbr fixed it, but it is not a part of this issue anymore. But the textarea in the file editor window is bigger! See the screen shots below.

The markdown 
--
![markdown](https://user-images.githubusercontent.com/37832730/40417942-511b4a66-5e81-11e8-8a07-a62717e2c8e0.PNG)


The file editor
--
![file](https://user-images.githubusercontent.com/37832730/40417944-54e0d54e-5e81-11e8-81c3-5442d4a89e8f.PNG)


This is a fix for issue #5456.