### PR TITLE
Created graph for daily github activity

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -363,7 +363,7 @@ function renderCircleDiagram(data)
   var str = "";
   str+="<div class='circleGraph'>";
   str+="<svg width='300' height='300'>";
-  str+="<circle id='circleGraphCircle' cx='150' cy='150' r='120' />";
+  str+="<circle class='circleGraphCircle' cx='150' cy='150' r='120' />";
   str+=renderHourMarkers();
   str+="</svg>";
   str+="</div>";
@@ -391,10 +391,10 @@ function renderHourMarkers()
         str += "'circleGraphLine'";
         str += " x2='"+xCoord+"' y2='"+yCoord+"' />";
     }
-    str += "<circle id='circleGraphInnerCircle' cx='"+MIDDLE+"' cy='"+MIDDLE+"' r=5 />";
+    str += "<circle class='circleGraphCircle' cx='"+MIDDLE+"' cy='"+MIDDLE+"' r=5 />";
   }
 
-  str += "<g id='circleGraphHours'>";
+  str += "<g class='circleGraphHours'>";
   for (i = 0, number = 18; i < 12; i++) {
     var xCoordNum = (Math.cos(toRadians(i*30)) * NUMRADIUS) + X_OFFSET;
     var yCoordNum = (Math.sin(toRadians(i*30)) * NUMRADIUS) + Y_OFFSET;
@@ -408,7 +408,7 @@ function renderHourMarkers()
   }
   str += "</g>";
   return str;
