### PR TITLE
Fix for #7319: UML line code

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1413,19 +1413,19 @@ function Symbol(kindOfSymbol) {
 
         // Calculating the mid point between start and end
         if (x2 > x1) {
-            middleBreakPointX = x1 + (x2 - x1) / 2;
+            middleBreakPointX = x1 + Math.abs(x2 - x1) / 2;
         } else if (x1 > x2) {
-            middleBreakPointX = x2 + (x1 - x2) / 2;
+            middleBreakPointX = x2 + Math.abs(x1 - x2) / 2;
         } else {
             middleBreakPointX = x1;
         }
 
         if (y2 > y1) { // The code breaks if you don't use Math.abs, can be removed if fixed
-            middleBreakPointY = Math.abs(y1) + Math.abs(y2 - y1) / 2;
+            middleBreakPointY = y1 + Math.abs(y2 - y1) / 2;
         } else if (y1 > y2) {
-            middleBreakPointY = Math.abs(y2) + Math.abs(y1 - y2) / 2;
+            middleBreakPointY = y2 + Math.abs(y1 - y2) / 2;
         } else {
-            middleBreakPointY = Math.abs(y1);
+            middleBreakPointY = y1;
         }
 
         // Start line

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1420,7 +1420,7 @@ function Symbol(kindOfSymbol) {
             middleBreakPointX = x1;
         }
 
-        if (y2 > y1) { // The code breaks if you don't use Math.abs, can be removed if fixed
+        if (y2 > y1) {
             middleBreakPointY = y1 + Math.abs(y2 - y1) / 2;
         } else if (y1 > y2) {
             middleBreakPointY = y2 + Math.abs(y1 - y2) / 2;


### PR DESCRIPTION
https://github.com/HGustavs/LenaSYS/issues/7319
Fixed so that calculation of middleBreakPointX and middleBreakPointY is correct. Turns out I didn't correctly understand the use of Math.abs() when I first wrote the code.
Fixes this issue that happens when moving a class off screen on the Y axis.
![umlbreakpoint](https://user-images.githubusercontent.com/37792313/58083234-e94f5480-7bb8-11e9-8d6d-58e9721a7b52.PNG)
