### PR TITLE
Fixed issue with clearer hover effects on toolbox buttons #6015

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -91,19 +91,19 @@
                               <h4 class="label tlabel" id="labelCreate">Create</h4>
                               <div class="toolbar-drawer" id="drawerCreate">
                                   <div class="tooltipdialog">
-                                      <button id='attributebutton' onclick='setMode("CreateERAttr");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Attribute">
+                                      <button id='attributebutton' onclick='setMode("CreateERAttr");' style="display: inline; border-radius: 5px; cursor: pointer" class='buttonsStyle unpressed' data="Create Attribute">
                                           <img class="toolboxButtons" src="../Shared/icons/diagram_create_attribute.svg">
                                       </button>
-                                      <button id='entitybutton' onclick='setMode("CreateEREntity");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Entity">
+                                      <button id='entitybutton' onclick='setMode("CreateEREntity");' style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Create Entity">
                                           <img class="toolboxButtons" src="../Shared/icons/diagram_create_entity.svg">
                                       </button>
-                                      <button id='relationbutton' onclick='setMode("CreateERRelation");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Relation">
+                                      <button id='relationbutton' onclick='setMode("CreateERRelation");' style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Create Relation">
                                           <img class="toolboxButtons" src="../Shared/icons/diagram_create_relation.svg">
                                       </button>
-                                      <button id='classbutton' onclick='setMode("CreateClass");' style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Create Class">
+                                      <button id='classbutton' onclick='setMode("CreateClass");' style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Create Class">
                                           <img class="toolboxButtons" src="../Shared/icons/diagram_create_class.svg">
                                     </button>
-                                      <button id='drawtextbutton' onclick="setMode('Text');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Text">
+                                      <button id='drawtextbutton' onclick="setMode('Text');" style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Draw Text">
                                           <img id='textButton' src="../Shared/icons/textbox.svg" style="filter: invert(100%);">
                                       </button>
                                   </div>
@@ -112,10 +112,10 @@
                           <div class="labelToolContainer">
                             <h4 class="label tlabel" id="labelDraw">Draw</h4>
                             <div class="toolbar-drawer" id="drawerDraw">
-                                <button id='squarebutton' onclick="setMode('Square');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Square">
+                                <button id='squarebutton' onclick="setMode('Square');" style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Draw Square">
                                     <img class="toolboxButtons" src="../Shared/icons/diagram_draw_square.svg">
                                 </button>
-                                <button id='drawfreebutton' onclick="setMode('Free');" style="display: inline; border-radius: 5px" class='buttonsStyle unpressed' data="Draw Free">
+                                <button id='drawfreebutton' onclick="setMode('Free');" style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Draw Free">
                                     <img class="toolboxButtons" src="../Shared/icons/diagram_draw_free.svg">
                                 </button>
                             </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1299,6 +1299,7 @@ input {
   filter:invert(100%);
 }
 .diagramAction{
+  cursor: pointer;
   border-radius: 5px;
   background-color: #614875;
   width: 47%;
@@ -1714,6 +1715,7 @@ div.submit-button:disabled {
 }
 
 .toolboxButtons {
+  cursor: pointer;
   width: 35px !important;
   height: 25px !important;
 }
@@ -1731,6 +1733,7 @@ div.submit-button:disabled {
 }
 
 #textButton {
+  cursor: pointer;
   width: 35px;
   height: 22px;
   margin-top: 3px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1715,18 +1715,19 @@ div.submit-button:disabled {
 }
 
 .toolboxButtons {
-  cursor: pointer;
   width: 35px !important;
   height: 25px !important;
 }
 
 #linebutton {
+  cursor: pointer;
   margin: 5px 0;
   display: inline;
   border-radius: 5px;
 }
 
 #umllinebutton {
+  cursor: pointer;
   display: inline;
   margin: 5px 0;
   border-radius: 5px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1734,7 +1734,6 @@ div.submit-button:disabled {
 }
 
 #textButton {
-  cursor: pointer;
   width: 35px;
   height: 22px;
   margin-top: 3px;


### PR DESCRIPTION
Fixed issue #6015 

I changed the cursor icon to a pointer when hovering over the toolbox buttons. I could add a small visual effect aswell, but I feel that the pointer is clear enough to let the user know that they are hovering over a button.