### PR TITLE
Fixed issue #6224: Tooltip for position of an entity (new branch)

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1953,7 +1953,12 @@ function reWrite() {
          + Math.round((zoomValue * 100)) + "%" + " </p>";
         document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
          + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " )</p>";
+         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) </p>";
+    if(hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free"){
+      var contentToAdd = document.createTextNode(" | Center coordinates of hovered object: X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y));
+      document.getElementById("valuesCanvas").appendChild(contentToAdd);
+      //document.getElementById("valuesCanvas").innerHTML += " | Center coordinates of hovered object: X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
+    }
     } else {
         document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
          + Math.round((zoomValue * 100)) + "%" + "   </p>";
@@ -2669,7 +2674,7 @@ function mousemoveevt(ev, t) {
                     if(sel.attachedSymbol.symbolkind == symbolKind.line || sel.attachedSymbol.symbolkind == symbolKind.umlLine) {
                         //The point belongs to a umlLine or Line
                         canvas.style.cursor = "pointer";
-                    } else {                    
+                    } else {
                         canvas.style.cursor = "url('../Shared/icons/hand_move.cur'), auto";
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1959,7 +1959,7 @@ function reWrite() {
        + Math.round((zoomValue * 100)) + "%" + " </p>";
       document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
        + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-       + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " | Center coordinates of hovered object: X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
+       + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
     }
     } else {
         document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1955,9 +1955,11 @@ function reWrite() {
          + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
          + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) </p>";
     if(hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free"){
-      var contentToAdd = document.createTextNode(" | Center coordinates of hovered object: X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y));
-      document.getElementById("valuesCanvas").appendChild(contentToAdd);
-      //document.getElementById("valuesCanvas").innerHTML += " | Center coordinates of hovered object: X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
+      document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
+       + Math.round((zoomValue * 100)) + "%" + " </p>";
+      document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
+       + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
+       + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " | Center coordinates of hovered object: X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
     }
     } else {
         document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -247,7 +247,7 @@ function Symbol(kindOfSymbol) {
 
             //only when object is created: changes position of points so that object is created from center point instead of topleft
             if(this.pointsAtSamePosition) {
-                //change all 3 points 0,5 * template width/height to the left/up to move object to mouse position  
+                //change all 3 points 0,5 * template width/height to the left/up to move object to mouse position
                 for (var i = this.topLeft; i <= this.centerPoint; i++) {
                     //entity and attribute template is the same size so either should work fine
                     points[i].x -= entityTemplate.width * 0.5;
@@ -311,7 +311,7 @@ function Symbol(kindOfSymbol) {
             }
             //only when object is created: changes position of points so that object is positioned from center point instead of topleft
             if(this.pointsAtSamePosition) {
-                //change all 3 points 0,5 * min width/height to the left/up to move object to mouse position  
+                //change all 3 points 0,5 * min width/height to the left/up to move object to mouse position
                 for (var i = this.topLeft; i <= this.centerPoint; i++) {
                     points[i].x -= this.minWidth * 0.5;
                     points[i].y -= this.minHeight * 0.5;
@@ -353,7 +353,7 @@ function Symbol(kindOfSymbol) {
 
             //only when object is created: changes position of points so that object is positioned from center point instead of topleft
             if(this.pointsAtSamePosition) {
-                //change all 3 points 0,5 * template width/height to the left/up to move object to mouse position  
+                //change all 3 points 0,5 * template width/height to the left/up to move object to mouse position
                 for (var i = this.topLeft; i <= this.centerPoint; i++) {
                     points[i].x -= relationTemplate.width * 0.5;
                     points[i].y -= relationTemplate.height * 0.5;
@@ -928,6 +928,10 @@ function Symbol(kindOfSymbol) {
             }
         }
 
+        if(this.isHovered && this.symbolkind != symbolKind.umlLine && this.symbolkind != symbolKind.line){
+          this.drawCenterCoordinatesTooltip();
+        }
+
         ctx.save();
 
         ctx.textAlign = "center";
@@ -1378,7 +1382,7 @@ function Symbol(kindOfSymbol) {
 
         ctx.lineWidth = this.properties['lineWidth'] * diagram.getZoomValue();
 
-        // Set as dotted lines depending on value  
+        // Set as dotted lines depending on value
         if (this.properties['key_type'] == "Implementation" || this.properties['key_type'] == "Dependency") {
             ctx.setLineDash([10, 10]);
         }
@@ -1504,13 +1508,13 @@ function Symbol(kindOfSymbol) {
         }
         ctx.lineTo(x2, y2);
         ctx.stroke();
-        
+
         this.drawUmlRelationLines(x1,y1,x2,y2, startLineDirection, endLineDirection);
     }
 
     //---------------------------------------------------------------
-    // drawUmlRelationLineFigures: Draw arrow or diamond shape 
-    // depending on linetype at one of the connected uml objects    
+    // drawUmlRelationLineFigures: Draw arrow or diamond shape
+    // depending on linetype at one of the connected uml objects
     //---------------------------------------------------------------
     this.drawUmlRelationLines = function(x1, y1, x2, y2, startLineDirection, endLineDirection) {
         // set start position to the right object line start
@@ -1519,7 +1523,7 @@ function Symbol(kindOfSymbol) {
             linePositions = { x:x2, y:y2 };
         }
         ctx.setLineDash([0]);
-        
+
         var type;
 
         // arrow filled
@@ -1561,7 +1565,7 @@ function Symbol(kindOfSymbol) {
             if (endLineDirection == "down"){
                 this.drawUmlLineRelation(linePositions.x, linePositions.y, xChange, yChange, true, type);
             } else if (endLineDirection == "left") {
-                this.drawUmlLineRelation(linePositions.x, linePositions.y, -yChange, -xChange, false, type);              
+                this.drawUmlLineRelation(linePositions.x, linePositions.y, -yChange, -xChange, false, type);
             } else if (endLineDirection == "right") {
                 this.drawUmlLineRelation(linePositions.x, linePositions.y, yChange, xChange, false, type);
             } else if (endLineDirection == "up") {
@@ -1593,9 +1597,9 @@ function Symbol(kindOfSymbol) {
         if (vertical) {
             ctx.lineTo(x, y + yC * 2);
             ctx.lineTo(x - xC, y + yC);
-        } else { 
+        } else {
             ctx.lineTo(x + xC * 2, y);
-            ctx.lineTo(x + xC, y - yC); 
+            ctx.lineTo(x + xC, y - yC);
         }
         ctx.closePath();
         ctx.stroke();
@@ -1618,8 +1622,8 @@ function Symbol(kindOfSymbol) {
         }
         if (vertical) {
             ctx.lineTo(x - xC, y + yC);
-        } else { 
-            ctx.lineTo(x + xC, y - yC); 
+        } else {
+            ctx.lineTo(x + xC, y - yC);
         }
         ctx.closePath();
         ctx.stroke();
@@ -1988,11 +1992,11 @@ function Symbol(kindOfSymbol) {
         var y1 = points[this.topLeft].y;
         var x2 = points[this.bottomRight].x;
         var y2 = points[this.bottomRight].y;
-        
+
         var offset = 10;
 
         return {
-            x: pixelsToCanvas(x2 + offset).x, 
+            x: pixelsToCanvas(x2 + offset).x,
             y: pixelsToCanvas(0, (y2 - (y2-y1)/2)).y};
     }
 
@@ -2005,7 +2009,7 @@ function Symbol(kindOfSymbol) {
         ctx.lineWidth = 1 * diagram.getZoomValue();
         //Draws the upper part of the lock
         ctx.beginPath();
-        //A slight x offset to get the correct position   
+        //A slight x offset to get the correct position
         ctx.arc(position.x + (5 * diagram.getZoomValue()), position.y, 4 * diagram.getZoomValue(), 1 * Math.PI, 2 * Math.PI);
         ctx.stroke();
         ctx.closePath();
@@ -2033,6 +2037,29 @@ function Symbol(kindOfSymbol) {
         ctx.fillText("Entity position is locked", position.x, position.y + offset);
 
         ctx.restore();
+    }
+
+    this.drawCenterCoordinatesTooltip = function() {
+      ctx.save();
+
+      var topLeftPosition = pixelsToCanvas(points[this.topLeft].x, points[this.topLeft].y);
+      var centerPosition = pixelsToCanvas(points[this.centerPoint].x, points[this.centerPoint].y);
+      var widthOfObject = points[this.bottomRight].x - points[this.topLeft].x;
+
+      var xPosition = 230;
+      var yPosition = 805;
+
+      ctx.fillStyle = "#00000";
+      ctx.fillRect(xPosition, yPosition, 300, 30);
+
+      var yOffset = 17;
+      var xOffset = 135;
+      ctx.fillStyle = "black";
+      ctx.font = "bold 14px Arial";
+      ctx.textAlign = "center";
+      ctx.fillText("Center coordinates of object: " + "X=" + Math.round(points[this.centerPoint].x) + " & " + "Y=" + Math.round(points[this.centerPoint].y), xPosition + xOffset, yPosition + yOffset);
+
+      ctx.restore();
     }
 }
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -928,7 +928,7 @@ function Symbol(kindOfSymbol) {
             }
         }
 
-        if(this.isHovered && this.symbolkind != symbolKind.umlLine && this.symbolkind != symbolKind.line){
+        if(this.isHovered && this.symbolkind != symbolKind.umlLine && this.symbolkind != symbolKind.line && developerModeActive){
           this.drawCenterCoordinatesTooltip();
         }
 
@@ -2046,8 +2046,8 @@ function Symbol(kindOfSymbol) {
       var centerPosition = pixelsToCanvas(points[this.centerPoint].x, points[this.centerPoint].y);
       var widthOfObject = points[this.bottomRight].x - points[this.topLeft].x;
 
-      var xPosition = 230;
-      var yPosition = 805;
+      var xPosition = canvas.width / 2 - 175;
+      var yPosition = canvas.height - 30;
 
       ctx.fillStyle = "#00000";
       ctx.fillRect(xPosition, yPosition, 300, 30);

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -928,10 +928,6 @@ function Symbol(kindOfSymbol) {
             }
         }
 
-        if(this.isHovered && this.symbolkind != symbolKind.umlLine && this.symbolkind != symbolKind.line && developerModeActive){
-          this.drawCenterCoordinatesTooltip();
-        }
-
         ctx.save();
 
         ctx.textAlign = "center";
@@ -2037,29 +2033,6 @@ function Symbol(kindOfSymbol) {
         ctx.fillText("Entity position is locked", position.x, position.y + offset);
 
         ctx.restore();
-    }
-
-    this.drawCenterCoordinatesTooltip = function() {
-      ctx.save();
-
-      var topLeftPosition = pixelsToCanvas(points[this.topLeft].x, points[this.topLeft].y);
-      var centerPosition = pixelsToCanvas(points[this.centerPoint].x, points[this.centerPoint].y);
-      var widthOfObject = points[this.bottomRight].x - points[this.topLeft].x;
-
-      var xPosition = canvas.width / 2 - 175;
-      var yPosition = canvas.height - 30;
-
-      ctx.fillStyle = "#00000";
-      ctx.fillRect(xPosition, yPosition, 300, 30);
-
-      var yOffset = 17;
-      var xOffset = 135;
-      ctx.fillStyle = "black";
-      ctx.font = "bold 14px Arial";
-      ctx.textAlign = "center";
-      ctx.fillText("Center coordinates of object: " + "X=" + Math.round(points[this.centerPoint].x) + " & " + "Y=" + Math.round(points[this.centerPoint].y), xPosition + xOffset, yPosition + yOffset);
-
-      ctx.restore();
     }
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1734,8 +1734,8 @@ div.submit-button:disabled {
 }
 
 .toolbarButtonPressed {
-  display: inline; 
-  border-radius: 5px; 
+  display: inline;
+  border-radius: 5px;
   cursor: pointer
 }
 


### PR DESCRIPTION
Issue: #6224 
Old pull-request that did not make it into the last merge: #6702 

I created a new pull-request for the new branch I made since I ran out of time to fix the issue on the other branch before the last merge. Therefore when this pull-request is approved, we can probably close the other one.

I placed the tooltip in the bottom left tooltip box where it already shows the coordinates for the mouse pointer. The tooltip for the position of an object only shows up when developer mode is enabled by request and when an object is actually being hovered over. The tooltip does not work for free draw objects right now, a lot of issues appeared when I tried to implement that. Let me know if I should try and get that fixed.