-  
+
   function toRadians(angle)
   {
       return angle * (Math.PI / 180);

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -358,6 +358,46 @@ function weekchoice(dateString){
     return str;
 }
 
+function renderCircleDiagram(data)
+{
+  var str = "";
+  str+="<div class='hours'>";
+  str+="<svg width='300' height='300'>";
+  str+="<circle id='circle' cx='150' cy='150' r='120' />";
+  str+="<g id='numbers'>";
+  str+=addHourNumbers();
+  str+="</g>";
+  str+="</svg>";
+  str+="</div>";
+}
+
+function addHourNumbers()
+{
+  var RADIUS = 140;
+  var X_OFFSET = RADIUS + 5;
+  var Y_OFFSET = RADIUS + 15;
+  var str = "";
+
+  var i, number;
+  for (i = 0, number = 18; i < 12; i++) {
+      var xCoord = (Math.cos(toRadians(i*30)) * RADIUS) + X_OFFSET;
+      var yCoord = (Math.sin(toRadians(i*30)) * RADIUS) + Y_OFFSET;
+      str += "<text x='"+xCoord+"' y='"+yCoord+"'>"+number+"</text>";
+      if (number === 22) {
+          number = 0;
+      } else {
+          number += 2;
+      }
+  }
+
+  return str;
+
+  function toRadians(angle)
+  {
+      return angle * (Math.PI / 180);
+  }
+}
+
 function intervaltocolor(size,val)
 {
     if(val<size*0.25){
@@ -435,6 +475,7 @@ function returnedSection(data)
 
     str+=renderBarDiagram(data);
     str+=renderLineDiagram(data);
+    str+=renderCircleDiagram(data);
 
     // Table heading
 	str+="<table class='fumho'>";

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -457,7 +457,7 @@ function renderActivityPoints(activities)
     for(var i = 0; i < uniquePoints.length; i++) {
       str+=(uniquePoints[i][0]+5)+","+(uniquePoints[i][1]+5)+" ";
     }
-    str+="' onmouseover='showAllActivity(event, "+JSON.stringify(activityTypes)+")' onmouseout='hideActivityInfo()' />";
+    str+="250,250' onmouseover='showAllActivity(event, "+JSON.stringify(activityTypes)+")' onmouseout='hideActivityInfo()' />";
   }
 
   uniquePoints.forEach(point => {

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -417,12 +417,14 @@ function renderCircleDiagram(data)
   var uniquePoints = Array.from(set).map(JSON.parse);
   uniquePoints.sort(([a,b,c,d], [e,f,g,h]) => d - h);
 
-  // Make a polygon between each point in the graph
-  str+="<polygon class='activityPolygon' points='";
-  for(var i = 0; i < uniquePoints.length; i++) {
-    str+=(uniquePoints[i][0]+5)+","+(uniquePoints[i][1]+5)+" ";
+  // Make a polygon between each point in the graph if the number of unique points is larger than 2
+  if (uniquePoints.length > 2) {
+    str+="<polygon class='activityPolygon' points='";
+    for(var i = 0; i < uniquePoints.length; i++) {
+      str+=(uniquePoints[i][0]+5)+","+(uniquePoints[i][1]+5)+" ";
+    }
+    str+="' onmouseover='showAllActivity(event, "+JSON.stringify(activityTypes)+")' onmouseout='hideActivityInfo()' />";
   }
-  str+="' onmouseover='showAllActivity(event, "+JSON.stringify(activityTypes)+")' onmouseout='hideActivityInfo()' />";
 
   // Make a rectangle for every activity and add it to the graph
   activityPoints.forEach(point => {
@@ -437,7 +439,14 @@ function renderCircleDiagram(data)
     str+="`"+type+"`, `"+hour+"`, "+percentage+", "+JSON.stringify(activityTypes)+")' onmouseout='hideActivityInfo()' />";
   });
   str+="</svg>";
-  str+="</div>";
+
+  // Hidden gradient used for mixed activity points
+  str+= "<svg style='width:0;height:0;position:absolute;'>";
+  str+= "<linearGradient id='mixedActivityGradient' x2='1' y2='1'>";
+  str+= "<stop offset='0%' stop-color='#6A4C93' />";
+  str+= "<stop offset='50%' stop-color='#2AB7CA' />";
+  str+= "<stop offset='100%' stop-color='#FE4A49' />";
+  str+= "</linearGradient></svg></div>";
 }
 
 function renderHourMarkers()

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -366,7 +366,6 @@ function toRadians(angle)
 function renderCircleDiagram(data)
 {
   var activities = JSON.parse(data);
-  console.log(activities);
   var str = "";
   str+="<h2 style='padding:10px'>Activities today</h2>";
   str+="<div class='circleGraph'>";
@@ -508,16 +507,11 @@ function showAllActivity(e, activities)
   var str = "";
 
   for (var i = 0; i < times.length; i++) {
-      var nextHour;
+      var prevHour = (parseInt(times[i])-1);
       var hourTypes = Object.keys(activities.times[times[i]]);
 
-      if (times[i].indexOf('0') === 0) {
-          nextHour = "0" + (parseInt(times[i])+1);
-      } else {
-          nextHour = (parseInt(times[i])+1);
-      }
       str += "<span class='activityInfoEntry'>";
-      str += "<strong>"+times[i]+".00 - "+nextHour+".00</strong><br>";
+      str += "<strong>"+prevHour+".00 - "+times[i]+".00</strong><br>";
       
       hourTypes.forEach(type => {
           str += type+": "+activities.times[times[i]][type]+"<br>";
@@ -537,17 +531,12 @@ function showActivityInfo(e, type, hour, pc, activities)
   var timeSpan = document.getElementById('activityTime');
   var pcSpan = document.getElementById('activityPercent');
   var countSpan = document.getElementById('activityCount');
-  var nextHour;
+  var prevHour = (parseInt(hour)-1);
   box.style.display = 'block';
   box.style.left = e.offsetX +10+ "px";
   box.style.top = e.offsetY +10+ "px";
 
-  if (hour.indexOf('0') === 0) {
-      nextHour = "0" + (parseInt(hour)+1);
-  } else {
-      nextHour = (parseInt(hour)+1);
-  }
-  timeSpan.innerHTML = hour+".00 - "+nextHour+".00";
+  timeSpan.innerHTML = prevHour+".00 - "+hour+".00";
   pcSpan.innerHTML = pc+"% Activity";
   var str = "";
   for (var i = 0; i < Object.keys(activities.times[hour]).length; i++) {

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -392,12 +392,13 @@ function renderCircleDiagram(data)
   activities.forEach(entry => {
     // Calculate position for the activity rectangle
     const RADIUS = 220;
+    const BASELINE = 30;
     var hour = entry.time.substr(0,2);
     var houroffset = parseInt(hour) + 6;
     var activityCount = activities.length;
     var percentage = hours[hour] / activityCount;
-    var angleFactor = (RADIUS+150) * percentage;
-    angleFactor > 220 ? angleFactor = 220 : angleFactor = angleFactor;    
+    var angleFactor = (RADIUS * percentage) + BASELINE;
+    angleFactor > RADIUS ? angleFactor = RADIUS : angleFactor = angleFactor;    
     var xCoord = (Math.cos(toRadians(houroffset*15)) * angleFactor) + 245;
     var yCoord = (Math.sin(toRadians(houroffset*15)) * angleFactor) + 245;
 
@@ -405,9 +406,7 @@ function renderCircleDiagram(data)
 
     // Count total activities of each type, and count total activities of each type at every time
     if (!Object.keys(activityTypes.times).includes(hour)) activityTypes.times[hour] = {};
-    if (!Object.keys(activityTypes.types).includes(type)) {
-            activityTypes.types[type] = 0;
-    }
+    if (!Object.keys(activityTypes.types).includes(type)) activityTypes.types[type] = 0;
     if (!Object.keys(activityTypes.times[hour]).includes(type)) activityTypes.times[hour][type] = 0;
     activityTypes.types[type] += 1;
     activityTypes.times[hour][type] += 1;

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -363,8 +363,8 @@ function renderCircleDiagram(data)
   var activities = data; //Fix this when database is available
   var str = "";
   str+="<div class='circleGraph'>";
-  str+="<svg width='300' height='300'>";
-  str+="<circle class='circleGraphCircle' cx='150' cy='150' r='120' />";
+  str+="<svg width='500' height='500'>";
+  str+="<circle class='circleGraphCircle' cx='250' cy='250' r='220' />";
   str+=renderHourMarkers();
   var hours = {};
   activities.forEach(entry => {
@@ -384,16 +384,34 @@ function renderCircleDiagram(data)
     }
 
   });
+  var activityPoints = [];
   activities.forEach(entry => {
-    const RADIUS = 120;
+    const RADIUS = 220;
     var hour = entry.time.substr(0,2);
     var houroffset = parseInt(hour) + 6;
     var activityCount = activities.length;
     var percentage = hours[hour] / activityCount;
-    var xCoord = (Math.cos(toRadians(houroffset*15)) * (RADIUS * percentage)) + 148;
-    var yCoord = (Math.sin(toRadians(houroffset*15)) * (RADIUS * percentage)) + 148;
+    var angleFactor = (RADIUS+150) * percentage;
+    angleFactor > 220 ? angleFactor = 220 : angleFactor = angleFactor;    
+    var xCoord = (Math.cos(toRadians(houroffset*15)) * angleFactor) + 245;
+    var yCoord = (Math.sin(toRadians(houroffset*15)) * angleFactor) + 245;
 
-    str+="<rect class='activitymarker' width='5' height='5' x='"+xCoord+"' y='"+yCoord+"' />";
+    activityPoints.push([xCoord, yCoord, activityType, hour]);
+  });
+  var set = new Set(activityPoints.map(JSON.stringify));
+  var uniquePoints = Array.from(set).map(JSON.parse);
+  uniquePoints.sort(([a,b,c,d], [e,f,g,h]) => d - h);
+
+  str+="<polygon class='activityPolygon' points='";
+  for(var i = 0; i < uniquePoints.length; i++) {
+    str+=(uniquePoints[i][0]+5)+","+(uniquePoints[i][1]+5)+" ";
+  }
+  str+="' />";
+  activityPoints.forEach(point => {
+    var xCoord = point[0];
+    var yCoord = point[1];
+    var activityType = point[2];
+    str+="<rect class='activitymarker "+activityType+"' width='10' height='10' x='"+xCoord+"' y='"+yCoord+"' onmouseover:'showActivityInfo()' />";
   });
   str+="</svg>";
   str+="</div>";
@@ -401,10 +419,10 @@ function renderCircleDiagram(data)
 
 function renderHourMarkers()
 {
-  const RADIUS = 120;
-  const NUMRADIUS = 140;
-  const MIDDLE = 150;
-  const X_OFFSET = NUMRADIUS + 5;
+  const RADIUS = 220;
+  const NUMRADIUS = 240;
+  const MIDDLE = 250;
+  const X_OFFSET = NUMRADIUS + 10;
   const Y_OFFSET = NUMRADIUS + 15;
   var str = "";
 
@@ -415,11 +433,15 @@ function renderHourMarkers()
 
     str += "<line x1='"+MIDDLE+"' y1='"+MIDDLE+"' class=";
     if (i % 2 === 0) {
-        str += "'circleGraphBigline'";
-        str += " x2='"+xCoord+"' y2='"+yCoord+"' />";
+      xCoord = (Math.cos(toRadians(i*15)) * (RADIUS+10)) + MIDDLE;
+      yCoord = (Math.sin(toRadians(i*15)) * (RADIUS+10)) + MIDDLE;
+      str += "'circleGraphBigline'";
+      str += " x2='"+xCoord+"' y2='"+yCoord+"' />";
     } else {
-        str += "'circleGraphLine'";
-        str += " x2='"+xCoord+"' y2='"+yCoord+"' />";
+      xCoord = (Math.cos(toRadians(i*15)) * RADIUS) + MIDDLE;
+      yCoord = (Math.sin(toRadians(i*15)) * RADIUS) + MIDDLE;
+      str += "'circleGraphLine'";
+      str += " x2='"+xCoord+"' y2='"+yCoord+"' />";
     }
     str += "<circle class='circleGraphCircle' cx='"+MIDDLE+"' cy='"+MIDDLE+"' r=5 />";
   }

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -363,11 +363,28 @@ function toRadians(angle)
 {
   return angle * (Math.PI / 180);
 }
-function renderCircleDiagram(data)
+function changeDay(date)
 {
+  AJAXService("updateday",{userid:"HGustavs", today: date},"CONTRIBUTION");
+}
+function renderCircleDiagram(data, day)
+{
+  var today = new Date();
+  if (!day) {
+    var YYYY = today.getFullYear();
+    var mm = today.getMonth() + 1;
+    var dd = today.getDate();
+    if (dd < 10) dd = '0'+dd;
+    if (mm < 10) mm = '0'+mm;
+    today = YYYY+"-"+mm+"-"+dd;
+  } else {
+    today = day;
+  }
+
   var activities = JSON.parse(data);
   var str = "";
   str+="<h2 style='padding:10px'>Activities today</h2>";
+  str+="<input type='date' id='circleGraphDatepicker' value="+today+" onchange='changeDay(this.value)' />";
   str+="<div class='circleGraph'>";
   str+="<div id='activityInfoBox'><span id='allActivity'></span><span id='activityTime'></span><span id='activityPercent'></span><span id='activityCount'></span></div>";
   str+="<svg width='500' height='500'>";
@@ -583,8 +600,15 @@ var momentexists=0;
 var resave = false;
 function returnedSection(data)
 {
-	retdata=data;
-    if(data['debug']!="NONE!") alert(data['debug']);
+  retdata=data;
+
+  if (Object.keys(data).length === 2) {
+    var div = document.getElementById('hourlyGraph');
+    div.innerHTML = renderCircleDiagram(JSON.stringify(data['events']),data['day']);
+    return;
+  }
+
+  if(data['debug']!="NONE!") alert(data['debug']);
 
   contribDataArr = [];
 	var str="";
@@ -638,7 +662,9 @@ function returnedSection(data)
 
     str+=renderBarDiagram(data);
     str+=renderLineDiagram(data);
+    str+="<div id='hourlyGraph'>";
     str+=renderCircleDiagram(JSON.stringify(data['todaysevents']));
+    str+="</div>";
 
     // Table heading
 	str+="<table class='fumho'>";

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -360,11 +360,41 @@ function weekchoice(dateString){
 
 function renderCircleDiagram(data)
 {
+  var activities = data; //Fix this when database is available
   var str = "";
   str+="<div class='circleGraph'>";
   str+="<svg width='300' height='300'>";
   str+="<circle class='circleGraphCircle' cx='150' cy='150' r='120' />";
   str+=renderHourMarkers();
+  var hours = {};
+  activities.forEach(entry => {
+    var hour = entry.time.substr(0,2);
+    var keys = Object.keys(hours);
+    var found = false;
+
+    for (var i = 0; i < keys.length; i++) {
+        if (keys[i] == hour) {
+            hours[hour] += 1;
+            found = true;
+            return;
+        }
+    }
+    if (Object.entries(hours).length === 0 || !found) {
+        hours[hour] = 1;
+    }
+
+  });
+  activities.forEach(entry => {
+    const RADIUS = 120;
+    var hour = entry.time.substr(0,2);
+    var houroffset = parseInt(hour) + 6;
+    var activityCount = activities.length;
+    var percentage = hours[hour] / activityCount;
+    var xCoord = (Math.cos(toRadians(houroffset*15)) * (RADIUS * percentage)) + 148;
+    var yCoord = (Math.sin(toRadians(houroffset*15)) * (RADIUS * percentage)) + 148;
+
+    str+="<rect class='activitymarker' width='5' height='5' x='"+xCoord+"' y='"+yCoord+"' />";
+  });
   str+="</svg>";
   str+="</div>";
 }

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -361,37 +361,54 @@ function weekchoice(dateString){
 function renderCircleDiagram(data)
 {
   var str = "";
-  str+="<div class='hours'>";
+  str+="<div class='circleGraph'>";
   str+="<svg width='300' height='300'>";
-  str+="<circle id='circle' cx='150' cy='150' r='120' />";
-  str+="<g id='numbers'>";
-  str+=addHourNumbers();
-  str+="</g>";
+  str+="<circle id='circleGraphCircle' cx='150' cy='150' r='120' />";
+  str+=renderHourMarkers();
   str+="</svg>";
   str+="</div>";
 }
 
-function addHourNumbers()
+function renderHourMarkers()
 {
-  var RADIUS = 140;
-  var X_OFFSET = RADIUS + 5;
-  var Y_OFFSET = RADIUS + 15;
+  const RADIUS = 120;
+  const NUMRADIUS = 140;
+  const MIDDLE = 150;
+  const X_OFFSET = NUMRADIUS + 5;
+  const Y_OFFSET = NUMRADIUS + 15;
   var str = "";
 
   var i, number;
-  for (i = 0, number = 18; i < 12; i++) {
-      var xCoord = (Math.cos(toRadians(i*30)) * RADIUS) + X_OFFSET;
-      var yCoord = (Math.sin(toRadians(i*30)) * RADIUS) + Y_OFFSET;
-      str += "<text x='"+xCoord+"' y='"+yCoord+"'>"+number+"</text>";
-      if (number === 22) {
-          number = 0;
-      } else {
-          number += 2;
-      }
+  for (i = 0; i < 24; i++) {
+    var xCoord = (Math.cos(toRadians(i*15)) * RADIUS) + MIDDLE;
+    var yCoord = (Math.sin(toRadians(i*15)) * RADIUS) + MIDDLE;
+
+    str += "<line x1='"+MIDDLE+"' y1='"+MIDDLE+"' class=";
+    if (i % 2 === 0) {
+        str += "'circleGraphBigline'";
+        str += " x2='"+xCoord+"' y2='"+yCoord+"' />";
+    } else {
+        str += "'circleGraphLine'";
+        str += " x2='"+xCoord+"' y2='"+yCoord+"' />";
+    }
+    str += "<circle id='circleGraphInnerCircle' cx='"+MIDDLE+"' cy='"+MIDDLE+"' r=5 />";
   }
 
+  str += "<g id='circleGraphHours'>";
+  for (i = 0, number = 18; i < 12; i++) {
+    var xCoordNum = (Math.cos(toRadians(i*30)) * NUMRADIUS) + X_OFFSET;
+    var yCoordNum = (Math.sin(toRadians(i*30)) * NUMRADIUS) + Y_OFFSET;
+    
+    str += "<text x='"+xCoordNum+"' y='"+yCoordNum+"'>"+number+"</text>";
+    if (number === 22) {
+        number = 0;
+    } else {
+        number += 2;
+    }
+  }
+  str += "</g>";
   return str;
-
+  
   function toRadians(angle)
   {
       return angle * (Math.PI / 180);

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -1,5 +1,8 @@
 <?php
 date_default_timezone_set("Europe/Stockholm");
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
 
 // Include basic application services!
 include_once "../Shared/sessions.php";
@@ -16,418 +19,463 @@ $debug="NONE!";
 
 $log_db = new PDO('sqlite:../../GHData/GHDataTest.db');
 
-$allusers=array();
+$opt = getOP('opt');
 
+$allusers=array();
 $allrowranks=array();
 $alleventranks=array();
 $allcommentranks=array();
-
 $allcommitranks=array();
 
 $draught=false;
 
-if(checklogin() && isSuperUser($_SESSION['uid'])) {
-    $gituser = getOP('userid');
-    $query = $log_db->prepare('select distinct(usr) from ( select blameuser as usr from blame where blamedate>"2019-03-31" and blamedate<"2020-01-01" union select author as usr from event where eventtime>"2019-03-31" and eventtime<"2020-01-01" union select author as usr from issue where issuetime>"2019-03-31" and issuetime<"2019-01-08") order by usr;');
-    if(!$query->execute()) {
-        $error=$query->errorInfo();
-        $debug="Error reading entries\n".$error[2];
-    }
-    $rows = $query->fetchAll();
-    foreach($rows as $row){
-        if(strlen($row['usr'])<9) array_push($allusers, $row['usr']);
-    }
-  
-    $draught=true;
-}else{
-    if(isset($_SESSION['uid'])){
-    	$userid=$_SESSION['uid'];
-    	$loginname=$_SESSION['loginname'];
-    	$lastname=$_SESSION['lastname'];
-    	$firstname=$_SESSION['firstname'];
-    }
-    $gituser=$loginname;
-}
-
-if(isset($_SESSION['uid'])){
-	$userid=$_SESSION['uid'];
-	$loginname=$_SESSION['loginname'];
-	$lastname=$_SESSION['lastname'];
-	$firstname=$_SESSION['firstname'];
-}else{
-	$userid=1;
-	$loginname="UNK";
-	$lastname="UNK";
-	$firstname="UNK";
-}
-
-//$debug=print_r($_SESSION,true);
-
-$startweek = strtotime('2019-04-01');									// First monday in january
-$currentweek=$startweek;
-$currentweekend=strtotime("+1 week",$currentweek);
-$weekno=1;
-
-$weeks = array();
-
-$commitrank="NOT FOUND";
-$commitrankno="NOT FOUND";
-$i=1;
-$query = $log_db->prepare('SELECT COUNT(*) as rowk, author FROM commitgit WHERE thedate>"2019-03-31" AND thedate<"2020-01-01" GROUP BY author ORDER BY rowk DESC;');
-if(!$query->execute()) {
-    $error=$query->errorInfo();
-    $debug="Error reading entries\n".$error[2];
-}
-$rows = $query->fetchAll();
-foreach($rows as $row){
-    if($row['author']==$gituser){
-        $commitrank=$i;
-        $commitrankno=$row['rowk'];
-    }
-  
-    if($draught) array_push($allcommitranks, $row);
-  
-    $i++;
-}
-$rowrank="NOT FOUND";
-$rowrankno="NOT FOUND";
-$i=1;
-$query = $log_db->prepare('SELECT sum(rowcnt) as rowk, blameuser FROM Bfile,Blame WHERE Blame.fileid=Bfile.id and blamedate>"2019-03-31" and blamedate<"2020-01-01" group by blameuser order by rowk desc;');
-if(!$query->execute()) {
-    $error=$query->errorInfo();
-    $debug="Error reading entries\n".$error[2];
-}
-$rows = $query->fetchAll();
-foreach($rows as $row){
-    if($row['blameuser']==$gituser){
-        $rowrank=$i;
-        $rowrankno=$row['rowk'];
-    }
-    if($draught) array_push($allrowranks, $row);
-  
-    $i++;
-  
-}
-
-$eventrankno="NOT FOUND";
-$eventrank="NOT FOUND";
-$i=1;
-$query = $log_db->prepare('SELECT count(*) as rowk, author FROM event where eventtime>"2019-03-31" AND  eventtime<"2020-01-01" and eventtime!="undefined" AND kind != "comment" group by author order by rowk desc;');
-if(!$query->execute()) {
-    $error=$query->errorInfo();
-    $debug="Error reading entries\n".$error[2];
-}
-$rows = $query->fetchAll();
-foreach($rows as $row){
-    if($row['author']==$gituser){
-        $eventrank=$i;
-        $eventrankno=$row['rowk'];
-    }
-  
-    if($draught) array_push($alleventranks, $row);
-  
-    $i++;
-}
-
-$commentrankno="NOT FOUND";
-$commentrank="NOT FOUND";
-$i=1;
-$query = $log_db->prepare('SELECT count(*) as rowk, author FROM event where eventtime>"2019-03-31" and eventtime!="undefined" and eventtime<"2020-01-01" and kind="comment" group by author order by rowk desc;');
-if(!$query->execute()) {
-    $error=$query->errorInfo();
-    $debug="Error reading entries\n".$error[2];
-}
-$rows = $query->fetchAll();
-foreach($rows as $row){
-    if($row['author']==$gituser){
-        $commentrank=$i;
-        $commentrankno=$row['rowk'];
-    }
-  
-    if($draught) array_push($allcommentranks, $row);
-  
-    $i++;
-}
-
-$issuerank="NOT FOUND";
-$issuerankno="NOT FOUND";
-$i=1;
-$query = $log_db->prepare('SELECT count(*) as rowk, author FROM issue where issuetime>"2019-03-31" and issuetime<"2020-01-01" and issuetime!="undefined" group by author order by rowk desc;');
-if(!$query->execute()) {
-    $error=$query->errorInfo();
-    $debug="Error reading entries\n".$error[2];
-}
-$rows = $query->fetchAll();
-foreach($rows as $row){
-    if($row['author']==$gituser){
-        $issuerank=$i;
-        $issuerankno=$row['rowk'];
-    }
-    $i++;
-}
-
-
-/*
-$overallrank="NOT FOUND";
-$overallrankno="NOT FOUND";
-$i=1;
-$query = $log_db->prepare('SELECT sum(rowk) as davegrowl,author FROM (SELECT count(*) as rowk, author FROM event where eventtime>"2017-03-03" and eventtime!="undefined" group by author having count(*)>4 UNION SELECT COUNT(*) as rowk,author FROM comment where commenttime>"2017-03-03" group by author UNION SELECT count(*) as rowk, author FROM issue where issuetime>"2017-03-01" and issuetime!="undefined" group by author order by rowk desc ) group by author order by davegrowl desc;');
-if(!$query->execute()) {
-    $error=$query->errorInfo();
-    $debug="Error reading entries".$error[2];
-}
-$rows = $query->fetchAll();
-foreach($rows as $row){
-    if($row['author']==$gituser){
-        $overallrank=$i;
-        $overallrankno=$row['davegrowl'];
-    }
-    
-    if($draught) array_push($alltotalranks, $row);
-    
-    $i++;
-}
-
-
-SELECT sum(rowk),author FROM (SELECT count(*) as rowk, author FROM event where eventtime>"2017-03-03" group by author UNION SELECT COUNT(*) as rowk,author FROM comment where commenttime>"2017-03-03" group by author UNION SELECT count(*) as rowk,author from issue where issuetime>"2017-03-03" group by author ) group by author order by rowk desc;
-*/
-
-do{
-  
-		// Number of issues created by user during the interval
-  
-		$issues= array();
-    $currentweekdate=date('Y-m-d', $currentweek);
-	$currentweekenddate=date('Y-m-d', $currentweekend);
-		$query = $log_db->prepare('SELECT * FROM issue WHERE author=:gituser AND issuetime>:issuefrom AND issuetime<:issueto;');
-        if(!$query->execute()) {
-            $error=$query->errorInfo();
-            $debug="Error reading entries\n".$error[2];
-        }
-		$query->bindParam(':gituser', $gituser);
-		$query->bindParam(':issuefrom', $currentweekdate);
-		$query->bindParam(':issueto', $currentweekenddate );
-		$query->execute();
-        $rows = $query->fetchAll();
-		foreach($rows as $row){
-				$issue = array(
-					'issueno' => $row['issueno'],
-					'title' => $row['title'],
-					'issuetime' =>$row['issuetime']
-				);
-				array_push($issues, $issue);
-		}
-  
-		// Event count of the various kinds of events during interval
-		$events = array();
-		$query = $log_db->prepare("SELECT kind,count(kind) as cnt FROM event WHERE kind!='comment' AND event.author=:gituser AND eventtime>:eventfrom AND eventtime<:eventto GROUP BY kind");
-		$query->bindParam(':gituser', $gituser);
-		$query->bindParam(':eventfrom', $currentweekdate);
-		$query->bindParam(':eventto', $currentweekenddate );
-        if(!$query->execute()) {
-            $error=$query->errorInfo();
-            $debug="Error reading entries\n".$error[2];
-        }
-        $rows = $query->fetchAll();
-		foreach($rows as $row){
-				$event = array(
-					'kind' => $row['kind'],
-					'cnt' => $row['cnt']
-				);
-				array_push($events, $event);
-		}
-  
-		// Number of comments posted by the user during the interval
-		$comments= array();
-		$query = $log_db->prepare('SELECT * FROM event WHERE author=:gituser AND eventtime>:eventfrom AND eventtime<:eventto AND kind="comment"');
-		$query->bindParam(':gituser', $gituser);
-		$query->bindParam(':eventfrom', $currentweekdate);
-		$query->bindParam(':eventto', $currentweekenddate );
-    if(!$query->execute()) {
-				$error=$query->errorInfo();
-				$debug="Error reading entries\n".$error[2];
+if(strcmp($opt,"get")==0) {
+	if(checklogin() && isSuperUser($_SESSION['uid'])) {
+		$gituser = getOP('userid');
+		$query = $log_db->prepare('select distinct(usr) from ( select blameuser as usr from blame where blamedate>"2019-03-31" and blamedate<"2020-01-01" union select author as usr from event where eventtime>"2019-03-31" and eventtime<"2020-01-01" union select author as usr from issue where issuetime>"2019-03-31" and issuetime<"2019-01-08") order by usr;');
+		if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error reading entries\n".$error[2];
 		}
 		$rows = $query->fetchAll();
 		foreach($rows as $row){
-				$comment = array(
-					'issueno' => $row['issueno'],
-					'content' => $row['content']
-				);
-				array_push($comments, $comment);
+			if(strlen($row['usr'])<9) array_push($allusers, $row['usr']);
 		}
-  
-		// Number of commits made by the user during the interval
-		$commits=array();
-		$query = $log_db->prepare('SELECT message,cid,author FROM commitgit WHERE author=:gituser AND thedate>:eventfrom AND thedate<:eventto');
-		$query->bindParam(':gituser', $gituser);
-		$query->bindParam(':eventfrom', $currentweekdate);
-		$query->bindParam(':eventto', $currentweekenddate );
-    if(!$query->execute()) {
-				$error=$query->errorInfo();
-				$debug="Error reading entries\n".$error[2];
+	  
+		$draught=true;
+	}else{
+		if(isset($_SESSION['uid'])){
+			$userid=$_SESSION['uid'];
+			$loginname=$_SESSION['loginname'];
+			$lastname=$_SESSION['lastname'];
+			$firstname=$_SESSION['firstname'];
 		}
-		$rows = $query->fetchAll();
-		foreach($rows as $row){
-				$commit=array(
-					'message' => $row['message'],
-					'cid' => $row['cid']
-				);
-				array_push($commits, $commit);
-		}
-  
-		// Number of lines changed in each file during interval
-		$files= array();
-        $query = $log_db->prepare('SELECT sum(rowcnt) as rowk, * FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and blamedate>:blamefrom and blamedate<:blameto GROUP BY filename');
-		$query->bindParam(':blamefrom', $currentweekdate);
-		$query->bindParam(':blameto', $currentweekenddate );
-		$query->bindParam(':gituser', $gituser);
-        if(!$query->execute()) {
-            $error=$query->errorInfo();
-            $debug="Error reading entries".$error[2];
-		}
-		$rows = $query->fetchAll();
-		foreach($rows as $row){
-				$file = array(
-					'path' => $row['path'],
-					'filename' => $row['filename'],
-					'lines' => $row['rowk']
-				);
-				array_push($files, $file);
-		}
-  
-		$week = array(
-			'weekno' => $weekno,
-			'weekstart' => $currentweekdate,
-			'weekend' => $currentweekenddate,
-			'events' => $events,
-			'issues' => $issues,
-			'comments' => $comments,
-			'commits' => $commits,
-			'files' => $files
-		);
-		array_push($weeks, $week);
-  
-		$currentweek=$currentweekend;
-  
-		$currentweekend=strtotime("+1 week",$currentweek);
-  
-		$weekno++;
-  
-}while($weekno<11);
-
-$today = date('Y-m-d');
-//$today = '2019-04-10'; // For testing purposes
-$todaysevents = array();
-
-// Events and issues by the user today
-$query = $log_db->prepare('SELECT kind, eventtimeh FROM event WHERE author=:gituser AND DATE(eventtime)=:today AND kind IN ("comment", "commit");');
-$query->bindParam(':gituser', $gituser);
-$query->bindParam(':today', $today);
-if(!$query->execute()) {
+		$gituser=$loginname;
+	}
+	
+	if(isset($_SESSION['uid'])){
+		$userid=$_SESSION['uid'];
+		$loginname=$_SESSION['loginname'];
+		$lastname=$_SESSION['lastname'];
+		$firstname=$_SESSION['firstname'];
+	}else{
+		$userid=1;
+		$loginname="UNK";
+		$lastname="UNK";
+		$firstname="UNK";
+	}
+	
+	//$debug=print_r($_SESSION,true);
+	
+	$startweek = strtotime('2019-04-01');									// First monday in january
+	$currentweek=$startweek;
+	$currentweekend=strtotime("+1 week",$currentweek);
+	$weekno=1;
+	
+	$weeks = array();
+	
+	$commitrank="NOT FOUND";
+	$commitrankno="NOT FOUND";
+	$i=1;
+	$query = $log_db->prepare('SELECT COUNT(*) as rowk, author FROM commitgit WHERE thedate>"2019-03-31" AND thedate<"2020-01-01" GROUP BY author ORDER BY rowk DESC;');
+	if(!$query->execute()) {
 		$error=$query->errorInfo();
 		$debug="Error reading entries\n".$error[2];
-}
-$rows = $query->fetchAll();
-foreach($rows as $row){
-		$event = array(
-			'type' => $row['kind'],
-			'time' => $row['eventtimeh']
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+		if($row['author']==$gituser){
+			$commitrank=$i;
+			$commitrankno=$row['rowk'];
+		}
+	  
+		if($draught) array_push($allcommitranks, $row);
+	  
+		$i++;
+	}
+	$rowrank="NOT FOUND";
+	$rowrankno="NOT FOUND";
+	$i=1;
+	$query = $log_db->prepare('SELECT sum(rowcnt) as rowk, blameuser FROM Bfile,Blame WHERE Blame.fileid=Bfile.id and blamedate>"2019-03-31" and blamedate<"2020-01-01" group by blameuser order by rowk desc;');
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading entries\n".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+		if($row['blameuser']==$gituser){
+			$rowrank=$i;
+			$rowrankno=$row['rowk'];
+		}
+		if($draught) array_push($allrowranks, $row);
+	  
+		$i++;
+	  
+	}
+	
+	$eventrankno="NOT FOUND";
+	$eventrank="NOT FOUND";
+	$i=1;
+	$query = $log_db->prepare('SELECT count(*) as rowk, author FROM event where eventtime>"2019-03-31" AND  eventtime<"2020-01-01" and eventtime!="undefined" AND kind != "comment" group by author order by rowk desc;');
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading entries\n".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+		if($row['author']==$gituser){
+			$eventrank=$i;
+			$eventrankno=$row['rowk'];
+		}
+	  
+		if($draught) array_push($alleventranks, $row);
+	  
+		$i++;
+	}
+	
+	$commentrankno="NOT FOUND";
+	$commentrank="NOT FOUND";
+	$i=1;
+	$query = $log_db->prepare('SELECT count(*) as rowk, author FROM event where eventtime>"2019-03-31" and eventtime!="undefined" and eventtime<"2020-01-01" and kind="comment" group by author order by rowk desc;');
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading entries\n".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+		if($row['author']==$gituser){
+			$commentrank=$i;
+			$commentrankno=$row['rowk'];
+		}
+	  
+		if($draught) array_push($allcommentranks, $row);
+	  
+		$i++;
+	}
+	
+	$issuerank="NOT FOUND";
+	$issuerankno="NOT FOUND";
+	$i=1;
+	$query = $log_db->prepare('SELECT count(*) as rowk, author FROM issue where issuetime>"2019-03-31" and issuetime<"2020-01-01" and issuetime!="undefined" group by author order by rowk desc;');
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading entries\n".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+		if($row['author']==$gituser){
+			$issuerank=$i;
+			$issuerankno=$row['rowk'];
+		}
+		$i++;
+	}
+	
+	
+	/*
+	$overallrank="NOT FOUND";
+	$overallrankno="NOT FOUND";
+	$i=1;
+	$query = $log_db->prepare('SELECT sum(rowk) as davegrowl,author FROM (SELECT count(*) as rowk, author FROM event where eventtime>"2017-03-03" and eventtime!="undefined" group by author having count(*)>4 UNION SELECT COUNT(*) as rowk,author FROM comment where commenttime>"2017-03-03" group by author UNION SELECT count(*) as rowk, author FROM issue where issuetime>"2017-03-01" and issuetime!="undefined" group by author order by rowk desc ) group by author order by davegrowl desc;');
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading entries".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+		if($row['author']==$gituser){
+			$overallrank=$i;
+			$overallrankno=$row['davegrowl'];
+		}
+		
+		if($draught) array_push($alltotalranks, $row);
+		
+		$i++;
+	}
+	
+	
+	SELECT sum(rowk),author FROM (SELECT count(*) as rowk, author FROM event where eventtime>"2017-03-03" group by author UNION SELECT COUNT(*) as rowk,author FROM comment where commenttime>"2017-03-03" group by author UNION SELECT count(*) as rowk,author from issue where issuetime>"2017-03-03" group by author ) group by author order by rowk desc;
+	*/
+	
+	do{
+	  
+			// Number of issues created by user during the interval
+	  
+			$issues= array();
+		$currentweekdate=date('Y-m-d', $currentweek);
+		$currentweekenddate=date('Y-m-d', $currentweekend);
+			$query = $log_db->prepare('SELECT * FROM issue WHERE author=:gituser AND issuetime>:issuefrom AND issuetime<:issueto;');
+			if(!$query->execute()) {
+				$error=$query->errorInfo();
+				$debug="Error reading entries\n".$error[2];
+			}
+			$query->bindParam(':gituser', $gituser);
+			$query->bindParam(':issuefrom', $currentweekdate);
+			$query->bindParam(':issueto', $currentweekenddate );
+			$query->execute();
+			$rows = $query->fetchAll();
+			foreach($rows as $row){
+					$issue = array(
+						'issueno' => $row['issueno'],
+						'title' => $row['title'],
+						'issuetime' =>$row['issuetime']
+					);
+					array_push($issues, $issue);
+			}
+	  
+			// Event count of the various kinds of events during interval
+			$events = array();
+			$query = $log_db->prepare("SELECT kind,count(kind) as cnt FROM event WHERE kind!='comment' AND event.author=:gituser AND eventtime>:eventfrom AND eventtime<:eventto GROUP BY kind");
+			$query->bindParam(':gituser', $gituser);
+			$query->bindParam(':eventfrom', $currentweekdate);
+			$query->bindParam(':eventto', $currentweekenddate );
+			if(!$query->execute()) {
+				$error=$query->errorInfo();
+				$debug="Error reading entries\n".$error[2];
+			}
+			$rows = $query->fetchAll();
+			foreach($rows as $row){
+					$event = array(
+						'kind' => $row['kind'],
+						'cnt' => $row['cnt']
+					);
+					array_push($events, $event);
+			}
+	  
+			// Number of comments posted by the user during the interval
+			$comments= array();
+			$query = $log_db->prepare('SELECT * FROM event WHERE author=:gituser AND eventtime>:eventfrom AND eventtime<:eventto AND kind="comment"');
+			$query->bindParam(':gituser', $gituser);
+			$query->bindParam(':eventfrom', $currentweekdate);
+			$query->bindParam(':eventto', $currentweekenddate );
+		if(!$query->execute()) {
+					$error=$query->errorInfo();
+					$debug="Error reading entries\n".$error[2];
+			}
+			$rows = $query->fetchAll();
+			foreach($rows as $row){
+					$comment = array(
+						'issueno' => $row['issueno'],
+						'content' => $row['content']
+					);
+					array_push($comments, $comment);
+			}
+	  
+			// Number of commits made by the user during the interval
+			$commits=array();
+			$query = $log_db->prepare('SELECT message,cid,author FROM commitgit WHERE author=:gituser AND thedate>:eventfrom AND thedate<:eventto');
+			$query->bindParam(':gituser', $gituser);
+			$query->bindParam(':eventfrom', $currentweekdate);
+			$query->bindParam(':eventto', $currentweekenddate );
+		if(!$query->execute()) {
+					$error=$query->errorInfo();
+					$debug="Error reading entries\n".$error[2];
+			}
+			$rows = $query->fetchAll();
+			foreach($rows as $row){
+					$commit=array(
+						'message' => $row['message'],
+						'cid' => $row['cid']
+					);
+					array_push($commits, $commit);
+			}
+	  
+			// Number of lines changed in each file during interval
+			$files= array();
+			$query = $log_db->prepare('SELECT sum(rowcnt) as rowk, * FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and blamedate>:blamefrom and blamedate<:blameto GROUP BY filename');
+			$query->bindParam(':blamefrom', $currentweekdate);
+			$query->bindParam(':blameto', $currentweekenddate );
+			$query->bindParam(':gituser', $gituser);
+			if(!$query->execute()) {
+				$error=$query->errorInfo();
+				$debug="Error reading entries".$error[2];
+			}
+			$rows = $query->fetchAll();
+			foreach($rows as $row){
+					$file = array(
+						'path' => $row['path'],
+						'filename' => $row['filename'],
+						'lines' => $row['rowk']
+					);
+					array_push($files, $file);
+			}
+	  
+			$week = array(
+				'weekno' => $weekno,
+				'weekstart' => $currentweekdate,
+				'weekend' => $currentweekenddate,
+				'events' => $events,
+				'issues' => $issues,
+				'comments' => $comments,
+				'commits' => $commits,
+				'files' => $files
+			);
+			array_push($weeks, $week);
+	  
+			$currentweek=$currentweekend;
+	  
+			$currentweekend=strtotime("+1 week",$currentweek);
+	  
+			$weekno++;
+	  
+	}while($weekno<11);
+	
+	$today = date('Y-m-d');
+	//$today = '2019-04-10'; // For testing purposes
+	$todaysevents = array();
+	
+	// Events and issues by the user today
+	$query = $log_db->prepare('SELECT kind, eventtimeh FROM event WHERE author=:gituser AND DATE(eventtime)=:today AND kind IN ("comment", "commit");');
+	$query->bindParam(':gituser', $gituser);
+	$query->bindParam(':today', $today);
+	if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error reading entries\n".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+			$event = array(
+				'type' => $row['kind'],
+				'time' => $row['eventtimeh']
+			);
+			array_push($todaysevents, $event);
+	}
+	$commits = array();
+	$query = $log_db->prepare('SELECT issuetimeh FROM issue WHERE author=:gituser AND DATE(issuetime)=:today;');
+	$query->bindParam(':gituser', $gituser);
+	$query->bindParam(':today', $today);
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading entries\n".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+		$issue = array(
+			'type' => 'issue',
+			'time' => $row['issuetimeh']
 		);
-		array_push($todaysevents, $event);
-}
-$commits = array();
-$query = $log_db->prepare('SELECT issuetimeh FROM issue WHERE author=:gituser AND DATE(issuetime)=:today;');
-$query->bindParam(':gituser', $gituser);
-$query->bindParam(':today', $today);
-if(!$query->execute()) {
-	$error=$query->errorInfo();
-	$debug="Error reading entries\n".$error[2];
-}
-$rows = $query->fetchAll();
-foreach($rows as $row){
-	$issue = array(
-		'type' => 'issue',
-		'time' => $row['issuetimeh']
+		array_push($todaysevents, $issue);
+	}
+	
+	
+	$count = array();
+	$currentdate = $startweek;
+	for($i=0;$i<70;$i++){
+		$currentdate=date('Y-m-d',$currentdate);
+		$daycount = array();
+		//Events
+		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND Date(eventtime)=:currentdate AND kind!="comment"');
+		$query->bindParam(':gituser', $gituser);
+		$query->bindParam(':currentdate', $currentdate);
+		if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error reading entries".$error[2];
+		}
+		$eventcount = $query->fetchAll();
+	  
+	  //Comments
+		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND Date(eventtime)=:currentdate AND kind="comment"');
+		$query->bindParam(':gituser', $gituser);
+		$query->bindParam(':currentdate', $currentdate);
+		if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error reading entries".$error[2];
+		}
+		$commentcount = $query->fetchAll();
+	  
+		//Commits
+		$query = $log_db->prepare('SELECT count(*) FROM commitgit WHERE author=:gituser AND Date(thedate)=:currentdate');
+		$query->bindParam(':gituser', $gituser);
+		$query->bindParam(':currentdate', $currentdate);
+		if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error reading entries".$error[2];
+		}
+		$commitcount = $query->fetchAll();
+		
+		//LOC
+		$query = $log_db->prepare('SELECT sum(rowcnt) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and Date(blamedate)=:currentdate');
+		$query->bindParam(':gituser', $gituser);
+		$query->bindParam(':currentdate', $currentdate);
+		if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error reading entries".$error[2];
+		}
+		$loccount = $query->fetchAll();
+		
+		$daycount = array('events' => $eventcount,
+						  'commits' => $commitcount,
+						  'loc' => $loccount,
+				'comments' => $commentcount);
+		$count[$currentdate] = $daycount;
+		$currentdate=strtotime("+1 day",strtotime($currentdate));
+	}
+	$array = array(
+		'debug' => $debug,
+		'weeks' => $weeks,
+		'rowrankno' => $rowrankno,
+		'rowrank' => $rowrank,
+		'eventrankno' => $eventrankno,
+		'eventrank' => $eventrank,
+		'issuerankno' => $issuerankno,
+		'issuerank' => $issuerank,
+		'commentrankno' => $commentrankno,
+		'commentrank' => $commentrank,
+		'commitrankno' => $commitrankno,
+		'commitrank' => $commitrank,
+		'allusers' => $allusers,
+		'allrowranks' => $allrowranks,
+		'alleventranks' => $alleventranks,
+		'allcommentranks' => $allcommentranks,
+		'allcommitranks' => $allcommitranks,
+		'githubuser' => $gituser,
+		'todaysevents' => $todaysevents,
+		'count' => $count
 	);
-	array_push($todaysevents, $issue);
+	
+	echo json_encode($array);
+} else if (strcmp($opt, "updateday")==0) {
+	$today = getOP('today');
+	$gituser = getOP('userid');
+	$todaysevents = array();
+	
+	// Events and issues by the user today
+	$query = $log_db->prepare('SELECT kind, eventtimeh FROM event WHERE author=:gituser AND DATE(eventtime)=:today AND kind IN ("comment", "commit");');
+	$query->bindParam(':gituser', $gituser);
+	$query->bindParam(':today', $today);
+	if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error reading entries\n".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+			$event = array(
+				'type' => $row['kind'],
+				'time' => $row['eventtimeh']
+			);
+			array_push($todaysevents, $event);
+	}
+	$commits = array();
+	$query = $log_db->prepare('SELECT issuetimeh FROM issue WHERE author=:gituser AND DATE(issuetime)=:today;');
+	$query->bindParam(':gituser', $gituser);
+	$query->bindParam(':today', $today);
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading entries\n".$error[2];
+	}
+	$rows = $query->fetchAll();
+	foreach($rows as $row){
+		$issue = array(
+			'type' => 'issue',
+			'time' => $row['issuetimeh']
+		);
+		array_push($todaysevents, $issue);
+	}
+	$array = array(
+		'day' => $today,
+		'events' => $todaysevents
+	);
+	echo json_encode($array);
 }
 
-
-$count = array();
-$currentdate = $startweek;
-for($i=0;$i<70;$i++){
-	$currentdate=date('Y-m-d',$currentdate);
-	$daycount = array();
-	//Events
-	$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND Date(eventtime)=:currentdate AND kind!="comment"');
-	$query->bindParam(':gituser', $gituser);
-	$query->bindParam(':currentdate', $currentdate);
-	if(!$query->execute()) {
-		$error=$query->errorInfo();
-		$debug="Error reading entries".$error[2];
-	}
-	$eventcount = $query->fetchAll();
-  
-  //Comments
-	$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND Date(eventtime)=:currentdate AND kind="comment"');
-	$query->bindParam(':gituser', $gituser);
-	$query->bindParam(':currentdate', $currentdate);
-	if(!$query->execute()) {
-		$error=$query->errorInfo();
-		$debug="Error reading entries".$error[2];
-	}
-	$commentcount = $query->fetchAll();
-  
-	//Commits
-	$query = $log_db->prepare('SELECT count(*) FROM commitgit WHERE author=:gituser AND Date(thedate)=:currentdate');
-	$query->bindParam(':gituser', $gituser);
-	$query->bindParam(':currentdate', $currentdate);
-	if(!$query->execute()) {
-		$error=$query->errorInfo();
-		$debug="Error reading entries".$error[2];
-	}
-	$commitcount = $query->fetchAll();
-	
-	//LOC
-	$query = $log_db->prepare('SELECT sum(rowcnt) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and Date(blamedate)=:currentdate');
-	$query->bindParam(':gituser', $gituser);
-	$query->bindParam(':currentdate', $currentdate);
-	if(!$query->execute()) {
-		$error=$query->errorInfo();
-		$debug="Error reading entries".$error[2];
-	}
-	$loccount = $query->fetchAll();
-	
-	$daycount = array('events' => $eventcount,
-					  'commits' => $commitcount,
-					  'loc' => $loccount,
-            'comments' => $commentcount);
-	$count[$currentdate] = $daycount;
-	$currentdate=strtotime("+1 day",strtotime($currentdate));
-}
-$array = array(
-	'debug' => $debug,
-	'weeks' => $weeks,
-    'rowrankno' => $rowrankno,
-	'rowrank' => $rowrank,
-    'eventrankno' => $eventrankno,
-	'eventrank' => $eventrank,
-    'issuerankno' => $issuerankno,
-	'issuerank' => $issuerank,
-    'commentrankno' => $commentrankno,
-    'commentrank' => $commentrank,
-    'commitrankno' => $commitrankno,
-    'commitrank' => $commitrank,
-    'allusers' => $allusers,
-    'allrowranks' => $allrowranks,
-    'alleventranks' => $alleventranks,
-    'allcommentranks' => $allcommentranks,
-    'allcommitranks' => $allcommitranks,
-	'githubuser' => $gituser,
-	'todaysevents' => $todaysevents,
-	'count' => $count
-);
-
-echo json_encode($array);
 
 ?>

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -315,8 +315,8 @@ do{
   
 }while($weekno<11);
 
-//$today = date('Y-m-d');
-$today = '2019-04-10'; // For testing purposes
+$today = date('Y-m-d');
+//$today = '2019-04-10'; // For testing purposes
 $todaysevents = array();
 
 // Events and issues by the user today

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -316,7 +316,7 @@ do{
 }while($weekno<11);
 
 //$today = date('Y-m-d');
-$today = '2019-04-04';
+$today = '2019-04-10'; // For testing purposes
 $todaysevents = array();
 
 // Events and issues by the user today

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -14,7 +14,7 @@ $vers=$_SESSION['coursevers'];
 
 $debug="NONE!";
 
-$log_db = new PDO('sqlite:../../GHData/GHdata_2019_2.db');
+$log_db = new PDO('sqlite:../../GHData/GHDataTest.db');
 
 $allusers=array();
 
@@ -315,6 +315,43 @@ do{
   
 }while($weekno<11);
 
+//$today = date('Y-m-d');
+$today = '2019-04-04';
+$todaysevents = array();
+
+// Events and issues by the user today
+$query = $log_db->prepare('SELECT kind, eventtimeh FROM event WHERE author=:gituser AND DATE(eventtime)=:today AND kind IN ("comment", "commit");');
+$query->bindParam(':gituser', $gituser);
+$query->bindParam(':today', $today);
+if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error reading entries\n".$error[2];
+}
+$rows = $query->fetchAll();
+foreach($rows as $row){
+		$event = array(
+			'type' => $row['kind'],
+			'time' => $row['eventtimeh']
+		);
+		array_push($todaysevents, $event);
+}
+$commits = array();
+$query = $log_db->prepare('SELECT issuetimeh FROM issue WHERE author=:gituser AND DATE(issuetime)=:today;');
+$query->bindParam(':gituser', $gituser);
+$query->bindParam(':today', $today);
+if(!$query->execute()) {
+	$error=$query->errorInfo();
+	$debug="Error reading entries\n".$error[2];
+}
+$rows = $query->fetchAll();
+foreach($rows as $row){
+	$issue = array(
+		'type' => 'issue',
+		'time' => $row['issuetimeh']
+	);
+	array_push($todaysevents, $issue);
+}
+
 
 $count = array();
 $currentdate = $startweek;
@@ -387,6 +424,7 @@ $array = array(
     'allcommentranks' => $allcommentranks,
     'allcommitranks' => $allcommitranks,
 	'githubuser' => $gituser,
+	'todaysevents' => $todaysevents,
 	'count' => $count
 );
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2959,38 +2959,75 @@ table {
   background-color: var(--color-background);
 }
 
+ /* Styling for circle graph */
 .circleGraph {
-  width:300px;
-  height:300px;
+  width:500px;
+  height:500px;
+  position: relative;
 }
-
+#activityInfoBox {
+  display: none;
+  position: absolute;
+  min-width: 150px;
+  background: lightgray;
+  color: black;
+  border: 1px solid black;
+  padding: 5px;
+  text-align: center;
+  font-size: 10pt;
+  font-family: sans-serif;
+}
+#activityInfoBox span {
+  display: block;
+  padding: 1px;
+  font-weight: bold;
+}
+#allActivity .activityInfoEntry {
+  display: block;
+  padding: 0 0 8px 0;
+  font-weight: 100;
+}
 .circleGraphCircle {
   stroke:black;
   stroke-width:1px;
   fill:white;
 }
