### PR TITLE
Fix for issue #6829: Consistency suggestion with zoom buttons

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -323,14 +323,14 @@
             <div id='valuesCanvas'></div>
             <div id="selectDiv">
               <span class="tooltipDecrease">
-                <button name="Zoom" id="zoomDecrease" class="zoomButtonStyle" type="button" onclick="changeZoom(-0.1);"> - </button>
+                <button name="Zoom" id="zoomDecrease" class="zoomButtonStyle" type="button" onclick="changeZoom(-0.1);">-</button>
                 <span class="tooltiptextDec">Zoom Out</span>
               </span>
               <span id="range">
                 <input name="Zoom" id="ZoomSelect" type="range" oninput="zoomInMode();" onchange="zoomInMode();" min="0.1" max="2" value="1" step="0.01" class="zoomSlider">
               </span>
               <span class="tooltipIncrease">
-                <button name="Zoom" id="zoomIncrease" class="zoomButtonStyle" type="button" onclick="changeZoom(0.1);"> + </button>
+                <button name="Zoom" id="zoomIncrease" class="zoomButtonStyle" type="button" onclick="changeZoom(0.1);">+</button>
                 <span class="tooltiptextInc" style="right: 68px">Zoom In</span>
               </span>
               <span id="zoomV"></span>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3927,6 +3927,7 @@ only screen and (max-device-width: 320px) {
 
 .zoomButtonStyle {
   transition: 0.25s background-color;
+  font-family: hack, "Lucida Console", Monaco, monospace;
 }
 
 .zoomButtonStyle:hover {


### PR DESCRIPTION
#6829 I'm not entirely sure about how the font is assigned here since i'm not that familiar with the font styling. I used a font that was implemented in `.markinglist` and it doesn't seem to be used anywhere but it works.