### PR TITLE
Fixed the drawing squares bug - Fix for #5534

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -47,7 +47,7 @@
 </head>
 <!-- Reads the content from the js-files -->
 <!-- updateGraphics() must be last -->
-<body onload="initializeCanvas(); canvasSize(); loadDiagram(); debugMode(); initToolbox(); updateGraphics();">
+<body onload="initializeCanvas(); canvasSize(); loadDiagram(); debugMode(); initToolbox(); updateGraphics();" onmouseup="mouseupevt(event)">
     <?php
         $noup = "SECTION";
         include '../Shared/navheader.php';

--- a/DuggaSys/diagram_figure.js
+++ b/DuggaSys/diagram_figure.js
@@ -498,12 +498,9 @@ function figureFreeDraw() {
 //--------------------------------------------------------------------
 function figureSquare() {
     if (isFirstPoint) {
-      console.log("if");
         p1 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);
         isFirstPoint = false;
     } else {
-      console.log("else");
-      console.log(points[1]);
         p3 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);
         p2 = points.addPoint(points[p1].x, points[p3].y, false);
         p4 = points.addPoint(points[p3].x, points[p1].y, false);

--- a/DuggaSys/diagram_figure.js
+++ b/DuggaSys/diagram_figure.js
@@ -149,7 +149,7 @@ function Path() {
             }
             // Reset opacity so that following draw operations are unaffected
             ctx.globalAlpha = 1.0;
-            
+
             if (strokestate) {
                 ctx.stroke();
             }
@@ -498,9 +498,12 @@ function figureFreeDraw() {
 //--------------------------------------------------------------------
 function figureSquare() {
     if (isFirstPoint) {
+      console.log("if");
         p1 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);
         isFirstPoint = false;
     } else {
+      console.log("else");
+      console.log(points[1]);
         p3 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);
         p2 = points.addPoint(points[p1].x, points[p3].y, false);
         p4 = points.addPoint(points[p3].x, points[p1].y, false);


### PR DESCRIPTION
The problem behind the issue was that the program did not register that the user lifted the mouse key and instead believed it was still pressed when it wasnt. This reversed the order of execution in events which bugged out the square drawing logic. 

Solution: Added the onmouseup listener that calls the mouseupevt function to the body tag.

Fix for #5534