### PR TITLE
State is no longer saved after moving the canvas, Fix for issue #7292

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3469,6 +3469,11 @@ function mouseupevt(ev) {
     if (diagramObject && p1BeforeResize.x == p2BeforeResize.x && p1BeforeResize.y == p2BeforeResize.y) {
         diagramObject.pointsAtSamePosition = true;
     }
+
+    if(uimode == "MoveAround" && md === mouseState.boxSelectOrCreateMode) {
+        saveState = false;
+    }
+
     hashFunction();
     updateGraphics();
     diagram.updateLineRelations();


### PR DESCRIPTION
Fix for issue #7292

state is no longer saved after moving the canvas.