### PR TITLE
Fix for #6264 Changed style value for move button

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1710,7 +1710,7 @@ div.submit-button:disabled {
 }
 
 #moveButton {
-  right: 2px;
+  right: 18px;
   top: 100;
   z-index: 2;
   position: absolute;


### PR DESCRIPTION
The move button has be adjusted a bit to the left to fit at the corner of the canvas.
#6264