### PR TITLE
Fix for #6963 Shortcut for clear diagram

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -100,11 +100,11 @@
                                 <h4 class="label tlabel" id="labelUndo">Undo/Redo</h4>
                                 <div class="toolbar-drawer" id="drawerUndo">
                                     <!-- Undo -->
-                                    <button class="diagramAction" id="undoButton" onclick='undoDiagram(event)' data="Undo">
+                                    <button class="diagramAction" id="undoButton" onclick='undoDiagram(event)' data="Undo (Ctrl + Z)">
                                         <img src="../Shared/icons/undo.svg" style="filter: invert(100%); text-align: center; margin-left: -15px; margin-right: -15px; width: 17px; height: 17px;">
                                     </button>
                                     <!-- Redo -->
-                                    <button class="diagramAction" id="redoButton" onclick='redoDiagram(event)' data="Redo">
+                                    <button class="diagramAction" id="redoButton" onclick='redoDiagram(event)' data="Redo (Ctrl + Y)">
                                         <img src="../Shared/icons/redo.svg" style="filter: invert(100%); text-align: center; margin-left: -15px; margin-right: -15px; width: 17px; height: 17px;">
                                     </button>
                                 </div>
@@ -143,6 +143,7 @@
                         <div class="drop-down-divider"></div>
                         <div class="drop-down-item">
                             <span class="drop-down-option" onclick='clearCanvas(); removeLocalStorage();'>Clear Diagram</span>
+                            <i id="hotkey-clear">Ctrl + A, Delete</i>
                         </div>
                     </div>
                 </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1469,45 +1469,43 @@ input {
   top: 100px;
 }
 
-.drop-down-item #hotkey-undo {
-  position: absolute  ;
-  font-size: 11px ;
+#hotkey-undo, #hotkey-redo, #hotkey-clear, #hotkey-front, #hotkey-back, #hotkey-developerMode, #hotkey-ER, #hotkey-UML {
+  position: absolute;
+  font-size: 11px;
   color: #3d3d3d;
+}
+
+.drop-down-item #hotkey-undo {
   right: 6px ;
   top: 10px;
 }
 .drop-down-item #hotkey-redo {
-  position: absolute ;
-  font-size: 11px ;
-  color: #3d3d3d;
   right: 6px ;
   top: 45px;
 }
 
-#hotkey-front, #hotkey-back, #hotkey-developerMode, #hotkey-ER, #hotkey-UML {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
-  right: 35px;
-}
-
-#hotkey-front {
+#hotkey-clear, #hotkey-front {
+  right: 6px ;
   top: 165px;
 }
 
 #hotkey-back {
+  right: 6px ;
   top: 195px;
 }
 
 #hotkey-developerMode{
+    right: 35px;
     top: 10px;
 }
 
 #hotkey-ER {
+  right: 35px;
   top: 85px;
 }
 
 #hotkey-UML {
+  right: 35px;
   top: 120px;
 }
 


### PR DESCRIPTION
#6963 Tool tip for "Clear diagram" added according to the comment from the supreme leader.