### PR TITLE
Moved comment block in accessed.js

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -18,19 +18,24 @@ function setup()
   AJAXService("GET",{cid:querystring['cid'],coursevers:querystring['coursevers']},"ACCESS");
 }
 
-/* Commented out this section because of the empty white box that appeared when mouseover the navbutt. Needs testing to assure it doesnt affect other pages.
+//  Instead of commenting out the functions as previously which caused uncaught reference errors
+//  function content was commented out to avoid having a white empty box appear.
 function hoverc()
 {
+    /*
     $('#dropdowns').css('display','none');
     $('#dropdownc').css('display','block');
+    */
 }
 
 function hovers()
 {
+  /*
   $('#dropdowns').css('display','block');
   $('#dropdownc').css('display','none');
+  */
 }
-*/
+
 function leavec()
 {
 		$('#dropdownc').css('display','none');


### PR DESCRIPTION
Undid the comment covering 2 functions to instead comment away the content of the functions. This avoids the uncaught reference error whenever the functions got called (were never removed and can't really be removed) and it avoids displaying an empty white box. This should fix issue #6037 and #6052 whilst keeping the fix on issue #5975