### PR TITLE
Fix for #6142

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4320,6 +4320,13 @@ only screen and (max-device-width: 320px) {
   margin-top: 6px;
 }
 
+[data-tooltip]:before {
+  visibility: visible;
+  opacity: 0.2;
+  transform: scale(1);
+  transform-origin: right center 0;
+}
+
 [data-tooltip]:hover:before {
   visibility: visible;
   opacity: 1;
@@ -5132,5 +5139,3 @@ textarea#filecont{
   color: white;
   border: 2px solid #614875;
 }
-
-


### PR DESCRIPTION
Made a fix for https://github.com/HGustavs/LenaSYS/issues/6142. The tooltips (in the fablist) next to the icons is now always shown. When you hover over the icons, the tooltips are 100% visible again. Solution shown below:

<img width="213" alt="fablist" src="https://user-images.githubusercontent.com/37792690/57701305-06859f80-765c-11e9-9be5-d29bff8b76c5.png">
