### PR TITLE
Fixed some styling in resulted

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -350,7 +350,7 @@ function gradeDugga(e, gradesys, cid, vers, moment, uid, mark, ukind, qversion, 
 }
 
 function makeImg(gradesys, cid, vers, moment, uid, mark, ukind,gfx,cls,qvariant,qid){
-  return "<img src=\""+gfx+"\" id=\"grade-"+moment+"-"+uid+"\" class=\""+cls+" gradeImg\" onclick=\"gradeDugga(event,"+gradesys+","+cid+",'"+vers+"',"+moment+","+uid+","+mark+",'"+ukind+"',"+qvariant+","+qid+");\"  />";
+  return "<img src=\""+gfx+"\" id=\"grade-"+moment+"-"+uid+"\" class=\""+cls+"\" onclick=\"gradeDugga(event,"+gradesys+","+cid+",'"+vers+"',"+moment+","+uid+","+mark+",'"+ukind+"',"+qvariant+","+qid+");\"  />";
 }
 
 function makeSelect(gradesys, cid, vers, moment, uid, mark, ukind, qvariant, qid)
@@ -673,7 +673,7 @@ function renderCell(col,celldata,cellid) {
 	if (filterList["minimode"]) {
 		// First column (Fname/Lname/SSN)
 		if (col == "FnameLnameSSN"){
-			str = "<div style='height:25px;' class='dugga-result-div resultTableCell'>";
+			str = "<div class='resultTableCell resultTableMini'>";
 				str += "<div class='resultTableText'>";
 					str += celldata.firstname + " " + celldata.lastname;
 				str += "</div>";
@@ -681,7 +681,7 @@ function renderCell(col,celldata,cellid) {
 			return str;
 		} else {
 			// color based on pass,fail,pending,assigned,unassigned
-			str = "<div style='height:25px;' class='resultTableCell ";
+			str = "<div class='resultTableCell resultTableMini ";
 				if(celldata.kind==4) { str += "dugga-moment "; }
 				if (celldata.grade === 1) {str += "dugga-fail";}
 				else if (celldata.grade > 1) {str += "dugga-pass";}
@@ -698,16 +698,19 @@ function renderCell(col,celldata,cellid) {
 	// Render normal mode
 	// First column (Fname/Lname/SSN)
 	if (col == "FnameLnameSSN"){
-		str = "<div class='resultTableCell' style='height:80px;'>";
+		str = "<div class='resultTableCell resultTableNormal'>";
 			str += "<div class='resultTableText'>";
-				str += celldata.grade;
+				str += celldata.firstname+" "+celldata.lastname+"<br>";
+				str += celldata.username+" / "+celldata.class+"<br>";
+				str += celldata.ssn+"<br>";
+				str += celldata.setTeacher;
 			str += "</div>";
 		str += "</div>";
 		return str;
 
 	} else {
 		// color based on pass,fail,pending,assigned,unassigned
-		str = "<div style='height:80px;' class='resultTableCell ";
+		str = "<div style='height:70px;' class='resultTableCell ";
 			if(celldata.kind==4) { str += "dugga-moment "; }
 			if (celldata.grade === 1) {str += "dugga-fail";}
 			else if (celldata.grade > 1) {str += "dugga-pass";}
@@ -727,7 +730,7 @@ function renderCell(col,celldata,cellid) {
 				} else {
 					str += makeSelect(celldata.gradeSystem, querystring['cid'], celldata.vers, celldata.lid, celldata.uid, celldata.grade, 'U', celldata.qvariant, celldata.quizId);
 				}
-				str += "<img id='korf' class='fist gradeImg";
+				str += "<img id='korf' class='fist";
 					if(celldata.userAnswer===null && !(celldata.quizfile=="feedback_dugga")){ // Always shows fist. Should be re-evaluated
 						str += " grading-hidden";
 					}
@@ -752,7 +755,7 @@ function renderCell(col,celldata,cellid) {
 			str += "</div>";
 
 			// Print times graded
-			str += "<div class='text-center'>";
+			str += "<div class='text-center resultTableText'>";
 				if(celldata.ishere===true && celldata.timesGraded!==0){
 					str += "Times Graded: " + celldata.timesGraded;
 				}

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -45,6 +45,30 @@ pdoConnect();
 		include '../Shared/loginbox.php';
 	?>
 
+	<!-- content START -->
+	<div id="content">
+		<div class="titles">
+			<h1 style='	width:100%;
+									margin-top:30px;
+									padding-top:50px;
+									padding-bottom:50px;
+									text-align:center;
+									position:fixed;
+									top:0;'>
+									Result
+			</h1>
+		</div>
+		<div id='searchBar' style='position:fixed; top:129px; right: 5px;'>
+			<input id='searchinput' type='text' name='search' placeholder='Search..' onkeyup='searchterm=document.getElementById("searchinput").value;searchKeyUp(event);myTable.renderTable();'/>
+			<button id='searchbutton' class='switchContent' onclick='return searchKeyUp(event);' type='button'>
+				<img id='lookingGlassSVG' style='height:18px;' src='../Shared/icons/LookingGlass.svg'/>
+			</button>
+		</div>
+		<div id="resultTable" style='width:fit-content; white-space: nowrap; position: absolute; margin-top: 100px; margin-bottom: 30px;'>
+		</div>
+	</div>
+	<!-- content END -->
+
 	<!-- -------------------=============####### Result Popover #######=============------------------- -->
 
 	<div id='resultpopover' class='resultPopover' style='display:none'>
@@ -104,25 +128,6 @@ pdoConnect();
 			<h3 style='width:100%;' id='Nameof'>Collective results</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 	</div>
-
-		<h1 style='	width:100%;
-								margin-top:30px;
-								padding-top:50px;
-								padding-bottom:50px;
-								text-align:center;
-								position:fixed;
-								top:0;
-								color:#614875;'>
-									Result
-		</h1>
-		<div id='searchBar' style='position:fixed; top:129px; right: 5px;'>
-			<input id='searchinput' type='text' name='search' placeholder='Search..' onkeyup='searchterm=document.getElementById("searchinput").value;searchKeyUp(event);myTable.renderTable();'/>
-			<button id='searchbutton' class='switchContent' onclick='return searchKeyUp(event);' type='button'>
-				<img id='lookingGlassSVG' style='height:18px;' src='../Shared/icons/LookingGlass.svg'/>
-			</button>
-		</div>
-		<div id="resultTable" style='width:fit-content; white-space: nowrap; position: absolute; margin-top: 160px;'>
-		</div>
 
 </body>
 </html>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2207,8 +2207,21 @@ span.arrow {
 }
 
 .resultTableText {
-	margin-left: 3px;
-	margin-right: 3px;
+  margin-left: 3px;
+  margin-right: 3px;
+  font-size: 13px;
+}
+
+.resultTableNormal {
+  height:70px;
+  align-items:center;
+  display:flex;
+}
+
+.resultTableMini {
+  height:25px;
+  align-items:center;
+  display:flex;
 }
 
 #resultTable td {
@@ -2217,8 +2230,13 @@ span.arrow {
   border: 0px;
 }
 
+.resultTable_counter {
+  text-align:center;
+}
+
 .resultTable_counter span {
-	margin-left: 5px;
+  margin-left: 3px;
+  margin-right: 3px;
 }
 
 #accessTable td {


### PR DESCRIPTION
Issue #4902
- Changed font size of all text elements in the table.
- Added classes for mini and normal mode to remove some inline styling.
- Added margins to the sides and bottom of the table and modified/moved the code in resulted.php to get a layout more similar to filed.
- Changed margins of row counter and centered the text.
- Removed the class "gradeImg" from the grading images as this was a remnant from the old mini-mode.

Magic heading and changes of the header was already fixed in other issues. 
The buttons for "add user" and "import user" are no longer present but the search bar seems to have a proper placement when compared to filed.