### PR TITLE
Grupp b2019 w21#7231

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1152,6 +1152,10 @@ function rowFilter(row) {
 
         name = name.replace(' ', '');
 
+        if(name.toUpperCase()).includes(searchterm.toUpperCase()) != false){
+          console.log("FOUND THE NAME " + searchterm + " IN " + name);
+        }
+
 				if (name.toUpperCase().indexOf(searchterm.toUpperCase()) != -1) {
 					return true;
 				}

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1063,7 +1063,6 @@ function smartSearch(splitSearch, row) {
 				var txt = document.createElement("textarea");
 				txt.innerHTML = row[lid].entryname;
 				var columnToFind = txt.value;
-        columnToFind = columnToFind.replace(' ', '');
         console.log(columnToFind);
 				if (columnToSearch.toUpperCase() === columnToFind.toUpperCase()) {
 					if (sortingType === sortingValue) {
@@ -1123,7 +1122,6 @@ function rowFilter(row) {
 	}
 
 	// divides the search on &&
-  searchterm = searchterm.replace(' ', '');
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
 

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1126,10 +1126,10 @@ function rowFilter(row) {
 
 	tempSplitSearch.forEach(function (s) {
 		if (s.length > 0)
-			splitSearch.push(s.trim().split(":"));
+			splitSearch.push(s.trim().replace(' ', '').split(":"));
 	})
 
-  console.log("splitsearch: "+splitSearch);
+  console.log("splitsearch: " + splitSearch);
 
   // The else makes sure that you can search on names without a search-category.
 	if (searchterm != "" && splitSearch != searchterm) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1063,8 +1063,6 @@ function smartSearch(splitSearch, row) {
 				var txt = document.createElement("textarea");
 				txt.innerHTML = row[lid].entryname;
 				var columnToFind = txt.value;
-        columnToFind = columnToFind.replace(' ', '');
-        console.log(columnToFind);
 				if (columnToSearch.toUpperCase() === columnToFind.toUpperCase()) {
 					if (sortingType === sortingValue) {
 						for (colname in row) {
@@ -1077,7 +1075,6 @@ function smartSearch(splitSearch, row) {
 								var txt = document.createElement("textarea");
 								txt.innerHTML = name;
 								var newName2 = txt.value;
-                newName2 = newName2.replace(' ', '');
 								if (newName2.toUpperCase().indexOf(columnToSearch.toUpperCase()) != -1) {
 									return true;
 								}
@@ -1124,7 +1121,6 @@ function rowFilter(row) {
 	}
 
 	// divides the search on &&
-  searchterm = searchterm.replace(' ', '');
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
 

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1063,6 +1063,7 @@ function smartSearch(splitSearch, row) {
 				var txt = document.createElement("textarea");
 				txt.innerHTML = row[lid].entryname;
 				var columnToFind = txt.value;
+        columnToFind = columnToFind.replace(' ', '');
 				if (columnToSearch.toUpperCase() === columnToFind.toUpperCase()) {
 					if (sortingType === sortingValue) {
 						for (colname in row) {
@@ -1121,7 +1122,7 @@ function rowFilter(row) {
 	}
 
 	// divides the search on &&
-  console.log(searchterm = searchterm.replace(' ', ''));
+  searchterm = searchterm.replace(' ', '');
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
 

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1121,7 +1121,7 @@ function rowFilter(row) {
 	}
 
 	// divides the search on &&
-  searchterm = searchterm.replace(' ', '');
+  console.log(searchterm = searchterm.replace(' ', ''));
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
 

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1029,6 +1029,7 @@ function smartSearch(splitSearch, row) {
 	for (var i = 0; i < splitSearch.length; i++) {
 		var index = i;
 		columnToSearch = splitSearch[i][1];
+    columnToSearch = columnToSearch.replace(' ', '');
 
 		for (var i = 0; i < moments.length; i++) {
 			lid = "lid:" + moments[i]["lid"];
@@ -1063,18 +1064,20 @@ function smartSearch(splitSearch, row) {
 				var txt = document.createElement("textarea");
 				txt.innerHTML = row[lid].entryname;
 				var columnToFind = txt.value;
+        columnToFind = columnToFind.replace(' ', '');
 				if (columnToSearch.toUpperCase() === columnToFind.toUpperCase()) {
 					if (sortingType === sortingValue) {
 						for (colname in row) {
 							if (colname == "lid:" + row[lid].lid) {
 								var name = "";
 								if (row[colname].entryname != null) {
-									name += row[colname].entryname + " ";
+									name += row[colname].entryname; // + " ";
 								}
                 // Makes sure that compares are posible even with å,ä and ö in the strings.
 								var txt = document.createElement("textarea");
 								txt.innerHTML = name;
 								var newName2 = txt.value;
+                newName2 = newName2.replace(' ', '');
 								if (newName2.toUpperCase().indexOf(columnToSearch.toUpperCase()) != -1) {
 									return true;
 								}

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1152,10 +1152,6 @@ function rowFilter(row) {
 
         name = name.replace(' ', '');
 
-        if(name.toUpperCase().includes(searchterm.toUpperCase()) != false){
-          console.log("FOUND THE NAME " + searchterm + " IN " + name);
-        }
-
 				if (name.toUpperCase().indexOf(searchterm.toUpperCase()) != -1) {
 					return true;
 				}

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1121,11 +1121,9 @@ function rowFilter(row) {
 	}
 
 	// divides the search on &&
+  searchterm = searchterm.replace(' ', '');
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
-
-  var spaceSlitSearch = [];
-  spaceSlitSearch = searchterm.split(" ");
 
 	tempSplitSearch.forEach(function (s) {
 		if (s.length > 0)

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -361,13 +361,13 @@ function gradeDugga(e, gradesys, cid, vers, moment, uid, mark, ukind, qversion, 
 	var currentTimeGetTime = currentTime.getTime();
 	if(document.getElementById('newFeedback') == null){
 		feedbackText = "";
-	} else {		
+	} else {
 		feedbackText = document.getElementById('newFeedback').value;
 	}
 
 	if ($(e.target).hasClass("Uc")) {
 		changeGrade(1, gradesys, cid, vers, moment, uid, mark, ukind, qversion, qid, null, feedbackText);
-		
+
 	} else if (($(e.target).hasClass("G")) || ($(e.target).hasClass("VG")) || ($(e.target).hasClass("U"))) {
 		changeGrade(0, gradesys, cid, vers, moment, uid, mark, ukind, qversion, qid, gradeExpire, feedbackText);
 	} else if ($(e.target).hasClass("Gc")) {
@@ -799,15 +799,15 @@ function renderCell(col, celldata, cellid) {
 			str += "<div style='font-weight:bold'>" + celldata.firstname + " " + celldata.lastname + "</div>";
 			str += "<div>" + celldata.username + " / " + celldata.class + "</div>";
 			str += "</div>";
-			return str;	
+			return str;
 		} else if (filterGrade === "none" || celldata.grade === filterGrade) {
 			// color based on pass,fail,pending,assigned,unassigned
 			str = "<div style='padding:10px;' class='resultTableCell ";
 			if (celldata.kind != 4 && celldata.needMarking == true && celldata.submitted < celldata.deadline) {
 				str += "dugga-pending";
-			} 
+			}
 			str += "'>";
-			// Creation of grading buttons		
+			// Creation of grading buttons
 			if (celldata.kind != 4 && celldata.needMarking == true && celldata.submitted < celldata.deadline) {
 				str += "<div class='gradeContainer resultTableText'>";
 				if (celldata.grade === null) {
@@ -846,10 +846,10 @@ function renderCell(col, celldata, cellid) {
 				}
 				str += "</div>";
 			}
-			return str;	
-		} 
-	}	
-	
+			return str;
+		}
+	}
+
 	else if(filterList["passedDeadline"]){
 				// First column (Fname/Lname/SSN)
 			if (col == "FnameLname") {
@@ -858,15 +858,15 @@ function renderCell(col, celldata, cellid) {
 				str += "<div style='font-weight:bold'>" + celldata.firstname + " " + celldata.lastname + "</div>";
 				str += "<div>" + celldata.username + " / " + celldata.class + "</div>";
 				str += "</div>";
-				return str;	
+				return str;
 			}else if (filterGrade === "none" || celldata.grade === filterGrade) {
 				// color based on pass,fail,pending,assigned,unassigned
 				str = "<div style='padding:10px;' class='resultTableCell ";
 				if (celldata.kind != 4 && celldata.needMarking == true && celldata.submitted > celldata.deadline) {
 					str += "dugga-pending-late-submission";
-				} 
+				}
 				str += "'>";
-				// Creation of grading buttons		
+				// Creation of grading buttons
 				if (celldata.kind != 4 && celldata.needMarking == true && celldata.submitted > celldata.deadline) {
 					str += "<div class='gradeContainer resultTableText'>";
 					if (celldata.grade === null) {
@@ -914,9 +914,9 @@ function renderCell(col, celldata, cellid) {
 					}
 					str += "</div>";
 				}
-				return str;	
-			} 
-	}	
+				return str;
+			}
+	}
 
 	// Render normal mode
 	// First column (Fname/Lname/SSN)
@@ -1123,6 +1123,10 @@ function rowFilter(row) {
 	// divides the search on &&
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
+
+  var spaceSlitSearch = [];
+  spaceSlitSearch = searchterm.split(" ");
+
 	tempSplitSearch.forEach(function (s) {
 		if (s.length > 0)
 			splitSearch.push(s.trim().split(":"));
@@ -1168,7 +1172,7 @@ function rowFilter(row) {
 }
 
 function renderSortOptions(col, status, colname) {
-	
+
 	str = "";
 	if (status == -1) {
 		if (col == "FnameLname") {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1120,8 +1120,9 @@ function rowFilter(row) {
 		}
 	}
 
-	// divides the search on &&
+  // Removes spaces so that it can tolerate "wrong" inputs when searching
   searchterm = searchterm.replace(' ', '');
+  // divides the search on &&
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
 

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1134,8 +1134,6 @@ function rowFilter(row) {
 			splitSearch.push(s.trim().split(":"));
 	})
 
-  console.log("splitsearch: "+splitSearch);
-
   // The else makes sure that you can search on names without a search-category.
 	if (searchterm != "" && splitSearch != searchterm) {
 		return smartSearch(splitSearch, row);
@@ -1149,9 +1147,7 @@ function rowFilter(row) {
 				if (row[colname]["lastname"] != null) {
 					name += row[colname]["lastname"];
 				}
-
         name = name.replace(' ', '');
-
 				if (name.toUpperCase().indexOf(searchterm.toUpperCase()) != -1) {
 					return true;
 				}

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1064,6 +1064,7 @@ function smartSearch(splitSearch, row) {
 				txt.innerHTML = row[lid].entryname;
 				var columnToFind = txt.value;
         columnToFind = columnToFind.replace(' ', '');
+        console.log(columnToFind);
 				if (columnToSearch.toUpperCase() === columnToFind.toUpperCase()) {
 					if (sortingType === sortingValue) {
 						for (colname in row) {
@@ -1130,6 +1131,8 @@ function rowFilter(row) {
 		if (s.length > 0)
 			splitSearch.push(s.trim().split(":"));
 	})
+
+  console.log("splitsearch: "+splitSearch);
 
   // The else makes sure that you can search on names without a search-category.
 	if (searchterm != "" && splitSearch != searchterm) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1121,13 +1121,15 @@ function rowFilter(row) {
 	}
 
 	// divides the search on &&
+  searchterm = searchterm.replace(' ', '');
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
 
 	tempSplitSearch.forEach(function (s) {
 		if (s.length > 0)
-			splitSearch.push(s.trim().split(":").replace(' ', ''));
+			splitSearch.push(s.trim().split(":"));
 	})
+
   console.log("splitsearch: "+splitSearch);
 
   // The else makes sure that you can search on names without a search-category.
@@ -1143,6 +1145,9 @@ function rowFilter(row) {
 				if (row[colname]["lastname"] != null) {
 					name += row[colname]["lastname"];
 				}
+
+        name = name.replace(' ', '');
+
 				if (name.toUpperCase().indexOf(searchterm.toUpperCase()) != -1) {
 					return true;
 				}

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1126,10 +1126,9 @@ function rowFilter(row) {
 
 	tempSplitSearch.forEach(function (s) {
 		if (s.length > 0)
-			splitSearch.push(s.trim().replace(' ', '').split(":"));
+			splitSearch.push(s.trim().split(":").replace(' ', ''));
 	})
-
-  console.log("splitsearch: " + splitSearch);
+  console.log("splitsearch: "+splitSearch);
 
   // The else makes sure that you can search on names without a search-category.
 	if (searchterm != "" && splitSearch != searchterm) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1071,7 +1071,7 @@ function smartSearch(splitSearch, row) {
 							if (colname == "lid:" + row[lid].lid) {
 								var name = "";
 								if (row[colname].entryname != null) {
-									name += row[colname].entryname; // + " ";
+									name += row[colname].entryname + " ";
 								}
                 // Makes sure that compares are posible even with å,ä and ö in the strings.
 								var txt = document.createElement("textarea");

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1063,6 +1063,7 @@ function smartSearch(splitSearch, row) {
 				var txt = document.createElement("textarea");
 				txt.innerHTML = row[lid].entryname;
 				var columnToFind = txt.value;
+        columnToFind = columnToFind.replace(' ', '');
         console.log(columnToFind);
 				if (columnToSearch.toUpperCase() === columnToFind.toUpperCase()) {
 					if (sortingType === sortingValue) {
@@ -1076,6 +1077,7 @@ function smartSearch(splitSearch, row) {
 								var txt = document.createElement("textarea");
 								txt.innerHTML = name;
 								var newName2 = txt.value;
+                newName2 = newName2.replace(' ', '');
 								if (newName2.toUpperCase().indexOf(columnToSearch.toUpperCase()) != -1) {
 									return true;
 								}
@@ -1122,6 +1124,7 @@ function rowFilter(row) {
 	}
 
 	// divides the search on &&
+  searchterm = searchterm.replace(' ', '');
 	var tempSplitSearch = searchterm.split("&&");
 	var splitSearch = [];
 

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1152,7 +1152,7 @@ function rowFilter(row) {
 
         name = name.replace(' ', '');
 
-        if(name.toUpperCase()).includes(searchterm.toUpperCase()) != false){
+        if(name.toUpperCase().includes(searchterm.toUpperCase()) != false){
           console.log("FOUND THE NAME " + searchterm + " IN " + name);
         }
 


### PR DESCRIPTION
Fixes #7231 

Made it possible to have blankspaces when searching in the resulted view.

e.g markg: färgduggor1hp is now possible but before you needed to be exact with the searching like this:
markg:färduggor 1hp.

works on names to like "sv e n" or "l e i f"

link: https://a17oscno.gruppb.webug.his.se:20002/DuggaSys/resulted.php?cid=2&coursevers=97732

edit: the aditional blankspaces in the code are a result of "auto indenting" in Atom if it is a problem then "sugest" a change to remove it and i will accept it.

