### PR TITLE
Added documentation to diagramservice.php - Fix for issue #5818

### DIFF
--- a/DuggaSys/diagramservice.php
+++ b/DuggaSys/diagramservice.php
@@ -1,4 +1,11 @@
 <?php
+    /********************************************************************************
+
+        diagramservice.php, reads github activity data for a user (Including number of
+        issues created, comments posted, lines of code modified) for every week and
+        returns it in a JSON object
+
+    ********************************************************************************/
     date_default_timezone_set("Europe/Stockholm");
     // Include basic application services!
     include_once "../Shared/sessions.php";


### PR DESCRIPTION
I've added an explanation for what the file does and what data it returns. I'm still a bit unsure on where this file is used and why the diagram needs it. It seems to serve about the same purpose as contributionservice.php. 