### PR TITLE
Grupp a2019 w19#6415

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1374,7 +1374,7 @@ function setMode(mode) { //"CreateClass" yet to be implemented in .php
 }
 
 $(document).ready(function() {
-    $("#linebutton, #attributebutton, #entitybutton, #relationbutton, #squarebutton, #drawfreebutton, #classbutton, #drawtextbutton, #umllinebutton").click(function() {
+    $("#linebutton, #attributebutton, #entitybutton, #relationbutton, #squarebutton, #drawfreebutton, #classbutton, #drawtextbutton").click(function() {
         $("#moveButton").removeClass("pressed").addClass("unpressed");
         $("#moveButton").css("visibility", "hidden");
         if ($(this).hasClass("pressed")) {
@@ -2375,8 +2375,6 @@ function switchToolbar(direction) {
     $(".buttonsStyle").hide();
     $("#linebutton").show();
     $("#classbutton").show();
-    $("#linebutton").hide();
-    $("#umllinebutton").show();
   } else if(toolbarState == toolbarDeveloperMode) {
     $(".toolbar-drawer").show();
     $("#drawerTools").show();
@@ -3040,8 +3038,8 @@ function mouseupevt(ev) {
             selected_objects.push(diagram[lastSelectedObject]);
             //resets the mode so that next click can move or select an object instead of drawing another line
             //only happens when a line has been created between 2 objects
-            if ($("#umllinebutton").hasClass("pressed")){
-                $("#umllinebutton.buttonsStyle").removeClass("pressed").addClass("unpressed");
+            if ($("#linebutton").hasClass("pressed")){
+                $("#linebutton.buttonsStyle").removeClass("pressed").addClass("unpressed");
             }
             uimode = "normal";
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2809,6 +2809,7 @@ function mouseupevt(ev) {
     if(movobj > -1) {
         if(diagram[movobj].symbolkind != symbolKind.line && uimode == "Moved") saveState = true;
     }
+    if (symbolStartKind != 1) {
     if (uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode) {
         saveState = false;
         //Check if you release on canvas or try to draw a line from entity to entity
@@ -2863,8 +2864,11 @@ function mouseupevt(ev) {
             }
         }
     }
-    if (uimode == "CreateUMLLine" && md == mouseState.boxSelectOrCreateMode) {
+    }
+    if (symbolStartKind == 1){
+    if (uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode) {
         saveState = false;
+        uimode = "CreateUMLLine";
         //Check if you release on canvas or try to draw a line from entity to entity
          if (hovobj == -1 || diagram[lineStartObj].symbolkind == symbolKind.erEntity && diagram[hovobj].symbolkind == symbolKind.erEntity) {
             md = mouseState.empty;
@@ -2916,6 +2920,7 @@ function mouseupevt(ev) {
                 }
             }
         }
+    }
     }
 
     // Code for creating symbols when mouse is released

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2809,7 +2809,7 @@ function mouseupevt(ev) {
     if(movobj > -1) {
         if(diagram[movobj].symbolkind != symbolKind.line && uimode == "Moved") saveState = true;
     }
-    if (symbolStartKind != 1) {
+    if (symbolStartKind != symbolKind.uml) {
     if (uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode) {
         saveState = false;
         //Check if you release on canvas or try to draw a line from entity to entity
@@ -2865,7 +2865,7 @@ function mouseupevt(ev) {
         }
     }
     }
-    if (symbolStartKind == 1){
+    if (symbolStartKind == symbolKind.uml){
     if (uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode) {
         saveState = false;
         uimode = "CreateUMLLine";

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -75,9 +75,6 @@
                                       <button id='linebutton' onclick='setMode("CreateLine");' class='buttonsStyle unpressed' data="Create Line">
                                           <img class="toolboxButtons" src="../Shared/icons/diagram_create_line.svg">
                                       </button>
-                                      <button id='umllinebutton' onclick='setMode("CreateUMLLine");' class='buttonsStyle unpressed' data="Create UML Line">
-                                          <img class="toolboxButtons" src="../Shared/icons/diagram_create_umlline.svg">
-                                      </button>
                                   </div>
                               </div>
                             </div>


### PR DESCRIPTION
Removed UML line button, and made the regular line tool button able to change line mode depending on start symbol. For example, if the start symbol is a class, it will change to the mode "CreateUMLLine" and draw kinked lines. If the start symbol is not a class, it will run the regular line tool.