### PR TITLE
Fix for issue #5618

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1336,12 +1336,18 @@ function findfilevers(filez,cfield,ctype,displaystate)
 							tab+="<tr'>"
 
 							tab+="<td>";
-							// Button for making / viewing feedback - note - only button for given feedback to students.
+
 							if (ctype == "link"){
 									tab+="<a href='"+filez[i].content+"' ><img src='../Shared/icons/file_download.svg' /></a>";
 							} else {
 									tab+="<a href='"+filelink+"' ><img src='../Shared/icons/file_download.svg' /></a>";
 							}
+
+              // if type is pdf, add an extenral_open icon to open in new tab next to download icon.
+              if (ctype == "pdf") {
+                tab +="\t<tab><a href='"+filelink+"' target='_blank'><img src='../Shared/icons/external_link_open.svg' /></a></tab>";
+              }
+
 							tab+="</td>";
 							tab+="<td>";
                             if (ctype == "link"){
@@ -1350,11 +1356,6 @@ function findfilevers(filez,cfield,ctype,displaystate)
                                     tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);' style='cursor: pointer;text-decoration:underline;'>"+filez[i].filename+"."+filez[i].extension+"</span>";
 							}
 
-              // if type is pdf, add a button to open in new tab.
-              if (ctype == "pdf") {
-                  tab +=" <span> hej </span>"
-                  // FIXME: fixa en target _blank länk här på en ikon som visar att det är ny tab.
-              }
 
 							tab+="</td><td>";
 							tab+=filez[i].updtime;+"</td>";

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -25,7 +25,7 @@ function getAllIndexes(haystack, needle) {
     while (i !== -1) {
         indexes.push(i);
         i = haystack.indexOf(needle, ++i);
-    }    
+    }
     return indexes;
 }
 
@@ -213,7 +213,7 @@ function makeoptionsItem(option,optionlist,optionstring,valuestring)
 }
 
 //----------------------------------------------------------------------------------
-// makeparams: Help function for hassle free preparation of a clickable param list 
+// makeparams: Help function for hassle free preparation of a clickable param list
 //----------------------------------------------------------------------------------
 
 function makeparams(paramarray)
@@ -1349,6 +1349,13 @@ function findfilevers(filez,cfield,ctype,displaystate)
 							} else {
                                     tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);' style='cursor: pointer;text-decoration:underline;'>"+filez[i].filename+"."+filez[i].extension+"</span>";
 							}
+
+              // if type is pdf, add a button to open in new tab.
+              if (ctype == "pdf") {
+                  tab +=" <span> hej </span>"
+                  // FIXME: fixa en target _blank länk här på en ikon som visar att det är ny tab.
+              }
+
 							tab+="</td><td>";
 							tab+=filez[i].updtime;+"</td>";
 
@@ -1505,7 +1512,7 @@ function FABUp(e)
 				createQuickItem();
 		}else if ($('.fab-btn-list').is(':visible') && (e.target.id!="fabBtn")) {
 				FABToggle();
-		}	
+		}
 }
 
 //----------------------------------------------------------------------------------

--- a/Shared/icons/external_link_open.svg
+++ b/Shared/icons/external_link_open.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px">
+    <path style="line-height:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;block-progression:tb;isolation:auto;mix-blend-mode:normal" d="M 25.980469 2.9902344 A 1.0001 1.0001 0 0 0 25.869141 3 L 20 3 A 1.0001 1.0001 0 1 0 20 5 L 23.585938 5 L 13.292969 15.292969 A 1.0001 1.0001 0 1 0 14.707031 16.707031 L 25 6.4140625 L 25 10 A 1.0001 1.0001 0 1 0 27 10 L 27 4.1269531 A 1.0001 1.0001 0 0 0 25.980469 2.9902344 z M 6 7 C 4.9069372 7 4 7.9069372 4 9 L 4 24 C 4 25.093063 4.9069372 26 6 26 L 21 26 C 22.093063 26 23 25.093063 23 24 L 23 14 L 23 11.421875 L 21 13.421875 L 21 16 L 21 24 L 6 24 L 6 9 L 14 9 L 16 9 L 16.578125 9 L 18.578125 7 L 16 7 L 14 7 L 6 7 z" font-weight="400" font-family="sans-serif" white-space="normal" overflow="visible"/>
+</svg>


### PR DESCRIPTION
Accidentally named the branch after another issue I was working on altough it had nothing commited to it, attempted to fix it but failed but this is a fix for issue #5618 and NOT #5628 which is still being worked on.
![image](https://user-images.githubusercontent.com/49194938/55786366-61a00180-5ab4-11e9-9af5-847be5651ff0.png)
The icon to the right of the download icon is the added one and should when clicked open the pdf in a new tab. To test this I reccomend making sure you have 1 user which you can log in to ( I used l94lewal after changing his password to a 10 round [bcrypt ](https://bcrypt-generator.com/) and changing it in phpmyadmin) then making a new quiz/test and having it be a generic_file_receive then putting submission type to pdf and uploading a random pdf as the user you chose before going on the superUser again to check in result. (OBS! make sure the person in access is set to the correct version, e.g. for Webbutveckling - datorgrafik it is ht15 that will be default)