### PR TITLE
Fixed issue #5804 and #5821 (which was referenced in issue #5804)

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -62,7 +62,7 @@
                             <img id="minimizeArrow" class="toolbarMaximized" src="../Shared/icons/arrow.svg">
                           </div>
                           <h3>Toolbar</h3>
-                          <div id="toolbar-toggleLayout"  onclick="toggleToolbarLayout();"> 
+                          <div id="toolbar-toggleLayout"  onclick="toggleToolbarLayout();">
                               <img id="layoutArrow" class="toolbarMaximized" src="../Shared/icons/rotateButton.svg">
                             </div>
                         </div>
@@ -135,7 +135,7 @@
                     </div>
                 </div>
                 <div class="menu-drop-down">
-                    <span class="label">File</span>
+                    <span class="drop-down-label">File</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
                             <a href="#" value='Save'>Save</a>
@@ -175,7 +175,7 @@
                     </div>
                 </div>
                 <div class="menu-drop-down">
-                    <span class="label">Edit</span>
+                    <span class="drop-down-label">Edit</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
                             <a href="#" onclick='undoDiagram()'>Undo</a>
@@ -204,7 +204,7 @@
                     </div>
                 </div>
                 <div class="menu-drop-down">
-                    <span class="label">View</span>
+                    <span class="drop-down-label">View</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
                             <a href="#" onclick='debugMode();'>Developer mode</a>
@@ -215,7 +215,7 @@
                     </div>
                 </div>
                 <div class="menu-drop-down">
-                    <span class="label">Align</span>
+                    <span class="drop-down-label">Align</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
                             <a href="#" onclick="align('top');">Top</a>
@@ -242,7 +242,7 @@
                     </div>
                 </div>
                 <div class="menu-drop-down">
-                    <span class="label">Distribute</span>
+                    <span class="drop-down-label">Distribute</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
                             <a href="#" onclick="distribute('horizontally');">Horizontal</a>
@@ -254,7 +254,7 @@
                 </div>
 
                 <div class="menu-drop-down">
-                    <span class="label">Help</span>
+                    <span class="drop-down-label">Help</span>
                     <div class="drop-down">
                         <div class="drop-down-text">
                             <a href="#">Move grid</a>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -150,7 +150,7 @@ p {
 
  #buttonDiv {
    position: fixed;
-   margin-top: -4%;
+   margin-top: -20px;
    height: 20px;
    background-color: white;
  }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1313,6 +1313,14 @@ input {
   padding: 0px 6px;
 }
 
+.menu-drop-down span.drop-down-label{
+  display: block;
+  height: 22px;
+  line-height: 22px;
+  padding: 0px 8px;
+  cursor: pointer;
+}
+
 .document-settings span.label:hover {
   cursor: pointer;
   background-color: rgb(240, 240, 240);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1318,7 +1318,11 @@ input {
   height: 22px;
   line-height: 22px;
   padding: 0px 8px;
+}
+
+.menu-drop-down span.drop-down-label:hover {
   cursor: pointer;
+  background-color: rgb(240, 240, 240);
 }
 
 .document-settings span.label:hover {


### PR DESCRIPTION
Issue #5804 and #5821 is fixed.

The menu bar won't float downwards anymore when rezising the window. Got help from @a17okaoz with this issue.

The menu bar won't be affected anymore when changing the direction of the toolbar. The problem was that the toolbar and the menu bar used the same span for the labels, which affected css.