### PR TITLE
Fix for issue #6224: Tool tip for position of an entity

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1588,8 +1588,8 @@ function developerMode() {
 var targetMode;     //the mode that we want to change to when trying to switch the toolbar
 
 //------------------------------------------------------------------------------
-// modeSwitchConfirmed: 
-// This function calls the switch methods if the change is accepted, called  
+// modeSwitchConfirmed:
+// This function calls the switch methods if the change is accepted, called
 // when clicking the dialog.
 //------------------------------------------------------------------------------
 function modeSwitchConfirmed(confirmed) {
@@ -1604,8 +1604,8 @@ function modeSwitchConfirmed(confirmed) {
 }
 
 //------------------------------------------------------------------------------
-// switchToolbarTo: 
-// This function switch opens a dialog for confirmation and sets which mode 
+// switchToolbarTo:
+// This function switch opens a dialog for confirmation and sets which mode
 // to change to.
 //------------------------------------------------------------------------------
 function switchToolbarTo(target){
@@ -2414,9 +2414,9 @@ function switchToolbar(direction) {
       toolbarState = 1;
     }
   }
-  
+
   document.getElementById('toolbarTypeText').innerHTML = "Mode: ER";
-  
+
   localStorage.setItem("toolbarState", toolbarState);
   //hides irrelevant buttons, and shows relevant buttons
   if(toolbarState == toolbarER) {

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1910,21 +1910,24 @@ function Symbol(kindOfSymbol) {
     this.drawCenterCoordinatesTooltip = function() {
       ctx.save();
 
+      var topLeftPosition = points[this.topLeft];
       var centerPosition = points[this.centerPoint];
+      var widthOfObject = points[this.bottomRight].x - points[this.topLeft].x;
 
-      var yOffset = -100;
-      var xOffset = 0;
+      var yOffset = -40;
+      var xOffset = -3;
 
       ctx.fillStyle = "#f5f5f5";
-      ctx.fillRect(centerPosition.x + xOffset, centerPosition.y + yOffset, 125, 50);
+      ctx.fillRect(topLeftPosition.x, topLeftPosition.y + yOffset, widthOfObject, 40);
 
       yOffset += 12;
       ctx.fillStyle = "black";
-      ctx.font = "12 px Arial";
-      ctx.fillText(" Center coordinates ", centerPosition.x, centerPosition.y + yOffset);
+      ctx.font = "12px Arial";
+      ctx.textAlign = "center";
+      ctx.fillText("Center coordinates", centerPosition.x, topLeftPosition.y + yOffset);
 
       yOffset += 20;
-      ctx.fillText("      X: " + Math.round(points[this.centerPoint].x) + "      Y: " + Math.round(points[this.centerPoint].y), centerPosition.x, centerPosition.y + yOffset);
+      ctx.fillText("X: " + Math.round(points[this.centerPoint].x) + "  Y: " + Math.round(points[this.centerPoint].y), centerPosition.x, topLeftPosition.y + yOffset);
 
       ctx.restore();
     }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -906,7 +906,7 @@ function Symbol(kindOfSymbol) {
             }
         }
 
-        if(this.isHovered){
+        if(this.isHovered && this.symbolkind != symbolKind.umlLine && this.symbolkind != symbolKind.line && this.symbolkind != symbolKind.text){
           this.drawCenterCoordinatesTooltip();
         }
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -906,6 +906,10 @@ function Symbol(kindOfSymbol) {
             }
         }
 
+        if(this.isHovered){
+          this.drawCenterCoordinatesTooltip();
+        }
+
         ctx.save();
 
         ctx.textAlign = "center";
@@ -1856,11 +1860,11 @@ function Symbol(kindOfSymbol) {
         var y1 = points[this.topLeft].y;
         var x2 = points[this.bottomRight].x;
         var y2 = points[this.bottomRight].y;
-        
+
         var offset = 10;
 
         return {
-            x: pixelsToCanvas(x2 + offset).x, 
+            x: pixelsToCanvas(x2 + offset).x,
             y: pixelsToCanvas(0, (y2 - (y2-y1)/2)).y};
     }
 
@@ -1873,7 +1877,7 @@ function Symbol(kindOfSymbol) {
         ctx.lineWidth = 1 * diagram.getZoomValue();
         //Draws the upper part of the lock
         ctx.beginPath();
-        //A slight x offset to get the correct position   
+        //A slight x offset to get the correct position
         ctx.arc(position.x + 5, position.y, 4, 1 * Math.PI, 2 * Math.PI);
         ctx.stroke();
         ctx.closePath();
@@ -1901,6 +1905,28 @@ function Symbol(kindOfSymbol) {
         ctx.fillText("Entity position is locked", position.x, position.y + offset);
 
         ctx.restore();
+    }
+
+    this.drawCenterCoordinatesTooltip = function() {
+      ctx.save();
+
+      var centerPosition = points[this.centerPoint];
+
+      var yOffset = -100;
+      var xOffset = 0;
+
+      ctx.fillStyle = "#f5f5f5";
+      ctx.fillRect(centerPosition.x + xOffset, centerPosition.y + yOffset, 125, 50);
+
+      yOffset += 12;
+      ctx.fillStyle = "black";
+      ctx.font = "12 px Arial";
+      ctx.fillText(" Center coordinates ", centerPosition.x, centerPosition.y + yOffset);
+
+      yOffset += 20;
+      ctx.fillText("      X: " + Math.round(points[this.centerPoint].x) + "      Y: " + Math.round(points[this.centerPoint].y), centerPosition.x, centerPosition.y + yOffset);
+
+      ctx.restore();
     }
 }
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1910,8 +1910,8 @@ function Symbol(kindOfSymbol) {
     this.drawCenterCoordinatesTooltip = function() {
       ctx.save();
 
-      var topLeftPosition = points[this.topLeft];
-      var centerPosition = points[this.centerPoint];
+      var topLeftPosition = pixelsToCanvas(points[this.topLeft].x, points[this.topLeft].y);
+      var centerPosition = pixelsToCanvas(points[this.centerPoint].x, points[this.centerPoint].y);
       var widthOfObject = points[this.bottomRight].x - points[this.topLeft].x;
 
       var yOffset = -40;

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1914,20 +1914,18 @@ function Symbol(kindOfSymbol) {
       var centerPosition = pixelsToCanvas(points[this.centerPoint].x, points[this.centerPoint].y);
       var widthOfObject = points[this.bottomRight].x - points[this.topLeft].x;
 
-      var yOffset = -40;
-      var xOffset = -3;
+      var xPosition = 230;
+      var yPosition = 805;
 
-      ctx.fillStyle = "#f5f5f5";
-      ctx.fillRect(topLeftPosition.x, topLeftPosition.y + yOffset, widthOfObject, 40);
+      ctx.fillStyle = "#00000";
+      ctx.fillRect(xPosition, yPosition, 300, 30);
 
-      yOffset += 12;
+      var yOffset = 17;
+      var xOffset = 135;
       ctx.fillStyle = "black";
-      ctx.font = "12px Arial";
+      ctx.font = "bold 14px Arial";
       ctx.textAlign = "center";
-      ctx.fillText("Center coordinates", centerPosition.x, topLeftPosition.y + yOffset);
-
-      yOffset += 20;
-      ctx.fillText("X: " + Math.round(points[this.centerPoint].x) + "  Y: " + Math.round(points[this.centerPoint].y), centerPosition.x, topLeftPosition.y + yOffset);
+      ctx.fillText("Center coordinates of object: " + "X=" + Math.round(points[this.centerPoint].x) + " & " + "Y=" + Math.round(points[this.centerPoint].y), xPosition + xOffset, yPosition + yOffset);
 
       ctx.restore();
     }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -906,7 +906,7 @@ function Symbol(kindOfSymbol) {
             }
         }
 
-        if(this.isHovered && this.symbolkind != symbolKind.umlLine && this.symbolkind != symbolKind.line && this.symbolkind != symbolKind.text){
+        if(this.isHovered && this.symbolkind != symbolKind.umlLine && this.symbolkind != symbolKind.line){
           this.drawCenterCoordinatesTooltip();
         }
 


### PR DESCRIPTION
Issue: #6224 

Added a tooltip for when hovering and moving an object, this tooltip appears above the object at the time. The design is not the most fancy ever, but it gets the job done. I removed the tooltip from lines and text boxes for the time being. I feel like a tooltip for lines seems unnecessary because the lines should be static between objects anyway. Tooltip for the text boxes is probably useful, but right now there is a problem where the tooltip box is not placed correctly above the text boxes. Let me know your opinion about this. There is no tooltip for free draw objects right now, since we are going to change them anyway if I understood correctly.

Let me know if I should change anything with how it looks or if there is something you want me to fix, like the text boxes thing. This is mostly a prototype right now, I just wanted some feedback on the changes I've made so far.