### PR TITLE
Added a button for going back to a specific course version

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -163,6 +163,11 @@ function changeProperty(targetobj,propertyname,propertyvalue)
 		AJAXService("UPDATE",{cid:querystring['cid'],uid:targetobj,prop:propertyname,val:propertyvalue},"ACCESS");
 }
 
+function showVersion(vers)
+{
+	window.location.href = "../DuggaSys/sectioned.php?courseid="+querystring['cid']+"&coursevers="+vers;
+}
+
 //----------------------------------------------------------------
 // renderCell <- Callback function that renders cells in the table
 //----------------------------------------------------------------
@@ -195,7 +200,7 @@ function renderCell(col,celldata,cellid) {
 			str="<select onchange='changeOpt(event)' id='"+col+"_"+obj.uid+"'>"+makeoptionsItem(obj.vers,filez['courses'],"versname","vers")+"</select>";
 			var checkSubmission = data => data.uid === obj.uid;
 			if (filez['submissions'].some(checkSubmission)) {
-				str+="<img id='oldSubmissionIcon' title='View submission from old version' style='height: 20px; float: right; margin-right: 10px;' src='../Shared/icons/DocumentDark.svg'>";
+				str+="<img id='oldSubmissionIcon' title='View old version' src='../Shared/icons/DocumentDark.svg' onclick='showVersion("+obj.vers+")'>";
 			};
 		}else if(col=="access"){
 			str="<select onchange='changeOpt(event)' id='"+col+"_"+obj.uid+"'>"+makeoptions(obj.access,["Teacher","Student"],["W","R"])	+"</select>";

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -193,6 +193,10 @@ function renderCell(col,celldata,cellid) {
 			str="<select onchange='changeOpt(event)' id='"+col+"_"+obj.uid+"'><option value='None'>None</option>"+makeoptionsItem(obj.examiner,filez['teachers'],"name","uid")+"</select>";
 		}else if(col=="vers"){
 			str="<select onchange='changeOpt(event)' id='"+col+"_"+obj.uid+"'>"+makeoptionsItem(obj.vers,filez['courses'],"versname","vers")+"</select>";
+			var checkSubmission = data => data.uid === obj.uid;
+			if (filez['submissions'].some(checkSubmission)) {
+				str+="<img id='oldSubmissionIcon' title='View submission from old version' style='height: 20px; float: right; margin-right: 10px;' src='../Shared/icons/DocumentDark.svg'>";
+			};
 		}else if(col=="access"){
 			str="<select onchange='changeOpt(event)' id='"+col+"_"+obj.uid+"'>"+makeoptions(obj.access,["Teacher","Student"],["W","R"])	+"</select>";
 		}else if(col == "requestedpasswordchange") {

--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -267,6 +267,7 @@ $teachers=array();
 $classes=array();
 $groups=array();
 $courses=array();
+$submissions=array();
 
 if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid))) {
 	$query = $pdo->prepare("SELECT user.uid as uid,username,access,firstname,lastname,ssn,class,modified,vers,requestedpasswordchange,examiner,`groups`, TIME_TO_SEC(TIMEDIFF(now(),addedtime))/60 AS newly FROM user, user_course WHERE cid=:cid AND user.uid=user_course.uid");
@@ -363,6 +364,26 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid))) {
 			);
 		}
 	}
+
+	// Find user submissions in old versions
+	$query=$pdo->prepare("SELECT course.cid, uid, vers.vers, versname FROM course, submission, vers WHERE course.cid=:cid AND course.cid=submission.cid AND vers.vers=submission.vers AND submission.vers!=activeversion;");
+	$query->bindParam(':cid', $cid);
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading submissions\n".$error[2];
+	}else{
+		foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
+			array_push(
+				$submissions,
+				array(
+					'cid' => $row['cid'],
+					'uid' => $row['uid'],
+					'vers' => $row['vers'],
+					'versname' => $row['versname']
+				)
+			);
+		}
+	}
 }
 
 $array = array(
@@ -373,7 +394,8 @@ $array = array(
 	'courses' => $courses,
 	'groups' => $groups,
 	'queryResult' => $queryResult,
-	'examiners' => $examiners
+	'examiners' => $examiners,
+	'submissions' => $submissions
 );
 
 echo json_encode($array);

--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -366,7 +366,7 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid))) {
 	}
 
 	// Find user submissions in old versions
-	$query=$pdo->prepare("SELECT course.cid, uid, vers.vers, versname FROM course, submission, vers WHERE course.cid=:cid AND course.cid=submission.cid AND vers.vers=submission.vers AND submission.vers!=activeversion;");
+	$query=$pdo->prepare("SELECT course.cid, uid, vers.vers, versname FROM course, userAnswer, vers WHERE course.cid=:cid AND course.cid=userAnswer.cid AND vers.vers=userAnswer.vers AND userAnswer.vers!=activeversion;");
 	$query->bindParam(':cid', $cid);
 	if(!$query->execute()) {
 		$error=$query->errorInfo();

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2377,6 +2377,13 @@ span.arrow {
 	margin-left: 5px;
 }
 
+#oldSubmissionIcon {
+  height: 20px; 
+  float: right; 
+  margin-right: 10px;
+  cursor:pointer;
+}
+
 #user td {
   padding: 0px;
   border-right: 3px dashed rgba(97,72,117,0);
@@ -4742,3 +4749,5 @@ textarea#filecont{
   color: #fff;
   border: 2px solid var(--color-primary);
 }
+
+

--- a/Shared/icons/DocumentDark.svg
+++ b/Shared/icons/DocumentDark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" x1="-467.5" y1="-144.5" x2="-465.5" y2="-142.5"/>
+<path fill="#464646" d="M14.836,10.452c-1.559,0-2.834-1.275-2.834-2.835V0.851H5.393c-1.562,0-2.84,1.275-2.84,2.834v16.581
+	c0,1.561,1.278,2.834,2.84,2.834h12.966c1.559,0,2.834-1.273,2.834-2.834v-9.812L14.836,10.452L14.836,10.452z"/>
+<path fill="#464646" d="M13.434,0.851h-0.057v5.516c0,1.56,1.273,2.835,2.836,2.835h4.979L13.434,0.851z"/>
+</svg>


### PR DESCRIPTION
For issue #5634 

This change adds a button to the Version cell of the access table if the user has made a submission in a version of the course other than the active version (i.e an old version).
![oldversions](https://user-images.githubusercontent.com/37792198/56744099-25d58f00-6778-11e9-9d4f-b7bc6a577d05.PNG)


The button itself is just the 'Document' icon with inverted colors, can be subject to change.