### PR TITLE
Rekation name is correct when copy paste

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -691,7 +691,7 @@ function copySymbol(symbol) {
     }else if(symbol.symbolkind == symbolKind.line) {
         clone.name = "Line" + diagram.length;
     } else{
-        clone.name = "RelationCopy" + diagram.length;
+        clone.name = "Relation" + diagram.length;
     }
 
     clone.topLeft = points.push(topLeftClone) - 1;
@@ -2759,7 +2759,7 @@ function mousemoveevt(ev, t) {
                       canvas.style.cursor = "default";
                   }
               }
-       
+
             // If mouse is not pressed highlight closest point
             points.clearAllSelects();
             movobj = diagram.itemClicked();


### PR DESCRIPTION
Issue #7115 Fixed. The relation name is corect when copy paste