### PR TITLE
Solution for 6321

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2768,6 +2768,10 @@ span.arrow {
   text-overflow: ellipsis;
 }
 
+.checkbox-dugga:nth-child(odd){
+    background-color: #eee;
+}
+
 .checkmoment {
   border-top: 1px solid #888;
   font-weight: bold;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38323901/57377181-186dcb00-71a2-11e9-9bcd-17c97dc17a1f.png)

This was a lot simpler than I originally thought. I started a new branch and tried without javascript. One change in css and it was solved. The children of class checkbox-dugga is #eee on every odd line.
Solution for #6321

test site:
https://c17alepe.webug.his.se:20002/DuggaSys/resulted.php?cid=2&coursevers=97732

Note to Tim, everything related to this can be closed. This new solution is much cleaner and more consistant #6555 and my old PR #6721