### PR TITLE
Update dugga open pdf new second fix

### DIFF
--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -559,7 +559,6 @@ function SortableTable(param)
         			document.getElementById(children[i].id.slice(0, -1)+"f").style.boxSizing = "border-box";
       		}
           document.getElementById(this.tableid+DELIMITER+"tblhead_mh").style.height = Math.round(document.getElementById(this.tableid+DELIMITER+"tblhead").getBoundingClientRect().height)+"px";
-          document.getElementById(this.tableid+DELIMITER+"tblhead_mhv").style.height = Math.round(document.getElementById(this.tableid+DELIMITER+"tblhead").getBoundingClientRect().height)+"px";
           document.getElementById(this.tableid+DELIMITER+"tblhead_mhf").style.height = Math.round(document.getElementById(this.tableid+DELIMITER+"tblhead").getBoundingClientRect().height)+"px";
     	} else {
     		  document.getElementById(this.tableid).innerHTML = str;

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -559,6 +559,7 @@ function SortableTable(param)
         			document.getElementById(children[i].id.slice(0, -1)+"f").style.boxSizing = "border-box";
       		}
           document.getElementById(this.tableid+DELIMITER+"tblhead_mh").style.height = Math.round(document.getElementById(this.tableid+DELIMITER+"tblhead").getBoundingClientRect().height)+"px";
+          document.getElementById(this.tableid+DELIMITER+"tblhead_mhv").style.height = Math.round(document.getElementById(this.tableid+DELIMITER+"tblhead").getBoundingClientRect().height)+"px";
           document.getElementById(this.tableid+DELIMITER+"tblhead_mhf").style.height = Math.round(document.getElementById(this.tableid+DELIMITER+"tblhead").getBoundingClientRect().height)+"px";
     	} else {
     		  document.getElementById(this.tableid).innerHTML = str;

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -25,7 +25,7 @@ function getAllIndexes(haystack, needle) {
     while (i !== -1) {
         indexes.push(i);
         i = haystack.indexOf(needle, ++i);
-    }    
+    }
     return indexes;
 }
 
@@ -213,7 +213,7 @@ function makeoptionsItem(option,optionlist,optionstring,valuestring)
 }
 
 //----------------------------------------------------------------------------------
-// makeparams: Help function for hassle free preparation of a clickable param list 
+// makeparams: Help function for hassle free preparation of a clickable param list
 //----------------------------------------------------------------------------------
 
 function makeparams(paramarray)
@@ -1326,12 +1326,17 @@ function findfilevers(filez,cfield,ctype,displaystate)
 							} else {
 									tab+="<a href='"+filelink+"' ><img src='../Shared/icons/file_download.svg' /></a>";
 							}
+
+              // if type is pdf, add an extenral_open icon to open in new tab next to download icon.
+              if (ctype == "pdf") {
+                tab +="\t<tab><a href='"+filelink+"' target='_blank'><img src='../Shared/icons/external_link_open.svg' /></a></tab>";
+              }
 							tab+="</td>";
 							tab+="<td>";
-                            if (ctype == "link"){
-                                    tab+="<span style='cursor: pointer;text-decoration:underline;'  onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);'>"+filez[i].content+"</span>";
+              if (ctype == "link"){
+                tab+="<span style='cursor: pointer;text-decoration:underline;'  onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);'>"+filez[i].content+"</span>";
 							} else {
-                                    tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);' style='cursor: pointer;text-decoration:underline;'>"+filez[i].filename+"."+filez[i].extension+"</span>";
+                tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);' style='cursor: pointer;text-decoration:underline;'>"+filez[i].filename+"."+filez[i].extension+"</span>";
 							}
 							tab+="</td><td>";
 							tab+=filez[i].updtime;+"</td>";
@@ -1489,7 +1494,7 @@ function FABUp(e)
 				createQuickItem();
 		}else if ($('.fab-btn-list').is(':visible') && (e.target.id!="fabBtn")) {
 				FABToggle();
-		}	
+		}
 }
 
 //----------------------------------------------------------------------------------

--- a/Shared/icons/external_link_open.svg
+++ b/Shared/icons/external_link_open.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px">
+    <path style="line-height:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;block-progression:tb;isolation:auto;mix-blend-mode:normal" d="M 25.980469 2.9902344 A 1.0001 1.0001 0 0 0 25.869141 3 L 20 3 A 1.0001 1.0001 0 1 0 20 5 L 23.585938 5 L 13.292969 15.292969 A 1.0001 1.0001 0 1 0 14.707031 16.707031 L 25 6.4140625 L 25 10 A 1.0001 1.0001 0 1 0 27 10 L 27 4.1269531 A 1.0001 1.0001 0 0 0 25.980469 2.9902344 z M 6 7 C 4.9069372 7 4 7.9069372 4 9 L 4 24 C 4 25.093063 4.9069372 26 6 26 L 21 26 C 22.093063 26 23 25.093063 23 24 L 23 14 L 23 11.421875 L 21 13.421875 L 21 16 L 21 24 L 6 24 L 6 9 L 14 9 L 16 9 L 16.578125 9 L 18.578125 7 L 16 7 L 14 7 L 6 7 z" font-weight="400" font-family="sans-serif" white-space="normal" overflow="visible"/>
+</svg>


### PR DESCRIPTION
Any pdf submission should be able to open in a new tab using the new added open external button.
This is the second pull request for this, the first one is at #5738 Made a new one now that we have a new base branch. Currently on the master the resulted.php is broken due to some javascript so it might be a little bit hard to test but the icon also shows up and works the same way when looking back at a already submitted pdf (i.e submit a pdf, go back onto the dugga and see if the button is there next to download and if clicking it opens a new tab with the pdf in it.