### PR TITLE
#6720: Styling on toolbox hover label

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1765,7 +1765,7 @@ div.submit-button:disabled {
   color: #fff;
   position: absolute;
   left: 70px;
-  top: 11%;
+  top: 55px;
   white-space: nowrap;
   z-index: 10;
   border-radius: 5px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1764,7 +1764,7 @@ div.submit-button:disabled {
   padding: 4px 8px;
   color: #fff;
   position: absolute;
-  left: 85px;
+  left: 70px;
   top: 11%;
   white-space: nowrap;
   z-index: 10;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1765,7 +1765,7 @@ div.submit-button:disabled {
   color: #fff;
   position: absolute;
   left: 70px;
-  top: 55px;
+  top: 45px;
   white-space: nowrap;
   z-index: 10;
   border-radius: 5px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1764,8 +1764,8 @@ div.submit-button:disabled {
   padding: 4px 8px;
   color: #fff;
   position: absolute;
-  left: 0;
-  top: 100%;
+  left: 85px;
+  top: 11%;
   white-space: nowrap;
   z-index: 10;
   border-radius: 5px;


### PR DESCRIPTION
https://github.com/HGustavs/LenaSYS/issues/6720

Placement of the tooltip text for when you hover over a button in the left toolbox has been changed to the top left corner of the canvas, as the previous placement doesn't work anymore with the new toolbox design.

Before:
![toolboxtip](https://user-images.githubusercontent.com/37792313/57453302-559b9100-7266-11e9-85bf-0947c4373b6b.png)

After:
![toolboxtip2](https://user-images.githubusercontent.com/37792313/57453308-59c7ae80-7266-11e9-988d-57fcd9444d0b.png)

I tried to make the tooltip relative to each button but weird things happened to the buttons on hover. I can try to investigate further on this if this placement of the label is what we really wish for. Otherwise I think it looks good with my solution.
![toolboxtip3](https://user-images.githubusercontent.com/37792313/57453410-a4492b00-7266-11e9-86ea-9f2a1356384b.png)
