### PR TITLE
Fix for issue #7040 No more text when double click

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -416,7 +416,7 @@ function keyDownHandler(e) {
         var temp = [];
         for(var i = 0; i < cloneTempArray.length; i++) {
             //Display cloned objects except lines
-            if(cloneTempArray[i].symbolkind != symbolKind.line 
+            if(cloneTempArray[i].symbolkind != symbolKind.line
                 && cloneTempArray[i].symbolkind != symbolKind.umlLine) {
                 const cloneIndex = copySymbol(cloneTempArray[i]) - 1;
                 temp.push(diagram[cloneIndex]);
@@ -3204,12 +3204,12 @@ function mouseupevt(ev) {
                 symbolEndKind = diagram[markedObject].symbolkind;
 
                 sel = diagram.closestPoint(currentMouseCoordinateX, currentMouseCoordinateY);
-              
+
                 //Check if you not start on a line and not end on a line or so that a line isn't connected to a text object,
                 // if then, set point1 and point2
                 //okToMakeLine is a flag for this
                 var okToMakeLine = true;
-              
+
                 if (symbolStartKind != symbolKind.umlLine && symbolEndKind != symbolKind.umlLine &&
                     symbolStartKind != symbolKind.text && symbolEndKind != symbolKind.text) {
                     var createNewPoint = false;
@@ -3423,13 +3423,11 @@ function countNumberOfSymbolKind(kind) {
 function doubleclick(ev) {
     if (lastSelectedObject != -1 && diagram[lastSelectedObject].targeted == true) {
         openAppearanceDialogMenu();
-    } else {
-        createText(currentMouseCoordinateX, currentMouseCoordinateY);
     }
 }
 
 function createText(posX, posY) {
-    var text = new Symbol(6);
+    var text = new Symbol(symbolKind.text);
     text.name = "New Text" + diagram.length;
     text.textLines.push({text:text.name});
 


### PR DESCRIPTION
#7040 remove creation of text object when double clicking. Additional: new Symbol(6) is changed to new Symbol(symbolKind.text); because the number 6 doesn't say anything.