### PR TITLE
Made using escape key to close windows work

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1230,8 +1230,8 @@ $(window).load(function() {
 	//There is an issue with using this code, it generates errors that stop execution
       $(window).keyup(function(event){
       	if(event.keyCode == 27) {
-          //closeWindows();
-          closeSelect();
+          closeWindows();
+          //closeSelect();
         }
       });
 });

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1230,8 +1230,11 @@ $(window).load(function() {
 	//There is an issue with using this code, it generates errors that stop execution
       $(window).keyup(function(event){
       	if(event.keyCode == 27) {
-          closeWindows();
-          //closeSelect();
+					if (window.location.href.indexOf('sectioned') !== -1) {
+						closeSelect();
+					} else {
+						closeWindows();
+					}          
         }
       });
 });


### PR DESCRIPTION
Fixes #7092 
Should now work everywhere.

There is a comment in the event listener from 2015:
`//There is an issue with using this code, it generates errors that stop execution`

But I could not find any such cases, so I guess that comment is outdated.