### PR TITLE
Fix for issue #6622: Re:Stop resizing locked objects

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2548,6 +2548,10 @@ function mousemoveevt(ev, t) {
         } else if (md == mouseState.noPointAvailable) {
             // If mouse is pressed down and no point is close show selection box
         } else if (md == mouseState.insidePoint) {
+            // If the selected object is locked, you can't resize the object
+            if (diagram[lastSelectedObject].locked) {
+                return;
+            }
             // If mouse is pressed down and at a point in selected object - move that point
             if(!sel.point.fake) {
                 sel.point.x = currentMouseCoordinateX;


### PR DESCRIPTION
A previous fix prevented the used from resizing locked objects but merge commit 19802dd8 removed an important if-statement (diagram.js:2539). This PR re-adds it. 