### PR TITLE
Fixed shortcuts #7333

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -512,8 +512,6 @@ function keyDownHandler(e) {
           toggleVirtualA4HolesRight(event);
     } else if(shiftIsClicked && key == kKey) {
           toggleGrid(event);
-    } else if(shiftIsClicked && key == lessThanKey) {
-          distribute(event, 'vertically');
     } else if(shiftIsClicked && key == upArrow) {
           align(event, 'top');
     } else if(shiftIsClicked && key == rightArrow) {
@@ -526,10 +524,6 @@ function keyDownHandler(e) {
           align(event, 'horizontalCenter');
     } else if(shiftIsClicked && key == periodKey) {
           align(event, 'verticalCenter');
-    } else if(shiftIsClicked && key == zKey) {
-          distribute(event, 'horizontally');
-    } else if(shiftIsClicked && key == lessThanKey) {
-          distribute(event, 'vertically');
     } else if(altIsClicked && key == key1) {
           addGroupToSelected(event);
     } else if(altIsClicked && key == key2) {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -217,7 +217,6 @@
                             <div class="drop-down-item">
                                 <div id="displayAllTools" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick="switchToolbarDev();"><img src="../Shared/icons/Arrow_down_right.png">Display All Tools</span>
-                                    <i id="hotkey-displayTools" class="hotKeys">Shift + B</i>
                                 </div>
                             </div>
                             <div class="drop-down-divider">
@@ -239,19 +238,16 @@
                             <div class="drop-down-item">
                                 <div id="a4-orientation-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleA4Orientation(event);'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Orientation</span>
-                                    <i id="hotkey-A4-Orientation" class="hotKeys">Shift + 5</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-holes-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleVirtualA4Holes(event);'><img src="../Shared/icons/Arrow_down_right.png">Toggle A4 Holes</span>
-                                    <i id="hotkey-Toggle-Holes" class="hotKeys">Shift + 6</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="a4-holes-item-right" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick='toggleVirtualA4HolesRight(event);'><img src="../Shared/icons/Arrow_down_right.png">A4 Holes Right</span>
-                                    <i id="hotkey-Holes-Right" class="hotKeys">Shift + 7</i>
                                 </div>
                             </div>
                         </div>
@@ -261,7 +257,6 @@
                         <div class="drop-down">
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="toggleGrid(event)">Snap to grid</span>
-                                <i id="hotkey-Snap-Grid" class="hotKeys">Shift + K</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>
@@ -285,11 +280,9 @@
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'horizontalCenter');">Horizontal center</span>
-                                <i id="hotkey-Align-Horizontal" class="hotKeys">Shift + ' , ' </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="align(event, 'verticalCenter');">Vertical center</span>
-                                <i id="hotkey-Align-Vertical" class="hotKeys">Shift + ' . ' </i>
                             </div>
                         </div>
                     </div>
@@ -298,11 +291,9 @@
                         <div class="drop-down">
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="distribute(event, 'horizontally');">Horizontal</span>
-                                <i id="hotkey-Distribute-Vertical" class="hotKeys">Shift + ' < ' </i>
                             </div>
                             <div class="drop-down-item">
                                 <span class="drop-down-option" onclick="distribute(event, 'vertically');">Vertical</span>
-                                <i id="hotkey-Distribute-Horizontal" class="hotKeys">Shift + Z </i>
                             </div>
                         </div>
                     </div>
@@ -321,14 +312,6 @@
                                 <span class="drop-down-option">Select multiple objects</span>
                                 <div id="hotkey-ctrl" class="hotKeys">
                                     <i>Ctrl + leftclick</i>
-                                </div>
-                            </div>
-                            <div class="drop-down-divider">
-                            </div>
-                            <div class="drop-down-text-non-clickable">
-                                <span class="drop-down-option">Lock object proportions</span>
-                                <div id="hotkey-shift" class="hotKeys">
-                                    <i>Shift</i>
                                 </div>
                             </div>
                         </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1534,6 +1534,16 @@ input {
   top: 85px;
 }
 
+#hotkey-undo {
+  right: 5px;
+  top: 10px;
+}
+
+#hotkey-redo {
+  right: 5px;
+  top: 43px;
+}
+
 #hotkey-UML {
   right: 35px;
   top: 120px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1488,19 +1488,10 @@ input {
   right: 6px;
   top: 55px;
 }
+
 #hotkey-shift {
   right: 6px;
   top: 100px;
-}
-
-#hotkey-undo, #hotkey-save, #hotkey-Distribute-Horizontal {
-  right: 5px;
-  top: 10px;
-}
-
-#hotkey-redo, #hotkey-load, #hotkey-Distribute-Vertical {
-  right: 5px;
-  top: 43px;
 }
 
 #hotkey-global {
@@ -1523,6 +1514,11 @@ input {
   top: 395px;
 }
 
+#hotkey-developerMode {
+  right: 35px;
+  top: 10px;
+}
+
 #hotkey-displayTools {
   right: 36px;
   top: 45px;
@@ -1531,21 +1527,6 @@ input {
 #hotkey-displayA4 {
   right: 39px;
   top: 164px;
-}
-
-#hotkey-A4-Orientation {
-  right: 39px;
-  top: 200px;
-}
-
-#hotkey-Toggle-Holes {
-  right: 39px;
-  top: 232px;
-}
-
-#hotkey-Holes-Right {
-  right: 39px;
-  top: 264px;
 }
 
 #hotkey-import {
@@ -1561,11 +1542,6 @@ input {
 #hotkey-back {
   right: 5px ;
   top: 195px;
-}
-
-#hotkey-developerMode, #hotkey-Snap-Grid{
-    right: 35px;
-    top: 10px;
 }
 
 #hotkey-ER {
@@ -1596,16 +1572,6 @@ input {
 #hotkey-Align-Left {
   right: 5px;
   top: 151px;
-}
-
-#hotkey-Align-Horizontal {
-  right: 5px;
-  top: 195px;
-}
-
-#hotkey-Align-Vertical {
-  right: 5px;
-  top: 228px;
 }
 
 #hotkey-delete {


### PR DESCRIPTION
#7333
Fixed the shortcuts
**Changes:**
Name change: Add group to selected -> Group objects
Name change: Remove group from selected -> Ungroup objects
hotkey change: Reset view to origin: from shift + 0 to shift + O

**Removed shortcuts:**
_FILE_
Shift + S for save
Shift + 0 for load
Shift + i for import
_EDIT:_
shift + G for global appearnace
shift + H for change appearance
alt + 1 for add group to selected
alt + 2 for remove group from selected
shift + 0 removed from reset view to origin
_VIEW:_
shift + B for display all tools
shift +5, 6, 7 for toggling A4 properties
_ALIGN:_
shift + K for snap to grid
shift + , for horizontal center
shift + . for vertical center
_DISTRIBUTE:_
shift + z for Horizontal
shift + < for Vertical
_HELP:_
shift for lock object proportions (row removed entirely)