### PR TITLE
FIx: Wrong arrow changes in sectioned.php when expanding headings  #6784

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -806,7 +806,7 @@ function returnedSection(data) {
         // Generate ID for collapsing arrows
         //var arrowID = item['entryname'].split(' ').join('').split(',').join('') + data.coursecode;
         var arrowID = item['moment'];
-
+        var arrowLID = item['lid'];
         // Content of Section Item
         if (itemKind == 0) {
           // Header
@@ -815,15 +815,15 @@ function returnedSection(data) {
           // Section
           str += "<div class='nowrap" + hideState + "' style='margin-left:8px;display:flex;align-items:center;' title='" + item['entryname'] + "'>";
           str += "<span class='ellipsis listentries-span'>" + item['entryname'] + "</span>";
-          str += "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + arrowID + "' class='arrowComp' style='display:inline-block;'>";
-          str += "<img src='../Shared/icons/right_complement.svg' id='arrowRight" + arrowID + "' class='arrowRight' style='display:none;'></div>";
+          str += "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + arrowLID + "' class='arrowComp' style='display:inline-block;'>";
+          str += "<img src='../Shared/icons/right_complement.svg' id='arrowRight" + arrowLID + "' class='arrowRight' style='display:none;'></div>";
         } else if (itemKind == 4) {
           // Moment
           var strz = makeTextArray(item['gradesys'], ["", "(U-G-VG)", "(U-G)"]);
           str += "<div class='nowrap" + hideState + "' style='margin-left:8px;display:flex;align-items:center;' title='" + item['entryname'] + "'>";
           str += "<span class='ellipsis listentries-span'>" + item['entryname'] + " " + strz + " </span>";
-          str += "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + arrowID + "' class='arrowComp' style='display:inline-block;'>";
-          str += "<img src='../Shared/icons/right_complement.svg'" + "id='arrowRight" + arrowID + "' class='arrowRight' style='display:none;'>";
+          str += "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + arrowLID + "' class='arrowComp' style='display:inline-block;'>";
+          str += "<img src='../Shared/icons/right_complement.svg'" + "id='arrowRight" + arrowLID + "' class='arrowRight' style='display:none;'>";
           str += "</div>";
         } else if (itemKind == 2) {
           // Code Example

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -803,10 +803,6 @@ function returnedSection(data) {
 
         // Close Information
         str += ">";
-        // Generate ID for collapsing arrows
-        //var arrowID = item['entryname'].split(' ').join('').split(',').join('') + data.coursecode;
-        var arrowID = item['moment'];
-        var arrowLID = item['lid'];
         // Content of Section Item
         if (itemKind == 0) {
           // Header
@@ -815,15 +811,15 @@ function returnedSection(data) {
           // Section
           str += "<div class='nowrap" + hideState + "' style='margin-left:8px;display:flex;align-items:center;' title='" + item['entryname'] + "'>";
           str += "<span class='ellipsis listentries-span'>" + item['entryname'] + "</span>";
-          str += "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + arrowLID + "' class='arrowComp' style='display:inline-block;'>";
-          str += "<img src='../Shared/icons/right_complement.svg' id='arrowRight" + arrowLID + "' class='arrowRight' style='display:none;'></div>";
+          str += "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + item['lid'] + "' class='arrowComp' style='display:inline-block;'>";
+          str += "<img src='../Shared/icons/right_complement.svg' id='arrowRight" + item['lid'] + "' class='arrowRight' style='display:none;'></div>";
         } else if (itemKind == 4) {
           // Moment
           var strz = makeTextArray(item['gradesys'], ["", "(U-G-VG)", "(U-G)"]);
           str += "<div class='nowrap" + hideState + "' style='margin-left:8px;display:flex;align-items:center;' title='" + item['entryname'] + "'>";
           str += "<span class='ellipsis listentries-span'>" + item['entryname'] + " " + strz + " </span>";
-          str += "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + arrowLID + "' class='arrowComp' style='display:inline-block;'>";
-          str += "<img src='../Shared/icons/right_complement.svg'" + "id='arrowRight" + arrowLID + "' class='arrowRight' style='display:none;'>";
+          str += "<img src='../Shared/icons/desc_complement.svg' id='arrowComp" + item['lid'] + "' class='arrowComp' style='display:inline-block;'>";
+          str += "<img src='../Shared/icons/right_complement.svg'" + "id='arrowRight" + item['lid'] + "' class='arrowRight' style='display:none;'>";
           str += "</div>";
         } else if (itemKind == 2) {
           // Code Example

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -41,7 +41,8 @@
 				<tr class='trsize nowrap'>
 					<td style='display: inline-block;'>
 						<div class='course-dropdown-div'>
-						
+						<select id="courseDropdownTop" class='course-dropdown' onchange='goToVersion(this.id)' >
+								</select>
 						</div>
 					</td>
 					<td class='editVers' style='display: inline-block;'>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -165,7 +165,7 @@
 								<img src='../Shared/icons/right_complement.svg' id='arrowStatisticsOpen'>
 								<img src='../Shared/icons/desc_complement.svg' id='arrowStatisticsClosed'>
 						</div>
-						<div class='nowrap' style='padding-left:5px' title='statistics'>
+						<div class='nowrap' style='padding-left:50px' title='statistics'>
 								<span class='listentries-span noselect' style='writing-mode:vertical-rl;text-orientation: sideways;'>Deadlines</span>
 						</div>
 				</div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -41,7 +41,7 @@
 				<tr class='trsize nowrap'>
 					<td style='display: inline-block;'>
 						<div class='course-dropdown-div'>
-						<select id="courseDropdownTop" class='course-dropdown' onchange='goToVersion(this.id)' >
+							<select id="courseDropdownTop" class='course-dropdown' onchange='goToVersion(this.id)' >
 								</select>
 						</div>
 					</td>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -165,7 +165,7 @@
 								<img src='../Shared/icons/right_complement.svg' id='arrowStatisticsOpen'>
 								<img src='../Shared/icons/desc_complement.svg' id='arrowStatisticsClosed'>
 						</div>
-						<div class='nowrap' style='padding-left:50px' title='statistics'>
+						<div class='nowrap' style='padding-left:5px' title='statistics'>
 								<span class='listentries-span noselect' style='writing-mode:vertical-rl;text-orientation: sideways;'>Deadlines</span>
 						</div>
 				</div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -41,8 +41,7 @@
 				<tr class='trsize nowrap'>
 					<td style='display: inline-block;'>
 						<div class='course-dropdown-div'>
-							
-								</select>
+						
 						</div>
 					</td>
 					<td class='editVers' style='display: inline-block;'>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -41,7 +41,7 @@
 				<tr class='trsize nowrap'>
 					<td style='display: inline-block;'>
 						<div class='course-dropdown-div'>
-								<select id="courseDropdownTop" class='course-dropdown' onchange='goToVersion(this.id)' >
+							
 								</select>
 						</div>
 					</td>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -41,8 +41,7 @@
 				<tr class='trsize nowrap'>
 					<td style='display: inline-block;'>
 						<div class='course-dropdown-div'>
-							<select id="courseDropdownTop" class='course-dropdown' onchange='goToVersion(this.id)' >
-								</select>
+							<select id="courseDropdownTop" class='course-dropdown' onchange='goToVersion(this.id)' ></select>
 						</div>
 					</td>
 					<td class='editVers' style='display: inline-block;'>


### PR DESCRIPTION
#6784

```
// Generate ID for collapsing arrows
//var arrowID = item['entryname'].split(' ').join('').split(',').join('') + data.coursecode;
var arrowID = item['moment'];
```
IMO this doesn't contribute anything. If "item['lid'] is not obvious enough by it self, then I think that naming should be changed rather than adding a new variable.
