### PR TITLE
DuggaEd: Added verification for Start date and Deadline

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -102,20 +102,33 @@ function updateDugga() {
 	var gradesys = $("#gradesys").val();
 	var template = $("#template").val();
   var qstart = $("#qstart").val()+" "+$("#qstartt").val()+":"+$("#qstartm").val();
-  if($("#qstart").val()=="")qstart="UNK";
+  if($("#qstart").val()=="") {
+	alert("Missing Start Date"); 
+	return;
+  }
 	var deadline = $("#deadline").val()+" "+$("#deadlinet").val()+":"+$("#deadlinem").val();
   var release = $("#release").val()+" "+$("#releaset").val()+":"+$("#releasem").val();
-  if($("#release").val()=="")release="UNK";
+  if($("#release").val()=="") {
+	alert("Missing Release Date"); 
+	return;
+  }
   var jsondeadline = {"deadline1":"", "comment1":"","deadline2":"", "comment2":"", "deadline3":"", "comment3":""};
   if($("#deadline").val()!=""){
       jsondeadline.deadline1=deadline;
       jsondeadline.comment1=$("#deadlinecomments1").val();
   }else{
-      deadline="UNK";
-      jsondeadline.deadline1="";
-      jsondeadline.comment1="";
+      alert("Missing Deadline 1");
+      return;
   }
 
+  if(release > qstart) {
+	alert("Release date after start date:\nRelease: "+release+" - Start: "+qstart);
+	return;
+  }
+  if(deadline < qstart) {
+	alert("Deadline before start:\nDeadline: "+deadline+" - Start: "+qstart);
+	return;
+  }
   if($("#deadline2").val()!=""){
       jsondeadline.deadline2=$("#deadline2").val()+" "+$("#deadlinet2").val()+":"+$("#deadlinem2").val();
       jsondeadline.comment2=$("#deadlinecomments2").val();

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -103,15 +103,12 @@ function updateDugga() {
 	var template = $("#template").val();
   var qstart = $("#qstart").val()+" "+$("#qstartt").val()+":"+$("#qstartm").val();
   if($("#qstart").val()=="") {
-	alert("Missing Start Date"); 
-	return;
+		alert("Missing Start Date"); 
+		return;
   }
 	var deadline = $("#deadline").val()+" "+$("#deadlinet").val()+":"+$("#deadlinem").val();
-  var release = $("#release").val()+" "+$("#releaset").val()+":"+$("#releasem").val();
-  if($("#release").val()=="") {
-	alert("Missing Release Date"); 
-	return;
-  }
+	var release = $("#release").val()+" "+$("#releaset").val()+":"+$("#releasem").val();
+	if($("#release").val()=="")release="UNK";
   var jsondeadline = {"deadline1":"", "comment1":"","deadline2":"", "comment2":"", "deadline3":"", "comment3":""};
   if($("#deadline").val()!=""){
       jsondeadline.deadline1=deadline;
@@ -120,14 +117,9 @@ function updateDugga() {
       alert("Missing Deadline 1");
       return;
   }
-
-  if(release > qstart) {
-	alert("Release date after start date:\nRelease: "+release+" - Start: "+qstart);
-	return;
-  }
   if(deadline < qstart) {
-	alert("Deadline before start:\nDeadline: "+deadline+" - Start: "+qstart);
-	return;
+		alert("Deadline before start:\nDeadline: "+deadline+" - Start: "+qstart);
+		return;
   }
   if($("#deadline2").val()!=""){
       jsondeadline.deadline2=$("#deadline2").val()+" "+$("#deadlinet2").val()+":"+$("#deadlinem2").val();


### PR DESCRIPTION
Fix for issue #6041 
The submitter is now required to pick a start date and deadline date.

I also added verification that deadline date is after start date.

Note: release date is allowed to be null because of this code in showDuggaservice:
`			if($today > $duggainfo['qrelease']  || is_null($duggainfo['qrelease'])){
				$feedback=file_get_contents($fedbname);				
			}`