### PR TITLE
Grupp a2019 w20 - Toolbar options in the wrong position #6882

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -62,60 +62,58 @@
                           </div>
                           <div class="toolsContainer">
                             <div class="labelToolContainer">
-                              <h4 class="label tlabel" id="labelTools">Tools</h4>
-                              <div class="toolbar-drawer" id="drawerTools">
-                                  <div class="tooltipdialog">
-                                      <button id='linebutton' onclick='setMode("CreateLine");' class='buttonsStyle unpressed toolbarButtonPressed' data="Create Line">
-                                          <img class="toolboxButtons" src="../Shared/icons/diagram_create_line.svg">
-                                      </button>
-                                  </div>
-                              </div>
+                                <h4 class="label tlabel" id="labelTools">Tools</h4>
+                                <div class="toolbar-drawer" id="drawerCreate">
+                                    <div class="tooltipdialog">
+                                        <!-- ER attribute -->
+                                        <button id='attributebutton' onclick='setMode("CreateERAttr");' style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Create Attribute">
+                                            <img class="toolboxButtons" src="../Shared/icons/diagram_create_attribute.svg">
+                                        </button>
+                                        <!-- ER entity -->
+                                        <button id='entitybutton' onclick='setMode("CreateEREntity");' style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Create Entity">
+                                            <img class="toolboxButtons" src="../Shared/icons/diagram_create_entity.svg">
+                                        </button>
+                                        <!-- ER Relation -->
+                                        <button id='relationbutton' onclick='setMode("CreateERRelation");' style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Create Relation">
+                                            <img class="toolboxButtons" src="../Shared/icons/diagram_create_relation.svg">
+                                        </button>
+                                        <!-- UML Create Class -->
+                                        <button id='classbutton' onclick='setMode("CreateClass");' style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Create Class">
+                                            <img class="toolboxButtons" src="../Shared/icons/diagram_create_class.svg">
+                                        </button>
+                                        <!-- Create Text -->
+                                        <button id='drawtextbutton' onclick="setMode('Text');" style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Draw Text">
+                                            <img id='textButton' src="../Shared/icons/textbox.svg" style="filter: invert(100%);">
+                                        </button>
+                                        <!-- Create Line -->
+                                        <button id='linebutton' onclick='setMode("CreateLine");' class='buttonsStyle unpressed' data="Create Line">
+                                            <img class="toolboxButtons" src="../Shared/icons/diagram_create_line.svg">
+                                        </button>
+                                        <!-- Create Square -->
+                                        <button id='squarebutton' onclick="setMode('Square');" style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Draw Square">
+                                            <img class="toolboxButtons" src="../Shared/icons/diagram_draw_square.svg">
+                                        </button>
+                                        <!-- Draw Free -->
+                                        <button id='drawfreebutton' onclick="setMode('Free');" style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Draw Free">
+                                            <img class="toolboxButtons" src="../Shared/icons/diagram_draw_free.svg">
+                                        </button>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="labelToolContainer">
-                              <h4 class="label tlabel" id="labelCreate">Create</h4>
-                              <div class="toolbar-drawer" id="drawerCreate">
-                                  <div class="tooltipdialog">
-                                      <button id='attributebutton' onclick='setMode("CreateERAttr");' class='buttonsStyle unpressed toolbarButtonPressed' data="Create Attribute">
-                                          <img class="toolboxButtons" src="../Shared/icons/diagram_create_attribute.svg">
-                                      </button>
-                                      <button id='entitybutton' onclick='setMode("CreateEREntity");' class='buttonsStyle unpressed toolbarButtonPressed' data="Create Entity">
-                                          <img class="toolboxButtons" src="../Shared/icons/diagram_create_entity.svg">
-                                      </button>
-                                      <button id='relationbutton' onclick='setMode("CreateERRelation");' class='buttonsStyle unpressed toolbarButtonPressed' data="Create Relation">
-                                          <img class="toolboxButtons" src="../Shared/icons/diagram_create_relation.svg">
-                                      </button>
-                                      <button id='classbutton' onclick='setMode("CreateClass");' class='buttonsStyle unpressed toolbarButtonPressed' data="Create Class">
-                                          <img class="toolboxButtons" src="../Shared/icons/diagram_create_class.svg">
+                            <div class="labelToolContainer" style = "margin-bottom: 0px;">
+                                <h4 class="label tlabel" id="labelUndo">Undo/Redo</h4>
+                                <div class="toolbar-drawer" id="drawerUndo">
+                                    <!-- Undo -->
+                                    <button class="diagramAction" id="undoButton" onclick='undoDiagram(event)' data="Undo">
+                                        <img src="../Shared/icons/undo.svg" style="filter: invert(100%); text-align: center; margin-left: -15px; margin-right: -15px; width: 17px; height: 17px;">
                                     </button>
