### PR TITLE
Adding db amount to interval

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -800,8 +800,8 @@ function returnedSection(data)
     str+="<tr>";
     str+="<td>GIT Commit</td>"
     str+="<td>"+data['commitrankno']+"</td>"
-    str+="<td style='background-color:"+intervaltocolor(41,data['commitrank'])+"'>"+data['commitrank']+"</td>";
-    str+="<td style='background-color:"+intervaltocolor(41,data['commitgrouprank'])+"'>"+data['commitgrouprank']+"</td>";
+    str+="<td style='background-color:"+intervaltocolor(data['amountInCourse'],data['commitrank'])+"'>"+data['commitrank']+"</td>";
+    str+="<td style='background-color:"+intervaltocolor(data['amountInGroups'],data['commitgrouprank'])+"'>"+data['commitgrouprank']+"</td>";
     str+="</tr>";
     str+="</table>";
 


### PR DESCRIPTION
Fixing issue #6973, commitranks are no longer hardcoded and get their amount value from the database.