### PR TITLE
If no timesheet table exists in the database, contribution will load

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -686,7 +686,12 @@ function returnedSection(data)
     return;
   }
   retdata=data;
-  if(data['debug']!="NONE!") alert(data['debug']);
+  if(data['debug']!="NONE!") {
+    if(data['debug']!="TIMESHEET") {
+      alert(data['debug']);
+    }
+    console.log("No timesheet table was found in the database.")
+  }
 
   contribDataArr = [];
 	var str="";

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -540,19 +540,21 @@ if(strcmp($opt,"get")==0) {
 	$query->bindParam(':vers', $vers);
 	if(!$query->execute()) {
 		$error=$query->errorInfo();
-		$debug="Error reading entries".$error[2];
+		$debug="TIMESHEET";
+	} else {
+		$rows = $query->fetchAll();
+		foreach($rows as $row){
+			$timesheet = array(
+				'day' => $row['day'],
+				'week' => intval($row['week']),
+				'type' => $row['type'],
+				'reference' => intval($row['reference']),
+				'comment' => $row['comment']
+			);
+			array_push($timesheets, $timesheet);
+		}
 	}
-	$rows = $query->fetchAll();
-	foreach($rows as $row){
-		$timesheet = array(
-			'day' => $row['day'],
-			'week' => intval($row['week']),
-			'type' => $row['type'],
-			'reference' => intval($row['reference']),
-			'comment' => $row['comment']
-		);
-		array_push($timesheets, $timesheet);
-	}
+
 	$array = array(
 		'debug' => $debug,
 		'weeks' => $weeks,

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -534,7 +534,7 @@ if(strcmp($opt,"get")==0) {
 		$currentdate=strtotime("+1 day",strtotime($currentdate));
 	}
 	$timesheets = array();
-	$query = $pdo->prepare('SELECT day, week, type, reference, comment FROM whatever WHERE uid=:userid AND cid=:cid AND vers=:vers;');
+	$query = $pdo->prepare('SELECT day, week, type, reference, comment FROM timesheet WHERE uid=:userid AND cid=:cid AND vers=:vers;');
 	$query->bindParam(':userid', $userid);
 	$query->bindParam(':cid', $cid);
 	$query->bindParam(':vers', $vers);

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -534,7 +534,7 @@ if(strcmp($opt,"get")==0) {
 		$currentdate=strtotime("+1 day",strtotime($currentdate));
 	}
 	$timesheets = array();
-	$query = $pdo->prepare('SELECT day, week, type, reference, comment FROM timesheet WHERE uid=:userid AND cid=:cid AND vers=:vers;');
+	$query = $pdo->prepare('SELECT day, week, type, reference, comment FROM whatever WHERE uid=:userid AND cid=:cid AND vers=:vers;');
 	$query->bindParam(':userid', $userid);
 	$query->bindParam(':cid', $cid);
 	$query->bindParam(':vers', $vers);

--- a/DuggaSys/templates/contribution.js
+++ b/DuggaSys/templates/contribution.js
@@ -4,7 +4,6 @@ function setup()
     var container = document.getElementById('frameContainer');
     var str = "<iframe style='position: fixed; top: 0; left: 0; width: 100%; height: 100%; border: none' onLoad='checkLeaveFrame(this)'";
     str += " src = 'contribution.php?cid="+inParams['cid']+"&coursevers="+inParams['coursevers']+"'>";
-    console.log(str);
     container.innerHTML = str;
 }
 


### PR DESCRIPTION
Fixes #6866 

Contribution will only throw an error if the timesheet table does not exist in the database. This simply handles the error by console logging a message saying that no such table exists.

You can simulate not having a timesheet table by changing row 537 in contributionservice.php:
`$query = $pdo->prepare('SELECT day, week, type, reference, comment FROM timesheet WHERE uid=:userid AND cid=:cid AND vers=:vers;');`

to:

`$query = $pdo->prepare('SELECT day, week, type, reference, comment FROM whatever WHERE uid=:userid AND cid=:cid AND vers=:vers;');`