### PR TITLE
Grupp b2019 w18#6220

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -207,7 +207,7 @@
 
   <!--<div id='previewpopover' class='previewPopover' style='display:none;'>-->
   <div id='previewpopover' class='loginBoxContainer' style='display:none; align-items:stretch;'>
-    <div style='width:100% max-height:none;' class="loginBox">
+    <div style='width:100%; max-height:none;' class="loginBox">
     		<div class='loginBoxheader'>
     			<h3 style='width:100%;' id='Nameof'>Submission and feedback view</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
     		</div>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -206,7 +206,7 @@
 <!---------------------=============####### Preview Popover #######=============--------------------->
 
   <!--<div id='previewpopover' class='previewPopover' style='display:none;'>-->
-  <div id='previewpopover' class='loginBoxContainer' style='display:none; align-items:none;'>
+  <div id='previewpopover' class='loginBoxContainer' style='display:none; align-items:stretch;'>
     <div class="loginBox">
     		<div class='loginBoxheader'>
     			<h3 style='width:100%;' id='Nameof'>Submission and feedback view</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -207,7 +207,7 @@
 
   <!--<div id='previewpopover' class='previewPopover' style='display:none;'>-->
   <div id='previewpopover' class='loginBoxContainer' style='display:none; align-items:stretch;'>
-    <div class="loginBox">
+    <div style='width:100% max-height:none;' class="loginBox">
     		<div class='loginBoxheader'>
     			<h3 style='width:100%;' id='Nameof'>Submission and feedback view</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
     		</div>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -206,7 +206,7 @@
 <!---------------------=============####### Preview Popover #######=============--------------------->
 
   <!--<div id='previewpopover' class='previewPopover' style='display:none;'>-->
-  <div id='previewpopover' class='loginBoxContainer' style='display:none;'>
+  <div id='previewpopover' class='loginBoxContainer' style='display:none; align-items:none;'>
     <div class="loginBox">
     		<div class='loginBoxheader'>
     			<h3 style='width:100%;' id='Nameof'>Submission and feedback view</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1133,6 +1133,7 @@ input {
 
 .loginBox td {
   margin-left: 4px;
+  margin-right: 4px;
 }
 
 .buttonLoginBox {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -716,9 +716,9 @@ header td {
   bottom: 8px;
   z-index: 11000;
   box-shadow: 2px 2px 4px #000;
-  padding: 4px;
+  /*padding: 4px;*/
   background-color: #ccc;
-  border: 2px solid #999;
+  /*border: 2px solid #999;*/
 }
 
 .previewpopover {


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/38323901/56824596-327ce480-6857-11e9-84b2-505c7b517d31.png)

after
![image](https://user-images.githubusercontent.com/38323901/56824609-41639700-6857-11e9-86a3-1f1fcdeed046.png)



Moved a header which was hidden behind the absolute submission window so that you can escape the previewpopup. It might be a good idea to see if any other boxes gets messed up by the style.css change. the loginbox class is for some reason used for the previewwindow.

#6220

test site, log in and click the text submission to see the change:
https://c17alepe.webug.his.se:20002/DuggaSys/showDugga.php?did=74&cid=324&coursevers=12324&moment=2328&segment=2386&highscoremode=0&comment=UNK&deadline=2019-05-15%2007:15:00

NOTE TO ISSUE-MASTER: The branch i created has the wrong issuenumber. it says 6022 but it should be 6220. Let me know if this is a problem