### PR TITLE
Changed image file from .jpg to .png - Fix for #6246

### DIFF
--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -1,5 +1,5 @@
 /************************************************************************
-      
+
     THIS FILE HANDLES THE SAVE, DOWNLOAD AND EXPORT FUNCTIONALITY
 
 ************************************************************************/
@@ -190,7 +190,7 @@ function Load() {
     for (var i = 0; i < b.diagram.length; i++) {
         diagram[i] = b.diagram[i];
     }
-    
+
     points.length = b.points.length;
     for (var i = 0; i < b.points.length; i++) {
         points[i] = b.points[i];
@@ -214,7 +214,7 @@ function ExportSVG(el) {
 }
 
 //------------------------------------------------
-// used when exporting the file as a .jpg image.
+// used when exporting the file as a .png image.
 //------------------------------------------------
 
 $(document).ready(function() {
@@ -224,6 +224,6 @@ $(document).ready(function() {
     }
 
     document.getElementById('picid').addEventListener('click', function() {
-        downloadCanvas(this, 'myCanvas', 'picture.jpg');
+        downloadCanvas(this, 'myCanvas', 'picture.png');
     }, false);
 });


### PR DESCRIPTION
A simple fix which changed the file type for the export image menu option from .jpg to .png

#6246