### PR TITLE
2 columns for draw buttons

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -102,11 +102,11 @@
                         </div>
                         <h4 class="label tlabel" id="labelDraw">Draw</h4>
                         <div class="toolbar-drawer" id="drawerDraw">
-                            <button id='squarebutton' onclick="setMode('Square');" class='buttonsStyle unpressed' data="Draw Square">
-                                <img src="../Shared/icons/diagram_draw_square.svg">
+                            <button id='squarebutton' onclick="setMode('Square');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Square">
+                                <img id="createButtons" src="../Shared/icons/diagram_draw_square.svg">
                             </button>
-                            <button id='drawfreebutton' onclick="setMode('Free');" class='buttonsStyle unpressed' data="Draw Free">
-                                <img src="../Shared/icons/diagram_draw_free.svg">
+                            <button id='drawfreebutton' onclick="setMode('Free');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Free">
+                                <img id="createButtons" src="../Shared/icons/diagram_draw_free.svg">
                             </button>
                         </div>
                         <h4 class="label tlabel" id="labelUndo">Undo/Redo</h4>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -85,28 +85,28 @@
                         <div class="toolbar-drawer" id="drawerCreate">
                             <div class="tooltipdialog">
                                 <button id='attributebutton' onclick='setMode("CreateERAttr");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Attribute">
-                                    <img id="createButtons" src="../Shared/icons/diagram_create_attribute.svg">
+                                    <img class="createButtons" src="../Shared/icons/diagram_create_attribute.svg">
                                 </button>
                                 <button id='entitybutton' onclick='setMode("CreateEREntity");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Entity">
-                                    <img id="createButtons" src="../Shared/icons/diagram_create_entity.svg">
+                                    <img class="createButtons" src="../Shared/icons/diagram_create_entity.svg">
                                 </button>
                             </div>
                             <div class="tooltipdialog">
                                 <button id='relationbutton' onclick='setMode("CreateERRelation");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Relation">
-                                    <img id="createButtons" src="../Shared/icons/diagram_create_relation.svg">
+                                    <img class="createButtons" src="../Shared/icons/diagram_create_relation.svg">
                                 </button>
                                 <button id='classbutton' onclick='setMode("CreateClass");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Class">
-                                    <img id="createButtons" src="../Shared/icons/diagram_create_class.svg">
+                                    <img class="createButtons" src="../Shared/icons/diagram_create_class.svg">
                                 </button>
                             </div>
                         </div>
                         <h4 class="label tlabel" id="labelDraw">Draw</h4>
                         <div class="toolbar-drawer" id="drawerDraw">
                             <button id='squarebutton' onclick="setMode('Square');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Square">
-                                <img id="createButtons" src="../Shared/icons/diagram_draw_square.svg">
+                                <img class="createButtons" src="../Shared/icons/diagram_draw_square.svg">
                             </button>
                             <button id='drawfreebutton' onclick="setMode('Free');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Free">
-                                <img id="createButtons" src="../Shared/icons/diagram_draw_free.svg">
+                                <img class="createButtons" src="../Shared/icons/diagram_draw_free.svg">
                             </button>
                         </div>
                         <h4 class="label tlabel" id="labelUndo">Undo/Redo</h4>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -85,28 +85,28 @@
                         <div class="toolbar-drawer" id="drawerCreate">
                             <div class="tooltipdialog">
                                 <button id='attributebutton' onclick='setMode("CreateERAttr");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Attribute">
-                                    <img class="createButtons" src="../Shared/icons/diagram_create_attribute.svg">
+                                    <img class="toolboxButtons" src="../Shared/icons/diagram_create_attribute.svg">
                                 </button>
                                 <button id='entitybutton' onclick='setMode("CreateEREntity");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Entity">
-                                    <img class="createButtons" src="../Shared/icons/diagram_create_entity.svg">
+                                    <img class="toolboxButtons" src="../Shared/icons/diagram_create_entity.svg">
                                 </button>
                             </div>
                             <div class="tooltipdialog">
                                 <button id='relationbutton' onclick='setMode("CreateERRelation");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Relation">
-                                    <img class="createButtons" src="../Shared/icons/diagram_create_relation.svg">
+                                    <img class="toolboxButtons" src="../Shared/icons/diagram_create_relation.svg">
                                 </button>
                                 <button id='classbutton' onclick='setMode("CreateClass");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Class">
-                                    <img class="createButtons" src="../Shared/icons/diagram_create_class.svg">
+                                    <img class="toolboxButtons" src="../Shared/icons/diagram_create_class.svg">
                                 </button>
                             </div>
                         </div>
                         <h4 class="label tlabel" id="labelDraw">Draw</h4>
                         <div class="toolbar-drawer" id="drawerDraw">
                             <button id='squarebutton' onclick="setMode('Square');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Square">
-                                <img class="createButtons" src="../Shared/icons/diagram_draw_square.svg">
+                                <img class="toolboxButtons" src="../Shared/icons/diagram_draw_square.svg">
                             </button>
                             <button id='drawfreebutton' onclick="setMode('Free');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Free">
-                                <img class="createButtons" src="../Shared/icons/diagram_draw_free.svg">
+                                <img class="toolboxButtons" src="../Shared/icons/diagram_draw_free.svg">
                             </button>
                         </div>
                         <h4 class="label tlabel" id="labelUndo">Undo/Redo</h4>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1635,8 +1635,8 @@ div.submit-button:disabled {
 }
 
 .toolboxButtons {
-  width: 35px;
-  height: 25px;
+  width: 35px !important;
+  height: 25px !important;
 }
 
 #moveButton img {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1634,7 +1634,7 @@ div.submit-button:disabled {
   border-radius: 0px;
 }
 
-#createButtons {
+.createButtons {
   width: 35px;
   height: 25px;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1634,7 +1634,7 @@ div.submit-button:disabled {
   border-radius: 0px;
 }
 
-.createButtons {
+.toolboxButtons {
   width: 35px;
   height: 25px;
 }


### PR DESCRIPTION
Changed so the buttons inside draw now are in 2 columns as well since there are more functionality coming down the line.
This is a fix for issue #5517  
![image](https://user-images.githubusercontent.com/37834994/40419513-e10cd208-5e85-11e8-972b-a18143a71a29.png)
