### PR TITLE
Update sectioned.js enter to delete section

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1387,12 +1387,14 @@ function mouseUp(e) {
 //----------------------------------------------------------------------------------
 
 $(window).keyup(function (event) {
+  console.log(event.keyCode);
   if (event.keyCode == 27) {
+    // if key is escape
     closeWindows();
     closeSelect();
     showSaveButton();
     hamburgerChange("escapePress");
-    document.activeElement.blur(); // to lose focus from the newItem button when pressing enter
+    document.activeElement.blur(); // to lose focus from the newItem button when pressing escape
   } else if (event.keyCode == 13) {
     //Remember that keycode 13 = enter button
     document.activeElement.blur();
@@ -1406,6 +1408,9 @@ $(window).keyup(function (event) {
     } else if (submitButtonDisplay == 'block' && editSectionDisplay == 'flex') {
       newItem();
       showSaveButton();
+    } else if (deleteButtonDisplay == 'flex') {
+      // Delete the item, allow enter to act as clicking "yes"  
+      confirmBox("deleteItem");
     } else if (isTypeValid() && testsAvailable == true) {
       confirmBox("closeConfirmBox");
       testsAvailable = false;


### PR DESCRIPTION
Added functionality for enter on deletebutotnDisplay.
This is to solve issue #6053 to make it easier to delete items on sectioned.php.
Click trahscan on an object and hit enter to delete it instead of having to press yes.