### PR TITLE
Fix for issue: #5997 "Menu getting overwritten by the toolbox"

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1985,7 +1985,7 @@ function initToolbox() {
     var element = document.getElementById('diagram-toolbar');
     var myCanvas = document.getElementById('myCanvas');
     var bound = myCanvas.getBoundingClientRect();
-    element.style.top = (bound.top+"px");
+    element.style.top = (150+"px");
     toolbarState = (localStorage.getItem("toolbarState") != null) ? localStorage.getItem("toolbarState") : 0;
     switchToolbar();
     element.style.display = "inline-block";
@@ -2100,7 +2100,7 @@ function initToolbox() {
     var element = document.getElementById('diagram-toolbar');
     var myCanvas = document.getElementById('myCanvas');
     var bound = myCanvas.getBoundingClientRect();
-    element.style.top = (bound.top+"px");
+    element.style.top = (150+"px");
     toolbarState = (localStorage.getItem("toolbarState") != null) ? localStorage.getItem("toolbarState") : 0;
     switchToolbar();
     element.style.display = "inline-block";

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1316,6 +1316,7 @@ input {
 
 .document-settings {
   font-size: 14px;
+  top: 150px;
 }
 
 .export-drop-down {


### PR DESCRIPTION
Moved the toolbox downwards towards the center rather than it starting in the upper-left corner.