-                                      <button id='drawtextbutton' onclick="setMode('Text');" class='buttonsStyle unpressed toolbarButtonPressed' data="Draw Text">
-                                          <img id='textButton' src="../Shared/icons/textbox.svg" style="filter: invert(100%);">
-                                      </button>
-                                  </div>
-                              </div>
-                            </div>
-                          <div class="labelToolContainer">
-                            <h4 class="label tlabel" id="labelDraw">Draw</h4>
-                            <div class="toolbar-drawer" id="drawerDraw">
-                                <button id='squarebutton' onclick="setMode('Square');" class='buttonsStyle unpressed toolbarButtonPressed' data="Draw Square">
-                                    <img class="toolboxButtons" src="../Shared/icons/diagram_draw_square.svg">
-                                </button>
-                                <button id='drawfreebutton' onclick="setMode('Free');" class='buttonsStyle unpressed toolbarButtonPressed' data="Draw Free">
-                                    <img class="toolboxButtons" src="../Shared/icons/diagram_draw_free.svg">
-                                </button>
-                            </div>
-                          </div>
-                          <div class="labelToolContainer" style = "margin-bottom: 0px;">
-                            <h4 class="label tlabel" id="labelUndo">Undo/Redo</h4>
-                            <div class="toolbar-drawer" id="drawerUndo">
-                                <button class="diagramAction" id="undoButton" onclick='undoDiagram(event)' data="Undo">
-                                    <img src="../Shared/icons/undo.svg" style="filter: invert(100%); text-align: center; margin-left: -15px; margin-right: -15px; width: 17px; height: 17px;">
-                                </button>
-                                <button class="diagramAction" id="redoButton" onclick='redoDiagram(event)' data="Redo">
-                                    <img src="../Shared/icons/redo.svg" style="filter: invert(100%); text-align: center; margin-left: -15px; margin-right: -15px; width: 17px; height: 17px;">
-                                </button>
+                                    <!-- Redo -->
+                                    <button class="diagramAction" id="redoButton" onclick='redoDiagram(event)' data="Redo">
+                                        <img src="../Shared/icons/redo.svg" style="filter: invert(100%); text-align: center; margin-left: -15px; margin-right: -15px; width: 17px; height: 17px;">
+                                    </button>
+                                </div>
                             </div>
                         </div>
-                      </div>
                     </div>
                 </div>
                 <div class="menu-drop-down">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -89,10 +89,6 @@
                                         <button id='linebutton' onclick='setMode("CreateLine");' class='buttonsStyle unpressed' data="Create Line">
                                             <img class="toolboxButtons" src="../Shared/icons/diagram_create_line.svg">
                                         </button>
-                                        <!-- Create Square -->
-                                        <button id='squarebutton' onclick="setMode('Square');" style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Draw Square">
-                                            <img class="toolboxButtons" src="../Shared/icons/diagram_draw_square.svg">
-                                        </button>
                                         <!-- Draw Free -->
                                         <button id='drawfreebutton' onclick="setMode('Free');" style="display: inline; border-radius: 5px; cursor: pointer;" class='buttonsStyle unpressed' data="Draw Free">
                                             <img class="toolboxButtons" src="../Shared/icons/diagram_draw_free.svg">


### PR DESCRIPTION
#6882 
The toolbar labels are now removed and the buttons are ordered in the correct manner, as illustrated by a17vikab
Note that the 'draw square' button is removed since it will no longer be used