### PR TITLE
Fix for issue #6354: Deselection of draw line

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2826,6 +2826,13 @@ function mouseupevt(ev) {
             lastSelectedObject = diagram.length -1;
             diagram[lastSelectedObject].targeted = true;
             selected_objects.push(diagram[lastSelectedObject]);
+            //resets the mode so that next click can move or select an object instead of drawing another line
+            //only happens when a line has been created between 2 objects
+            if ($("#linebutton").hasClass("pressed")){
+                $("#linebutton.buttonsStyle").removeClass("pressed").addClass("unpressed");
+            }            
+            uimode = "normal";
+
             createCardinality();
             updateGraphics();
         }
@@ -2871,6 +2878,13 @@ function mouseupevt(ev) {
             lastSelectedObject = diagram.length -1;
             diagram[lastSelectedObject].targeted = true;
             selected_objects.push(diagram[lastSelectedObject]);
+            //resets the mode so that next click can move or select an object instead of drawing another line
+            //only happens when a line has been created between 2 objects
+            if ($("#umllinebutton").hasClass("pressed")){
+                $("#umllinebutton.buttonsStyle").removeClass("pressed").addClass("unpressed");
+            }            
+            uimode = "normal";
+
             createCardinality();
             updateGraphics();
             }


### PR DESCRIPTION
#6354 
The line tool is only deselected when the line has been created, so that if you don't draw a line to an object then the line the tool will not be deselected and you can draw as it was intended. This behaviour can be changed though, depending on how we want it to work.