### PR TITLE
Snap to grid menu option moved to "Align" category - Fix for #5763

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -62,7 +62,7 @@
                             <img id="minimizeArrow" class="toolbarMaximized" src="../Shared/icons/arrow.svg">
                           </div>
                           <h3>Toolbar</h3>
-                          <div id="toolbar-toggleLayout"  onclick="toggleToolbarLayout();"> 
+                          <div id="toolbar-toggleLayout"  onclick="toggleToolbarLayout();">
                               <img id="layoutArrow" class="toolbarMaximized" src="../Shared/icons/rotateButton.svg">
                             </div>
                         </div>
@@ -209,14 +209,16 @@
                         <div class="drop-down-item">
                             <a href="#" onclick='debugMode();'>Developer mode</a>
                         </div>
-                        <div class="drop-down-item">
-                            <a href="#" onclick="toggleGrid(this)">Snap to grid</a>
-                        </div>
                     </div>
                 </div>
                 <div class="menu-drop-down">
                     <span class="label">Align</span>
                     <div class="drop-down">
+                        <div class="drop-down-item">
+                            <a href="#" onclick="toggleGrid(this)">Snap to grid</a>
+                        </div>
+                        <div class="drop-down-divider">
+                        </div>
                         <div class="drop-down-item">
                             <a href="#" onclick="align('top');">Top</a>
                         </div>
@@ -230,7 +232,6 @@
                             <a href="#" onclick="align('left');">Left</a>
                         </div>
                         <div class="drop-down-divider">
-
                         </div>
                         <div class="drop-down-item">
                             <a href="#" onclick="align('horizontalCenter');">Horizontal center</a>
@@ -238,7 +239,6 @@
                         <div class="drop-down-item">
                             <a href="#" onclick="align('verticalCenter');">Vertical center</a>
                         </div>
-
                     </div>
                 </div>
                 <div class="menu-drop-down">
@@ -252,7 +252,6 @@
                         </div>
                     </div>
                 </div>
-
                 <div class="menu-drop-down">
                     <span class="label">Help</span>
                     <div class="drop-down">


### PR DESCRIPTION
The menu option was moved from the "View" category to "Align category as seen in the image: 
![grid snap fix](https://user-images.githubusercontent.com/37793141/55885011-6beff780-5ba9-11e9-9abc-29e8f81119f1.PNG)
Fix #5763 