### PR TITLE
Added right margin to TopMenuStatic

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3663,6 +3663,7 @@ only screen and (min-device-width: 1085px) {
     position: fixed;
     top: 3px;
     left: 100px;
+    right: 100px;
     z-index: 5001;
   }
 }


### PR DESCRIPTION
Fixes #7135 

The issue was that 'TopMenuStatic' overlayed the logout button. The reason it worked when the inspect window was open was that the menu moved down due to media queries.