### PR TITLE
Fix for issue #6545: Undoing and redoing Draw Free tool doesn't work 

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2573,6 +2573,7 @@ function figureFreeDraw() {
             selected_objects.push(figurePath);
             lastSelectedObject = diagram.length - 1;
             cleanUp();
+            SaveState();
         } else {
             // Temporary store the new line and then render it
             var tempPath = new Path;


### PR DESCRIPTION
#6545 