### PR TITLE
Filter for duggas sumbitted after deadline

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -764,7 +764,6 @@ function deadlineFilterHandler() {
 
 function renderCell(col, celldata, cellid) {
 	gradeFilterHandler();
-	console.log(celldata.deadline);
 	
 	// Render minimode
 	if (filterList["minimode"]) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -798,9 +798,7 @@ function renderCell(col, celldata, cellid) {
 					str += "dugga-pending-late-submission";
 				} 
 				str += "'>";
-				// Creation of grading buttons
-				console.log(celldata.ishere);
-				
+				// Creation of grading buttons		
 				if (celldata.kind != 4 && celldata.needMarking == true && celldata.submitted > celldata.deadline) {
 					str += "<div class='gradeContainer resultTableText'>";
 					if (celldata.grade === null) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -798,9 +798,56 @@ function renderCell(col, celldata, cellid) {
 					str += "dugga-pending-late-submission";
 				} 
 				str += "'>";
-				str += "</div>";
+				// Creation of grading buttons
+				if (celldata.ishere === true || celldata.kind == 4) {
+					str += "<div class='gradeContainer resultTableText'>";
+					if (celldata.grade === null) {
+						str += makeSelect(celldata.gradeSystem, querystring['cid'], celldata.vers, celldata.lid, celldata.uid, celldata.grade, 'I', celldata.qvariant, celldata.quizId);
+					} else if (celldata.grade === -1) {
+						str += makeSelect(celldata.gradeSystem, querystring['cid'], celldata.vers, celldata.lid, celldata.uid, celldata.grade, 'IFeedback', celldata.qvariant, celldata.quizId);
+					} else {
+						str += makeSelect(celldata.gradeSystem, querystring['cid'], celldata.vers, celldata.lid, celldata.uid, celldata.grade, 'U', celldata.qvariant, celldata.quizId);
+					}
+					str += "<img id='korf' class='fist";
+					if (celldata.userAnswer === null && !(celldata.quizfile == "feedback_dugga")) { // Always shows fist. Should be re-evaluated
+						str += " grading-hidden";
+					}
+					str += "' src='../Shared/icons/FistV.png' onclick='clickResult(\"" + querystring['cid'] + "\",\"" + celldata.vers + "\",\"" + celldata.lid + "\",\"" + celldata.quizfile + "\",\"" + celldata.firstname + "\",\"" + celldata.lastname + "\",\"" + celldata.uid + "\",\"" + celldata.submitted + "\",\"" + celldata.marked + "\",\"" + celldata.grade + "\",\"" + celldata.gradeSystem + "\",\"" + celldata.lid + "\",\"" + celldata.qvariant + "\",\"" + celldata.quizId + "\",\"" + celldata.entryname + "\");'";
+					str += "/>";
+					//Print times graded
+					str += "<div class='text-center resultTableText WriteOutTimesGraded'>";
+					if (celldata.timesGraded !== 0) {
+						str += '(' + celldata.timesGraded + ')';
+					}
+					str += "</div>";
+					str += "</div>";
+
+					// Print submitted time and change color to red if passed deadline
+					str += "<div class='text-center resultTableText'";
+					for (var p = 0; p < moments.length; p++) {
+						if (moments[p].link == celldata.quizId) {
+							if (Date.parse(moments[p].deadline) < Date.parse(celldata.submitted)) {
+								str += " style='color:red;'";
+							}
+							break;
+						}
+					}
+					str += ">";
+					if (celldata.submitted.getTime() !== timeZero.getTime()) {
+						str += celldata.submitted.toLocaleDateString() + " " + celldata.submitted.toLocaleTimeString();
+					}
+					for (var p = 0; p < moments.length; p++) {
+						if (moments[p].link == celldata.quizId) {
+							if (Date.parse(moments[p].deadline) < Date.parse(celldata.submitted)) {
+								str += "<img src='../Shared/icons/warningTriangle.svg' style='width:12px;height:12px;' title='Late submission'>";
+							}
+							break;
+						}
+					}
+					str += "</div>";
+				}
 				return str;	
-		}
+			} 
 	}	
 
 	// Render normal mode

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -799,7 +799,9 @@ function renderCell(col, celldata, cellid) {
 				} 
 				str += "'>";
 				// Creation of grading buttons
