### PR TITLE
resetToolbar removed

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1221,16 +1221,6 @@ function toggleA4Orientation() {
     updateGraphics();
 }
 
-//------------------------------------------------------------
-// resetToolbar: resets the toolbar to it's original position
-//------------------------------------------------------------
-
-function resetToolbarPosition(){
-    //Assign position for the toolbar according to the canvas bounds
-    document.getElementById("diagram-toolbar").style.top = (boundingRect.top + "px");
-    document.getElementById("diagram-toolbar").style.left = (boundingRect.left + "px");
-}
-
 //----------------------------------------------------
 // openImportDialog: Opens the dialog menu for import
 //----------------------------------------------------

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -195,9 +195,6 @@
                         <div class="drop-down-item">
                             <span class="drop-down-option" onclick='resetViewToOrigin();'>Reset view to origin</span>
                         </div>
-                        <div class="drop-down-item">
-                            <span class="drop-down-option" onclick='resetToolbarPosition();'>Reset toolbar position</span>
-                        </div>
                     </div>
                 </div>
                 <div class="menu-drop-down">


### PR DESCRIPTION
#6643
The resetToolbarPosition function has been removed from diagram.js
The drop-down-item div concerning reset toolbar has been removed from diagram.php