### PR TITLE
solution for 6321

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2721,12 +2721,8 @@ span.arrow {
   text-overflow: ellipsis;
 }
 
-.checkbox-dugga:nth-child(even){
-    background-color: blue;
-}
-
 .checkbox-dugga:nth-child(odd){
-    background-color: red;
+    background-color: #eee;
 }
 
 .checkmoment {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2721,6 +2721,14 @@ span.arrow {
   text-overflow: ellipsis;
 }
 
+.checkbox-dugga:nth-child(even){
+    background-color: blue;
+}
+
+.checkbox-dugga:nth-child(odd){
+    background-color: red;
+}
+
 .checkmoment {
   border-top: 1px solid #888;
   font-weight: bold;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/38323901/57323175-94fe9c00-7105-11e9-8f8f-a70b27760924.png)


This was a lot simpler than I originally thought. I started a new branch and tried without javascript. One change in css and it was solved. The children of class checkbox-dugga is #eee on every odd line.
Solution for #6321 

test site: 
https://c17alepe.webug.his.se:20002/DuggaSys/resulted.php?cid=2&coursevers=97732

Note to Tim, everything related to this can be closed. This new solution is much cleaner and more consistant https://github.com/HGustavs/LenaSYS/pull/6555