### PR TITLE
Positioning of A4 holes #6414

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -94,7 +94,7 @@ var p3 = null;                      // Middlepoint/centerPoint
 var snapToGrid = false;             // Will the clients actions snap to grid
 var toggleA4 = false;               // toggle if a4 outline is drawn
 var toggleA4Holes = false;          // toggle if a4 holes are drawn
-var switchSideA4Holes = false;      // switching the sides of the A4-holes
+var switchSideA4Holes = "left";      // switching the sides of the A4-holes
 var A4Orientation = "portrait";     // If virtual A4 is portrait or landscape
 var crossStrokeStyle1 = "#f64";     // set the color for the crosses.
 var crossFillStyle = "#d51";
@@ -1157,7 +1157,7 @@ function drawVirtualA4() {
 
     if(toggleA4Holes) {
         if(A4Orientation == "portrait"){
-            if (switchSideA4Holes) {
+            if (switchSideA4Holes == "left") {
                 // The Holes on the left side.
                 //Upper 2 holes
                 drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
@@ -1165,7 +1165,7 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
                 drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
-                switchSideA4Holes = false;
+                switchSideA4Holes = "right";
             }else {
                 // The holes on the right side.
                 //Upper 2 holes
@@ -1174,11 +1174,11 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
                 drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
-                switchSideA4Holes = true;
+                switchSideA4Holes = "left";
             }
         }
         else if(A4Orientation == "landscape") {
-            if (switchSideA4Holes) {
+            if (switchSideA4Holes == "left") {
                 // The holes on the upper side.
                 //Upper 2 holes
                 drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
@@ -1186,7 +1186,7 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
                 drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
-                switchSideA4Holes = false;
+                switchSideA4Holes = "right";
 
             }else {
                 // The holes on the bottom side.
@@ -1196,7 +1196,7 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
                 drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
-                switchSideA4Holes = true;
+                switchSideA4Holes = "left";
             }
       }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -94,7 +94,7 @@ var p3 = null;                      // Middlepoint/centerPoint
 var snapToGrid = false;             // Will the clients actions snap to grid
 var toggleA4 = false;               // toggle if a4 outline is drawn
 var toggleA4Holes = false;          // toggle if a4 holes are drawn
-var switchSideA4Holes = "left";      // switching the sides of the A4-holes
+var switchSideA4Holes = "left";     // switching the sides of the A4-holes
 var A4Orientation = "portrait";     // If virtual A4 is portrait or landscape
 var crossStrokeStyle1 = "#f64";     // set the color for the crosses.
 var crossFillStyle = "#d51";
@@ -1165,7 +1165,6 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
                 drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
-                switchSideA4Holes = "right";
             }else {
                 // The holes on the right side.
                 //Upper 2 holes
@@ -1174,7 +1173,7 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
                 drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
-                switchSideA4Holes = "left";
+
             }
         }
         else if(A4Orientation == "landscape") {
@@ -1186,8 +1185,6 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
                 drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
-                switchSideA4Holes = "right";
-
             }else {
                 // The holes on the bottom side.
                 //Upper 2 holes
@@ -1196,7 +1193,7 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
                 drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
-                switchSideA4Holes = "left";
+
             }
       }
     }
@@ -1215,8 +1212,9 @@ function drawCircle(cx, cy, radius) {
 
 function showA4State(){
     //Sets icons based on the state of the A4
-    setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), toggleA4Holes);
+    setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), false);
     setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), true);
+    setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), false);
 
 }
 
@@ -1224,16 +1222,35 @@ function hideA4State(){
     //Hides icons when toggling off the A4
     setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), false);
     setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), false);
+    setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), false);
 }
 
 function toggleVirtualA4Holes() {
+    //Toggle a4 holes to the A4-paper.
     if (toggleA4Holes) {
         toggleA4Holes = false;
         setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), toggleA4Holes);
+        $("#a4-holes-item-right").toggleClass("drop-down-item drop-down-item-disabled");
+        setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
         updateGraphics();
     } else {
         toggleA4Holes = true;
         setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), toggleA4Holes);
+        $("#a4-holes-item-right").toggleClass("drop-down-item drop-down-item-disabled");
+        setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
+        updateGraphics();
+    }
+}
+
+function toggleVirtualA4HolesRight() {
+    //Switch a4 holes from left to right of the A4-paper.
+    if (switchSideA4Holes == "right") {
+        switchSideA4Holes = "left";
+        setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), switchSideA4Holes == "right");
+        updateGraphics();
+    } else {
+        switchSideA4Holes = "right";
+        setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), switchSideA4Holes == "right");
         updateGraphics();
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -94,6 +94,7 @@ var p3 = null;                      // Middlepoint/centerPoint
 var snapToGrid = false;             // Will the clients actions snap to grid
 var toggleA4 = false;               // toggle if a4 outline is drawn
 var toggleA4Holes = false;          // toggle if a4 holes are drawn
+var switchSideA4Holes = false;      // switching the sides of the A4-holes
 var A4Orientation = "portrait";     // If virtual A4 is portrait or landscape
 var crossStrokeStyle1 = "#f64";     // set the color for the crosses.
 var crossFillStyle = "#d51";
@@ -471,7 +472,7 @@ function moveToFront(){
             front.push(diagram[0]);
         }
         else {
-            back.push(diagram[0]);            
+            back.push(diagram[0]);
         }
         diagram.splice(0, 1);
     }
@@ -497,7 +498,7 @@ function moveToBack(){
             back.push(diagram[0]);
         }
         else {
-            front.push(diagram[0]);            
+            front.push(diagram[0]);
         }
         diagram.splice(0, 1);
     }
