### PR TITLE
Made some templates more mobile friendly

### DIFF
--- a/DuggaSys/templates/clipping_masking_dugga.html
+++ b/DuggaSys/templates/clipping_masking_dugga.html
@@ -1,5 +1,5 @@
-<div id="container" style="display:flex; justify-content:flex-start;">
-    <div id='duggaInfoBox2' style="min-width:170px;width:300px;margin:0 4px 0 4px;">
+<div id="container" class="clippingContainer" style="display:flex; justify-content:flex-start;">
+    <div id='clippingInfoBox'>
       
           <div class='loginBoxheader'>
                 <h3>Transformations-dugga</h3>
@@ -9,7 +9,7 @@
                 <p style="margin-left: 4px;">Lycka till och glöm inte att spara duggan! En gul lampa betyder att duggan är inlämnad.</p>
             
     </div>
-    <div id='duggaInfoBox2' style="min-width:120px;width:300px;margin:0 4px 0 4px;">
+    <div id='clippingInfoBox2'>
       
           <div class='loginBoxheader'>
                 <h3>Målbild</h3>

--- a/DuggaSys/templates/curve-dugga.html
+++ b/DuggaSys/templates/curve-dugga.html
@@ -1,5 +1,5 @@
-<div id="container" style="display:flex;">
-    <div id='duggaInfoBox' style="max-width:300px;">
+<div id="container" class="curveContainer" style="display:flex; justify-content:flex-start;">
+    <div id='curveInfoBox'>
         <div class='loginBoxheader'>
             <h3>Kurv-duggan</h3>
         </div>

--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -1,5 +1,5 @@
 <div id="container">
-    <table style="width:100%; border-collapse:separate; border-spacing: 10px;">
+    <table id="htmlCssTable" style="width:100%; border-collapse:separate; border-spacing: 10px;">
         <tr>
             <td id="target-col" class="dugga-col" style="max-width:400px;min-width:350px;vertical-align:top; background-color:#FFF;box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:scroll;">
                 <div style="">

--- a/DuggaSys/templates/transforms-dugga.html
+++ b/DuggaSys/templates/transforms-dugga.html
@@ -1,5 +1,5 @@
-<div id="container" style="display:flex; justify-content:flex-start;">
-    <div id='duggaInfoBox2' style="width:300px;min-width: 300px;">
+<div id="container" style="display:flex; justify-content:flex-start; flex-wrap: wrap; overflow: auto; flex: 1; min-height: 100vh">
+    <div id='transformInfoBox'>
       
           <div class='loginBoxheader'>
                 <h3>Transformations-dugga</h3>
@@ -14,7 +14,7 @@
 
     <canvas id='a' style='background-color:#FFFFFF; border:2px solid black; display:block;'></canvas>
 
-    <div id="toolbox" style="min-width:340px;width:340px;display: flex;flex-direction: column;justify-content: flex-start;">
+    <div id="transformToolbox" style="min-width:340px;width:340px;display: flex;flex-direction: column;justify-content: flex-start;">
         <!-- Draw tools -->
         <div style="flex-grow: 1">     
             <div class='loginBoxheader'>

--- a/DuggaSys/templates/transforms-dugga.html
+++ b/DuggaSys/templates/transforms-dugga.html
@@ -1,4 +1,4 @@
-<div id="container" style="display:flex; justify-content:flex-start; flex-wrap: wrap; overflow: auto; flex: 1; min-height: 100vh">
+<div id="container" class="transformContainer" style="display:flex; justify-content:flex-start;">
     <div id='transformInfoBox'>
       
           <div class='loginBoxheader'>

--- a/DuggaSys/templates/transforms-dugga.js
+++ b/DuggaSys/templates/transforms-dugga.js
@@ -259,10 +259,7 @@ function fitToContainer()
 		canvas.width = window.innerHeight - 100;
 		canvas.height = canvas.width;
 	}
-
-	document.getElementById("opTableContainer").style.maxHeight=(canvas.height-25-38)+"px";
-	document.getElementById("container").style.height=(canvas.height-50)+"px";
-
+	
 	sf = canvas.width / 200;
 }
 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -406,3 +406,19 @@ svg text {
 		display: block;
 	}
  }
+
+  /* --------------================################================-------------- *
+ *                      	        Transform Dugga				       								   *
+ * --------------================################================-------------- */
+ #transformInfoBox {
+	min-width: 300px;
+	width: 300px;
+}
+@media only screen and (max-width: 1360px) {
+ #transformInfoBox {
+	 width: 100%;
+ }
+ #transformInfoBox .loginBoxheader {
+	 width: 100%;
+ }
+}

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -394,3 +394,15 @@ svg text {
 		margin-top: 10px;
 	}
 }
+
+ /* --------------================################================-------------- *
+ *                      	         HTML-CSS Dugga				       								   *
+ * --------------================################================-------------- */
+
+ @media only screen and (max-width: 800px) {
+	#htmlCssTable > tbody,
+	#htmlCssTable > tbody > tr, 
+	#htmlCssTable > tbody > tr > td {
+		display: block;
+	}
+ }

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -422,3 +422,28 @@ svg text {
 	 width: 100%;
  }
 }
+
+  /* --------------================################================-------------- *
+ *                      	     Clipping Masking Dugga				       							 *
+ * --------------================################================-------------- */
+#clippingInfoBox {
+min-width:170px;
+width:300px;
+margin:0 4px 0 4px;
+}
+#clippingInfoBox2 {
+min-width:120px;
+width:300px;
+margin:0 4px 0 4px;
+}
+ @media only screen and (max-width: 1360px) {
+	#clippingInfoBox {
+		width:100%;
+	}
+	#clippingInfoBox2 {
+		width:100%;
+	}
+	.clippingContainer {
+		flex-wrap: wrap;
+	}
+}

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -421,20 +421,23 @@ svg text {
  #transformInfoBox .loginBoxheader {
 	 width: 100%;
  }
+ .transformContainer {
+	 flex-wrap: wrap;
+ }
 }
 
   /* --------------================################================-------------- *
  *                      	     Clipping Masking Dugga				       							 *
  * --------------================################================-------------- */
 #clippingInfoBox {
-min-width:170px;
-width:300px;
-margin:0 4px 0 4px;
+	min-width:170px;
+	width:300px;
+	margin:0 4px 0 4px;
 }
 #clippingInfoBox2 {
-min-width:120px;
-width:300px;
-margin:0 4px 0 4px;
+	min-width:120px;
+	width:300px;
+	margin:0 4px 0 4px;
 }
  @media only screen and (max-width: 1360px) {
 	#clippingInfoBox {

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -447,3 +447,20 @@ margin:0 4px 0 4px;
 		flex-wrap: wrap;
 	}
 }
+
+  /* --------------================################================-------------- *
+ *                      	          Curve Dugga				       							       *
+ * --------------================################================-------------- */
+ #curveInfoBox {
+	max-width:300px;
+ }
+
+@media only screen and (max-width: 1360px) {
+	#curveInfoBox {
+		width: 100%;
+		max-width: 100%;
+	}
+	.curveContainer {
+		flex-wrap: wrap;
+	}
+}


### PR DESCRIPTION
Fixes #6458 

Dugga templates affected:

- html_css_dugga
- transforms-dugga
- clipping_masking_dugga
- curve-dugga

These are the only ones I could find that were broken on smaller screens. There was also boxmodell but that dugga doesn't work without a variant which I couldn't find any examples for.