### PR TITLE
Fix for #6821: Remove cardinality option for non entity-relation ER-lines

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3947,10 +3947,8 @@ function objectAppearanceMenu(form) {
 
         if (cardinalityOption) {
             loadLineForm(form, 'diagram_forms.php?form=lineType&cardinality=' + diagram[lastSelectedObject].cardinality[0].symbolKind);
-            console.log("Cards");
         }else {
             loadLineForm(form, 'diagram_forms.php?form=lineType&cardinality=-1');
-            console.log("No cards");
         }
     }
     // ER relation selected

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3932,7 +3932,26 @@ function objectAppearanceMenu(form) {
     }
     // Lines selected
     else if (diagram[lastSelectedObject].symbolkind == symbolKind.line || diagram[lastSelectedObject].symbolkind == symbolKind.umlLine) {
-        loadLineForm(form, 'diagram_forms.php?form=lineType&cardinality=' + diagram[lastSelectedObject].cardinality[0].symbolKind);
+        var cardinalityOption = true;
+        var connObjects = diagram[lastSelectedObject].getConnectedObjects();
+        // Only show cardinality option if the line goes between an entity and a relation
+        if (diagram[lastSelectedObject].symbolkind == symbolKind.line) {
+            var atLeastOneEntity = connObjects[0].symbolkind==symbolKind.erEntity ? true :
+                connObjects[1] && connObjects[1].symbolkind==symbolKind.erEntity;
+            var atLeastOneRelation = connObjects[0].symbolkind==symbolKind.erRelation ? true :
+                connObjects[1].symbolkind==symbolKind.erRelation;
+
+            if ((atLeastOneEntity && atLeastOneRelation) == false)
+                cardinalityOption = false;
+        }
+
+        if (cardinalityOption) {
+            loadLineForm(form, 'diagram_forms.php?form=lineType&cardinality=' + diagram[lastSelectedObject].cardinality[0].symbolKind);
+            console.log("Cards");
+        }else {
+            loadLineForm(form, 'diagram_forms.php?form=lineType&cardinality=-1');
+            console.log("No cards");
+        }
     }
     // ER relation selected
     else if (diagram[lastSelectedObject].symbolkind == symbolKind.erRelation) {

--- a/DuggaSys/diagram_forms.php
+++ b/DuggaSys/diagram_forms.php
@@ -128,7 +128,16 @@
   //form for lines
   else if($form == 'lineType') {
       $cardinality = $_GET['cardinality'];
-      if($cardinality != 1) {
+      if($cardinality == -1) {
+        echo"
+        Line type: </br>
+        <select onchange=\"changeObjectAppearance('lineType');\" id='object_type'>
+            <option value='normal'>Normal</option>
+            <option value='Forced'>Forced</option>
+            <option value='Derived'>Derived</option>
+        </select></br>
+        ";
+      }else if($cardinality != 1) {
         echo"
         Line type: </br>
         <select onchange=\"changeObjectAppearance('lineType');\" id='object_type'>

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -799,7 +799,7 @@ function Symbol(kindOfSymbol) {
     }
 
     //----------------------------------------------------------------
-    // getConnectedObjects: returns an array with the two objects that a specific line is connected to,
+    // getConnectedObjects: returns an array with the objects that a specific line is connected to,
     //                      function is used on line objects
     //----------------------------------------------------------------
 


### PR DESCRIPTION
Previously one could set the cardinality for lines between attributes and for lines between entities and attributes. These should not have cardinalities so this PR removes the cardinality option for those cases. 

#6821 