### PR TITLE
Fixed issue #6377: Move cursor was displayed when it should not be

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -747,7 +747,8 @@ window.addEventListener("mousemove", function()
     let indexOfHoveredObject = diagram.indexOf(diagram.checkForHover(currentMouseCoordinateX, currentMouseCoordinateY));
     if (indexOfHoveredObject != -1) {
             for (let i = 0; i < diagram.length; i++) {
-                // If the symbol is a line or an umlline or the object is locked the cursor pointer will remain default, otherwise it's of type all-scroll
+                // If the symbol is a line or an umlline or the object is locked or the user is trying to draw a line between entities the cursor pointer will remain default, 
+                // otherwise it's of type "all-scroll"
                 if (diagram[indexOfHoveredObject].symbolkind != 4 && !diagram[indexOfHoveredObject].locked && diagram[indexOfHoveredObject].symbolkind != 7 && uimode != "CreateLine") {
                     canvas.style.cursor = "all-scroll";
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -747,7 +747,7 @@ window.addEventListener("mousemove", function()
     let indexOfHoveredObject = diagram.indexOf(diagram.checkForHover(currentMouseCoordinateX, currentMouseCoordinateY));
     if (indexOfHoveredObject != -1) {
             for (let i = 0; i < diagram.length; i++) {
-                // If the symbol is a line or an umlline or the object is locked or the user is trying to draw a line between entities the cursor pointer will remain default, 
+                // If the symbol is a line or an umlline or the object is locked or the user is trying to draw a line between entities the cursor pointer will remain default,
                 // otherwise it's of type "all-scroll"
                 if (diagram[indexOfHoveredObject].symbolkind != 4 && !diagram[indexOfHoveredObject].locked && diagram[indexOfHoveredObject].symbolkind != 7 && uimode != "CreateLine") {
                     canvas.style.cursor = "all-scroll";
@@ -2352,7 +2352,7 @@ function mousemoveevt(ev, t) {
         sel = diagram.closestPoint(currentMouseCoordinateX, currentMouseCoordinateY);
 
         if (sel.distance < tolerance) {
-            canvas.style.cursor = "url('../Shared/icons/hand_move.cur'), auto";
+            canvas.style.cursor = "default";
         } else {
             if(uimode == "MoveAround"){
                 canvas.style.cursor = "all-scroll";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -36,12 +36,12 @@ AJAXService("get", {}, "DIAGRAM");
 
 ************************************************************/
 
-const kind = { 
-    path: 1, 
+const kind = {
+    path: 1,
     symbol: 2
 };
-const symbolKind = { 
-    uml: 1,  
+const symbolKind = {
+    uml: 1,
     erAttribute: 2,
     erEntity: 3,
     line: 4,
@@ -52,9 +52,9 @@ const symbolKind = {
 const mouseState = {
     empty: 0,                       // empty
     noPointAvailable: 1,            // mouse is pressed down and no point is close show selection box
-    insidePoint: 2,                 // mouse is pressed down and at a point in selected object 
-    insideMovableObject: 3,         // mouse pressed down inside a movable object  
-    boxSelectOrCreateMode: 4        // Box select or Create mode 
+    insidePoint: 2,                 // mouse is pressed down and at a point in selected object
+    insideMovableObject: 3,         // mouse pressed down inside a movable object
+    boxSelectOrCreateMode: 4        // Box select or Create mode
 };
 
 var gridSize = 16;                  // Distance between lines in grid
@@ -742,19 +742,20 @@ diagram.checkForHover = function(posX, posY) {
 }
 
 // Indicates that objects are movable by changing the appearance of the cursor
-window.addEventListener("mousemove", function() 
-{   
+window.addEventListener("mousemove", function()
+{
     let indexOfHoveredObject = diagram.indexOf(diagram.checkForHover(currentMouseCoordinateX, currentMouseCoordinateY));
     if (indexOfHoveredObject != -1) {
             for (let i = 0; i < diagram.length; i++) {
-                if (diagram[indexOfHoveredObject].symbolkind != 4 && !diagram[indexOfHoveredObject].locked) {
+                // If the symbol is a line or an umlline or the object is locked the cursor pointer will remain default, otherwise it's of type all-scroll
+                if (diagram[indexOfHoveredObject].symbolkind != 4 && !diagram[indexOfHoveredObject].locked && diagram[indexOfHoveredObject].symbolkind != 7) {
                     canvas.style.cursor = "all-scroll";
-                } 
+                }
             }
         } else {
             canvas.style.cursor = "default";
         }
-    }, 
+    },
     false
 );
 
@@ -939,7 +940,7 @@ function toggleVirtualA4() {
         updateGraphics();
     }
     $("#a4-holes-item").toggleClass("drop-down-item drop-down-item-disabled");
-    setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);   
+    setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
 
 }
 
@@ -1393,7 +1394,7 @@ consloe.log = function(gobBluth) {
 
 
 //------------------------------------------------------------------------------
-// developerMode: 
+// developerMode:
 // this function show and hides developer options.
 //------------------------------------------------------------------------------
 
@@ -1438,7 +1439,7 @@ function developerMode() {
 // changes to ER. It changes toolbar and turn on/off crosses on the menu.
 //------------------------------------------------------------------------------
 var crossER = false;
-function switchToolbarER() { 
+function switchToolbarER() {
     toolbarState = 1;                                                               // Change the toolbar to ER.
     switchToolbar('ER');                                                            // ---||---
     document.getElementById('toolbarTypeText').innerHTML = 'ER';                    // Change the text to ER.
@@ -2195,7 +2196,7 @@ function switchToolbar(direction) {
       toolbarState = 1;
     }
   }
-  
+
   document.getElementById('toolbarTypeText').innerHTML = "ER";
   localStorage.setItem("toolbarState", toolbarState);
   //hides irrelevant buttons, and shows relevant buttons

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -748,7 +748,7 @@ window.addEventListener("mousemove", function()
     if (indexOfHoveredObject != -1) {
             for (let i = 0; i < diagram.length; i++) {
                 // If the symbol is a line or an umlline or the object is locked the cursor pointer will remain default, otherwise it's of type all-scroll
-                if (diagram[indexOfHoveredObject].symbolkind != 4 && !diagram[indexOfHoveredObject].locked && diagram[indexOfHoveredObject].symbolkind != 7) {
+                if (diagram[indexOfHoveredObject].symbolkind != 4 && !diagram[indexOfHoveredObject].locked && diagram[indexOfHoveredObject].symbolkind != 7 && uimode != "CreateLine") {
                     canvas.style.cursor = "all-scroll";
                 }
             }


### PR DESCRIPTION
Issue: #6377 

Fixed the issue when hovering over a umlline and when trying to draw lines between entities it would show a move cursor. Now it shows the default cursor when these actions are being done.