### PR TITLE
FIXED weak (copied) entities gets strong while they were shaken #7187

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -671,7 +671,6 @@ function copySymbol(symbol) {
     clone.isOval = jQuery.extend(true, {}, symbol.isOval);
     clone.isAttribute = jQuery.extend(true, {}, symbol.isAttribute);
     clone.isRelation = jQuery.extend(true, {}, symbol.isRelation);
-    clone.isLine = jQuery.extend(true, {}, symbol.isLine);
     clone.pointsAtSamePosition = jQuery.extend(true, {}, symbol.pointsAtSamePosition);
     clone.operations = jQuery.extend(true, {}, symbol.operations);
     clone.attributes = jQuery.extend(true, {}, symbol.operations);


### PR DESCRIPTION
#7187 
The isLine attribute was the bad villain who messed with weak entities while they were shaken