### PR TITLE
Ladexport textarea fixed

### DIFF
--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -183,7 +183,7 @@ pdoConnect();
 			<h3 style='width:100%;' id='resultlistheader'>Collective results</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
     </div>
     <div style='display:flex;flex-direction:column;flex:1;'>
-      <textarea id='resultlistarea' style='flex:1;overflow:scroll;padding:5px;margin:5px 0 5px 0;'></textarea>
+      <textarea id='resultlistarea' style='resize:none;flex:1;overflow:scroll;padding:5px;margin:5px 0 5px 0;'></textarea>
       <input type='button' value='Close' onclick='closeLadexport();' style='width:100px;align-self:flex-end'>
     </div>
 	</div>


### PR DESCRIPTION
The ability to resize textarea has been removed. Fixes #7038
Before: 
![image](https://user-images.githubusercontent.com/37792256/57757010-cd4d3e00-76f4-11e9-8bde-2ddd26c5b645.png)

After: 
![image](https://user-images.githubusercontent.com/37792256/57756934-a989f800-76f4-11e9-8f32-671f74a715c3.png)
