### PR TITLE
Made the line button consistent with the others

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -77,7 +77,7 @@
                         <div class="toolbar-drawer" id="drawerTools">
                             <div class="tooltipdialog">
                                 <button id='linebutton' onclick='setMode("CreateLine");' class='buttonsStyle unpressed' data="Create Line">
-                                    <img src="../Shared/icons/diagram_create_line.svg">
+                                    <img class="toolboxButtons" src="../Shared/icons/diagram_create_line.svg">
                                 </button>
                             </div>
                         </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1633,6 +1633,11 @@ div.submit-button:disabled {
   height: 25px !important;
 }
 
+#linebutton {
+  margin: 5px 0;
+  border-radius: 5px;
+}
+
 #textButton {
   width: 35px;
   height: 22px;


### PR DESCRIPTION
In the diagram toolbar, we forgot to change the line button so it looked like the other buttons. This is now fixed.