### PR TITLE
Added .rar files to allowed file extensions

### DIFF
--- a/DuggaSys/filereceive_dugga.php
+++ b/DuggaSys/filereceive_dugga.php
@@ -280,7 +280,7 @@ if($ha){
 				$allowedExtensions = [
 					"pdf"		=> ["application/pdf"],
 					"zip"		=> ["application/zip"],
-					//"rar"	=> [
+					"rar"		=> ["application/x-rar"]
 				];
 
 				$swizzled = swizzleArray($_FILES['uploadedfile']);


### PR DESCRIPTION
Fix #6895 
Now possible to upload .rar files

Test with the Rapport template