### PR TITLE
Fixed issue #6759: Hotkey exists but not shown as a label in the menu bar

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -185,6 +185,7 @@
                         </div>
                         <div class="drop-down-item">
                             <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
+                            <i id="hotkey-delete">Delete/Backspace</i>
                         </div>
                         <div class="drop-down-divider"></div>
                         <div class="drop-down-item">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -185,7 +185,7 @@
                         </div>
                         <div class="drop-down-item">
                             <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
-                            <i id="hotkey-delete">Delete</i>
+                            <i id="hotkey-delete">Delete/Backspace</i>
                         </div>
                         <div class="drop-down-divider"></div>
                         <div class="drop-down-item">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -185,7 +185,7 @@
                         </div>
                         <div class="drop-down-item">
                             <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
-                            <i id="hotkey-delete">Delete/Backspace</i>
+                            <i id="hotkey-delete">Delete</i>
                         </div>
                         <div class="drop-down-divider"></div>
                         <div class="drop-down-item">

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1498,6 +1498,13 @@ input {
   top: 195px;
 }
 
+.drop-down-item #hotkey-delete {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 6px;
+  top: 272px;
+}
 /* --------------================################================-------------- *
  *                       END TOOLBAR/DROPDOWN/APPLICATION                       *
  * --------------================################================-------------- */


### PR DESCRIPTION
Issue: #6759 

Added a hotkey shortcut label to the delete option in the menu bar. Right now I have it as "Delete/Backspace" since you can delete an object with both hotkeys. But I can also change it to only "Delete" or maybe even "Del" if thats preferable. Let me know your opinion.