### PR TITLE
Removed logic for disabling 'draw line' after a line had been drawn #6879

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3387,7 +3387,12 @@ function mouseupevt(ev) {
             lastSelectedObject = diagram.length -1;
             diagram[lastSelectedObject].targeted = true;
             selected_objects.push(diagram[lastSelectedObject]);
-
+            //resets the mode so that next click can move or select an object instead of drawing another line
+            //only happens when a line has been created between 2 objects
+            if ($("#linebutton").hasClass("pressed")){
+                $("#linebutton.buttonsStyle").removeClass("pressed").addClass("unpressed");
+            }
+            uimode = "normal";
             createCardinality();
             updateGraphics();
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3329,12 +3329,6 @@ function mouseupevt(ev) {
             lastSelectedObject = diagram.length -1;
             diagram[lastSelectedObject].targeted = true;
             selected_objects.push(diagram[lastSelectedObject]);
-            //resets the mode so that next click can move or select an object instead of drawing another line
-            //only happens when a line has been created between 2 objects
-            if ($("#linebutton").hasClass("pressed")){
-                $("#linebutton.buttonsStyle").removeClass("pressed").addClass("unpressed");
-            }
-            uimode = "normal";
 
             createCardinality();
             updateGraphics();
@@ -3393,12 +3387,6 @@ function mouseupevt(ev) {
             lastSelectedObject = diagram.length -1;
             diagram[lastSelectedObject].targeted = true;
             selected_objects.push(diagram[lastSelectedObject]);
-            //resets the mode so that next click can move or select an object instead of drawing another line
-            //only happens when a line has been created between 2 objects
-            if ($("#linebutton").hasClass("pressed")){
-                $("#linebutton.buttonsStyle").removeClass("pressed").addClass("unpressed");
-            }
-            uimode = "normal";
 
             createCardinality();
             updateGraphics();


### PR DESCRIPTION
#6879
Removed the logic for disabling the 'draw line' functionality after a line had been drawn.
Now you can draw as many lines as you want.