### PR TITLE
Fix for #6419 Zooming relative to mouse coordinates

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1154,7 +1154,7 @@ function drawVirtualA4() {
     if(A4Orientation == "portrait"){
         for (var i = 0; i < a4Rows; i++) {
             for (var j = 0; j < a4Columns; j++) {
-                ctx.strokeRect(zeroX + a4Width * j, zeroY + a4Height * i, a4Width, a4Height); 
+                ctx.strokeRect(zeroX + a4Width * j, zeroY + a4Height * i, a4Width, a4Height);
             }
         }
     }
@@ -1162,7 +1162,7 @@ function drawVirtualA4() {
     else if(A4Orientation == "landscape") {
         for (var i = 0; i < a4Rows; i++) {
             for (var j = 0; j < a4Columns; j++) {
-                ctx.strokeRect(zeroX + a4Height * j, zeroY + a4Width * i, a4Height, a4Width); 
+                ctx.strokeRect(zeroX + a4Height * j, zeroY + a4Width * i, a4Height, a4Width);
             }
         }
     }
@@ -1179,7 +1179,7 @@ function drawVirtualA4() {
                         drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
                         //Latter two holes
                         drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
-                        drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius); 
+                        drawCircle(leftHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
                     }
                 }
             }else {
@@ -1191,7 +1191,7 @@ function drawVirtualA4() {
                         drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
                         //Latter two holes
                         drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
-                        drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius); 
+                        drawCircle(rightHoleOffsetX + zeroX + a4Width * j, ((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroY + a4Height * i, holeRadius);
                     }
                 }
             }
@@ -1206,7 +1206,7 @@ function drawVirtualA4() {
                         drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius);
                         //Latter two holes
                         drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius);
-                        drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius); 
+                        drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX + a4Height * j, leftHoleOffsetX + zeroY + a4Width * i, holeRadius);
                     }
                 }
             }else {
@@ -1218,7 +1218,7 @@ function drawVirtualA4() {
                         drawCircle(((a4Height / 2) - 34 * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius);
                         //Latter two holes
                         drawCircle(((a4Height / 2) + (34+21) * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius);
-                        drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius); 
+                        drawCircle(((a4Height / 2) + 34 * pixelsPerMillimeter) + zeroX + a4Height * j, rightHoleOffsetX + zeroY + a4Width * i, holeRadius);
                     }
                 }
             }
@@ -2522,10 +2522,12 @@ function changeZoom(zoomValue){
 }
 
 //-----------------------
-// Canvas zoom on scroll
+// Canvas zoom on scroll with mouse pointer in focus
 //-----------------------
 
 function scrollZoom(event) {
+  let currentMouseX = pixelsToCanvas(currentMouseCoordinateX).x;
+  let currentMouseY = pixelsToCanvas(0, currentMouseCoordinateY).y;
     if(event.deltaY > 124){
         changeZoom(-0.1);
     } else if (event.deltaY < -124) {
@@ -2535,6 +2537,9 @@ function scrollZoom(event) {
     } else if (event.deltaY < -5) {
         changeZoom(0.01);
     }
+    origoOffsetX += currentMouseX - pixelsToCanvas(currentMouseCoordinateX).x;
+    origoOffsetY += currentMouseY - pixelsToCanvas(0, currentMouseCoordinateY).y;
+    updateGraphics();
 }
 
 //----------------------------------------------------------------------
@@ -2622,7 +2627,7 @@ function mousemoveevt(ev, t) {
                 if(sel.attachedSymbol.symbolkind == symbolKind.line || sel.attachedSymbol.symbolkind == symbolKind.umlLine) {
                     //The point belongs to a umlLine or Line
                     canvas.style.cursor = "pointer";
-                } else {                    
+                } else {
                     canvas.style.cursor = "url('../Shared/icons/hand_move.cur'), auto";
                 }
             } else {
@@ -2656,20 +2661,20 @@ function mousemoveevt(ev, t) {
                     var object;
                     // the movement change we wan't to make
                     var change = ((currentMouseCoordinateX - sel.point.x) + (currentMouseCoordinateY - sel.point.y)) / 2;
-                    // find the object that has the point we want to move 
+                    // find the object that has the point we want to move
                     for (var i = 0; i < diagram.length; i++) {
                         if (points[diagram[i].bottomRight] == sel.point || points[diagram[i].topLeft] == sel.point) {
                             object = diagram[i];
                             // the objects current width and height
                             var xDiff = points[object.bottomRight].x - points[object.topLeft].x;
                             var yDiff = points[object.bottomRight].y - points[object.topLeft].y;
-                            // For making sure the proportions stay the same when the object is at it's minimum size on one of the axes 
+                            // For making sure the proportions stay the same when the object is at it's minimum size on one of the axes
                             // so that it doesn't keep resizing one of the axes independently of the other
 
                             // if x size is equal to the objects min width
                             if (minSizeCheck(xDiff, object, "x")) {
                                 var xDiffNew;
-                                // set the new size depending on which point we're moving 
+                                // set the new size depending on which point we're moving
                                 if (points[object.bottomRight] == sel.point){
                                     xDiffNew = (sel.point.x + change) - points[object.topLeft].x;
                                 } else if (points[object.topLeft] == sel.point){
@@ -2694,7 +2699,7 @@ function mousemoveevt(ev, t) {
                             }
                         }
                     }
-                    // apply resize 
+                    // apply resize
                     sel.point.x += change;
                     sel.point.y += change;
                 } else {
@@ -3513,7 +3518,7 @@ function loadLineForm(element, dir) {
                 var tempLineDirection = lineDirection;
                 if (lineDirection == "" || lineDirection == null) {
                     diagram[lastSelectedObject].lineDirection = "First";
-                    tempLineDirection = "First";  
+                    tempLineDirection = "First";
                 }
 
                 setSelectedOption('object_type', diagram[lastSelectedObject].properties['key_type']);
@@ -3688,7 +3693,7 @@ function changeObjectAppearance(object_type) {
     } else if (diagram[lastSelectedObject].symbolkind == symbolKind.umlLine) {
         diagram[lastSelectedObject].properties['key_type'] = document.getElementById('object_type').value;
         diagram[lastSelectedObject].properties['key_type'] = document.getElementById('line_direction').value;
-        // something about the line type ?? 
+        // something about the line type ??
     } else if (diagram[lastSelectedObject].kind == kind.path) {
         diagram[lastSelectedObject].fillColor = document.getElementById('figureFillColor').value;
         diagram[lastSelectedObject].opacity = document.getElementById('figureOpacity').value / 100;
@@ -3751,7 +3756,7 @@ function changeCardinality(isUML) {
 function changeLineDirection() {
     diagram[lastSelectedObject].lineDirection = document.getElementById('line_direction').value;
     console.log("lineDirection " + diagram[lastSelectedObject].lineDirection);
-} 
+}
 
 //Close the errorMessageDialog for Composite
 function closeErrorMessageDialog() {


### PR DESCRIPTION
#6419 Zoom focuses on mouse pointer now instead of origo. Zooming in and out should not lose the object the mouse pointer is on.