### PR TITLE
Fix for#6271: display multiple A4 sheets

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1134,6 +1134,7 @@ function drawVirtualA4() {
     const rightHoleOffsetX = 198 * pixelsPerMillimeter;
     const holeRadius = 3 * pixelsPerMillimeter;
 
+    // Number of A4 sheets to draw out
     var a4Rows;
     var a4Columns;
 
@@ -1149,6 +1150,7 @@ function drawVirtualA4() {
     ctx.strokeStyle = "black"
     ctx.setLineDash([10]);
 
+    // Draw A4 sheets in portrait mode
     if(A4Orientation == "portrait"){
         for (var i = 0; i < a4Rows; i++) {
             for (var j = 0; j < a4Columns; j++) {
@@ -1156,6 +1158,7 @@ function drawVirtualA4() {
             }
         }
     }
+    // Draw A4 sheets in landscape mode
     else if(A4Orientation == "landscape") {
         for (var i = 0; i < a4Rows; i++) {
             for (var j = 0; j < a4Columns; j++) {
@@ -1164,6 +1167,7 @@ function drawVirtualA4() {
         }
     }
 
+    // Draw A4 holes
     if(toggleA4Holes) {
         if(A4Orientation == "portrait"){
             if (switchSideA4Holes == "left") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1139,7 +1139,12 @@ function drawVirtualA4() {
     ctx.setLineDash([10]);
 
     if(A4Orientation == "portrait"){
-        ctx.strokeRect(zeroX, zeroY, a4Width, a4Height);
+        //ctx.strokeRect(zeroX, zeroY, a4Width, a4Height);
+        for (var i = 0; i < 6; i++) {
+            for (var j = 0; j < 20; j++) {
+                ctx.strokeRect(zeroX + a4Width * j, zeroY + a4Height * i, a4Width, a4Height); 
+            }
+        }
     }
     else if(A4Orientation == "landscape") {
         ctx.strokeRect(zeroX, zeroY, a4Height, a4Width);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1159,20 +1159,28 @@ function drawVirtualA4() {
         if(A4Orientation == "portrait"){
             if (switchSideA4Holes == "left") {
                 // The Holes on the left side.
-                //Upper 2 holes
-                drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
-                drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY, holeRadius);
-                //Latter two holes
-                drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
-                drawCircle(leftHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
+                for (var i = 0; i < 6; i++) {
+                    for (var j = 0; j < 20; j++) {
+                        //Upper 2 holes
+                        drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
+                        drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
+                        //Latter two holes
+                        drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
+                        drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius); 
+                    }
+                }
             }else {
                 // The holes on the right side.
-                //Upper 2 holes
-                drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
-                drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY, holeRadius);
-                //Latter two holes
-                drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY, holeRadius);
-                drawCircle(rightHoleOffsetX + zeroX, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY, holeRadius);
+                for (var i = 0; i < 6; i++) {
+                    for (var j = 0; j < 20; j++) {
+                        //Upper 2 holes
+                        drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
+                        drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
+                        //Latter two holes
+                        drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
+                        drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius); 
+                    }
+                }
             }
         }
         else if(A4Orientation == "landscape") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1134,22 +1134,31 @@ function drawVirtualA4() {
     const rightHoleOffsetX = 198 * pixelsPerMillimeter;
     const holeRadius = 3 * pixelsPerMillimeter;
 
+    var a4Rows;
+    var a4Columns;
+
+    if (A4Orientation == "portrait") {
+        a4Rows = 6;
+        a4Columns = 20;
+    } else if(A4Orientation == "landscape") {
+        a4Rows = 9;
+        a4Columns = 14;
+    }
+
     ctx.save();
     ctx.strokeStyle = "black"
     ctx.setLineDash([10]);
 
     if(A4Orientation == "portrait"){
-        //ctx.strokeRect(zeroX, zeroY, a4Width, a4Height);
-        for (var i = 0; i < 6; i++) {
-            for (var j = 0; j < 20; j++) {
+        for (var i = 0; i < a4Rows; i++) {
+            for (var j = 0; j < a4Columns; j++) {
                 ctx.strokeRect(zeroX + a4Width * j, zeroY + a4Height * i, a4Width, a4Height); 
             }
         }
     }
     else if(A4Orientation == "landscape") {
-        //ctx.strokeRect(zeroX, zeroY, a4Height, a4Width);
-        for (var i = 0; i < 9; i++) {
-            for (var j = 0; j < 14; j++) {
+        for (var i = 0; i < a4Rows; i++) {
+            for (var j = 0; j < a4Columns; j++) {
                 ctx.strokeRect(zeroX + a4Height * j, zeroY + a4Width * i, a4Height, a4Width); 
             }
         }
@@ -1159,8 +1168,8 @@ function drawVirtualA4() {
         if(A4Orientation == "portrait"){
             if (switchSideA4Holes == "left") {
                 // The Holes on the left side.
-                for (var i = 0; i < 6; i++) {
-                    for (var j = 0; j < 20; j++) {
+                for (var i = 0; i < a4Rows; i++) {
+                    for (var j = 0; j < a4Columns; j++) {
                         //Upper 2 holes
                         drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
                         drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
@@ -1171,8 +1180,8 @@ function drawVirtualA4() {
                 }
             }else {
                 // The holes on the right side.
-                for (var i = 0; i < 6; i++) {
-                    for (var j = 0; j < 20; j++) {
+                for (var i = 0; i < a4Rows; i++) {
+                    for (var j = 0; j < a4Columns; j++) {
                         //Upper 2 holes
                         drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
                         drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
@@ -1186,8 +1195,8 @@ function drawVirtualA4() {
         else if(A4Orientation == "landscape") {
             if (switchSideA4Holes == "left") {
                 // The holes on the upper side.
-                for (var i = 0; i < 9; i++) {
-                    for (var j = 0; j < 14; j++) {
+                for (var i = 0; i < a4Rows; i++) {
+                    for (var j = 0; j < a4Columns; j++) {
                         //Upper 2 holes
                         drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius);
                         drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius);
@@ -1198,8 +1207,8 @@ function drawVirtualA4() {
                 }
             }else {
                 // The holes on the bottom side.
-                for (var i = 0; i < 9; i++) {
-                    for (var j = 0; j < 14; j++) {
+                for (var i = 0; i < a4Rows; i++) {
+                    for (var j = 0; j < a4Columns; j++) {
                         //Upper 2 holes
                         drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius);
                         drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1150,7 +1150,7 @@ function drawVirtualA4() {
         //ctx.strokeRect(zeroX, zeroY, a4Height, a4Width);
         for (var i = 0; i < 9; i++) {
             for (var j = 0; j < 14; j++) {
-                ctx.strokeRect(zeroX + a4Height * i, zeroY + a4Width * j, a4Height, a4Width); 
+                ctx.strokeRect(zeroX + a4Height * j, zeroY + a4Width * i, a4Height, a4Width); 
             }
         }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1186,20 +1186,28 @@ function drawVirtualA4() {
         else if(A4Orientation == "landscape") {
             if (switchSideA4Holes == "left") {
                 // The holes on the upper side.
-                //Upper 2 holes
-                drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
-                drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
-                //Latter two holes
-                drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
-                drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, leftHoleOffsetX + zeroY, holeRadius);
+                for (var i = 0; i < 9; i++) {
+                    for (var j = 0; j < 14; j++) {
+                        //Upper 2 holes
+                        drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius);
+                        drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius);
+                        //Latter two holes
+                        drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius);
+                        drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius); 
+                    }
+                }
             }else {
                 // The holes on the bottom side.
-                //Upper 2 holes
-                drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
-                drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
-                //Latter two holes
-                drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
-                drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX, rightHoleOffsetX + zeroY, holeRadius);
+                for (var i = 0; i < 9; i++) {
+                    for (var j = 0; j < 14; j++) {
+                        //Upper 2 holes
+                        drawCircle(((a4Height / 2) - (34+21) * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius);
+                        drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius);
+                        //Latter two holes
+                        drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius);
+                        drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius); 
+                    }
+                }
             }
       }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,12 @@ function drawVirtualA4() {
         }
     }
     else if(A4Orientation == "landscape") {
-        ctx.strokeRect(zeroX, zeroY, a4Height, a4Width);
+        //ctx.strokeRect(zeroX, zeroY, a4Height, a4Width);
+        for (var i = 0; i < 9; i++) {
+            for (var j = 0; j < 14; j++) {
+                ctx.strokeRect(zeroX + a4Height * i, zeroY + a4Width * j, a4Height, a4Width); 
+            }
+        }
     }
 
     if(toggleA4Holes) {


### PR DESCRIPTION
https://github.com/HGustavs/LenaSYS/issues/6271

Displaying virtual A4 now draws enough rows and columns of A4 sheets to fill entire canvas (positive coordinates) instead of just one.