-				if (celldata.ishere === true || celldata.kind == 4) {
+				console.log(celldata.ishere);
+				
+				if (celldata.kind != 4 && celldata.needMarking == true && celldata.submitted > celldata.deadline) {
 					str += "<div class='gradeContainer resultTableText'>";
 					if (celldata.grade === null) {
 						str += makeSelect(celldata.gradeSystem, querystring['cid'], celldata.vers, celldata.lid, celldata.uid, celldata.grade, 'I', celldata.qvariant, celldata.quizId);

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -208,6 +208,7 @@ function process() {
 	dstr += makeCustomFilter("showTeachers", "Show Teachers");
 	dstr += makeCustomFilter("onlyPending", "Only pending");
 	dstr += makeCustomFilter("minimode", "Mini mode");
+	dstr += makeCustomFilter("passedDeadline", "Passed Deadline");
 
 	document.getElementById("customfilter").innerHTML = dstr;
 	var dstr = "";
@@ -744,29 +745,9 @@ function gradeFilterHandler() {
 			break;
 	}
 }
-function deadlineFilterHandler() {
-	// getting the alternative that the filter have.
-	isLate = false;
-	var argument = document.getElementById("deadlineFilter").value;
-	switch (argument) {
-		case "late":
-			isLate = true;
-			console.log(isLate);
-			break;
-		case "notLate":
-			isLate = false;
-			console.log(isLate);
-			break;
-		default:
-		isLate = "none";
-			break;
-	}
-	return isLate;
-}
 
 function renderCell(col, celldata, cellid) {
 	gradeFilterHandler();
-	deadlineFilterHandler();
 	// Render minimode
 	if (filterList["minimode"]) {
 		// First column (Fname/Lname/SSN)

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -744,9 +744,26 @@ function gradeFilterHandler() {
 			break;
 	}
 }
+function deadlineFilterHandler() {
+	// getting the alternative that the filter have.
+	filterDeadline = 0;
+	var argument = document.getElementById("deadlineFilter").value;
+	switch (argument) {
+		case "dugga-pending-late-submission":
+		filterDeadline = 3;
+			break;
+		case "dugga-pending":
+		filterDeadline = 2;
+			break;
+		default:
+		filterDeadline = "none";
+			break;
+	}
+}
 
 function renderCell(col, celldata, cellid) {
 	gradeFilterHandler();
+	
 	// Render minimode
 	if (filterList["minimode"]) {
 		// First column (Fname/Lname/SSN)

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -746,23 +746,25 @@ function gradeFilterHandler() {
 }
 function deadlineFilterHandler() {
 	// getting the alternative that the filter have.
-	filterDeadline = 0;
+	isLate = false;
 	var argument = document.getElementById("deadlineFilter").value;
 	switch (argument) {
-		case "dugga-pending-late-submission":
-		filterDeadline = 3;
+		case "late":
+		isLate = true;
 			break;
-		case "dugga-pending":
-		filterDeadline = 2;
+		case "notLate":
+		isLate = false;
 			break;
 		default:
-		filterDeadline = "none";
+		isLate = "none";
 			break;
 	}
+	return isLate;
 }
 
 function renderCell(col, celldata, cellid) {
 	gradeFilterHandler();
+	console.log(celldata.deadline);
 	
 	// Render minimode
 	if (filterList["minimode"]) {
@@ -1048,6 +1050,7 @@ function rowFilter(row) {
 }
 
 function renderSortOptions(col, status, colname) {
+	
 	str = "";
 	if (status == -1) {
 		if (col == "FnameLname") {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -781,7 +781,27 @@ function renderCell(col, celldata, cellid) {
 			str += "</div>";
 			return str;
 		}
-	}
+		// Render passed deadline duggas
+	} else if(filterList["passedDeadline"]){
+				// First column (Fname/Lname/SSN)
+			if (col == "FnameLname") {
+				str = "<div class='resultTableCell resultTableNormal'>";
+				str += "<div class='resultTableText'>";
+				str += "<div style='font-weight:bold'>" + celldata.firstname + " " + celldata.lastname + "</div>";
+				str += "<div>" + celldata.username + " / " + celldata.class + "</div>";
+				str += "</div>";
+				return str;	
+			}else if (filterGrade === "none" || celldata.grade === filterGrade) {
+				// color based on pass,fail,pending,assigned,unassigned
+				str = "<div style='padding:10px;' class='resultTableCell ";
+				if (celldata.kind != 4 && celldata.needMarking == true && celldata.submitted > celldata.deadline) {
+					str += "dugga-pending-late-submission";
+				} 
+				str += "'>";
+				str += "</div>";
+				return str;	
+		}
+	}	
 
 	// Render normal mode
 	// First column (Fname/Lname/SSN)

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -750,10 +750,12 @@ function deadlineFilterHandler() {
 	var argument = document.getElementById("deadlineFilter").value;
 	switch (argument) {
 		case "late":
-		isLate = true;
+			isLate = true;
+			console.log(isLate);
 			break;
 		case "notLate":
-		isLate = false;
+			isLate = false;
+			console.log(isLate);
 			break;
 		default:
 		isLate = "none";
@@ -764,7 +766,7 @@ function deadlineFilterHandler() {
 
 function renderCell(col, celldata, cellid) {
 	gradeFilterHandler();
-	
+	deadlineFilterHandler();
 	// Render minimode
 	if (filterList["minimode"]) {
 		// First column (Fname/Lname/SSN)

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -85,10 +85,10 @@ pdoConnect();
 			</div>
 			<div style="display:flex; flex-direction:column;justify-content:space-between;margin:5px;">
 				<label>Deadline:</label>
-				<select id="deadlineFilter" onchange="updateTable();">
+				<select id="deadlineFilter" onchange="deadlineFilterHandler(); updateTable();">
 					<option value="Filter-none" selected>inget</option>
-					<option value="dugga-pending-late-submission">Efter deadline</option>
-					<option value="dugga-pending">Innan deadline</option>
+					<option value="late">Efter deadline</option>
+					<option value="notLate">Innan deadline</option>
 				</select>
 			</div>
 

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -83,15 +83,6 @@ pdoConnect();
 					<option value="Filter-U">U</option>
 				</select>
 			</div>
-			<div style="display:flex; flex-direction:column;justify-content:space-between;margin:5px;">
-				<label>Deadline:</label>
-				<select id="deadlineFilter" onchange="deadlineFilterHandler(); updateTable();">
-					<option value="Filter-none" selected>inget</option>
-					<option value="late">Efter deadline</option>
-					<option value="notLate">Innan deadline</option>
-				</select>
-			</div>
-
     </div>
     
 		<!--<div id="resultTable" style='width:fit-content; white-space: nowrap; position: absolute; margin-top: 100px; margin-bottom: 30px;'>-->

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -83,6 +83,15 @@ pdoConnect();
 					<option value="Filter-U">U</option>
 				</select>
 			</div>
+			<div style="display:flex; flex-direction:column;justify-content:space-between;margin:5px;">
+				<label>Deadline:</label>
+				<select id="deadlineFilter" onchange="updateTable();">
+					<option value="Filter-none" selected>inget</option>
+					<option value="dugga-pending-late-submission">Efter deadline</option>
+					<option value="dugga-pending">Innan deadline</option>
+				</select>
+			</div>
+
     </div>
     
 		<!--<div id="resultTable" style='width:fit-content; white-space: nowrap; position: absolute; margin-top: 100px; margin-bottom: 30px;'>-->

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -51,6 +51,7 @@ h4{font-family: Calibri,sans-serif;font-size:1.2em; color: #000;}
  touch-action: none;
 }
 
+
 h1{color: #000;}
 
 strong {font-weight: bold;}


### PR DESCRIPTION
Fixes #4959
Added a filter for filtering out duggas submitted after deadline in resluted. When clicking the cone icon, a filter called "Passed deadline" should appear. This filter should only show the orange duggas (late and pending)
 
![bild](https://user-images.githubusercontent.com/37792256/57684508-39b53800-7636-11e9-9a18-fc503c0bef14.png)

Test site: https://a17alian.groupb.webug.his.se:20002/DuggaSys/resulted.php?cid=2&coursevers=97732