-
 .circleGraphHours {
   text-anchor: middle;
 }
-
 .circleGraphBigline {
   fill: black;
   stroke:black;
   stroke-width:2px;
 }
-
 .circleGraphLine {
   fill: gray;
   stroke:gray;
   stroke-width:1px;
 }
-
 .activitymarker {
-  fill: red;
-  stroke-width: 1px;
+  stroke-width: 0.5px;
   stroke: black;
 }
+rect[class*="activitymarker"]:hover {
+  fill: greenyellow;
+}
+.activitymarker.commit {
+  fill: royalblue;
+}
+.activitymarker.pullrequest {
+  fill: purple;
+}
+.activitymarker.issue {
+  fill: red;
+}
+.activityPolygon {
+  opacity: 0.8;
+  fill: yellow;
+  stroke-width: 0.5px;
+  stroke: red;
+}
+
 /* JQuery UI Complement for missing icons in the DatePicker */
 
 .ui-datepicker .ui-datepicker-next span {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -223,7 +223,12 @@ p {
 #content {
   background: var(--color-background);
   min-height: calc(100vh - 80px);
-  margin: 65px 10px 15px 10px;
+  margin-top: 65px;
+}
+
+#TopMenuStatic {
+  margin-left: 10px;
+  margin-right: 10px;
 }
 
 #contentDiagram {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3010,20 +3010,23 @@ table {
   stroke: black;
 }
 rect[class*="activitymarker"]:hover {
-  fill: greenyellow;
+  fill: #8AC926;
 }
 .activitymarker.commit {
-  fill: royalblue;
+  fill: #2AB7CA;
 }
 .activitymarker.pullrequest {
-  fill: purple;
+  fill: #6A4C93;
 }
 .activitymarker.issue {
-  fill: red;
+  fill: #FE4A49;
+}
+.activitymarker.mixed {
+  fill: url("#mixedActivityGradient");
 }
 .activityPolygon {
   opacity: 0.8;
-  fill: yellow;
+  fill: #FED766;
   stroke-width: 0.5px;
   stroke: red;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2992,7 +2992,7 @@ table {
   stroke-width:1px;
   fill:white;
 }
-.circleGraphHours {
+#circleGraphHours {
   text-anchor: middle;
 }
 .circleGraphBigline {
@@ -3015,7 +3015,7 @@ rect[class*="activitymarker"]:hover {
 .activitymarker.commit {
   fill: #2AB7CA;
 }
-.activitymarker.pullrequest {
+.activitymarker.comment {
   fill: #6A4C93;
 }
 .activitymarker.issue {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2959,6 +2959,32 @@ table {
   background-color: var(--color-background);
 }
 
+.circleGraph {
+  width:300px;
+  height:300px;
+}
+
+.circleGraphCircle {
+  stroke:black;
+  stroke-width:1px;
+  fill:white;
+}
+
+.circleGraphHours {
+  text-anchor: middle;
+}
+
+.circleGraphBigline {
+  fill: black;
+  stroke:black;
+  stroke-width:2px;
+}
+
+.circleGraphLine {
+  fill: gray;
+  stroke:gray;
+  stroke-width:1px;
+}
 /* JQuery UI Complement for missing icons in the DatePicker */
 
 .ui-datepicker .ui-datepicker-next span {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2985,6 +2985,12 @@ table {
   stroke:gray;
   stroke-width:1px;
 }
+
+.activitymarker {
+  fill: red;
+  stroke-width: 1px;
+  stroke: black;
+}
 /* JQuery UI Complement for missing icons in the DatePicker */
 
 .ui-datepicker .ui-datepicker-next span {


### PR DESCRIPTION
Issue #6304 

How it looks on server:
![onserver](https://user-images.githubusercontent.com/37792198/56899196-27ae9380-6a93-11e9-88e2-37f4a7018d09.PNG)

Currently the graph only tracks comments, commits, and issues. This can be modified later on if more event types are needed. The activity boxes on the graph has different colors depending on the event type, and is multicolored if several different types are on the same hour.

When the user hovers over a box, information about the activities that hour are shown. User can also hover over the polygon to show information about the whole day.

The polygon is only drawn when there are three or more points of activity.

This can be hard to test since the database we use only has data for HGustavs and a97marbr, so the events are mainly comments. What I did to test this was:

- sqlite3 GHDataTest.db
- SELECT * FROM event WHERE author='HGustavs' AND kind IN ('comment', 'commit');
- Find a day with a lot of activity over several hours
- Change $today in contributionservice.php to that date

You can also use the datepicker to choose a date.

To make a contribution dugga:
Make a new item in sectioned
Change 'Type' to Test and 'Link' to Contribution