### PR TITLE
Fix for #6788: Gray out options correctly in view menu

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1710,7 +1710,9 @@ function developerMode(event) {
         toolbarState = 3;                                                               // Change the toolbar to DEV.
         switchToolbarDev();                                                             // ---||---
         document.getElementById('toolbarTypeText').innerHTML = 'Mode: DEV';             // Change the text to DEV.
-        $("#displayAllTools").toggleClass("drop-down-item drop-down-item-disabled");    // Remove disable of displayAllTools id.
+        $("#displayAllTools").removeClass("drop-down-item drop-down-item-disabled");    // Remove disable of displayAllTools id.
+        $("#er-item").addClass("drop-down-item drop-down-item-disabled");               // Disable ER and UML options
+        $("#uml-item").addClass("drop-down-item drop-down-item-disabled");
         setCheckbox($(".drop-down-option:contains('ER')"), crossER=false);              // Turn off crossER.
         setCheckbox($(".drop-down-option:contains('UML')"), crossUML=false);            // Turn off crossUML.
         setCheckbox($(".drop-down-option:contains('Display All Tools')"),
@@ -1723,7 +1725,9 @@ function developerMode(event) {
         toolbarState = 1;                                                               // Change the toolbar back to ER.
         switchToolbar('ER');                                                            // ---||---
         document.getElementById('toolbarTypeText').innerHTML = 'Mode: ER';              // Change the text to ER.
-        $("#displayAllTools").toggleClass("drop-down-item drop-down-item-disabled");    // Add disable of displayAllTools id.
+        $("#displayAllTools").addClass("drop-down-item drop-down-item-disabled");       // Add disable of displayAllTools id.
+        $("#er-item").removeClass("drop-down-item drop-down-item-disabled");            // Disable ER and UML options
+        $("#uml-item").removeClass("drop-down-item drop-down-item-disabled");
         setCheckbox($(".drop-down-option:contains('UML')"), crossUML=false);            // Turn off crossUML.
         setCheckbox($(".drop-down-option:contains('Display All Tools')"),
             crossDEV=false);                                                            // Turn off crossDEV.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1101,17 +1101,25 @@ function toggleVirtualA4(event) {
     if (toggleA4) {
         // A4 is disabled
         toggleA4 = false;
+
+        $("#a4-holes-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#a4-orientation-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#a4-holes-item-right").addClass("drop-down-item drop-down-item-disabled");
         hideA4State();
         updateGraphics();
     } else {
         toggleA4 = true;
+        $("#a4-holes-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#a4-orientation-item").removeClass("drop-down-item drop-down-item-disabled");
+        if (toggleA4Holes) {
+            $("#a4-holes-item-right").removeClass("drop-down-item drop-down-item-disabled");
+        }else {
+            $("#a4-holes-item-right").addClass("drop-down-item drop-down-item-disabled");
+        }
         showA4State();
         updateGraphics();
     }
-    $("#a4-holes-item").toggleClass("drop-down-item drop-down-item-disabled");
-    setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
 
-    $("#a4-orientation-item").toggleClass("drop-down-item drop-down-item-disabled");
     setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
 
 }
@@ -1242,6 +1250,11 @@ function showA4State(){
     setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), true);
     switchSideA4Holes = "left";
     setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), switchSideA4Holes == "right");
+
+    // Show A4 options
+    $("#a4-orientation-item").removeClass("drop-down-item drop-down-item-disabled");
+    $("#a4-holes-item").removeClass("drop-down-item drop-down-item-disabled");
+    $("#a4-holes-item-right").addClass("drop-down-item drop-down-item-disabled");
 }
 
 function hideA4State(){
@@ -1253,8 +1266,12 @@ function hideA4State(){
     setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), false);
     setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), toggleA4Holes);
     setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), switchSideA4Holes == "right");
-    $("#a4-holes-item-right").toggleClass("drop-down-item drop-down-item-disabled");
     setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
+
+    // Grey out disabled options
+    $("#a4-orientation-item").addClass("drop-down-item drop-down-item-disabled");
+    $("#a4-holes-item").addClass("drop-down-item drop-down-item-disabled");
+    $("#a4-holes-item-right").addClass("drop-down-item drop-down-item-disabled");
 }
 
 function toggleVirtualA4Holes() {
@@ -1262,13 +1279,13 @@ function toggleVirtualA4Holes() {
     if (toggleA4Holes) {
         toggleA4Holes = false;
         setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), toggleA4Holes);
-        $("#a4-holes-item-right").toggleClass("drop-down-item drop-down-item-disabled");
+        $("#a4-holes-item-right").addClass("drop-down-item drop-down-item-disabled");
         setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
         updateGraphics();
     } else {
         toggleA4Holes = true;
         setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), toggleA4Holes);
-        $("#a4-holes-item-right").toggleClass("drop-down-item drop-down-item-disabled");
+        $("#a4-holes-item-right").removeClass("drop-down-item drop-down-item-disabled");
         setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
         updateGraphics();
     }
@@ -1694,8 +1711,6 @@ function developerMode(event) {
         switchToolbarDev();                                                             // ---||---
         document.getElementById('toolbarTypeText').innerHTML = 'Mode: DEV';             // Change the text to DEV.
         $("#displayAllTools").toggleClass("drop-down-item drop-down-item-disabled");    // Remove disable of displayAllTools id.
-        setCheckbox($(".drop-down-option:contains('Display Virtual A4')"),
-            toggleA4=false);                                                            // Turn off crosstoggleA4.
         setCheckbox($(".drop-down-option:contains('ER')"), crossER=false);              // Turn off crossER.
         setCheckbox($(".drop-down-option:contains('UML')"), crossUML=false);            // Turn off crossUML.
         setCheckbox($(".drop-down-option:contains('Display All Tools')"),

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1281,6 +1281,9 @@ function toggleVirtualA4Holes() {
         setCheckbox($(".drop-down-option:contains('Toggle A4 Holes')"), toggleA4Holes);
         $("#a4-holes-item-right").addClass("drop-down-item drop-down-item-disabled");
         setCheckbox($(".drop-down-option:contains('Display Virtual A4')"), toggleA4);
+
+        switchSideA4Holes = "left"; // Disable the 'A4 Holes Right' option
+        setCheckbox($(".drop-down-option:contains('A4 Holes Right')"), switchSideA4Holes == "right");
         updateGraphics();
     } else {
         toggleA4Holes = true;

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -202,10 +202,10 @@
                             <span class="drop-down-option" onclick="switchToolbarDev();"><img src="../Shared/icons/Arrow_down_right.png">Display All Tools</span>
                         </div>
                         <div class="drop-down-divider"></div>
-                        <div class="drop-down-item">
+                        <div id="er-item" class="drop-down-item">
                             <span class="drop-down-option" onclick="switchToolbarTo('ER');">ER</span>
                         </div>
-                        <div class="drop-down-item">
+                        <div id="uml-item" class="drop-down-item">
                             <span class="drop-down-option" onclick="switchToolbarTo('UML');">UML</span>
                         </div>
                         <div class="drop-down-divider"></div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1441,7 +1441,7 @@ input {
   cursor: default ;
 }
 
-#a4-holes-item.drop-down-item-disabled {
+.drop-down-item-disabled {
   opacity: 0.5;
   cursor: default ;
 }


### PR DESCRIPTION
I've tried to make the view options gray out correctly when disabled. I haven't fixed other issues like how you can still click on disabled options but that can be fixed in another issue or pull request. Because of that, the reviewer should ignore problems relating to clicking on disabled options. 

This PR makes the ER/UML options gray out when entering dev-mode and should make the A4 options gray out correctly. 