### PR TITLE
Fix for issue #6905: Drawing lines between attributes should be allowed 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3214,11 +3214,11 @@ function mouseupevt(ev) {
                     //Code for making sure enitities not connect to the same attribute multiple times
                     if (symbolEndKind == symbolKind.erEntity && symbolStartKind == symbolKind.erAttribute) {
                         if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) > 0) {
-                            okToMakeLine= false;
+                            okToMakeLine = false;
                         }
                     } else if (symbolEndKind == symbolKind.erAttribute && symbolStartKind == symbolKind.erEntity) {
                         if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) > 0) {
-                            okToMakeLine= false;
+                            okToMakeLine = false;
                         }
                     } else if (symbolEndKind == symbolKind.erEntity && symbolStartKind == symbolKind.erRelation) {
                         if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) >= 2) okToMakeLine = false;
@@ -3230,19 +3230,6 @@ function mouseupevt(ev) {
                         okToMakeLine = false;
                     }
                     if (diagram[lineStartObj] == diagram[markedObject]) okToMakeLine = false;
-
-                    // Can't draw line between two ER attributes if one of them is not composite
-                    if (symbolStartKind == symbolKind.erAttribute && symbolEndKind == symbolKind.erAttribute) {
-                        if (diagram[markedObject].properties.key_type === "Composite" || diagram[lineStartObj].properties.key_type === "Composite") {
-                        okToMakeLine = true;
-                        } else {
-                            okToMakeLine = false;
-                            // Add error dialog
-                            $("#errorMessageDialog").css("display", "flex");
-                            var toolbarTypeText = document.getElementById('toolbarTypeText').innerHTML;
-                            document.getElementById("errorMessage").innerHTML = "Error! None of the objects are Composite";
-                        }
-                    }
 
                     if (okToMakeLine) {
                         saveState = true;
@@ -3941,18 +3928,12 @@ function changeCardinality(isUML) {
         }
     }
 }
-
+// Changes direction for uml line relations 
 function changeLineDirection() {
     diagram[lastSelectedObject].lineDirection = document.getElementById('line_direction').value;
     console.log("lineDirection " + diagram[lastSelectedObject].lineDirection);
 }
-
-//Close the errorMessageDialog for Composite
-function closeErrorMessageDialog() {
-    $("#errorMessageDialog").hide();
-}
-
-//Checks if there are any duplicates of entities with the same name.
+// Checks if there are any duplicates of entities with the same name.
 function checkDuplicate(name, kind) {
     var numberOfSymbolKind = 0;
     for(let i = 0; i < diagram.length; i++) {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -417,23 +417,6 @@
             </div>
         </div>
     </div>
-
-    <!-- Error message when non objects are not composite-->
-    <div id="errorMessageDialog" class="loginBoxContainer importDiagram">
-        <div class="loginBox messageContainer">
-            <div class="loginBoxheader messageHeader">
-                <h3 id="errorMessage"></h3>
-                <div class='cursorPointer' onclick='closeErrorMessageDialog();'>
-                    x
-                </div>
-            </div>
-            <div class="mode-wrap">
-                <div id="importButtonWrap" class="importButtonWrap">
-                    <button id="cancelButton" class="submit-button uploadButton" onclick="closeErrorMessageDialog();">Cancel</button>
-                </div>
-            </div>
-        </div>
-    </div>
     <!-- content END -->
     <?php
         include '../Shared/loginbox.php';

--- a/DuggaSys/diagram_forms.php
+++ b/DuggaSys/diagram_forms.php
@@ -48,7 +48,6 @@
       "<option value=\'Partial key\'>Partial key</option>
       "<option value=\'normal\' selected="true">Normal</option>
       "<option value=\'Multivalue\'>Multivalue</option>
-      "<option value=\'Composite\'>Composite</option>
       "<option value=\'Drive\'>Derive</option>
       </select></br>
       '.$backgroundColor.$fontFamily.$fontColor.$textSize.$lineColors.$okButton;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4965,25 +4965,6 @@ textarea#mrkdwntxt {
   padding-right: 10px;
 }
 
-/* Composite error message dialog */
-.errorMessageDialog {
-  display: none;
-  background-color: rgba(0,0,0,0);
-}
-
-.messageContainer {
-  min-height: 80px;
-}
-
-#cancelButton {
-  border-radius: 3px;
-}
-
-.messageHeader h3 {
-  padding-right: 10px;
-}
-
-
 /* Import diagram */
 
 .importDiagram {


### PR DESCRIPTION
#6905 
Instead of dealing with the hassle of having composite attributes separate to the "normal" attribute and changing to composite when drawing lines depending on which entities or attributes the attribute is already attached to, I have now entirely scrapped composite attributes and always allow them to be connected instead.