### PR TITLE
Fixed issue #6407: Zoom-buttons hover effect should not be able to be hovered

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3708,7 +3708,7 @@ only screen and (max-device-width: 320px) {
   left: -15px;
 }
 
-.tooltipDecrease:hover .tooltiptextDec{
+button:hover + .tooltiptextDec{
   visibility: visible;
 }
 #range{
@@ -3751,7 +3751,7 @@ only screen and (max-device-width: 320px) {
   right: -20px;
 }
 
-.tooltipIncrease:hover .tooltiptextInc{
+button:hover + .tooltiptextInc{
   visibility: visible;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3708,7 +3708,7 @@ only screen and (max-device-width: 320px) {
   left: -15px;
 }
 
-button:hover + .tooltiptextDec{
+#zoomDecrease:hover + .tooltiptextDec{
   visibility: visible;
 }
 #range{
@@ -3751,7 +3751,7 @@ button:hover + .tooltiptextDec{
   right: -20px;
 }
 
-button:hover + .tooltiptextInc{
+#zoomIncrease:hover + .tooltiptextInc{
   visibility: visible;
 }
 


### PR DESCRIPTION
Issue: #6407

When the mouse cursor is not hovering over the zoom-buttons, the tooltip should disappear correctly now. And it's no longer possible to hover over the tooltip text the zoom-buttons hover effect generate.