### PR TITLE
Fix for issue #7393: Creating freedraw by right clicking doesn't update the linewidth for the new object 

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2729,9 +2729,9 @@ function figureFreeDraw() {
             md = mouseState.empty; // To prevent selectbox spawn when clicking out of freedraw mode
             diagram.push(figurePath);
             figurePath.figureType = "Free";
+            figurePath.properties['lineWidth'] = getLineThickness();
             selected_objects.push(figurePath);
             lastSelectedObject = diagram.length - 1;
-            figurePath.properties['lineWidth'] = getLineThickness();
             cleanUp();
             SaveState();
         } else {
@@ -2770,6 +2770,7 @@ function endFreeDraw(){
     md = mouseState.empty; // To prevent selectbox spawn when clicking out of freedraw mode
     diagram.push(figurePath);
     figurePath.figureType = "Free";
+    figurePath.properties['lineWidth'] = getLineThickness();
     selected_objects.push(figurePath);
     lastSelectedObject = diagram.length - 1;
     cleanUp();


### PR DESCRIPTION
#7393 