### PR TITLE
Update style.css fixed fab-btn background color

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3949,120 +3949,120 @@ only screen and (max-device-width: 320px) {
 
 /* First item */
 
-.btn-floating li:nth-last-child(1) a {
+.fab-btn-list :nth-last-child(1) a {
   background-color: #6ead2a;
   color: white;
 }
 
-.btn-floating li:nth-last-child(1) a:hover {
+.fab-btn-list :nth-last-child(1) a:hover {
   background-color: #83ae55;
   color: white;
 }
 
 /* Second item */
 
-.btn-floating li:nth-last-child(2) a {
+.fab-btn-list :nth-last-child(2) a {
   background-color: #adc726;
   color: white;
 }
 
-.btn-floating li:nth-last-child(2) a:hover {
+.fab-btn-list :nth-last-child(2) a:hover {
   background-color: #b8cd4e;
   color: white;
 }
 
 /* Third item */
 
-.btn-floating li:nth-last-child(3) a {
+.fab-btn-list :nth-last-child(3) a {
   background-color: #e9a901;
   color: white;
 }
 
-.btn-floating li:nth-last-child(3) a:hover {
+.fab-btn-list :nth-last-child(4) a:hover {
   background-color: #ddae37;
   color: white;
 }
 
 /* Fourth item */
 
-.btn-floating li:nth-last-child(4) a {
+.fab-btn-list :nth-last-child(4) a {
   background-color: #dc7e34;
   color: white;
 }
 
-.btn-floating li:nth-last-child(4) a:hover {
+.fab-btn-list :nth-last-child(4) a:hover {
   background-color: #d78b50;
   color: white;
 }
 
 /* Fifth item */
 
-.btn-floating li:nth-last-child(5) a {
+.fab-btn-list :nth-last-child(5) a {
   background-color: #d14d58;
   color: white;
 }
 
-.btn-floating li:nth-last-child(5) a:hover {
+.fab-btn-list :nth-last-child(5) a:hover {
   background-color: #d16a72;
   color: white;
 }
 
 /* Sixth item */
 
-.btn-floating li:nth-last-child(6) a {
+.fab-btn-list :nth-last-child(6) a {
   background-color: #cb438d;
   color: white;
 }
 
-.btn-floating li:nth-last-child(6) a:hover {
+.fab-btn-list :nth-last-child(6) a:hover {
   background-color: #d0599a;
   color: white;
 }
 
 /* Seventh item */
 
-.btn-floating li:nth-last-child(7) a {
+.fab-btn-list :nth-last-child(7) a {
   background-color: #a844cc;
   color: white;
 }
 
-.btn-floating li:nth-last-child(7) a:hover {
+.fab-btn-list :nth-last-child(7) a:hover {
   background-color: #b560d3;
   color: white;
 }
 
 /* Eighth item */
 
-.btn-floating li:nth-last-child(8) a {
+.fab-btn-list :nth-last-child(8) a {
   background-color: #6f34dc;
   color: white;
 }
 
-.btn-floating li:nth-last-child(8) a:hover {
+.fab-btn-list :nth-last-child(8) a:hover {
   background-color: #7e4ed7;
   color: white;
 }
 
 /* Ninth item */
 
-.btn-floating li:nth-last-child(9) a {
+.fab-btn-list :nth-last-child(9) a {
   background-color: #1f65cd;
   color: white;
 }
 
-.btn-floating li:nth-last-child(9) a:hover {
+.fab-btn-list :nth-last-child(9) a:hover {
   background-color: #487fd1;
   color: white;
 }
 
 /* Tenth item */
 
-.btn-floating li:nth-last-child(10) a {
+.fab-btn-list :nth-last-child(10) a {
   background-color: blue;
   color: white;
 }
 
-.btn-floating li:nth-last-child(10) a:hover {
+.fab-btn-list :nth-last-child(10) a:hover {
   background-color: pink;
   color: white;
 }


### PR DESCRIPTION
Fxied issue #5761 
Changed the class in style.css at around row 4000.
It should affect the fab when left clicking and holding (you'll see some smaller buttons appear above it). On live (gruppc2019w16) they should all have a transparent background and be hard to click/tell what it is. But this should give them all differently colored backgrounds. Works on sectioned.php, in result(result is currently broken though) and all fab buttons that have extra buttons come up when you left click hold them (courseeed.php for example does not have this.