@@ -1139,7 +1140,8 @@ function drawVirtualA4() {
     const a4Width = 210 * pixelsPerMillimeter;
     const a4Height = 297 * pixelsPerMillimeter;
     // size of a4 hole, from specification ISO 838 and the swedish "triohålning"
-    const holeOffsetX = 12 * pixelsPerMillimeter;
+    const leftHoleOffsetX = 12 * pixelsPerMillimeter;
+    const rightHoleOffsetX = 198 * pixelsPerMillimeter;
     const holeRadius = 3 * pixelsPerMillimeter;
 
     ctx.save();
@@ -1155,21 +1157,48 @@ function drawVirtualA4() {
 
     if(toggleA4Holes) {
         if(A4Orientation == "portrait"){
-            //Upper 2 holes
-            drawCircle(holeOffsetX + zeroX, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
-            drawCircle(holeOffsetX + zeroX, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY, holeRadius);
-            //Latter two holes
-            drawCircle(holeOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
-            drawCircle(holeOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
+            if (switchSideA4Holes) {
+                // The Holes on the left side.
+                //Upper 2 holes
+                drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
+                drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY, holeRadius);
+                //Latter two holes
+                drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
+                drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
+                switchSideA4Holes = false;
+            }else {
+                // The holes on the right side.
+                //Upper 2 holes
+                drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
+                drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY, holeRadius);
+                //Latter two holes
+                drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
+                drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
+                switchSideA4Holes = true;
+            }
         }
         else if(A4Orientation == "landscape") {
-            //Upper 2 holes
-            drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX, holeOffsetX + zeroY, holeRadius);
-            drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX, holeOffsetX + zeroY, holeRadius);
-            //Latter two holes
-            drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, holeOffsetX + zeroY, holeRadius);
-            drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, holeOffsetX + zeroY, holeRadius);
-        }
+            if (switchSideA4Holes) {
+                // The holes on the upper side.
+                //Upper 2 holes
+                drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
+                drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
+                //Latter two holes
+                drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
+                drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
+                switchSideA4Holes = false;
+
+            }else {
+                // The holes on the bottom side.
+                //Upper 2 holes
+                drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
+                drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
+                //Latter two holes
+                drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
+                drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
+                switchSideA4Holes = true;
+            }
+      }
     }
     ctx.restore();
 }
@@ -1624,7 +1653,7 @@ function developerMode() {
         crossStrokeStyle1 = "#f64";
         crossFillStyle = "#d51";
         crossStrokeStyle2 = "#d51";
-        drawOrigo();   
+        drawOrigo();
         toolbarState = 3;                                                               // Change the toolbar to DEV.
         switchToolbarDev();                                                             // ---||---
         document.getElementById('toolbarTypeText').innerHTML = 'Mode: DEV';             // Change the text to DEV.
@@ -3091,8 +3120,8 @@ function mouseupevt(ev) {
         p2BeforeResize.y = points[diagramObject.bottomRight].y;
     }
 
-    //If the object is created by just clicking and not dragging then set variable so that points 
-    //are moved to mouse position inside the adjust function 
+    //If the object is created by just clicking and not dragging then set variable so that points
+    //are moved to mouse position inside the adjust function
     if (diagramObject && p1BeforeResize.x == p2BeforeResize.x && p1BeforeResize.y == p2BeforeResize.y) {
         diagramObject.pointsAtSamePosition = true;
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1125,6 +1125,7 @@ function toggleVirtualA4() {
 
     $("#a4-orientation-item").toggleClass("drop-down-item drop-down-item-disabled");
     setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
+
 }
 
 function drawVirtualA4() {
@@ -1173,7 +1174,6 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
                 drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
-
             }
         }
         else if(A4Orientation == "landscape") {
@@ -1193,7 +1193,6 @@ function drawVirtualA4() {
                 //Latter two holes
                 drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
                 drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
-
             }
       }
     }
@@ -1215,7 +1214,6 @@ function showA4State(){
     setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), false);
     setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), true);
     setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), false);
-
 }
 
 function hideA4State(){
@@ -1223,6 +1221,9 @@ function hideA4State(){
     setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), false);
     setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), false);
     setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), false);
+
+    $("#a4-holes-item-right").toggleClass("drop-down-item drop-down-item-disabled");
+    setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
 }
 
 function toggleVirtualA4Holes() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1221,9 +1221,12 @@ function hideA4State(){
     setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), false);
     setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), false);
     setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), false);
-
     $("#a4-holes-item-right").toggleClass("drop-down-item drop-down-item-disabled");
     setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
+
+    //Reset the variables after disable the A4
+    toggleA4Holes = false;
+    switchSideA4Holes = "left";
 }
 
 function toggleVirtualA4Holes() {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -226,6 +226,9 @@
                         <div id="a4-holes-item" class="drop-down-item-disabled">
                             <span class="drop-down-option" onclick='toggleVirtualA4Holes();'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Holes</span>
                         </div>
+                        <div id="a4-holes-item-right" class="drop-down-item-disabled">
+                            <span class="drop-down-option" onclick='toggleVirtualA4HolesRight();'><img src="../Shared/icons/Arrow_down_right.png">A4 Holes Right</span>
+                        </div>
                     </div>
                 </div>
                 <div class="menu-drop-down">


### PR DESCRIPTION
By clicking "Toggle A4-Holes" you change the position of the holes of the A4 from left-right & upper-bottom (Horizontal and vertical). At the moment you click the menu item to shift sides. A future issue would be instead of a checkmark put an icon who describe which side the holes are at. I will write that issue when it's approved and merged.

#6414
