### PR TITLE
Fix for #6738 Resetting key press when focus is lost

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -367,7 +367,6 @@ function generateExampleCode() {
 function resetButtonsPressed() {
     ctrlIsClicked = false;
     shiftIsClicked = false;
-    alert("Hej");
 }
 
 //--------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -357,6 +357,21 @@ function generateExampleCode() {
 }
 
 //--------------------------------------------------------------------
+// This function check if focus on diagram was lost
+// Put your action here if you want focus lost as trigger
+//--------------------------------------------------------------------
+setInterval( checkFocus, 200 );
+function checkFocus() {
+  if ( document.hasFocus() ) {
+    // Put the code you want to run while in focuse here:
+  } else {
+    // Put the code you want to run when focuse is lost here:
+    ctrlIsClicked = false;
+    shiftIsClicked = false;
+  }
+}
+
+//--------------------------------------------------------------------
 // diagram - Stores a global list of diagram objects
 //           A diagram object could for instance be a path, or a symbol
 //--------------------------------------------------------------------
@@ -2375,7 +2390,7 @@ function diagramToSVG() {
 // NOT like:
 //         setCheckbox(checkboxElement, true); // checkboxVar is unchanged
 // The last example results in unchanged behaviour in the diagram but with
-// the checkbox icon appearing as if it is active. 
+// the checkbox icon appearing as if it is active.
 //----------------------------------------------------------------------
 
 function setCheckbox(element, check) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -248,6 +248,9 @@ window.addEventListener("keydown", this.keyDownHandler);
 var ctrlIsClicked = false;
 var shiftIsClicked = false;
 
+// This event checks if the user leaves the diagram.php
+window.addEventListener('blur', resetButtonsPressed);
+
 //--------------------------------------------------------------
 // DIAGRAM EXAMPLE DATA SECTION
 //--------------------------------------------------------------
@@ -360,15 +363,11 @@ function generateExampleCode() {
 // This function check if focus on diagram was lost
 // Put your action here if you want focus lost as trigger
 //--------------------------------------------------------------------
-setInterval( checkFocus, 200 );
-function checkFocus() {
-  if ( document.hasFocus() ) {
-    // Put the code you want to run while in focuse here:
-  } else {
-    // Put the code you want to run when focuse is lost here:
+
+function resetButtonsPressed() {
     ctrlIsClicked = false;
     shiftIsClicked = false;
-  }
+    alert("Hej");
 }
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
#6738 Switching tab or window now resets the pressed buttons. Buttons handled now are Ctrl and Shift. If you wish to add more it's just to put in what keys you wish to add. Very simple. Just check the code.