### PR TITLE
G2 a16rasja 5525

### DIFF
--- a/DuggaSys/diagram_symbol.js
+++ b/DuggaSys/diagram_symbol.js
@@ -885,6 +885,8 @@ function Symbol(kind) {
             ctx.lineTo(x2 + 5, y2 + 5);
             ctx.lineTo(x1 - 5, y2 + 5);
             ctx.lineTo(x1 - 5, y1 - 5);
+            ctx.stroke();
+            ctx.lineWidth = this.lineWidth;
         }
 
         ctx.moveTo(x1, y1);
@@ -1188,7 +1190,7 @@ function Symbol(kind) {
         var textX = 0;
         if (this.textAlign == "start") textX = x1 + 10;
         else if (this.textAlign == "end") textX = x2 - 10;
-        else textX = midX; 
+        else textX = midX;
         return textX;
     }
 


### PR DESCRIPTION
Fixed linewidth for weak entities.
The lines still 'joins' each other when changing the global appearance.

![chrome_2018-05-24_12-02-41](https://user-images.githubusercontent.com/37794628/40478892-8ce2979c-5f4a-11e8-9a58-4f58f7dc0cb5.png)

This is part of a solution for issue #5525.