### PR TITLE
Fixed changing font size in codeviewer  - Grupp c2019 w20 6925

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -174,9 +174,6 @@ function returned(data)
 			$("#box"+boxid).css("font-size", retData['box'][boxid-1][6] + "px");
 		}else if(boxtype === "DOCUMENT"){
 
-			// set font size
-			$("#box"+boxid).css("font-size", retData['box'][boxid-1][6] + "px");
-
 			// Print out description in a document box
 			$("#"+contentid).removeClass("codebox").addClass("descbox");
 			var desc = boxcontent;
@@ -204,6 +201,10 @@ function returned(data)
 			$("#"+contentid).html(desc);
 			$("#"+contentid).css("margin-top", boxmenuheight);
 			createboxmenu(contentid,boxid,boxtype);
+
+				// set font size
+				$("#box"+boxid).css("font-size", retData['box'][boxid-1][6] + "px");
+				
 			// Make room for the menu by setting padding-top equals to height of menubox
 			if($("#"+contentid+"menu").height() == null){
 				boxmenuheight = 0;

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -173,6 +173,10 @@ function returned(data)
 			// set font size
 			$("#box"+boxid).css("font-size", retData['box'][boxid-1][6] + "px");
 		}else if(boxtype === "DOCUMENT"){
+
+			// set font size
+			$("#box"+boxid).css("font-size", retData['box'][boxid-1][6] + "px");
+
 			// Print out description in a document box
 			$("#"+contentid).removeClass("codebox").addClass("descbox");
 			var desc = boxcontent;

--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -29,7 +29,7 @@
 		<link type="text/css" href="../Shared/css/whiteTheme.css" rel="stylesheet" />
 		<link type="text/css" href="../Shared/css/codeviewer.css" rel="stylesheet" />
 		<link type="text/css" href="../Shared/css/markdown.css" rel="stylesheet" />
-		<link rel="shortcut icon" href="../Shared/icons/placeholder.ico"/>
+		<link rel="shortcut icon" href="../Shared/icons/favico.ico"/>
 		<script type="text/javascript" src="../Shared/js/jquery-1.11.0.min.js"></script>
 		<script type="text/javascript" src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
 		<script type="text/javascript" src="../Shared/dugga.js"></script>

--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -29,7 +29,7 @@
 		<link type="text/css" href="../Shared/css/whiteTheme.css" rel="stylesheet" />
 		<link type="text/css" href="../Shared/css/codeviewer.css" rel="stylesheet" />
 		<link type="text/css" href="../Shared/css/markdown.css" rel="stylesheet" />
-		<link rel="shortcut icon" href="../Shared/icons/favico.ico"/>
+		<link rel="shortcut icon" href="../Shared/icons/placeholder.ico"/>
 		<script type="text/javascript" src="../Shared/js/jquery-1.11.0.min.js"></script>
 		<script type="text/javascript" src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
 		<script type="text/javascript" src="../Shared/dugga.js"></script>


### PR DESCRIPTION
Previously when changing font size for a document nothing happened when changing since the code did not exists. Added the code for it and it seems to be working.

You can test this by going in to the course "Packningsbyte på om606 med Bosse bildoktorn" and then the codeviewer dugga (or creating it yourself somewhere else.)

Small and big text
![image](https://user-images.githubusercontent.com/49199993/57608677-b16b6000-756d-11e9-8524-70ad8b4ac4ff.png)
