### PR TITLE
Fix: Saving what mode you're in doesn't quite work #7152

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1115,8 +1115,8 @@ function initializeCanvas() {
     document.getElementById("canvasDiv").innerHTML = "<canvas id='myCanvas' style='border:1px solid #000000;' width='"
                 + (widthWindow * zoomValue) + "' height='" + (heightWindow * zoomValue)
                 + "' onmousemove='mousemoveevt(event,this);' onmousedown='mousedownevt(event);' onmouseup='mouseupevt(event);'></canvas>";
-    document.getElementById("valuesCanvas").innerHTML = "<p><b>Zoom:</b> " + Math.round((zoomValue * 100))
-                + "%   |   <b>Coordinates:</b> X=" + sx + " & Y=" + sy + "</p>";
+    document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> X=" + sx + " & Y=" + sy + "</p>";
+    document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> " + Math.round((zoomValue * 100)) + "%" + " </p>";
     canvas = document.getElementById("myCanvas");
     if (canvas.getContext) {
         ctx = canvas.getContext("2d");
@@ -1782,20 +1782,21 @@ function developerMode(event) {
     updateGraphics();
 }
 
+var refreshedPage = true;
 function setModeOnRefresh() {
     toolbarState = localStorage.getItem("toolbarState");
     if(toolbarState == 1) {
-        switchToolbarER();
+        switchToolbarTo('ER');
         hideCrosses();
         developerModeActive = false;
     } else if(toolbarState == 2) {
-        switchToolbarUML();
+        switchToolbarTo('UML');
         hideCrosses();
         developerModeActive = false;
     } else if(toolbarState == 3) {
         showCrosses();
         developerModeActive = true;
-        switchToolbarDev();
+        switchToolbarTo('Dev');
         setCheckbox($(".drop-down-option:contains('Developer mode')"), developerModeActive);
         $("#displayAllTools").removeClass("drop-down-item drop-down-item-disabled");
     }
@@ -1829,6 +1830,8 @@ function modeSwitchConfirmed(confirmed) {
             switchToolbarER();
         } else if (targetMode == 'UML') {
             switchToolbarUML();
+        } else if (targetMode == 'Dev'){
+          switchToolbarDev();
         }
     }
 }
@@ -2037,12 +2040,19 @@ function reWrite() {
         document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
         + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) </p>";
-        if(hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free"){
+        if(hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free" && refreshedPage == true){
             document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
             + Math.round((zoomValue * 100)) + "%" + " </p>";
             document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
             + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-            + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
+            + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " |";
+            refreshedPage = false;
+        } else if (hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free"){
+          document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
+          + Math.round((zoomValue * 100)) + "%" + " </p>";
+          document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
+          + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
+          + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
         }
     } else {
         document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1764,8 +1764,7 @@ function developerMode(event) {
         crossStrokeStyle1 = "#f64";
         crossFillStyle = "#d51";
         crossStrokeStyle2 = "#d51";
-        drawOrigo();
-        toolbarState = 3;                                                               // Change the toolbar to DEV.
+        drawOrigo();                                                               // Change the toolbar to DEV.
         switchToolbarDev();                                                             // ---||---
         document.getElementById('toolbarTypeText').innerHTML = 'Mode: DEV';             // Change the text to DEV.
         $("#displayAllTools").removeClass("drop-down-item drop-down-item-disabled");    // Remove disable of displayAllTools id.
@@ -1774,22 +1773,8 @@ function developerMode(event) {
         setCheckbox($(".drop-down-option:contains('Display All Tools')"),
             crossDEV=true);                                                             // Turn on crossDEV.
     } else {
-      toolbarState = localStorage.getItem("toolbarState");                             // Change the toolbar back to ER.
-        if(toolbarState == 1) {
-          switchToolbarER();
-        } else if(toolbarState == 2) {
-          switchToolbarUML();
-        } else if(toolbarState == 3) {
-          switchToolbar('Dev');                                                           // ---||---
-          document.getElementById('toolbarTypeText').innerHTML = 'Mode: DEV';             // Change the text to UML.
-          setCheckbox($(".drop-down-option:contains('Display All Tools')"),
-              crossDEV=false);                                                             // Turn on crossDEV.
-          setCheckbox($(".drop-down-option:contains('UML')"), crossUML=false);            // Turn off crossUML.
-          setCheckbox($(".drop-down-option:contains('ER')"), crossER=false);              // Turn off crossER.
-          toolbarState = 1;
-          switchToolbarER();
-          $("#displayAllTools").addClass("drop-down-item drop-down-item-disabled");
-        }
+        switchToolbarER();
+        $("#displayAllTools").addClass("drop-down-item drop-down-item-disabled");
         crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
         crossFillStyle = "rgba(255, 102, 68, 0.0)";
         crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
@@ -1826,8 +1811,8 @@ function modeSwitchConfirmed(confirmed) {
 
 function switchToolbarTo(target) {
     targetMode = target;
-    //only ask for confirmation when developer mode is off or if the user has started drawing something
-    if(developerModeActive || diagram.length < 1) {
+    //only ask for confirmation when developer mode is off
+    if(developerModeActive) {
         modeSwitchConfirmed(true);
     } else {
         $("#modeSwitchDialog").css("display", "flex");
@@ -3082,7 +3067,7 @@ function mouseupevt(ev) {
         if(figureType == "Text") {
             createText(currentMouseCoordinateX, currentMouseCoordinateY);
         }
-        
+
         if(figureType == "Free") {
             createFigure();
             return;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -439,44 +439,32 @@ function keyDownHandler(e) {
     }
     else if(key == ctrlKey || key == windowsKey) {
         ctrlIsClicked = true;
-    }
-    else if(key == escapeKey) {
+    } else if(key == escapeKey) {
         cancelFreeDraw();
-    }
-    else if((key == key1 || key == num1) && shiftIsClicked){
+    } else if((key == key1 || key == num1) && shiftIsClicked){
         moveToFront();
-    }
-    else if((key == key2 || key == num2) && shiftIsClicked){
+    } else if((key == key2 || key == num2) && shiftIsClicked){
         moveToBack();
-    }
-    else if(shiftIsClicked && key == lKey) {
+    } else if(shiftIsClicked && key == lKey) {
       document.getElementById("linebutton").click();
-    }
-    else if(shiftIsClicked && key == aKey && targetMode == "ER") {
+    } else if(shiftIsClicked && key == aKey && targetMode == "ER") {
       document.getElementById("attributebutton").click();
     }
     else if(shiftIsClicked && key == eKey && targetMode == "ER") {
       document.getElementById("entitybutton").click();
-    }
-    else if(shiftIsClicked && key == rKey && targetMode == "ER") {
+    } else if(shiftIsClicked && key == rKey && targetMode == "ER") {
       document.getElementById("relationbutton").click();
-    }
-    else if(shiftIsClicked && key == cKey && targetMode == "UML") {
+    } else if(shiftIsClicked && key == cKey && targetMode == "UML") {
       document.getElementById("classbutton").click();
-    }
-    else if(shiftIsClicked && key == tKey && targetMode == "ER") {
+    } else if(shiftIsClicked && key == tKey && targetMode == "ER") {
       document.getElementById("drawtextbutton").click();
-    }
-    else if(shiftIsClicked && key == fKey) {
+    } else if(shiftIsClicked && key == fKey) {
       document.getElementById("drawfreebutton").click();
-    }
-    else if(shiftIsClicked && key == dKey) {
+    } else if(shiftIsClicked && key == dKey) {
       developerMode(event);
-    }
-    else if(shiftIsClicked && key == nKey) {
+    } else if(shiftIsClicked && key == nKey) {
         switchToolbarTo("ER");
-    }
-    else if(shiftIsClicked && key == mKey) {
+    } else if(shiftIsClicked && key == mKey) {
         switchToolbarTo("UML");
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1756,14 +1756,13 @@ consloe.log = function(gobBluth) {
 // this function show and hides developer options.
 //------------------------------------------------------------------------------
 
-var developerModeActive = false;                // used to repressent a switch for whenever the developerMode is enabled or not.
+var
+developerModeActive = true;                // used to repressent a switch for whenever the developerMode is enabled or not.
 function developerMode(event) {
     event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
     developerModeActive = !developerModeActive;
     if(developerModeActive) {
-        crossStrokeStyle1 = "#f64";
-        crossFillStyle = "#d51";
-        crossStrokeStyle2 = "#d51";
+        showCrosses();
         drawOrigo();                                                               // Change the toolbar to DEV.
         switchToolbarDev();                                                             // ---||---
         document.getElementById('toolbarTypeText').innerHTML = 'Mode: DEV';             // Change the text to DEV.
@@ -1777,39 +1776,45 @@ function developerMode(event) {
         switchToolbarER();
         $("#displayAllTools").addClass("drop-down-item drop-down-item-disabled");
         setCheckbox($(".drop-down-option:contains('Developer mode')"), false);
-        crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-        crossFillStyle = "rgba(255, 102, 68, 0.0)";
-        crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
+        hideCrosses();
     }
     reWrite();
     updateGraphics();
 }
 
-function setModeOnRefresh(){
-    toolbarState = localStorage.getItem("toolbarState");                             // Change the toolbar back to ER.
-  if(toolbarState == 1) {
-    switchToolbarER();
-    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-    crossFillStyle = "rgba(255, 102, 68, 0.0)";
-    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-  } else if(toolbarState == 2) {
-    switchToolbarUML();
-    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-    crossFillStyle = "rgba(255, 102, 68, 0.0)";
-    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-  } else if(toolbarState == 3) {
+function setModeOnRefresh() {
+    toolbarState = localStorage.getItem("toolbarState");
+    if(toolbarState == 1) {
+        switchToolbarER();
+        hideCrosses();
+        developerModeActive = false;
+    } else if(toolbarState == 2) {
+        switchToolbarUML();
+        hideCrosses();
+        developerModeActive = false;
+    } else if(toolbarState == 3) {
+        showCrosses();
+        developerModeActive = true;
+        switchToolbarDev();
+        setCheckbox($(".drop-down-option:contains('Developer mode')"), developerModeActive);
+        $("#displayAllTools").removeClass("drop-down-item drop-down-item-disabled");
+    }
+    else {
+        switchToolbarER();
+    }
+}
+
+function showCrosses() {
     crossStrokeStyle1 = "#f64";
     crossFillStyle = "#d51";
     crossStrokeStyle2 = "#d51";
-    developerModeActive = true;
-    switchToolbarDev();
-    updateGraphics();
-    setCheckbox($(".drop-down-option:contains('Developer mode')"), developerModeActive);
-    $("#displayAllTools").removeClass("drop-down-item drop-down-item-disabled");
-  }
 }
 
-var targetMode = "ER";     // The mode that we want to change to when trying to switch the toolbar. Set default here.
+function hideCrosses() {
+    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
+    crossFillStyle = "rgba(255, 102, 68, 0.0)";
+    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
+}
 
 //------------------------------------------------------------------------------
 // modeSwitchConfirmed:
@@ -2028,23 +2033,23 @@ function reWrite() {
     if(developerModeActive) {
         //We are now in developer mode
         document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
-         + Math.round((zoomValue * 100)) + "%" + " </p>";
+        + Math.round((zoomValue * 100)) + "%" + " </p>";
         document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
-         + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) </p>";
-    if(hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free"){
-      document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
-       + Math.round((zoomValue * 100)) + "%" + " </p>";
-      document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
-       + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-       + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
-    }
+        + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
+        + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) </p>";
+        if(hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free"){
+            document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
+            + Math.round((zoomValue * 100)) + "%" + " </p>";
+            document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
+            + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
+            + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
+        }
     } else {
         document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
-         + Math.round((zoomValue * 100)) + "%" + "   </p>";
+        + Math.round((zoomValue * 100)) + "%" + "   </p>";
         document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
-         + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + "</p>";
+        + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
+        + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + "</p>";
     }
 }
 
@@ -2885,9 +2890,7 @@ function mousemoveevt(ev, t) {
                     ctx.stroke();
                     ctx.setLineDash([]);
                     if (!developerModeActive) {
-                        crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-                        crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-                        crossFillStyle = "rgba(255, 102, 68, 0.0)";
+                        hideCrosses();
                     }
                 }
             } else if (uimode == "CreateEREntity") {
@@ -2903,9 +2906,7 @@ function mousemoveevt(ev, t) {
                 ctx.setLineDash([]);
                 ctx.closePath();
                 if (!developerModeActive) {
-                    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-                    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-                    crossFillStyle = "rgba(255, 102, 68, 0.0)";
+                    hideCrosses();
                 }
             } else if(uimode == "CreateERRelation") {
                 ctx.setLineDash([3, 3]);
@@ -2922,9 +2923,7 @@ function mousemoveevt(ev, t) {
                 ctx.setLineDash([]);
                 ctx.closePath();
                 if (!developerModeActive) {
-                    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-                    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-                    crossFillStyle = "rgba(255, 102, 68, 0.0)";
+                    hideCrosses();
                 }
             } else if(uimode == "CreateERAttr") {
                 ctx.setLineDash([3, 3]);
@@ -2933,9 +2932,7 @@ function mousemoveevt(ev, t) {
                 ctx.stroke();
                 ctx.setLineDash([]);
                 if (!developerModeActive) {
-                    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-                    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-                    crossFillStyle = "rgba(255, 102, 68, 0.0)";
+                    hideCrosses();
                 }
             } else if(uimode == "CreateLine") {
                 // Path settings for preview line
@@ -2947,9 +2944,7 @@ function mousemoveevt(ev, t) {
                 ctx.stroke();
                 ctx.setLineDash([]);
                 if (!developerModeActive) {
-                    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-                    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-                    crossFillStyle = "rgba(255, 102, 68, 0.0)";
+                    hideCrosses();
                 }
             } else if(uimode == "CreateUMLLine") {
                 // Path settings for preview line
@@ -2961,10 +2956,8 @@ function mousemoveevt(ev, t) {
                 ctx.stroke();
                 ctx.setLineDash([]);
                 if (!developerModeActive) {
-                    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-                    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-                    crossFillStyle = "rgba(255, 102, 68, 0.0)";
-                    }
+                    hideCrosses();
+                }
                 } else {
                 ctx.setLineDash([3, 3]);
                 ctx.beginPath();
@@ -2978,9 +2971,7 @@ function mousemoveevt(ev, t) {
                 ctx.setLineDash([]);
                 ctx.closePath();
                 if (!developerModeActive) {
-                    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
-                    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
-                    crossFillStyle = "rgba(255, 102, 68, 0.0)";
+                    hideCrosses();
                 }
             }
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -132,6 +132,7 @@ var symbolStartKind;                    // Is used to store which kind of object
 var symbolEndKind;                      // Is used to store which kind of object you end on
 var cloneTempArray = [];                // Is used to store all selected objects when ctrl+c is pressed
 var spacebarKeyPressed = false;         // True when entering MoveAround mode by pressing spacebar.
+var toolbarState = 1;                   // Set default toolbar state to ER.
 
 // Keyboard keys
 const backspaceKey = 8;
@@ -926,7 +927,7 @@ diagram.targetItemsInsideSelectionBox = function (ex, ey, sx, sy, hover) {
                         setTargetedForSymbolGroup(this[i], true);
                     } else if (hover) {
                         this[i].isHovered = true;
-                    } 
+                    }
                 }
             } else if (!ctrlIsClicked) {
                 if (!hover) this[i].targeted = false;
@@ -1808,14 +1809,13 @@ consloe.log = function(gobBluth) {
 // this function show and hides developer options.
 //------------------------------------------------------------------------------
 
-var
-developerModeActive = true;                // used to repressent a switch for whenever the developerMode is enabled or not.
+var developerModeActive = true;                // used to repressent a switch for whenever the developerMode is enabled or not.
 function developerMode(event) {
     event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
     developerModeActive = !developerModeActive;
     if(developerModeActive) {
         showCrosses();
-        drawOrigo();                                                               // Change the toolbar to DEV.
+        drawOrigo();                                                                    // Draw origo on canvas
         switchToolbarDev();                                                             // ---||---
         document.getElementById('toolbarTypeText').innerHTML = 'Mode: DEV';             // Change the text to DEV.
         $("#displayAllTools").removeClass("drop-down-item drop-down-item-disabled");    // Remove disable of displayAllTools id.
@@ -1851,9 +1851,10 @@ function setModeOnRefresh() {
         switchToolbarTo('Dev');
         setCheckbox($(".drop-down-option:contains('Developer mode')"), developerModeActive);
         $("#displayAllTools").removeClass("drop-down-item drop-down-item-disabled");
-    }
-    else {
+    } else {
         switchToolbarER();
+        hideCrosses();
+        developerModeActive = false;
     }
 }
 
@@ -2171,24 +2172,24 @@ function addGroupToSelected(event) {
     // find all symbols/freedraw objects that is going to be in the group
     for (var i = 0; i < selected_objects.length; i++) {
         // do not group lines
-        if(selected_objects[i].kind == kind.symbol && 
+        if(selected_objects[i].kind == kind.symbol &&
             (selected_objects[i].symbolkind == symbolKind.line || selected_objects[i].symbolkind == symbolKind.umlLine)) {
             continue;
         } else {
             tempList.push(selected_objects[i]);
         }
     }
-    // remove the current group the objects have 
+    // remove the current group the objects have
     for (var i = 0; i < tempList.length; i++ ) {
         tempList[i].group = 0;
     }
     // check what group numbers already exist
     var currentGroups = [];
     for (var i = 0; i < diagram.length; i++) {
-        // don't check lines 
+        // don't check lines
         if (diagram[i].kind == kind.symbol && (diagram[i].symbolkind == symbolKind.line || diagram[i].symbolkind == symbolKind.umlLine)) {
-        } else { 
-            if (diagram[i].group != 0) { 
+        } else {
+            if (diagram[i].group != 0) {
                 currentGroups.push(diagram[i].group);
             }
         }
@@ -2218,7 +2219,7 @@ function removeGroupFromSelected(event) {
     event.stopPropagation();
     for (var i = 0; i < selected_objects.length; i++) {
         // do not do anything with lines
-        if (selected_objects[i].kind == kind.symbol && 
+        if (selected_objects[i].kind == kind.symbol &&
             (selected_objects[i].symbolkind == symbolKind.line || selected_objects[i].symbolkind == symbolKind.umlLine)) {
             continue;
         }
@@ -2670,8 +2671,6 @@ function setOrientationIcon(element, check) {
 // DIAGRAM TOOLBOX SECTION
 // ----------------------------------------------------------------------------
 
-var toolbarState;
-
 const toolbarER = 1;
 const toolbarUML = 2;
 const toolbarDeveloperMode = 3;
@@ -2910,7 +2909,7 @@ function mousemoveevt(ev, t) {
             // Select a new point only if mouse is not already moving a point or selection box
             sel = diagram.closestPoint(currentMouseCoordinateX, currentMouseCoordinateY);
             if (sel.distance < tolerance / zoomValue) {
-                // check so that the point we're hovering over belongs to an object that's selected 
+                // check so that the point we're hovering over belongs to an object that's selected
                 var pointBelongsToObject = false;
                 for (var i = 0; i < selected_objects.length; i++) {
                     if (sel.attachedSymbol == selected_objects[i]) {
@@ -3543,7 +3542,7 @@ function mouseupevt(ev) {
             lastSelectedObject = diagram.length -1;
             diagram[lastSelectedObject].targeted = true;
             selected_objects.push(diagram[lastSelectedObject]);
-            
+
             uimode = "CreateLine";
             createCardinality();
             updateGraphics();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2096,23 +2096,23 @@ function reWrite() {
         document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
         + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + Math.round(origoOffsetX / zoomValue) + ", " + Math.round(origoOffsetY / zoomValue) + " ) </p>";
-        
+
         if (hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free" && refreshedPage == true) {
             document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
             + Math.round((zoomValue * 100)) + "%" + " </p>";
             document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
             + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-            + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + sx + ", " + sy + " ) " + " |";
+            + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + Math.round(origoOffsetX / zoomValue) + ", " + Math.round(origoOffsetY / zoomValue) + " )";
             refreshedPage = false;
         } else if (hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free") {
               document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
               + Math.round((zoomValue * 100)) + "%" + " </p>";
               document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
               + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-              + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + Math.round(origoOffsetX / zoomValue) + ", " + Math.round(origoOffsetY / zoomValue) + " ) " 
-              + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" 
+              + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + Math.round(origoOffsetX / zoomValue) + ", " + Math.round(origoOffsetY / zoomValue) + " ) "
+              + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y="
               + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
-          }    
+          }
     } else {
         document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
         + Math.round((zoomValue * 100)) + "%" + "   </p>";
@@ -2700,8 +2700,7 @@ function zoomInMode(event) {
     let currentMouseY = pixelsToCanvas(0, currentMouseCoordinateY).y;
 
     let centerX = (canvas.width / 2 - origoOffsetX) / zoomValue;
-    let centerY = (canvas.height / 2 - 
-                  ) / zoomValue;
+    let centerY = (canvas.height / 2 - origoOffsetY) / zoomValue;
 
     let oldZoom = zoomValue;
     zoomValue = document.getElementById("ZoomSelect").value;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -154,6 +154,7 @@ const eKey = 69;
 const fKey = 70;
 const lKey = 76;
 const mKey = 77;
+const nKey = 78;
 const rKey = 82;
 const tKey = 84;
 const vKey = 86;
@@ -473,12 +474,11 @@ function keyDownHandler(e) {
     else if(shiftIsClicked && key == dKey) {
       developerMode(event);
     }
-    else if(shiftIsClicked && key == mKey) {
-      if(targetMode == "ER"){
-        switchToolbarTo("UML");
-      } else {
+    else if(shiftIsClicked && key == nKey) {
         switchToolbarTo("ER");
-      }
+    }
+    else if(shiftIsClicked && key == mKey) {
+        switchToolbarTo("UML");
     }
 }
 
@@ -1831,7 +1831,7 @@ function modeSwitchConfirmed(confirmed) {
         } else if (targetMode == 'UML') {
             switchToolbarUML();
         } else if (targetMode == 'Dev'){
-          switchToolbarDev();
+            switchToolbarDev();
         }
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1756,7 +1756,7 @@ consloe.log = function(gobBluth) {
 // this function show and hides developer options.
 //------------------------------------------------------------------------------
 
-var developerModeActive = true;                // used to repressent a switch for whenever the developerMode is enabled or not.
+var developerModeActive = false;                // used to repressent a switch for whenever the developerMode is enabled or not.
 function developerMode(event) {
     event.stopPropagation();                    // This line stops the collapse of the menu when it's clicked
     developerModeActive = !developerModeActive;
@@ -1772,16 +1772,41 @@ function developerMode(event) {
         setCheckbox($(".drop-down-option:contains('UML')"), crossUML=false);            // Turn off crossUML.
         setCheckbox($(".drop-down-option:contains('Display All Tools')"),
             crossDEV=true);                                                             // Turn on crossDEV.
+        setCheckbox($(".drop-down-option:contains('Developer mode')"), true);
     } else {
         switchToolbarER();
         $("#displayAllTools").addClass("drop-down-item drop-down-item-disabled");
+        setCheckbox($(".drop-down-option:contains('Developer mode')"), false);
         crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
         crossFillStyle = "rgba(255, 102, 68, 0.0)";
         crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
     }
     reWrite();
     updateGraphics();
+}
+
+function setModeOnRefresh(){
+    toolbarState = localStorage.getItem("toolbarState");                             // Change the toolbar back to ER.
+  if(toolbarState == 1) {
+    switchToolbarER();
+    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
+    crossFillStyle = "rgba(255, 102, 68, 0.0)";
+    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
+  } else if(toolbarState == 2) {
+    switchToolbarUML();
+    crossStrokeStyle1 = "rgba(255, 102, 68, 0.0)";
+    crossFillStyle = "rgba(255, 102, 68, 0.0)";
+    crossStrokeStyle2 = "rgba(255, 102, 68, 0.0)";
+  } else if(toolbarState == 3) {
+    crossStrokeStyle1 = "#f64";
+    crossFillStyle = "#d51";
+    crossStrokeStyle2 = "#d51";
+    developerModeActive = true;
+    switchToolbarDev();
+    updateGraphics();
     setCheckbox($(".drop-down-option:contains('Developer mode')"), developerModeActive);
+    $("#displayAllTools").removeClass("drop-down-item drop-down-item-disabled");
+  }
 }
 
 var targetMode = "ER";     // The mode that we want to change to when trying to switch the toolbar. Set default here.
@@ -1973,10 +1998,10 @@ function loadDiagram() {
                 points[i] = b.points[i];
             }
         }
-    }
     deselectObjects();
     updateGraphics();
     SaveState();
+}
 }
 
 //----------------------------------------------------------------------

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -42,7 +42,7 @@
 </head>
 <!-- Reads the content from the js-files -->
 <!-- updateGraphics() must be last -->
-<body onload="initializeCanvas(); canvasSize(); loadDiagram(); developerMode(event); initToolbox(); updateGraphics();"
+<body onload="initializeCanvas(); canvasSize(); loadDiagram(); setModeOnRefresh(); initToolbox(); updateGraphics();"
  onmousedown="mouseDown()" onmouseup="mouseUp()" style="overflow-y: hidden;">
     <?php
         $noup = "SECTION";

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -206,7 +206,7 @@
                             </div>
                             <div id="er-item" class="drop-down-item">
                                 <span class="drop-down-option" onclick="switchToolbarTo('ER');">ER</span>
-                                <i id="hotkey-ER">Shift + M</i>
+                                <i id="hotkey-ER">Shift + N</i>
                             </div>
                             <div id="uml-item" class="drop-down-item">
                                 <span class="drop-down-option" onclick="switchToolbarTo('UML');">UML</span>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -222,7 +222,7 @@
                             </div>
                             <div id="er-item" class="drop-down-item">
                                 <span class="drop-down-option" onclick="switchToolbarTo('ER');">ER</span>
-                                <i id="hotkey-ER" class="hotKeys">Shift + M</i>
+                                <i id="hotkey-ER" class="hotKeys">Shift + N</i>
                             </div>
                             <div id="uml-item" class="drop-down-item">
                                 <span class="drop-down-option" onclick="switchToolbarTo('UML');">UML</span>


### PR DESCRIPTION
**Issue: #7152** (related to issue: #6933 and #7089)

* When refreshing the page the chosen toolbar is loaded in from the local storage and works as it is expected to do.

* Fixed functions to remove duplicated code and stuff.

* Changed key binding to two separate key bindings to prevent duplicate switches.

**Co-author: @a16jenja**
