### PR TITLE
Add checkboxes to diagram menu - Fix for issue #5694

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -730,6 +730,7 @@ function toggleGrid() {
     } else {
         snapToGrid = false;
     }
+    setCheckbox($("a:contains('Snap to grid')"), snapToGrid);
 }
 
 // Opens the dialog menu for import
@@ -1047,6 +1048,7 @@ function debugMode() {
         ghostingCrosses = true;
     }
     updateGraphics();
+    setCheckbox($("a:contains('Developer mode')"), !ghostingCrosses);
 }
 
 //calculate the hash. does this by converting all objects to strings from diagram. then do some sort of calculation. used to save the diagram. it also save the local diagram
@@ -1538,4 +1540,18 @@ function diagramToSVG() {
         if (diagram[i].kind == 2 && diagram[i].symbolkind != 4) str += diagram[i].symbolToSVG(i);
     }
     return str;
+}
+
+// Check or uncheck the checkbox contained in 'element'
+// This function adds a checkbox element if there is none
+function setCheckbox(element, check) {
+    if ($(element).children(".material-icons").length == 0) {
+        $(element).append("<i class=\"material-icons\" style=\"float: right; padding-right: 8px; font-size: 18px;\">check</i>");
+    }
+
+    if (check) {
+        $(element).children(".material-icons").show();
+    }else {
+        $(element).children(".material-icons").hide();
+    }
 }

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -15,6 +15,7 @@
     <title>Section Editor</title>
     <link type="text/css" href="../Shared/css/style.css" rel="stylesheet">
     <link type="text/css" href="../Shared/css/jquery-ui-1.10.4.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="../Shared/js/jquery-1.11.0.min.js"></script>
     <script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
     <script src="../Shared/dugga.js"></script>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49195031/55942791-765fcf00-5c45-11e9-94db-85f0ca6b4a27.png)
The checkboxes are not specified in the html document but are instead added to the page from javascript in a setCheckbox method. This can be called on any element that needs a checkbox element.