### PR TITLE
fixed styling for zoom bar #6379

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -314,7 +314,7 @@
             -->
             <div id='valuesCanvas'></div>
             <div id="selectDiv">
-              <div class="tooltipDecrease" style="position: static; padding-top: 5px">
+              <div class="tooltipDecrease" style="position: static;">
                 <button name="Zoom" id="zoomDecrease" type="button" onclick="changeZoom(-0.1);"> - </button>
                 <span class="tooltiptextDec">Zoom Out</span>
               </div>
@@ -323,7 +323,7 @@
               </div>
               <div class="tooltipIncrease" style="position: static;">
                 <button name="Zoom" id="zoomIncrease" type="button" onclick="changeZoom(0.1);"> + </button>
-                <span class="tooltiptextInc">Zoom In</span>
+                <span class="tooltiptextInc" style="right: 68px">Zoom In</span>
               </div>
               <div id="zoomV"></div>
             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -314,14 +314,14 @@
             -->
             <div id='valuesCanvas'></div>
             <div id="selectDiv">
-              <div class="tooltipDecrease">
+              <div class="tooltipDecrease" style="position: static; padding-top: 5px">
                 <button name="Zoom" id="zoomDecrease" type="button" onclick="changeZoom(-0.1);"> - </button>
                 <span class="tooltiptextDec">Zoom Out</span>
               </div>
-              <div id="range">
-                <input name="Zoom" id="ZoomSelect" type="range" oninput="zoomInMode();" onchange="zoomInMode();" min="0.1" max="2" value="1" step="0.1">
+              <div id="range" style="padding-right: 8px;">
+                <input name="Zoom" id="ZoomSelect" type="range" oninput="zoomInMode();" onchange="zoomInMode();" min="0.1" max="2" value="1" step="0.1" class="zoomSlider">
               </div>
-              <div class="tooltipIncrease">
+              <div class="tooltipIncrease" style="position: static;">
                 <button name="Zoom" id="zoomIncrease" type="button" onclick="changeZoom(0.1);"> + </button>
                 <span class="tooltiptextInc">Zoom In</span>
               </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3930,9 +3930,12 @@ only screen and (max-device-width: 320px) {
   opacity: 0.7;
 }
 
+.zoomSlider:active {
+  opacity: 1;
+}
+
 /* The slider handle (use -webkit- (Chrome, Opera, Safari, Edge) and -moz- (Firefox) to override default look) */
 .zoomSlider::-webkit-slider-thumb {
-  opacity: 1;
   -webkit-appearance: none; /* Override default look */
   appearance: none;
   width: 15px; /* Set a specific slider handle width */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3908,10 +3908,6 @@ only screen and (max-device-width: 320px) {
   right: 4px;
 }
 
-.slidecontainer {
-  width: 100%; /* Width of the outside container */
-}
-
 /* The slider itself */
 .zoomSlider {
   -webkit-appearance: none;  /* Override default CSS styles */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3784,6 +3784,8 @@ only screen and (max-device-width: 320px) {
 /* Is used to style a Select-box in diagram.php. */
 
 #selectDiv {
+  display: flex;
+  align-items: center;
   background-color: #fff;
   border-radius: 6px;
   border: 2px solid #d4d4d4;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3908,6 +3908,49 @@ only screen and (max-device-width: 320px) {
   right: 4px;
 }
 
+.slidecontainer {
+  width: 100%; /* Width of the outside container */
+}
+
+/* The slider itself */
+.zoomSlider {
+  -webkit-appearance: none;  /* Override default CSS styles */
+  appearance: none;
+  width: 100%; /* Full-width */
+  height: 5px; /* Specified height */
+  background: #d3d3d3;  /* Grey background */
+  outline: none; /* Remove outline */
+  opacity: 1; /* Set transparency (for mouse-over effects on hover) */
+  -webkit-transition: .2s; /* 0.2 seconds transition on hover */
+  transition: opacity .2s;
+}
+
+/* Mouse-over effects */
+.zoomSlider:hover {
+  opacity: 0.7;
+}
+
+/* The slider handle (use -webkit- (Chrome, Opera, Safari, Edge) and -moz- (Firefox) to override default look) */
+.zoomSlider::-webkit-slider-thumb {
+  opacity: 1;
+  -webkit-appearance: none; /* Override default look */
+  appearance: none;
+  width: 15px; /* Set a specific slider handle width */
+  height: 15px; /* Slider handle height */
+  border-radius: 50%; 
+  background: var(--color-primary);  /*Purple background */
+  cursor: pointer; /* Cursor on hover */
+}
+
+.zoomSlider::-moz-range-thumb {
+  opacity: 1;
+  width: 15px; /* Set a specific slider handle width */
+  height: 15px; /* Slider handle height */
+  border-radius: 50%;
+  background: var(--color-primary); /* Purple background */
+  cursor: pointer; /* Cursor on hover */
+}
+
 /* Used to rotate the picture that is used as a arrow */
 
 @keyframes roteraPil {


### PR DESCRIPTION
#6379 
added some styling to the zoombar.
Changed the handle and made it transparent when hovered.

Tried to make it so that only the handle was made transparent when hovered but failed with that approach. Can be made in a new issue in the future if it is requested