### PR TITLE
Fix for #6349. Preventing collapsing when clicking on menu items

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -471,7 +471,7 @@ function moveToFront(){
             front.push(diagram[0]);
         }
         else {
-            back.push(diagram[0]);            
+            back.push(diagram[0]);
         }
         diagram.splice(0, 1);
     }
@@ -497,7 +497,7 @@ function moveToBack(){
             back.push(diagram[0]);
         }
         else {
-            front.push(diagram[0]);            
+            front.push(diagram[0]);
         }
         diagram.splice(0, 1);
     }
@@ -1099,7 +1099,9 @@ function deselectObjects() {
 //             functionality is related to currentMouseCoordinateX and currentMouseCoordinateY
 //-----------------------------------------------------------------------------------
 
-function toggleGrid() {
+function toggleGrid(event) {
+    event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
+
     if (snapToGrid == false) {
         snapToGrid = true;
     } else {
@@ -1108,7 +1110,9 @@ function toggleGrid() {
     setCheckbox($(".drop-down-option:contains('Snap to grid')"), snapToGrid);
 }
 
-function toggleVirtualA4() {
+function toggleVirtualA4(event) {
+    event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
+
     if (toggleA4) {
         // A4 is disabled
         toggleA4 = false;
@@ -1617,14 +1621,15 @@ consloe.log = function(gobBluth) {
 //------------------------------------------------------------------------------
 
 var developerModeActive = true;                // used to repressent a switch for whenever the developerMode is enabled or not.
-function developerMode() {
+function developerMode(event) {
+    event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
     developerModeActive = !developerModeActive;
     if(developerModeActive) {
         console.log('developermode: ON');       // Shows that the developer have the developermode active.
         crossStrokeStyle1 = "#f64";
         crossFillStyle = "#d51";
         crossStrokeStyle2 = "#d51";
-        drawOrigo();   
+        drawOrigo();
         toolbarState = 3;                                                               // Change the toolbar to DEV.
         switchToolbarDev();                                                             // ---||---
         document.getElementById('toolbarTypeText').innerHTML = 'Mode: DEV';             // Change the text to DEV.
@@ -1644,11 +1649,12 @@ function developerMode() {
         $("#displayAllTools").toggleClass("drop-down-item drop-down-item-disabled");    // Add disable of displayAllTools id.
         setCheckbox($(".drop-down-option:contains('UML')"), crossUML);                  // Turn off crossUML.
         setCheckbox($(".drop-down-option:contains('Display All Tools')"), crossDEV);    // Turn off crossDEV.
-        setCheckbox($(".drop-down-option:contains('ER')"), !crossER);                   // Turn on crossER.
+        setCheckbox($(".drop-down-option:contains('ER')"), !crossER);                   // Turn on crossER
     }
     reWrite();
     updateGraphics();
     setCheckbox($(".drop-down-option:contains('Developer mode')"), developerModeActive);
+
 }
 
 var targetMode;     //the mode that we want to change to when trying to switch the toolbar
@@ -1922,7 +1928,9 @@ function setRefreshTime() {
 // lockSelected: the selected objects are locked
 //----------------------------------------------------------------------
 
-function lockSelected() {
+function lockSelected(event) {
+    event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
+
     for(var i = 0; i < selected_objects.length; i++) {
         if(selected_objects[i].kind == kind.symbol){
             // Lines should not be possible to lock
@@ -1942,7 +1950,9 @@ function lockSelected() {
     SaveState();
 }
 
-function align(mode) {
+function align(event, mode) {
+    event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
+
     if(mode == 'top') {
        alignTop(selected_objects);
     }
@@ -2118,8 +2128,10 @@ function sortObjects(selected_objects, mode) {
 //            vertically or horizontally
 //----------------------------------------------------------------------
 
-function distribute(axis) {
+function distribute(event, axis) {
   let spacing = 30;
+
+    event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
 
     if(axis=='vertically') {
       // Added spacing when there are objects that overlap eachother.
@@ -2153,7 +2165,8 @@ function distribute(axis) {
 // undoDiagram: removes the last object that was drawn
 //----------------------------------------------------------------------
 
-function undoDiagram() {
+function undoDiagram(event) {
+    event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
     if (diagramNumberHistory > 1) diagramNumberHistory--;
     var tmpDiagram = localStorage.getItem("diagram" + diagramNumberHistory);
     if (tmpDiagram != null) LoadImport(tmpDiagram);
@@ -2163,7 +2176,8 @@ function undoDiagram() {
 // redoDiagram: restores the last object that was removed
 //----------------------------------------------------------------------
 
-function redoDiagram() {
+function redoDiagram(event) {
+    event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
     if (diagramNumberHistory < diagramNumber) diagramNumberHistory++;
     var tmpDiagram = localStorage.getItem("diagram" + diagramNumberHistory);
     if (tmpDiagram != null) LoadImport(tmpDiagram);
@@ -2262,18 +2276,6 @@ function globalStrokeColor() {
     for (var i = 0; i < diagram.length; i++) {
             diagram[i].properties['strokeColor'] = document.getElementById('StrokeColor').value;
     }
-}
-
-function undoDiagram() {
-    if (diagramNumberHistory > 1) diagramNumberHistory--;
-    var tmpDiagram = localStorage.getItem("diagram" + diagramNumberHistory);
-    if (tmpDiagram != null) LoadImport(tmpDiagram);
-}
-
-function redoDiagram() {
-    if (diagramNumberHistory < diagramNumber) diagramNumberHistory++;
-    var tmpDiagram = localStorage.getItem("diagram" + diagramNumberHistory);
-    if (tmpDiagram != null) LoadImport(tmpDiagram);
 }
 
 function diagramToSVG() {
@@ -2859,11 +2861,11 @@ function mouseupevt(ev) {
             symbolEndKind = diagram[hovobj].symbolkind;
 
             sel = diagram.closestPoint(currentMouseCoordinateX, currentMouseCoordinateY);
-            //Check if you not start on a line and not end on a line or so that a line isn't connected to a text object, 
+            //Check if you not start on a line and not end on a line or so that a line isn't connected to a text object,
             // if then, set point1 and point2
             //okToMakeLine is a flag for this
             var okToMakeLine = true;
-            if(symbolStartKind != symbolKind.line && symbolEndKind != symbolKind.line && 
+            if(symbolStartKind != symbolKind.line && symbolEndKind != symbolKind.line &&
                 symbolStartKind != symbolKind.text && symbolEndKind != symbolKind.text) {
                 var createNewPoint = false;
                 if (diagram[lineStartObj].symbolkind == symbolKind.erAttribute) {
@@ -2928,11 +2930,11 @@ function mouseupevt(ev) {
              symbolEndKind = diagram[hovobj].symbolkind;
 
              sel = diagram.closestPoint(currentMouseCoordinateX, currentMouseCoordinateY);
-            //Check if you not start on a line and not end on a line or so that a line isn't connected to a text object, 
+            //Check if you not start on a line and not end on a line or so that a line isn't connected to a text object,
             // if then, set point1 and point2
             //okToMakeLine is a flag for this
             var okToMakeLine = true;
-            if(symbolStartKind != symbolKind.umlLine && symbolEndKind != symbolKind.umlLine && 
+            if(symbolStartKind != symbolKind.umlLine && symbolEndKind != symbolKind.umlLine &&
                 symbolStartKind != symbolKind.text && symbolEndKind != symbolKind.text) {
                 var createNewPoint = false;
                 if (diagram[lineStartObj].symbolkind == symbolKind.erAttribute) {
@@ -3114,8 +3116,8 @@ function mouseupevt(ev) {
         p2BeforeResize.y = points[diagramObject.bottomRight].y;
     }
 
-    //If the object is created by just clicking and not dragging then set variable so that points 
-    //are moved to mouse position inside the adjust function 
+    //If the object is created by just clicking and not dragging then set variable so that points
+    //are moved to mouse position inside the adjust function
     if (diagramObject && p1BeforeResize.x == p2BeforeResize.x && p1BeforeResize.y == p2BeforeResize.y) {
         diagramObject.pointsAtSamePosition = true;
     }

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -43,7 +43,7 @@
 </head>
 <!-- Reads the content from the js-files -->
 <!-- updateGraphics() must be last -->
-<body onload="initializeCanvas(); canvasSize(); loadDiagram(); developerMode(); initToolbox(); updateGraphics();"
+<body onload="initializeCanvas(); canvasSize(); loadDiagram(); developerMode(event); initToolbox(); updateGraphics();"
  onmousedown="mouseDown()" onmouseup="mouseUp()" style="overflow-y: hidden;">
     <?php
         $noup = "SECTION";
@@ -161,11 +161,11 @@
                     <span class="drop-down-label">Edit</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick='undoDiagram()'>Undo</span>
+                            <span class="drop-down-option" onclick='undoDiagram(event)'>Undo</span>
                             <i id="hotkey-undo">Ctrl + Z</i>
                         </div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick='redoDiagram()'>Redo</span>
+                            <span class="drop-down-option" onclick='redoDiagram(event)'>Redo</span>
                             <i id="hotkey-redo">Ctrl + Y</i>
                         </div>
                         <div class="drop-down-divider"></div>
@@ -186,7 +186,7 @@
                         </div>
                         <div class="drop-down-divider"></div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick='lockSelected()'>Lock/Unlock selected</span>
+                            <span class="drop-down-option" onclick='lockSelected(event)'>Lock/Unlock selected</span>
                         </div>
                         <div class="drop-down-item">
                             <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
@@ -204,7 +204,7 @@
                     <span class="drop-down-label">View</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick='developerMode();'>Developer mode</span>
+                            <span class="drop-down-option" onclick='developerMode(event);'>Developer mode</span>
                         </div>
                         <div id="displayAllTools" class="drop-down-item">
                             <span class="drop-down-option" onclick="switchToolbarDev();"><img src="../Shared/icons/Arrow_down_right.png">Display All Tools</span>
@@ -218,7 +218,7 @@
                         </div>
                         <div class="drop-down-divider"></div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="toggleVirtualA4()">Display Virtual A4</span>
+                            <span class="drop-down-option" onclick="toggleVirtualA4(event)">Display Virtual A4</span>
                         </div>
                         <div id="a4-orientation-item" class="drop-down-item-disabled">
                             <span class="drop-down-option" onclick='toggleA4Orientation();'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Orientation</span>
@@ -232,28 +232,28 @@
                     <span class="drop-down-label">Align</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="toggleGrid(this)">Snap to grid</span>
+                            <span class="drop-down-option" onclick="toggleGrid(event)">Snap to grid</span>
                         </div>
                         <div class="drop-down-divider"></div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="align('top');">Top</span>
+                            <span class="drop-down-option" onclick="align(event, 'top');">Top</span>
                         </div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="align('right');">Right</span>
+                            <span class="drop-down-option" onclick="align(event, 'right');">Right</span>
                         </div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="align('bottom');">Bottom</span>
+                            <span class="drop-down-option" onclick="align(event, 'bottom');">Bottom</span>
                         </div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="align('left');">Left</span>
+                            <span class="drop-down-option" onclick="align(event, 'left');">Left</span>
                         </div>
                         <div class="drop-down-divider">
                         </div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="align('horizontalCenter');">Horizontal center</span>
+                            <span class="drop-down-option" onclick="align(event, 'horizontalCenter');">Horizontal center</span>
                         </div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="align('verticalCenter');">Vertical center</span>
+                            <span class="drop-down-option" onclick="align(event, 'verticalCenter');">Vertical center</span>
                         </div>
                     </div>
                 </div>
@@ -261,10 +261,10 @@
                     <span class="drop-down-label">Distribute</span>
                     <div class="drop-down">
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="distribute('horizontally');">Horizontal</span>
+                            <span class="drop-down-option" onclick="distribute(event, 'horizontally');">Horizontal</span>
                         </div>
                         <div class="drop-down-item">
-                            <span class="drop-down-option" onclick="distribute('vertically');">Vertical</span>
+                            <span class="drop-down-option" onclick="distribute(event, 'vertically');">Vertical</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
#6349 is an issue about preventing the menu to collapse after one of the items is clicked. Not all menus prevented. Just those that where decided trough discussion. There was a double undo and redo function so I kept just one. In case you wonder why so much code was deleted.