### PR TITLE
Markdown icon fix

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -122,18 +122,19 @@ pdoConnect();
                 <div class="markdown">
                     <fieldset id="markset">
                         <legend>  Markdown</legend>
-
-                        <span id="boldText" onclick="boldText()" title="Bold"><b>B</b></span>
-                        <span id="cursiveText" onclick="cursiveText()" title="Italic"><i>i</i></span>
-                        <span id="codeBlockText" onclick="codeBlockText()" title="CodeBlock">&#10065;</span>
-                        <span id="lists" onclick="lists()" title="lists"><img id="listSymbol" class="fab-icon"
+                        <div class="markdown-icon-div">
+                        <span class="markdown-icons" onclick="boldText()" title="Bold"><b>B</b></span>
+                        <span class="markdown-icons" onclick="cursiveText()" title="Italic"><i>i</i></span>
+                        <span class="markdown-icons" onclick="codeBlockText()" title="CodeBlock">&#10065;</span>
+                        <span class="markdown-icons" onclick="lists()" title="lists"><img
                                                                                 src="../Shared/icons/list-symbol.svg"></span>
-                        <span id="quoteText" onclick="quoteText()" title="quote">&#10078;</span>
-                        <span id="linkz" onclick="linkText()" title="link"><img id="linkFabBtnImgPrev" class="fab-icon"
+                        <span class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</span>
+                        <span class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img
                                                                                 src="../Shared/icons/link-icon.svg"></span>
-                        <span id="img" onclick="externalImg()" title="Img"><img id="insert-photo" class="fab-icon"
+                        <span class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img
                                                                                 src="../Shared/icons/insert-photo.svg"></span>
-                        <span class="headerType" title="Header">aA&#9663;</span>
+                        <span class="markdown-icons" id="headerIcon" title="Header">aA&#9663;</span>
+
                         <div class="selectHeader" id="select-header">
                             <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>
                             <span id="headerType2" onclick="selected();headerVal2()" value="H2">Header 2</span>
@@ -141,9 +142,8 @@ pdoConnect();
                             <span id="headerType4" onclick="selected();headerVal4()" value="H4">Header 4</span>
                             <span id="headerType5" onclick="selected();headerVal5()" value="H5">Header 5</span>
                             <span id="headerType6" onclick="selected();headerVal6()" value="H6">Header 6</span>
-
                         </div>
-
+                        </div>
                             <div class="markText">
                             <textarea id="mrkdwntxt" oninput="updatePreview(this.value)" name="markdowntext"></textarea>
                             </div>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -133,7 +133,7 @@ pdoConnect();
                                                                                 src="../Shared/icons/link-icon.svg"></span>
                         <span class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img
                                                                                 src="../Shared/icons/insert-photo.svg"></span>
-                        <span class="markdown-icons" id="headerIcon" title="Header">aA&#9663;</span>
+                        <span class="markdown-icons headerType" id="headerIcon" title="Header">aA&#9663;</span>
 
                         <div class="selectHeader" id="select-header">
                             <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>

--- a/DuggaSys/preview.php
+++ b/DuggaSys/preview.php
@@ -130,10 +130,6 @@
             #headerType3:hover {
                 background-color: rgb(200,200,200);
             }
-            .headerType {
-                cursor: pointer;
-                margin-left: 150px;
-            }
 
             .show-dropdown-content {
                 display: block;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4226,14 +4226,13 @@ textarea#mrkdwntxt {
 }
 
 #select-header {
+  top: 50px;
+  left: 192px;
   max-width: 63px;
   position: absolute;
   z-index: 2000;
-  right: 38%;
   background-color: rgba(255, 255, 255, 255);
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);
-}
-#inputSave {
 }
 
 @media only screen and (max-width: 900px) {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4221,13 +4221,6 @@ textarea#mrkdwntxt {
   padding: 5px 27px 6px 3px;
 }
 
-.headerType {
-  cursor: pointer;
-  margin-left: 35.75%;
-  position: absolute;
-  margin-top: -0.75%
-}
-
 .show-dropdown-content {
     display: block;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4345,6 +4345,30 @@ textarea#mrkdwntxt {
 /* --------------================################================-------------- *
  *                               Edit file preview                              *
  * --------------================################================-------------- */
+.markdown-icons {
+  cursor:pointer;
+  width: 24px;
+  height: 24px;
+  text-align: center;
+  line-height: 24px;
+  vertical-align: middle;
+}
+
+.markdown-icon-div{
+  display: flex;
+}
+
+#quoteIcon {
+  margin-top: 2px;
+}
+
+#linkIcon {
+  filter: invert(100%);
+}
+
+#imgIcon, #headerIcon {
+  margin-left: 4px;
+}
 
 
 .editFileWindow {


### PR DESCRIPTION
Fixes the alignment of the markdown icons, so that they go in a straight, (almost) centered line. Fix made by @b16andka 

I also fixed some last minute changes.