### PR TITLE
Made important word highlighting work with strings

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -986,8 +986,11 @@ function issetDrop(dname) {
 //----------------------------------------------------------
 
 function highlightKeyword(kw) {
+	kwDoubleQuotes = '"'+kw+'"';
+	kwSingleQuote = "'"+kw+"'";
+
 	$(".impword").each(function () {
-		if (this.innerHTML == kw) {
+		if (this.innerHTML == kw || this.innerHTML == kwDoubleQuotes || this.innerHTML == kwSingleQuote) {
 			$(this).addClass("imphi");
 		}
 	});
@@ -999,8 +1002,10 @@ function highlightKeyword(kw) {
 //----------------------------------------------------------
 
 function dehighlightKeyword(kw) {
+	kwDoubleQuotes = '"'+kw+'"';
+	kwSingleQuote = "'"+kw+"'";
 	$(".impword").each(function () {
-		if (this.innerHTML == kw) {
+		if (this.innerHTML == kw || this.innerHTML == kwDoubleQuotes || this.innerHTML == kwSingleQuote) {
 			$(this).removeClass("imphi");
 		}
 	});
@@ -1439,7 +1444,7 @@ function rendercode(codestring, boxid, wordlistid, boxfilename) {
 				important.indexOf(withQuote) != -1 ||
 				important.indexOf(withSingleQuote) != -1) {
 
-				cont += "<span id='IW" + iwcounter + "' class='impword' onmouseover='highlightKeyword(\"" + tokenvalue + "\")' onmouseout='dehighlightKeyword(\"" + tokenvalue + "\")'>" + tokenvalue + "</span>";
+				cont += "<span id='IW" + iwcounter + "' class='impword' onmouseover='highlightKeyword(\"" + withoutQuote + "\")' onmouseout='dehighlightKeyword(\"" + withoutQuote + "\")'>" + tokenvalue + "</span>";
 			} else {
 				cont += "<span class='string'>" + tokenvalue + "</span>";
 			}

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1430,7 +1430,20 @@ function rendercode(codestring, boxid, wordlistid, boxfilename) {
 		} else if (tokens[i].kind == "blockcomment") {
 			cont += "<span class='comment'>" + tokenvalue + "</span>";
 		} else if (tokens[i].kind == "string") {
-			cont += "<span class='string'>" + tokenvalue + "</span>";
+
+			var withoutQuote = tokenvalue.replace(/(?:\"|')/g, "");
+			var withQuote = tokenvalue.replace(/(?:\"|')/g, "&quot;");
+			var withSingleQuote = tokenvalue.replace(/(?:\"|')/g, "\'");
+
+			if (important.indexOf(withoutQuote) != -1 ||
+				important.indexOf(withQuote) != -1 ||
+				important.indexOf(withSingleQuote) != -1) {
+
+				cont += "<span id='IW" + iwcounter + "' class='impword' onmouseover='highlightKeyword(\"" + tokenvalue + "\")' onmouseout='dehighlightKeyword(\"" + tokenvalue + "\")'>" + tokenvalue + "</span>";
+			} else {
+				cont += "<span class='string'>" + tokenvalue + "</span>";
+			}
+
 		} else if (tokens[i].kind == "number") {
 			cont += "<span class='number'>" + tokenvalue + "</span>";
 		} else if (tokens[i].kind == "name") {


### PR DESCRIPTION
Fixes #1818 

To test this you need a file containing strings. Upload a file with fileed, HTML for example, and edit some words to have double and single quotes.
![codequotes](https://user-images.githubusercontent.com/37792198/58091167-389d8100-7bc9-11e9-8f35-987eb2604506.PNG)

Next, go to Example settings and add those words to the 'Important words'. This should work with all of these cases:

- "word" highlights "word"
- "word" highlights  'word'
- 'word' highlights "word"
- 'word' highlights 'word'
- word highlights "word"
- word highlights 'word'