### PR TITLE
Fixed issue #6297: Map hotkeys to dropdown functions

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -151,6 +151,8 @@ const cKey = 67;
 const dKey = 68;
 const eKey = 69;
 const fKey = 70;
+const gKey = 71;
+const hKey = 72;
 const lKey = 76;
 const mKey = 77;
 const rKey = 82;
@@ -478,6 +480,13 @@ function keyDownHandler(e) {
       } else {
         switchToolbarTo("ER");
       }
+    }
+    else if(shiftIsClicked && key == gKey) {
+        globalAppearanceMenu();
+    }
+
+    else if(shiftIsClicked && key == hKey) {
+        openAppearanceDialogMenu();
     }
 }
 
@@ -2078,16 +2087,16 @@ function reWrite() {
          + Math.round((zoomValue * 100)) + "%" + " </p>";
         document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
          + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) 
+         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0)
          + " | Top-left Corner(" + Math.round(origoOffsetX / zoomValue) + ", " + Math.round(origoOffsetY / zoomValue) + " ) </p>";
     if(hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free"){
       document.getElementById("zoomV").innerHTML = "<p><b>Zoom:</b> "
        + Math.round((zoomValue * 100)) + "%" + " </p>";
       document.getElementById("valuesCanvas").innerHTML = "<p><b>Coordinates:</b> "
        + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
-       + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) 
-       + " | Top-left Corner(" + Math.round(origoOffsetX / zoomValue) + ", " + Math.round(origoOffsetY / zoomValue) + " ) " 
-       + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y=" 
+       + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0)
+       + " | Top-left Corner(" + Math.round(origoOffsetX / zoomValue) + ", " + Math.round(origoOffsetY / zoomValue) + " ) "
+       + " | <b>Center coordinates of hovered object:</b> X=" + Math.round(points[hoveredObject.centerPoint].x) + " & Y="
        + Math.round(points[hoveredObject.centerPoint].y) + "</p>";
     }
     } else {
@@ -3443,7 +3452,7 @@ function mouseupevt(ev) {
             lastSelectedObject = diagram.length -1;
             diagram[lastSelectedObject].targeted = true;
             selected_objects.push(diagram[lastSelectedObject]);
-            
+
             uimode = "CreateLine";
             createCardinality();
             updateGraphics();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -144,6 +144,7 @@ const upArrow = 38;
 const rightArrow = 39;
 const downArrow = 40;
 const deleteKey = 46;
+const key0 = 48;
 const key1 = 49;
 const key2 = 50;
 const key4 = 52;
@@ -158,9 +159,11 @@ const eKey = 69;
 const fKey = 70;
 const gKey = 71;
 const hKey = 72;
+const iKey = 73;
 const lKey = 76;
 const mKey = 77;
 const rKey = 82;
+const sKey = 83;
 const tKey = 84;
 const vKey = 86;
 const zKey = 90;
@@ -480,7 +483,7 @@ function keyDownHandler(e) {
           openAppearanceDialogMenu();
     } else if(shiftIsClicked && key == xKey) {
           lockSelected(event);
-    } else if(shiftIsClicked && key == oKey) {
+    } else if(shiftIsClicked && key == key0) {
           resetViewToOrigin();
     } else if(shiftIsClicked && key == bKey) {
           switchToolbarDev();
@@ -492,7 +495,16 @@ function keyDownHandler(e) {
           toggleVirtualA4Holes();
     } else if(shiftIsClicked && key == key7) {
           toggleVirtualA4HolesRight();
+    } else if(shiftIsClicked && key == iKey) {
+          openImportDialog();
     }
+
+    /* Add this when we add function to load and save options in the menu.
+    else if(shiftIsClicked && key == oKey) {
+          Load function here...
+    } else if(shiftIsClicked && key == sKey) {
+          Save function here...
+    } */
 }
 
 //----------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -412,7 +412,7 @@ function keyDownHandler(e) {
             deactivateMovearound();
         }
         updateGraphics();
-    } else if(key == upArrow || key == downArrow || key == leftArrow || key == rightArrow) {//arrow keys
+    } else if((key == upArrow || key == downArrow || key == leftArrow || key == rightArrow) && !shiftIsClicked) { 
         arrowKeyPressed(key);
         moveCanvasView(key);
     } else if(key == ctrlKey || key == windowsKey) {
@@ -497,6 +497,14 @@ function keyDownHandler(e) {
           toggleVirtualA4HolesRight();
     } else if(shiftIsClicked && key == iKey) {
           openImportDialog();
+    } else if(shiftIsClicked && key == upArrow) {
+          align(event, 'top');
+    } else if(shiftIsClicked && key == rightArrow) {
+          align(event, 'right');
+    } else if(shiftIsClicked && key == downArrow) {
+          align(event, 'bottom');
+    } else if(shiftIsClicked && key == leftArrow) {
+          align(event, 'left');
     }
 
     /* Add this when we add function to load and save options in the menu.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -173,6 +173,9 @@ const oKey = 79;
 const windowsKey = 91;
 const num1 = 97;
 const num2 = 98;
+const commaKey = 188;
+const periodKey = 190;
+const lessThanKey = 226;
 
 // Mouse clicks
 const rightMouseClick = 2;
@@ -412,7 +415,7 @@ function keyDownHandler(e) {
             deactivateMovearound();
         }
         updateGraphics();
-    } else if((key == upArrow || key == downArrow || key == leftArrow || key == rightArrow) && !shiftIsClicked) { 
+    } else if((key == upArrow || key == downArrow || key == leftArrow || key == rightArrow) && !shiftIsClicked) {
         arrowKeyPressed(key);
         moveCanvasView(key);
     } else if(key == ctrlKey || key == windowsKey) {
@@ -505,6 +508,14 @@ function keyDownHandler(e) {
           align(event, 'bottom');
     } else if(shiftIsClicked && key == leftArrow) {
           align(event, 'left');
+    } else if(shiftIsClicked && key == commaKey) {
+          align(event, 'horizontalCenter');
+    } else if(shiftIsClicked && key == periodKey) {
+          align(event, 'verticalCenter');
+    } else if(shiftIsClicked && key == zKey) {
+          distribute(event, 'horizontally');
+    } else if(shiftIsClicked && key == lessThanKey) {
+          distribute(event, 'vertically');
     }
 
     /* Add this when we add function to load and save options in the menu.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -160,6 +160,8 @@ const tKey = 84;
 const vKey = 86;
 const zKey = 90;
 const yKey = 89;
+const xKey = 88;
+const oKey = 79;
 const windowsKey = 91;
 const num1 = 97;
 const num2 = 98;
@@ -437,57 +439,45 @@ function keyDownHandler(e) {
             diagram[i].targeted = true;
         }
         updateGraphics();
-    }
-    else if(key == ctrlKey || key == windowsKey) {
+    } else if(key == ctrlKey || key == windowsKey) {
         ctrlIsClicked = true;
-    }
-    else if(key == escapeKey) {
+    } else if(key == escapeKey) {
         cancelFreeDraw();
-    }
-    else if((key == key1 || key == num1) && shiftIsClicked){
+    } else if((key == key1 || key == num1) && shiftIsClicked){
         moveToFront();
-    }
-    else if((key == key2 || key == num2) && shiftIsClicked){
+    } else if((key == key2 || key == num2) && shiftIsClicked){
         moveToBack();
-    }
-    else if(shiftIsClicked && key == lKey) {
+    } else if(shiftIsClicked && key == lKey) {
       document.getElementById("linebutton").click();
-    }
-    else if(shiftIsClicked && key == aKey && targetMode == "ER") {
+    } else if(shiftIsClicked && key == aKey && targetMode == "ER") {
       document.getElementById("attributebutton").click();
-    }
-    else if(shiftIsClicked && key == eKey && targetMode == "ER") {
+    } else if(shiftIsClicked && key == eKey && targetMode == "ER") {
       document.getElementById("entitybutton").click();
-    }
-    else if(shiftIsClicked && key == rKey && targetMode == "ER") {
+    } else if(shiftIsClicked && key == rKey && targetMode == "ER") {
       document.getElementById("relationbutton").click();
-    }
-    else if(shiftIsClicked && key == cKey && targetMode == "UML") {
+    } else if(shiftIsClicked && key == cKey && targetMode == "UML") {
       document.getElementById("classbutton").click();
-    }
-    else if(shiftIsClicked && key == tKey && targetMode == "ER") {
+    } else if(shiftIsClicked && key == tKey && targetMode == "ER") {
       document.getElementById("drawtextbutton").click();
-    }
-    else if(shiftIsClicked && key == fKey) {
+    } else if(shiftIsClicked && key == fKey) {
       document.getElementById("drawfreebutton").click();
-    }
-    else if(shiftIsClicked && key == dKey) {
+    } else if(shiftIsClicked && key == dKey) {
       developerMode(event);
-    }
-    else if(shiftIsClicked && key == mKey) {
+    } else if(shiftIsClicked && key == mKey) {
       if(targetMode == "ER"){
         switchToolbarTo("UML");
       } else {
         switchToolbarTo("ER");
       }
-    }
-    else if(shiftIsClicked && key == gKey) {
-        globalAppearanceMenu();
-    }
-
-    else if(shiftIsClicked && key == hKey) {
-        openAppearanceDialogMenu();
-    }
+    } else if(shiftIsClicked && key == gKey) {
+          globalAppearanceMenu();
+    } else if(shiftIsClicked && key == hKey) {
+          openAppearanceDialogMenu();
+    } else if(shiftIsClicked && key == xKey) {
+          lockSelected(event);
+    } else if(shiftIsClicked && key == oKey) {
+          resetViewToOrigin();
+      }
 }
 
 //----------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1444,7 +1444,6 @@ function hideA4State() {
 }
 
 function toggleVirtualA4Holes(event) {
-    event.stopPropagation();
     // Toggle a4 holes to the A4-paper.
     if (toggleA4 && toggleA4Holes) {
         toggleA4Holes = false;
@@ -1465,7 +1464,6 @@ function toggleVirtualA4Holes(event) {
 }
 
 function toggleVirtualA4HolesRight(event) {
-    event.stopPropagation();
     // Switch a4 holes from left to right of the A4-paper.
     if (switchSideA4Holes == "right" && toggleA4) {
         switchSideA4Holes = "left";
@@ -1479,7 +1477,6 @@ function toggleVirtualA4HolesRight(event) {
 }
 
 function toggleA4Orientation(event) {
-    event.stopPropagation();
     if (A4Orientation == "portrait" && toggleA4) {
         A4Orientation = "landscape";
         setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), true);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -147,6 +147,9 @@ const deleteKey = 46;
 const key1 = 49;
 const key2 = 50;
 const key4 = 52;
+const key5 = 53;
+const key6 = 54;
+const key7 = 55;
 const aKey = 65;
 const bKey = 66;
 const cKey = 67;
@@ -483,6 +486,12 @@ function keyDownHandler(e) {
           switchToolbarDev();
     } else if(shiftIsClicked && key == key4) {
           toggleVirtualA4(event);
+    } else if(shiftIsClicked && key == key5) {
+          toggleA4Orientation();
+    } else if(shiftIsClicked && key == key6) {
+          toggleVirtualA4Holes();
+    } else if(shiftIsClicked && key == key7) {
+          toggleVirtualA4HolesRight();
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -160,6 +160,7 @@ const fKey = 70;
 const gKey = 71;
 const hKey = 72;
 const iKey = 73;
+const kKey = 75;
 const lKey = 76;
 const mKey = 77;
 const rKey = 82;
@@ -498,8 +499,10 @@ function keyDownHandler(e) {
           toggleVirtualA4Holes();
     } else if(shiftIsClicked && key == key7) {
           toggleVirtualA4HolesRight();
-    } else if(shiftIsClicked && key == iKey) {
-          openImportDialog();
+    } else if(shiftIsClicked && key == kKey) {
+          toggleGrid(event);
+    } else if(shiftIsClicked && key == lessThanKey) {
+          distribute(event, 'vertically');
     } else if(shiftIsClicked && key == upArrow) {
           align(event, 'top');
     } else if(shiftIsClicked && key == rightArrow) {
@@ -983,7 +986,7 @@ diagram.targetItemsInsideSelectionBox = function (ex, ey, sx, sy, hover) {
                         setTargetedForSymbolGroup(this[i], true);
                     } else if (hover) {
                         this[i].isHovered = true;
-                    } 
+                    }
                 }
             } else if (!ctrlIsClicked) {
                 if (!hover) this[i].targeted = false;
@@ -1763,11 +1766,11 @@ function drawGrid() {
 // Sets the color depending on whether the gridline should be darker or brighter grey
 //-------------------------------------------------------------------------------------
 
-function setLineColor(counter){    
+function setLineColor(counter){
     if(counter % 5 == 0){
         ctx.strokeStyle = "rgb(208, 208, 220)";
     } else {
-        ctx.strokeStyle = "rgb(238, 238, 250)";            
+        ctx.strokeStyle = "rgb(238, 238, 250)";
     }
 }
 
@@ -2196,24 +2199,24 @@ function addGroupToSelected(event) {
     // find all symbols/freedraw objects that is going to be in the group
     for (var i = 0; i < selected_objects.length; i++) {
         // do not group lines
-        if(selected_objects[i].kind == kind.symbol && 
+        if(selected_objects[i].kind == kind.symbol &&
             (selected_objects[i].symbolkind == symbolKind.line || selected_objects[i].symbolkind == symbolKind.umlLine)) {
             continue;
         } else {
             tempList.push(selected_objects[i]);
         }
     }
-    // remove the current group the objects have 
+    // remove the current group the objects have
     for (var i = 0; i < tempList.length; i++ ) {
         tempList[i].group = 0;
     }
     // check what group numbers already exist
     var currentGroups = [];
     for (var i = 0; i < diagram.length; i++) {
-        // don't check lines 
+        // don't check lines
         if (diagram[i].kind == kind.symbol && (diagram[i].symbolkind == symbolKind.line || diagram[i].symbolkind == symbolKind.umlLine)) {
-        } else { 
-            if (diagram[i].group != 0) { 
+        } else {
+            if (diagram[i].group != 0) {
                 currentGroups.push(diagram[i].group);
             }
         }
@@ -2243,7 +2246,7 @@ function removeGroupFromSelected(event) {
     event.stopPropagation();
     for (var i = 0; i < selected_objects.length; i++) {
         // do not do anything with lines
-        if (selected_objects[i].kind == kind.symbol && 
+        if (selected_objects[i].kind == kind.symbol &&
             (selected_objects[i].symbolkind == symbolKind.line || selected_objects[i].symbolkind == symbolKind.umlLine)) {
             continue;
         }
@@ -2943,7 +2946,7 @@ function mousemoveevt(ev, t) {
             // Select a new point only if mouse is not already moving a point or selection box
             sel = diagram.closestPoint(currentMouseCoordinateX, currentMouseCoordinateY);
             if (sel.distance < tolerance / zoomValue) {
-                // check so that the point we're hovering over belongs to an object that's selected 
+                // check so that the point we're hovering over belongs to an object that's selected
                 var pointBelongsToObject = false;
                 for (var i = 0; i < selected_objects.length; i++) {
                     if (sel.attachedSymbol == selected_objects[i]) {
@@ -4077,7 +4080,7 @@ function changeCardinality(isUML) {
         }
     }
 }
-// Changes direction for uml line relations 
+// Changes direction for uml line relations
 function changeLineDirection() {
     diagram[lastSelectedObject].lineDirection = document.getElementById('line_direction').value;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -146,7 +146,9 @@ const downArrow = 40;
 const deleteKey = 46;
 const key1 = 49;
 const key2 = 50;
+const key4 = 52;
 const aKey = 65;
+const bKey = 66;
 const cKey = 67;
 const dKey = 68;
 const eKey = 69;
@@ -477,7 +479,11 @@ function keyDownHandler(e) {
           lockSelected(event);
     } else if(shiftIsClicked && key == oKey) {
           resetViewToOrigin();
-      }
+    } else if(shiftIsClicked && key == bKey) {
+          switchToolbarDev();
+    } else if(shiftIsClicked && key == key4) {
+          toggleVirtualA4(event);
+    }
 }
 
 //----------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -494,11 +494,11 @@ function keyDownHandler(e) {
     } else if(shiftIsClicked && key == key4) {
           toggleVirtualA4(event);
     } else if(shiftIsClicked && key == key5) {
-          toggleA4Orientation();
+          toggleA4Orientation(event);
     } else if(shiftIsClicked && key == key6) {
-          toggleVirtualA4Holes();
+          toggleVirtualA4Holes(event);
     } else if(shiftIsClicked && key == key7) {
-          toggleVirtualA4HolesRight();
+          toggleVirtualA4HolesRight(event);
     } else if(shiftIsClicked && key == kKey) {
           toggleGrid(event);
     } else if(shiftIsClicked && key == lessThanKey) {
@@ -1444,6 +1444,7 @@ function hideA4State() {
 }
 
 function toggleVirtualA4Holes(event) {
+    event.stopPropagation();
     // Toggle a4 holes to the A4-paper.
     if (toggleA4 && toggleA4Holes) {
         toggleA4Holes = false;
@@ -1464,6 +1465,7 @@ function toggleVirtualA4Holes(event) {
 }
 
 function toggleVirtualA4HolesRight(event) {
+    event.stopPropagation();
     // Switch a4 holes from left to right of the A4-paper.
     if (switchSideA4Holes == "right" && toggleA4) {
         switchSideA4Holes = "left";
@@ -1477,6 +1479,7 @@ function toggleVirtualA4HolesRight(event) {
 }
 
 function toggleA4Orientation(event) {
+    event.stopPropagation();
     if (A4Orientation == "portrait" && toggleA4) {
         A4Orientation = "landscape";
         setOrientationIcon($(".drop-down-option:contains('Toggle A4 Orientation')"), true);

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -180,6 +180,7 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='lockSelected(event)'>Lock/Unlock selected</span>
+                                <i id="hotkey-lock">Shift + X</i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
@@ -189,6 +190,7 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='resetViewToOrigin();'>Reset view to origin</span>
+                                <i id="hotkey-resetView">Shift + O</i>
                             </div>
                         </div>
                     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -204,6 +204,7 @@
                             <div class="drop-down-item">
                                 <div id="displayAllTools" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick="switchToolbarDev();"><img src="../Shared/icons/Arrow_down_right.png">Display All Tools</span>
+                                    <i id="hotkey-displayTools">Shift + B</i>
                                 </div>
                             </div>
                             <div class="drop-down-divider">
@@ -220,6 +221,7 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="toggleVirtualA4(event)">Display Virtual A4</span>
+                                <i id="hotkey-displayA4">Shift + 4</i>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-orientation-item" class="drop-down-item-disabled">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -275,9 +275,11 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'horizontalCenter');">Horizontal center</span>
+                                <i id="hotkey-Align-Horizontal" class="hotKeys">Shift + , </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'verticalCenter');">Vertical center</span>
+                                <i id="hotkey-Align-Vertical" class="hotKeys">Shift + . </i>
                             </div>
                         </div>
                     </div>
@@ -286,9 +288,11 @@
                         <div class="drop-down">
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="distribute(event, 'horizontally');">Horizontal</span>
+                                <i id="hotkey-Distribute-Vertical" class="hotKeys">Shift + < </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="distribute(event, 'vertically');">Vertical</span>
+                                <i id="hotkey-Distribute-Horizontal" class="hotKeys">Shift + Z </i>
                             </div>
                         </div>
                     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -236,19 +236,19 @@
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-orientation-item" class="drop-down-item-disabled">
-                                    <span class="drop-down-option" onclick='toggleA4Orientation();'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Orientation</span>
+                                    <span class="drop-down-option" onclick='toggleA4Orientation(event);'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Orientation</span>
                                     <i id="hotkey-A4-Orientation" class="hotKeys">Shift + 5</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-holes-item" class="drop-down-item-disabled">
-                                    <span class="drop-down-option" onclick='toggleVirtualA4Holes();'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Holes</span>
+                                    <span class="drop-down-option" onclick='toggleVirtualA4Holes(event);'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Holes</span>
                                     <i id="hotkey-Toggle-Holes" class="hotKeys">Shift + 6</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-holes-item-right" class="drop-down-item-disabled">
-                                    <span class="drop-down-option" onclick='toggleVirtualA4HolesRight();'><img src="../Shared/icons/Arrow_down_right.png">A4 Holes Right</span>
+                                    <span class="drop-down-option" onclick='toggleVirtualA4HolesRight(event);'><img src="../Shared/icons/Arrow_down_right.png">A4 Holes Right</span>
                                     <i id="hotkey-Holes-Right" class="hotKeys">Shift + 7</i>
                                 </div>
                             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -141,7 +141,7 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='clearCanvas(); removeLocalStorage();'>Clear Diagram</span>
-                                <i id="hotkey-clear">Ctrl + A, Delete</i>
+                                <i id="hotkey-clear" class="hotKeys">Ctrl + A, Delete</i>
                             </div>
                         </div>
                     </div>
@@ -150,47 +150,47 @@
                         <div class="drop-down">
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='undoDiagram(event)'>Undo</span>
-                                <i id="hotkey-undo">Ctrl + Z</i>
+                                <i id="hotkey-undo" class="hotKeys">Ctrl + Z</i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='redoDiagram(event)'>Redo</span>
-                                <i id="hotkey-redo">Ctrl + Y</i>
+                                <i id="hotkey-redo" class="hotKeys">Ctrl + Y</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='globalAppearanceMenu();'>Global Appearance</span>
-                                <i id="hotkey-global">Shift + G</i>
+                                <i id="hotkey-global" class="hotKeys">Shift + G</i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='openAppearanceDialogMenu();'>Change Appearance</span>
-                                <i id="hotkey-appearance">Shift + H</i>
+                                <i id="hotkey-appearance" class="hotKeys">Shift + H</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='moveToFront()'>Move selected to front</span>
-                                <i id="hotkey-front">Shift + 1</i>
+                                <i id="hotkey-front" class="hotKeys">Shift + 1</i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='moveToBack()'>Move selected to back</span>
-                                <i id="hotkey-back">Shift + 2</i>
+                                <i id="hotkey-back" class="hotKeys">Shift + 2</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='lockSelected(event)'>Lock/Unlock selected</span>
-                                <i id="hotkey-lock">Shift + X</i>
+                                <i id="hotkey-lock" class="hotKeys">Shift + X</i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
-                                <i id="hotkey-delete">Delete/Backspace</i>
+                                <i id="hotkey-delete" class="hotKeys">Delete/Backspace</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='resetViewToOrigin();'>Reset view to origin</span>
-                                <i id="hotkey-resetView">Shift + O</i>
+                                <i id="hotkey-resetView" class="hotKeys">Shift + O</i>
                             </div>
                         </div>
                     </div>
@@ -199,46 +199,46 @@
                         <div class="drop-down">
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='developerMode(event);'>Developer mode</span>
-                                <i id="hotkey-developerMode">Shift + D</i>
+                                <i id="hotkey-developerMode" class="hotKeys">Shift + D</i>
                             </div>
                             <div class="drop-down-item">
                                 <div id="displayAllTools" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick="switchToolbarDev();"><img src="../Shared/icons/Arrow_down_right.png">Display All Tools</span>
-                                    <i id="hotkey-displayTools">Shift + B</i>
+                                    <i id="hotkey-displayTools" class="hotKeys">Shift + B</i>
                                 </div>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div id="er-item" class="drop-down-item">
                                 <span class="drop-down-option" onclick="switchToolbarTo('ER');">ER</span>
-                                <i id="hotkey-ER">Shift + M</i>
+                                <i id="hotkey-ER" class="hotKeys">Shift + M</i>
                             </div>
                             <div id="uml-item" class="drop-down-item">
                                 <span class="drop-down-option" onclick="switchToolbarTo('UML');">UML</span>
-                                <i id="hotkey-UML">Shift + M</i>
+                                <i id="hotkey-UML" class="hotKeys">Shift + M</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="toggleVirtualA4(event)">Display Virtual A4</span>
-                                <i id="hotkey-displayA4">Shift + 4</i>
+                                <i id="hotkey-displayA4" class="hotKeys">Shift + 4</i>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-orientation-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleA4Orientation();'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Orientation</span>
-                                    <i id="hotkey-A4-Orientation">Shift + 5</i>
+                                    <i id="hotkey-A4-Orientation" class="hotKeys">Shift + 5</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-holes-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleVirtualA4Holes();'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Holes</span>
-                                    <i id="hotkey-Toggle-Holes">Shift + 6</i>
+                                    <i id="hotkey-Toggle-Holes" class="hotKeys">Shift + 6</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-holes-item-right" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleVirtualA4HolesRight();'><img src="../Shared/icons/Arrow_down_right.png">A4 Holes Right</span>
-                                    <i id="hotkey-Holes-Right">Shift + 7</i>
+                                    <i id="hotkey-Holes-Right" class="hotKeys">Shift + 7</i>
                                 </div>
                             </div>
                         </div>
@@ -289,7 +289,7 @@
                         <div class="drop-down">
                             <div class="drop-down-text-non-clickable">
                                 <span class="drop-down-option">Move camera</span>
-                                <div id="hotkey-space">
+                                <div id="hotkey-space" class="hotKeys">
                                     <i>Blankspace</i>
                                 </div>
                             </div>
@@ -297,7 +297,7 @@
                             </div>
                             <div class="drop-down-text-non-clickable">
                                 <span class="drop-down-option">Select multiple objects</span>
-                                <div id="hotkey-ctrl">
+                                <div id="hotkey-ctrl" class="hotKeys">
                                     <i>Ctrl + leftclick</i>
                                 </div>
                             </div>
@@ -305,7 +305,7 @@
                             </div>
                             <div class="drop-down-text-non-clickable">
                                 <span class="drop-down-option">Lock object proportions</span>
-                                <div id="hotkey-shift">
+                                <div id="hotkey-shift" class="hotKeys">
                                     <i>Shift</i>
                                 </div>
                             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -226,16 +226,19 @@
                             <div class="drop-down-item">
                                 <div id="a4-orientation-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleA4Orientation();'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Orientation</span>
+                                    <i id="hotkey-A4-Orientation">Shift + 5</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-holes-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleVirtualA4Holes();'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Holes</span>
+                                    <i id="hotkey-Toggle-Holes">Shift + 6</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-holes-item-right" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleVirtualA4HolesRight();'><img src="../Shared/icons/Arrow_down_right.png">A4 Holes Right</span>
+                                    <i id="hotkey-Holes-Right">Shift + 7</i>
                                 </div>
                             </div>
                         </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -275,11 +275,11 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'horizontalCenter');">Horizontal center</span>
-                                <i id="hotkey-Align-Horizontal" class="hotKeys">Shift + , </i>
+                                <i id="hotkey-Align-Horizontal" class="hotKeys">Shift + ' , ' </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'verticalCenter');">Vertical center</span>
-                                <i id="hotkey-Align-Vertical" class="hotKeys">Shift + . </i>
+                                <i id="hotkey-Align-Vertical" class="hotKeys">Shift + ' . ' </i>
                             </div>
                         </div>
                     </div>
@@ -288,7 +288,7 @@
                         <div class="drop-down">
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="distribute(event, 'horizontally');">Horizontal</span>
-                                <i id="hotkey-Distribute-Vertical" class="hotKeys">Shift + < </i>
+                                <i id="hotkey-Distribute-Vertical" class="hotKeys">Shift + ' < ' </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="distribute(event, 'vertically');">Vertical</span>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -114,14 +114,17 @@
                         <div class="drop-down">
                             <div class="drop-down-item">
                                 <span class="drop-down-option">Save</span>
+                                <i id="hotkey-save" class="hotKeys">Shift + S</i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option">Load</span>
+                                <i id="hotkey-load" class="hotKeys">Shift + O</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" id="buttonid" onclick="openImportDialog();">Import</span>
+                                <span class="drop-down-option" onclick="openImportDialog();">Import</span>
+                                <i id="hotkey-import" class="hotKeys">Shift + I</i>
                             </div>
                             <div class="drop-down-item export-drop-down-head">
                                 <span class="drop-down-option" id="exportid">Export...</span>
@@ -190,7 +193,7 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='resetViewToOrigin();'>Reset view to origin</span>
-                                <i id="hotkey-resetView" class="hotKeys">Shift + O</i>
+                                <i id="hotkey-resetView" class="hotKeys">Shift + 0</i>
                             </div>
                         </div>
                     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -251,20 +251,25 @@
                         <div class="drop-down">
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="toggleGrid(event)">Snap to grid</span>
+                                <i id="hotkey-Snap-Grid" class="hotKeys">Shift + K</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'top');">Top</span>
+                                <i id="hotkey-Align-Top" class="hotKeys">Shift + ⇧ </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'right');">Right</span>
+                                <i id="hotkey-Align-Right" class="hotKeys">Shift + ⇨ </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'bottom');">Bottom</span>
+                                <i id="hotkey-Align-Bottom" class="hotKeys">Shift + ⇩ </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'left');">Left</span>
+                                <i id="hotkey-Align-Left" class="hotKeys">Shift + ⇦ </i>
                             </div>
                             <div class="drop-down-divider">
                             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -160,9 +160,11 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='globalAppearanceMenu();'>Global Appearance</span>
+                                <i id="hotkey-global">Shift + G</i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick='openAppearanceDialogMenu();'>Change Appearance</span>
+                                <i id="hotkey-appearance">Shift + H</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1493,7 +1493,7 @@ input {
   top: 100px;
 }
 
-#hotkey-undo, #hotkey-save {
+#hotkey-undo, #hotkey-save, #hotkey-Snap-Grid {
   right: 5px;
   top: 10px;
 }
@@ -1576,6 +1576,26 @@ input {
 #hotkey-UML {
   right: 35px;
   top: 120px;
+}
+
+#hotkey-Align-Top {
+  right: 5px;
+  top: 55px;
+}
+
+#hotkey-Align-Right {
+  right: 5px;
+  top: 87px;
+}
+
+#hotkey-Align-Bottom {
+  right: 5px;
+  top: 120px;
+}
+
+#hotkey-Align-Left {
+  right: 5px;
+  top: 151px;
 }
 
 .drop-down-item #hotkey-delete {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1555,8 +1555,32 @@ input {
   position: absolute;
   font-size: 11px;
   color: #3d3d3d;
-  right: 37px;
+  right: 39px;
   top: 164px;
+}
+
+.drop-down-item #hotkey-A4-Orientation {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 39px;
+  top: 200px;
+}
+
+.drop-down-item #hotkey-Toggle-Holes {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 39px;
+  top: 232px;
+}
+
+.drop-down-item #hotkey-Holes-Right {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 39px;
+  top: 264px;
 }
 
 #hotkey-clear, #hotkey-front {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1527,13 +1527,29 @@ input {
   top: 119px;
 }
 
+.drop-down-item #hotkey-lock {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 6px;
+  top: 241px;
+}
+
+.drop-down-item #hotkey-resetView {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 6px;
+  top: 317px;
+}
+
 #hotkey-clear, #hotkey-front {
-  right: 6px ;
+  right: 5px ;
   top: 165px;
 }
 
 #hotkey-back {
-  right: 6px ;
+  right: 5px ;
   top: 195px;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1493,12 +1493,12 @@ input {
   top: 100px;
 }
 
-#hotkey-undo, #hotkey-save, #hotkey-Snap-Grid {
+#hotkey-undo, #hotkey-save, #hotkey-Snap-Grid, #hotkey-Distribute-Horizontal {
   right: 5px;
   top: 10px;
 }
 
-#hotkey-redo, #hotkey-load {
+#hotkey-redo, #hotkey-load, #hotkey-Distribute-Vertical {
   right: 5px;
   top: 43px;
 }
@@ -1596,6 +1596,16 @@ input {
 #hotkey-Align-Left {
   right: 5px;
   top: 151px;
+}
+
+#hotkey-Align-Horizontal {
+  right: 5px;
+  top: 195px;
+}
+
+#hotkey-Align-Vertical {
+  right: 5px;
+  top: 228px;
 }
 
 .drop-down-item #hotkey-delete {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1472,113 +1472,78 @@ input {
   cursor: default !important;
 }
 
+.hotKeys {
+  position: absolute;
+  font-size: 9px;
+  color: #3d3d3d;
+  opacity: 0.5;
+}
+
 #hotkey-space {
-  position: absolute  !important;
-  font-size: 11px !important;
-  color: #3d3d3d  !important;
   right: 6px;
   top: 10px;
 }
 
 #hotkey-ctrl {
-  position: absolute  !important;
-  font-size: 11px  !important;
-  color: #3d3d3d !important;
   right: 6px;
   top: 55px;
 }
 #hotkey-shift {
-  position: absolute !important;
-  font-size: 11px !important;
-  color: #3d3d3d !important;
-  right: 6px !important;
+  right: 6px;
   top: 100px;
 }
 
-#hotkey-undo, #hotkey-redo, #hotkey-clear, #hotkey-front, #hotkey-back, #hotkey-developerMode, #hotkey-ER, #hotkey-UML {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
-}
-
 .drop-down-item #hotkey-undo {
-  right: 6px ;
+  right: 6px;
   top: 10px;
 }
 
 .drop-down-item #hotkey-redo {
-  right: 6px ;
+  right: 6px;
   top: 45px;
 }
 
 .drop-down-item #hotkey-global {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 4px;
   top: 86px;
 }
 
 .drop-down-item #hotkey-appearance {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 5px;
   top: 119px;
 }
 
 .drop-down-item #hotkey-lock {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 6px;
   top: 241px;
 }
 
 .drop-down-item #hotkey-resetView {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 6px;
   top: 317px;
 }
 
 .drop-down-item #hotkey-displayTools {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 36px;
   top: 45px;
 }
 
 .drop-down-item #hotkey-displayA4 {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 39px;
   top: 164px;
 }
 
 .drop-down-item #hotkey-A4-Orientation {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 39px;
   top: 200px;
 }
 
 .drop-down-item #hotkey-Toggle-Holes {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 39px;
   top: 232px;
 }
 
 .drop-down-item #hotkey-Holes-Right {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 39px;
   top: 264px;
 }
@@ -1609,9 +1574,6 @@ input {
 }
 
 .drop-down-item #hotkey-delete {
-  position: absolute;
-  font-size: 11px;
-  color: #3d3d3d;
   right: 6px;
   top: 272px;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1543,6 +1543,22 @@ input {
   top: 317px;
 }
 
+.drop-down-item #hotkey-displayTools {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 36px;
+  top: 45px;
+}
+
+.drop-down-item #hotkey-displayA4 {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 37px;
+  top: 164px;
+}
+
 #hotkey-clear, #hotkey-front {
   right: 5px ;
   top: 165px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1493,7 +1493,7 @@ input {
   top: 100px;
 }
 
-#hotkey-undo, #hotkey-save, #hotkey-Snap-Grid, #hotkey-Distribute-Horizontal {
+#hotkey-undo, #hotkey-save, #hotkey-Distribute-Horizontal {
   right: 5px;
   top: 10px;
 }
@@ -1563,7 +1563,7 @@ input {
   top: 195px;
 }
 
-#hotkey-developerMode{
+#hotkey-developerMode, #hotkey-Snap-Grid{
     right: 35px;
     top: 10px;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1511,6 +1511,22 @@ input {
   top: 45px;
 }
 
+.drop-down-item #hotkey-global {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 4px;
+  top: 86px;
+}
+
+.drop-down-item #hotkey-appearance {
+  position: absolute;
+  font-size: 11px;
+  color: #3d3d3d;
+  right: 5px;
+  top: 119px;
+}
+
 #hotkey-clear, #hotkey-front {
   right: 6px ;
   top: 165px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1493,59 +1493,64 @@ input {
   top: 100px;
 }
 
-.drop-down-item #hotkey-undo {
-  right: 6px;
+#hotkey-undo, #hotkey-save {
+  right: 5px;
   top: 10px;
 }
 
-.drop-down-item #hotkey-redo {
-  right: 6px;
-  top: 45px;
+#hotkey-redo, #hotkey-load {
+  right: 5px;
+  top: 43px;
 }
 
-.drop-down-item #hotkey-global {
+#hotkey-global {
   right: 4px;
   top: 86px;
 }
 
-.drop-down-item #hotkey-appearance {
+#hotkey-appearance {
   right: 5px;
   top: 119px;
 }
 
-.drop-down-item #hotkey-lock {
+#hotkey-lock {
   right: 6px;
   top: 241px;
 }
 
-.drop-down-item #hotkey-resetView {
+#hotkey-resetView {
   right: 6px;
   top: 317px;
 }
 
-.drop-down-item #hotkey-displayTools {
+#hotkey-displayTools {
   right: 36px;
   top: 45px;
 }
 
-.drop-down-item #hotkey-displayA4 {
+#hotkey-displayA4 {
   right: 39px;
   top: 164px;
 }
 
-.drop-down-item #hotkey-A4-Orientation {
+#hotkey-A4-Orientation {
   right: 39px;
   top: 200px;
 }
 
-.drop-down-item #hotkey-Toggle-Holes {
+#hotkey-Toggle-Holes {
   right: 39px;
   top: 232px;
 }
 
-.drop-down-item #hotkey-Holes-Right {
+#hotkey-Holes-Right {
   right: 39px;
   top: 264px;
+}
+
+#hotkey-import {
+  right: 7px;
+  top: 86px;
 }
 
 #hotkey-clear, #hotkey-front {


### PR DESCRIPTION
Issue: #6297 
**Co-author: @a17jacsv**

Added hotkey for all drop down options in the menu bar. Also fixed a class that contains all the styling for the hotkey labels to remove duplicate code in style.css. Added save and load hotkey labels in comment brackets even though the functions are not implemented yet. We choose the hotkeys we thought were appropriate and close to each other if they were similar in some way. Feedback on this would be appreciated.
