### PR TITLE
Tabel sorting fix for the access, test and files tab.

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1,3 +1,4 @@
+// Test comment
 
 /********************************************************************************
    Globals
@@ -742,6 +743,7 @@ function gradeFilterHandler()
 }
 
 function renderCell(col,celldata,cellid) {
+  gradeFilterHandler();
 	// Render minimode
 	if (filterList["minimode"]) {
 		// First column (Fname/Lname/SSN)
@@ -752,7 +754,7 @@ function renderCell(col,celldata,cellid) {
 				str += "</div>";
 			str += "</div>";
 			return str;
-		} else {
+		} else if(filterGrade==="none" || celldata.grade===filterGrade){
 			// color based on pass,fail,pending,assigned,unassigned
       str = "<div class='resultTableCell resultTableMini ";
 				if(celldata.kind==4) { str += "dugga-moment "; }
@@ -781,7 +783,7 @@ function renderCell(col,celldata,cellid) {
 		str += "</div>";
 		return str;
 
-	} else {
+	} else if(filterGrade==="none" || celldata.grade===filterGrade){
 		// color based on pass,fail,pending,assigned,unassigned
     str = "<div style='height:70px;' class='resultTableCell ";
     if(celldata.kind==4) { str += "dugga-moment "; }
@@ -1125,4 +1127,9 @@ function closeLadexport()
 {
     document.getElementById("resultlistarea").value="";
     document.getElementById("resultlistpopover").style.display="none";
+}
+
+function updateTable()
+{
+  myTable.renderTable();
 }

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -42,6 +42,8 @@ function defaultRowFilter()
 	return true;
 }
 
+
+
 // Global sorting function global
 function sortableInternalSort(a,b)
 {
@@ -50,13 +52,27 @@ function sortableInternalSort(a,b)
     var colname = sortableTable.currentTable.getSortcolumn();
     if ((sortableTable.currentTable.sortkind % 2)==0) {
       //alert("Compare: "+a+" "+b);
-      ret = compare(a[colname],b[colname]);
+      ret = newCompare(a[colname],b[colname]);
     } else {
       //alert("Compare: "+b+" "+a);
-      ret = compare(b[colname],a[colname]);
+      ret = newCompare(b[colname],a[colname]);
     }
     return ret;
 }
+// function sortableInternalSort(a,b)
+// {
+//     var ret = 0;
+//     //var colname = sortableTable.currentTable.getKeyByValue();
+//     var colname = sortableTable.currentTable.getSortcolumn();7
+//     if ((sortableTable.currentTable.sortkind % 2)==0) {
+//       //alert("Compare: "+a+" "+b);
+//       ret = compare(a[colname],b[colname]);
+//     } else {
+//       //alert("Compare: "+b+" "+a);
+//       ret = compare(b[colname],a[colname]);
+//     }
+//     return ret;
+// }
 
 function clearUpdateCellInternal()
 {
@@ -668,4 +684,58 @@ function SortableTable(param)
 
         return str;
     }
+}
+function newCompare(firstCell,secoundCell)
+{
+    let col = sortableTable.currentTable.getSortcolumn(); // Get column name
+    let status = sortableTable.currentTable.getSortkind(); // Get if the sort arrow is up or down.
+    let val=0;
+    let colOrder = sortableTable.currentTable.getColumnOrder(); // Get all the columns in the table.
+    var firstCellTemp;
+    var secoundCellTemp;
+
+    console.log(firstCell);
+    console.log(secoundCell);
+    //Check if the cell is a valid cell in the table.
+    if (colOrder.includes(col)) {
+        //Check if the cells contains a date object.
+        if(Date.parse(firstCell) && Date.parse(secoundCell)){
+        firstCellTemp = firstCell;
+        secoundCellTemp = secoundCell;
+        }else{
+          //Check if any cell is null.
+            if(firstCell === null || secoundCell === null){
+              firstCellTemp = firstCell;
+              secoundCellTemp = secoundCell;
+            }else{
+              //Convert to json object
+              if(JSON.stringify(firstCell) || JSON.stringify(secoundCell)){
+                firstCellTemp = firstCell;
+                secoundCellTemp = secoundCell;
+              }else{
+                firstCell=JSON.parse(firstCell);
+                secoundCell=JSON.parse(secoundCell);
+                //Get the first letter from the value.
+                firstCellTemp = Object.values(firstCell)[0];
+                secoundCellTemp = Object.values(secoundCell)[0];
+            }
+          }
+       }
+
+        firstCellTemp=$('<div/>').html(firstCellTemp).text();
+        secoundCellTemp=$('<div/>').html(secoundCellTemp).text();
+        if(status==0){
+            val = secoundCellTemp.toLocaleUpperCase().localeCompare(firstCellTemp.toLocaleUpperCase());
+        }else{
+            val = firstCellTemp.toLocaleUpperCase().localeCompare(secoundCellTemp.toLocaleUpperCase());
+        }
+    }
+    else{
+        if((status%2)==0){
+            val=firstCellTemp<secoundCell;
+        }else{
+            val=secoundCell<firstCellTemp;
+        }
+    }
+    return val;
 }


### PR DESCRIPTION
This is a solution that solves the sorting problem for the tables in access, test and  files tab on course front page. Instead of using 3 different compare functions i made one compare function that all sortingTables can use. The compare function is universal and can be used for more tables later on.

This solution works for the tabels at the pages stated above but do not work for the results table under the "Results tab" on the course front page.

My suggestion is that we take this solution and then adding the results table as an new issue and trying to solve that one with this solution.