### PR TITLE
Fix for #5776

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -261,12 +261,12 @@
                 <div class="menu-drop-down">
                     <span class="drop-down-label">Help</span>
                     <div class="drop-down">
-                        <div class="drop-down-text">
+                        <div class="drop-down-text-non-clickable">
                             <span class="drop-down-option">Move grid</span>
                             <div id="hotkey-space"><i>Blankspace</i></div>
                         </div>
                         <div class="drop-down-divider"></div>
-                        <div class="drop-down-text">
+                        <div class="drop-down-text-non-clickable">
                             <span class="drop-down-option">Select multiple objects</span>
                             <div id="hotkey-ctrl"><i>Ctrl + leftclick</i></div>
                         </div>


### PR DESCRIPTION
Fix for #5776 
Changed class for div to "drop-down-text-non-clickable", which is currently non-existent but might be useful in the future.