### PR TITLE
Removed acceptance of duplicates

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3435,6 +3435,7 @@ function countNumberOfSymbolKind(kind) {
   for(let i = 0; i < diagram.length; i++) {
       if(diagram[i].symbolkind == kind) {
           numberOfSymbolKind++;
+      }
   }
   return numberOfSymbolKind;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3274,7 +3274,7 @@ function mouseupevt(ev) {
 
     if (uimode == "CreateClass" && md == mouseState.boxSelectOrCreateMode) {
         var classB = new Symbol(symbolKind.uml); // UML
-        let newValue = checkDuplicate("New", symbolKind.uml);
+        var newValue = checkDuplicate("New", symbolKind.uml);
         classB.name = "New" + newValue;
         classB.operations.push({text:"- makemore()"});
         classB.attributes.push({text:"+ height:Integer"});
@@ -3289,7 +3289,7 @@ function mouseupevt(ev) {
         diagramObject = diagram[lastSelectedObject];
     } else if (uimode == "CreateERAttr" && md == mouseState.boxSelectOrCreateMode) {
         erAttributeA = new Symbol(symbolKind.erAttribute); // ER attributes
-        let newValue = checkDuplicate("Attr", symbolKind.erAttribute);
+        var newValue = checkDuplicate("Attr", symbolKind.erAttribute);
         erAttributeA.name = "Attr" + newValue;
         erAttributeA.topLeft = p1;
         erAttributeA.bottomRight = p2;
@@ -3303,7 +3303,7 @@ function mouseupevt(ev) {
         diagramObject = diagram[lastSelectedObject];
     } else if (uimode == "CreateEREntity" && md == mouseState.boxSelectOrCreateMode) {
         erEnityA = new Symbol(symbolKind.erEntity); // ER entity
-        let newValue = checkDuplicate("Entity", symbolKind.erEntity);
+        var newValue = checkDuplicate("Entity", symbolKind.erEntity);
         erEnityA.name = "Entity" + newValue;;
         erEnityA.topLeft = p1;
         erEnityA.bottomRight = p2;
@@ -3344,7 +3344,7 @@ function mouseupevt(ev) {
         }
     } else if (uimode == "CreateERRelation" && md == mouseState.boxSelectOrCreateMode) {
         erRelationA = new Symbol(symbolKind.erRelation); // ER Relation
-        let newValue = checkDuplicate("Relation", symbolKind.erRelation);
+        var newValue = checkDuplicate("Relation", symbolKind.erRelation);
         erRelationA.name = "Relation" + newValue;
         erRelationA.topLeft = p1;
         erRelationA.bottomRight = p2;
@@ -3364,7 +3364,7 @@ function mouseupevt(ev) {
                     setIsLockHovered(diagram[i], currentMouseCoordinateX, currentMouseCoordinateY);
                     if (diagram[i].isLockHovered) {
                         diagram[i].isLocked = false;
-                    }    
+                    }
                 }
             }
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3237,7 +3237,7 @@ function mouseupevt(ev) {
         }
     } else if (uimode == "CreateERRelation" && md == mouseState.boxSelectOrCreateMode) {
         erRelationA = new Symbol(symbolKind.erRelation); // ER Relation
-        let newValue = checkDuplicate("Entity", symbolKind.erRelation);
+        let newValue = checkDuplicate("Relation", symbolKind.erRelation);
         erRelationA.name = "Relation" + newValue;
         erRelationA.topLeft = p1;
         erRelationA.bottomRight = p2;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2377,7 +2377,7 @@ function diagramToSVG() {
 // NOT like:
 //         setCheckbox(checkboxElement, true); // checkboxVar is unchanged
 // The last example results in unchanged behaviour in the diagram but with
-// the checkbox icon appearing as if it is active. 
+// the checkbox icon appearing as if it is active.
 //----------------------------------------------------------------------
 
 function setCheckbox(element, check) {
@@ -2651,7 +2651,7 @@ function mousemoveevt(ev, t) {
                     if(sel.attachedSymbol.symbolkind == symbolKind.line || sel.attachedSymbol.symbolkind == symbolKind.umlLine) {
                         //The point belongs to a umlLine or Line
                         canvas.style.cursor = "pointer";
-                    } else {                    
+                    } else {
                         canvas.style.cursor = "url('../Shared/icons/hand_move.cur'), auto";
                     }
                 }
@@ -3167,7 +3167,17 @@ function mouseupevt(ev) {
 
     if (uimode == "CreateClass" && md == mouseState.boxSelectOrCreateMode) {
         var classB = new Symbol(symbolKind.uml); // UML
-        classB.name = "New" + countNumberOfSymbolKind(symbolKind.uml);
+        var numberOfSymbolKind = 0;
+        for(let i = 0; i < diagram.length; i++){
+            //Checks for duplicates with the same number and adds +1 to it.
+            if (diagram[i].name == "New" + countNumberOfSymbolKind(symbolKind.uml)) {
+                numberOfSymbolKind = 1;
+            }
+        }
+        //Variable that adds +1 to numberOfSymbolKind if there were a duplicate otherwise it's 0.
+        var newValue = countNumberOfSymbolKind(symbolKind.uml) + numberOfSymbolKind;
+
+        classB.name = "New" + newValue;
         classB.operations.push({text:"- makemore()"});
         classB.attributes.push({text:"+ height:Integer"});
         classB.topLeft = p1;
@@ -3181,7 +3191,17 @@ function mouseupevt(ev) {
         diagramObject = diagram[lastSelectedObject];
     } else if (uimode == "CreateERAttr" && md == mouseState.boxSelectOrCreateMode) {
         erAttributeA = new Symbol(symbolKind.erAttribute); // ER attributes
-        erAttributeA.name = "Attr" + countNumberOfSymbolKind(symbolKind.erAttribute);
+        var numberOfSymbolKind = 0;
+        for(let i = 0; i < diagram.length; i++){
+            //Checks for duplicates with the same number and adds +1 to it.
+            if (diagram[i].name == "Attr" + countNumberOfSymbolKind(symbolKind.erAttribute)) {
+                numberOfSymbolKind = 1;
+            }
+        }
+        //Variable that adds +1 to numberOfSymbolKind if there were a duplicate otherwise it's 0.
+        var newValue = countNumberOfSymbolKind(symbolKind.erAttribute) + numberOfSymbolKind;
+
+        erAttributeA.name = "Attr" + newValue;
         erAttributeA.topLeft = p1;
         erAttributeA.bottomRight = p2;
         erAttributeA.centerPoint = p3;
@@ -3194,7 +3214,18 @@ function mouseupevt(ev) {
         diagramObject = diagram[lastSelectedObject];
     } else if (uimode == "CreateEREntity" && md == mouseState.boxSelectOrCreateMode) {
         erEnityA = new Symbol(symbolKind.erEntity); // ER entity
-        erEnityA.name = "Entity" + countNumberOfSymbolKind(symbolKind.erEntity);
+
+        var numberOfSymbolKind = 0;
+        for(let i = 0; i < diagram.length; i++){
+            //Checks for duplicates with the same number and adds +1 to it.
+            if (diagram[i].name == "Entity" + countNumberOfSymbolKind(symbolKind.erEntity)) {
+                numberOfSymbolKind = 1;
+            }
+        }
+        //Variable that adds +1 to numberOfSymbolKind if there were a duplicate otherwise it's 0.
+        var newValue = countNumberOfSymbolKind(symbolKind.erEntity) + numberOfSymbolKind;
+
+        erEnityA.name = "Entity" + newValue;;
         erEnityA.topLeft = p1;
         erEnityA.bottomRight = p2;
         erEnityA.centerPoint = p3;
@@ -3234,7 +3265,18 @@ function mouseupevt(ev) {
         }
     } else if (uimode == "CreateERRelation" && md == mouseState.boxSelectOrCreateMode) {
         erRelationA = new Symbol(symbolKind.erRelation); // ER Relation
-        erRelationA.name = "Relation" + countNumberOfSymbolKind(symbolKind.erRelation);
+
+        var numberOfSymbolKind = 0;
+        for(let i = 0; i < diagram.length; i++){
+            //Checks for duplicates with the same number and adds +1 to it.
+            if (diagram[i].name == "Relation" + countNumberOfSymbolKind(symbolKind.erRelation)) {
+                numberOfSymbolKind = 1;
+            }
+        }
+        //Variable that adds +1 to numberOfSymbolKind if there were a duplicate otherwise it's 0.
+        var newValue = countNumberOfSymbolKind(symbolKind.erRelation) + numberOfSymbolKind;
+
+        erRelationA.name = "Relation" + newValue;
         erRelationA.topLeft = p1;
         erRelationA.bottomRight = p2;
         erRelationA.centerPoint = p3;
@@ -3310,10 +3352,10 @@ function mouseupevt(ev) {
 }
 
 function countNumberOfSymbolKind(kind) {
-  let numberOfSymbolKind = 0;
+  var numberOfSymbolKind = 0;
   for(let i = 0; i < diagram.length; i++){
     if(diagram[i].symbolkind == kind) {
-      numberOfSymbolKind++;
+        numberOfSymbolKind++;
     }
   }
   return numberOfSymbolKind;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3167,16 +3167,7 @@ function mouseupevt(ev) {
 
     if (uimode == "CreateClass" && md == mouseState.boxSelectOrCreateMode) {
         var classB = new Symbol(symbolKind.uml); // UML
-        var numberOfSymbolKind = 0;
-        for(let i = 0; i < diagram.length; i++){
-            //Checks for duplicates with the same number and adds +1 to it.
-            if (diagram[i].name == "New" + countNumberOfSymbolKind(symbolKind.uml)) {
-                numberOfSymbolKind = 1;
-            }
-        }
-        //Variable that adds +1 to numberOfSymbolKind if there were a duplicate otherwise it's 0.
-        var newValue = countNumberOfSymbolKind(symbolKind.uml) + numberOfSymbolKind;
-
+        let newValue = checkDuplicate("New", symbolKind.uml);
         classB.name = "New" + newValue;
         classB.operations.push({text:"- makemore()"});
         classB.attributes.push({text:"+ height:Integer"});
@@ -3191,16 +3182,7 @@ function mouseupevt(ev) {
         diagramObject = diagram[lastSelectedObject];
     } else if (uimode == "CreateERAttr" && md == mouseState.boxSelectOrCreateMode) {
         erAttributeA = new Symbol(symbolKind.erAttribute); // ER attributes
-        var numberOfSymbolKind = 0;
-        for(let i = 0; i < diagram.length; i++){
-            //Checks for duplicates with the same number and adds +1 to it.
-            if (diagram[i].name == "Attr" + countNumberOfSymbolKind(symbolKind.erAttribute)) {
-                numberOfSymbolKind = 1;
-            }
-        }
-        //Variable that adds +1 to numberOfSymbolKind if there were a duplicate otherwise it's 0.
-        var newValue = countNumberOfSymbolKind(symbolKind.erAttribute) + numberOfSymbolKind;
-
+        let newValue = checkDuplicate("Attr", symbolKind.erAttribute);
         erAttributeA.name = "Attr" + newValue;
         erAttributeA.topLeft = p1;
         erAttributeA.bottomRight = p2;
@@ -3214,17 +3196,7 @@ function mouseupevt(ev) {
         diagramObject = diagram[lastSelectedObject];
     } else if (uimode == "CreateEREntity" && md == mouseState.boxSelectOrCreateMode) {
         erEnityA = new Symbol(symbolKind.erEntity); // ER entity
-
-        var numberOfSymbolKind = 0;
-        for(let i = 0; i < diagram.length; i++){
-            //Checks for duplicates with the same number and adds +1 to it.
-            if (diagram[i].name == "Entity" + countNumberOfSymbolKind(symbolKind.erEntity)) {
-                numberOfSymbolKind = 1;
-            }
-        }
-        //Variable that adds +1 to numberOfSymbolKind if there were a duplicate otherwise it's 0.
-        var newValue = countNumberOfSymbolKind(symbolKind.erEntity) + numberOfSymbolKind;
-
+        let newValue = checkDuplicate("Entity", symbolKind.erEntity);
         erEnityA.name = "Entity" + newValue;;
         erEnityA.topLeft = p1;
         erEnityA.bottomRight = p2;
@@ -3265,17 +3237,7 @@ function mouseupevt(ev) {
         }
     } else if (uimode == "CreateERRelation" && md == mouseState.boxSelectOrCreateMode) {
         erRelationA = new Symbol(symbolKind.erRelation); // ER Relation
-
-        var numberOfSymbolKind = 0;
-        for(let i = 0; i < diagram.length; i++){
-            //Checks for duplicates with the same number and adds +1 to it.
-            if (diagram[i].name == "Relation" + countNumberOfSymbolKind(symbolKind.erRelation)) {
-                numberOfSymbolKind = 1;
-            }
-        }
-        //Variable that adds +1 to numberOfSymbolKind if there were a duplicate otherwise it's 0.
-        var newValue = countNumberOfSymbolKind(symbolKind.erRelation) + numberOfSymbolKind;
-
+        let newValue = checkDuplicate("Entity", symbolKind.erRelation);
         erRelationA.name = "Relation" + newValue;
         erRelationA.topLeft = p1;
         erRelationA.bottomRight = p2;
@@ -3828,4 +3790,16 @@ function changeLineDirection() {
 //Close the errorMessageDialog for Composite
 function closeErrorMessageDialog() {
     $("#errorMessageDialog").hide();
+}
+
+//Checks if there are any duplicates of entities with the same name.
+function checkDuplicate(name, kind) {
+    var numberOfSymbolKind = 0;
+    for(let i = 0; i < diagram.length; i++) {
+        //Checks for duplicates with the same number and adds +1 to it.
+        if (diagram[i].name == name + countNumberOfSymbolKind(kind)) {
+            numberOfSymbolKind = 1;
+        }
+    }
+    return countNumberOfSymbolKind(kind) + numberOfSymbolKind;
 }


### PR DESCRIPTION
If you delete an object and add a new one it's not one with a duplicated name as it was before. It does not reuse numbers it only adds +1 to so there are no duplicates. This works on all objects.

_This is a partial fix of issue #6724 as all requirements are not done and couldn't solve the re-usage of deleted entities as it was complex._


