### PR TITLE
Fix for #5720 install guide text for the install.php GUI

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -31,13 +31,13 @@
     $putFileHere = cdirname(getcwd(), 1); // Path to lenasys
     echo "
                     <div id='warning' class='modal'>
-                
+
                         <!-- Modal content -->
                         <div class='modal-content'>
                             <span title='Close pop-up' class='close''>&times;</span>
                                 <span id='dialogText'></span>
                         </div>
-                
+
                     </div>";
     ?>
 
@@ -131,7 +131,9 @@
 ?>
                 <div class="inputContent" id="td2" valign=top>
                     <p id="infoText"><b>Enter root log-in credentials for the database you want to use.<br>
-                        Default user has name 'root'. If password for root user is unknown ask a teacher or someone who knows.</b></p><hr>
+                        Default user has name 'root'. If password for root user is unknown ask a teacher or someone who knows.
+                      If no password is set, please set a password to your mySQL root user.<br>
+                      To set a password for mysqladmin in xampp shell: mysqladmin --user=root password "password"</b></p><hr>
                     Enter MySQL root user. <br>
                     <input title="Enter MySQL root user." class="page2input" type="text" name="mysqlRoot" placeholder="Root" value="root"/> <br>
                     Enter password for MySQL root user. <br>
@@ -417,13 +419,13 @@
         /* Pop-up window when installation is done. Hidden from start. */
         echo "
                     <div id='warning' class='modal'>
-                
+
                         <!-- Modal content -->
                         <div class='modal-content'>
                             <span title='Close pop-up' class='close''>&times;</span>
                                 <span id='dialogText'></span>
                         </div>
-                
+
                     </div>";
 
         /* Javascripts for warning pop-up */
@@ -434,12 +436,12 @@
                 var btn = document.getElementById('showModalBtn'); // Get the button that opens the modal
                 var span = document.getElementsByClassName('close')[0]; // Get the button that opens the modal
                 var filePath = '{$putFileHere}';
-                
+
                 document.getElementById('dialogText').innerHTML = '<div><h1>!!!WARNING!!!</h1><br>' +
                     '<h2>READ INSTRUCTIONS UNDER INSTALL PROGRESS.</h2>' +
                     '<p>If you don\'t follow these instructions nothing will work. Group 3 will not take any ' +
                     'responsibility for your failing system.</p>';
-                
+
                 // When the user clicks on <span> (x), close the modal
                 span.onclick = function() {
                     modal.style.display = 'none';
@@ -503,17 +505,17 @@
             truncateDecimals = function (number) {
                 return Math[number < 0 ? 'ceil' : 'floor'](number);
             };
-            
+
             var totalSteps = {$totalSteps};
             var completedStepsLatest = 0; // This variable is used on window resize.
-            
+
             function updateProgressBar(completedSteps){
                 var totalWidth = document.getElementById(\"progressBar\").clientWidth;
                 var stepWidth = totalWidth / totalSteps;
                 var completedWidth;
-                
-                /* if window was resized (completedsteps = -1) take latest copleted steps. 
-                 * Else update to new completed step. 
+
+                /* if window was resized (completedsteps = -1) take latest copleted steps.
+                 * Else update to new completed step.
                  */
                 if (completedSteps === -1) {
                     completedWidth = stepWidth * completedStepsLatest;
@@ -521,15 +523,15 @@
                     completedStepsLatest = completedSteps;
                     completedWidth = stepWidth * completedSteps;
                 }
-                
+
                 /* Calculate length */
                 document.getElementById(\"progressRect\").setAttribute(\"width\", \"\" + completedWidth + \"\");
-                
+
                 /* Update percentage text */
-                document.getElementById(\"percentageText\").innerHTML = \"\" + 
-                truncateDecimals((document.getElementById(\"progressRect\").getAttribute(\"width\") / totalWidth) * 100) + 
+                document.getElementById(\"percentageText\").innerHTML = \"\" +
+                truncateDecimals((document.getElementById(\"progressRect\").getAttribute(\"width\") / totalWidth) * 100) +
                 \"%\";
-                
+
                 /* Decide color depending on how far progress has gone */
                 if (document.getElementById(\"progressRect\").getAttribute(\"width\") / totalWidth < 0.33){
                     document.getElementById(\"progressRect\").setAttribute(\"fill\", \"rgb(197,81,83)\");
@@ -607,7 +609,7 @@
                 echo "<span id='successText' />Successfully removed old user, {$username}.</span><br>";
                 } catch (PDOException $e) {
                 $errors++;
-                echo "<span id='failText' />User with name {$username} 
+                echo "<span id='failText' />User with name {$username}
                             does not already exist. Will only make a new one (not write over).</span><br>";
                 }
                 $completedSteps++;
@@ -622,7 +624,7 @@
                     echo "<span id='successText' />Successfully removed old database, {$databaseName}.</span><br>";
                 } catch (PDOException $e) {
                     $errors++;
-                    echo "<span id='failText' />Database with name {$databaseName} 
+                    echo "<span id='failText' />Database with name {$databaseName}
                             does not already exist. Will only make a new one (not write over).</span><br>";
                 }
                 $completedSteps++;
@@ -788,7 +790,7 @@
 
         echo '<div id="copied1">Copied to clipboard!<br></div>';
 
-        echo "<br><b> Now create a directory named 'log' (if you dont already have it)<br> 
+        echo "<br><b> Now create a directory named 'log' (if you dont already have it)<br>
                 with a sqlite database inside at " . $putFileHere . " with permissions 777<br>
                 (Copy all code below/just click the box and paste it into bash shell as one statement to do this).</b><br>";
         echo "<div title='Click to copy this!' class='codeBox' onclick='selectText(\"codeBox2\")'><code id='codeBox2'>";


### PR DESCRIPTION
The guide now instructs the user to set a root password if none is set (default for some applications like xampp). It also shows a sample shell command to set a password. See last 2 sentences in image below: 
![guide2](https://user-images.githubusercontent.com/37793141/55731380-6a43f980-5a1a-11e9-92ac-f78f5cb3986d.PNG)
#5720 