### PR TITLE
Fix for #5763 - Moved menu option to "Align" category

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -62,7 +62,7 @@
                             <img id="minimizeArrow" class="toolbarMaximized" src="../Shared/icons/arrow.svg">
                           </div>
                           <h3>Toolbar</h3>
-                          <div id="toolbar-toggleLayout"  onclick="toggleToolbarLayout();"> 
+                          <div id="toolbar-toggleLayout"  onclick="toggleToolbarLayout();">
                               <img id="layoutArrow" class="toolbarMaximized" src="../Shared/icons/rotateButton.svg">
                             </div>
                         </div>
@@ -209,14 +209,16 @@
                         <div class="drop-down-item">
                             <a href="#" onclick='debugMode();'>Developer mode</a>
                         </div>
-                        <div class="drop-down-item">
-                            <a href="#" onclick="toggleGrid(this)">Snap to grid</a>
-                        </div>
                     </div>
                 </div>
                 <div class="menu-drop-down">
                     <span class="label">Align</span>
                     <div class="drop-down">
+                        <div class="drop-down-item">
+                            <a href="#" onclick="toggleGrid(this)">Snap to grid</a>
+                        </div>
+                        <div class="drop-down-divider">
+                        </div>
                         <div class="drop-down-item">
                             <a href="#" onclick="align('top');">Top</a>
                         </div>
@@ -230,7 +232,6 @@
                             <a href="#" onclick="align('left');">Left</a>
                         </div>
                         <div class="drop-down-divider">
-
                         </div>
                         <div class="drop-down-item">
                             <a href="#" onclick="align('horizontalCenter');">Horizontal center</a>
@@ -238,7 +239,6 @@
                         <div class="drop-down-item">
                             <a href="#" onclick="align('verticalCenter');">Vertical center</a>
                         </div>
-
                     </div>
                 </div>
                 <div class="menu-drop-down">


### PR DESCRIPTION
The menu option: Snap to grid was move from "View" to "Align" category in the menu of the diagram.
Fix for #5763 