### PR TITLE
Fixed text boxes #7108

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3080,8 +3080,11 @@ function mouseupevt(ev) {
         if(figureType == "Text") {
             createText(currentMouseCoordinateX, currentMouseCoordinateY);
         }
-        createFigure();
-        if(figureType == "Free") return;
+        
+        if(figureType == "Free") {
+            createFigure();
+            return;
+        }
     }
     // Code for creating a new class
     if (md == mouseState.boxSelectOrCreateMode && (uimode == "CreateClass" || uimode == "CreateERAttr" || uimode == "CreateEREntity" || uimode == "CreateERRelation")) {


### PR DESCRIPTION
#7108 
Seems like the issue where the text boxes was given a new 'free draw' line was because of a displacement of the createFigure() method in the diagram.js file.