### PR TITLE
Fix for issue #7312: Error message when double clicking line 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3795,7 +3795,7 @@ function loadLineForm(element, dir) {
         if(file.readyState === 4) {
             element.innerHTML = file.responseText;
             if(globalAppearanceValue == 0) {
-                var cardinalityVal = diagram[lastSelectedObject].cardinality[0].value
+                var cardinalityVal = diagram[lastSelectedObject].cardinality[0].value;
                 var cardinalityValUML = diagram[lastSelectedObject].cardinality[0].valueUML;
                 var lineDirection = diagram[lastSelectedObject].lineDirection;
                 var tempCardinality = cardinalityVal == "" || cardinalityVal == null ? "None" : cardinalityVal;
@@ -3806,8 +3806,14 @@ function loadLineForm(element, dir) {
                     tempLineDirection = "First";
                 }
                 setSelectedOption('object_type', diagram[lastSelectedObject].properties['key_type']);
-                setSelectedOption('cardinality', tempCardinality);
-                setSelectedOption('line_direction', tempLineDirection);
+                // check if the form that is loaded is for a line can have cardinality 
+                if (cardinalityValue != 1) {
+                    setSelectedOption('cardinality', tempCardinality);
+                    // check if the form that is loaded is for a line can have a linedirection (uml lines) 
+                    if (cardinalityValue != 2) {
+                        setSelectedOption('line_direction', tempLineDirection);
+                    }
+                }
                 if(cardinalityValUML) setSelectedOption('cardinalityUml', tempCardinalityUML);
             }
         }
@@ -3910,6 +3916,9 @@ function globalAppearanceMenu() {
     loadFormIntoElement(form,'diagram_forms.php?form=globalType');
 }
 
+// determines which form should be loaded when line form is opened
+var cardinalityValue; 
+
 //----------------------------------------------------------------------
 // objectAppearanceMenu: EDITS A SINGLE OBJECT WITHIN THE DIAGRAM
 //----------------------------------------------------------------------
@@ -3946,11 +3955,17 @@ function objectAppearanceMenu(form) {
                 cardinalityOption = false;
         }
 
-        if (cardinalityOption) {
-            loadLineForm(form, 'diagram_forms.php?form=lineType&cardinality=' + diagram[lastSelectedObject].cardinality[0].symbolKind);
-        }else {
-            loadLineForm(form, 'diagram_forms.php?form=lineType&cardinality=-1');
+        if (cardinalityOption) { // uml line or er line with cardinality
+            if (diagram[lastSelectedObject].cardinality[0].symbolKind == 1) { // uml line 
+                cardinalityValue = 3;
+            } else { //er line with cardinality
+                cardinalityValue = 2;
+            }
+        } else { // normal er line
+            cardinalityValue = 1;
         }
+
+        loadLineForm(form, 'diagram_forms.php?form=lineType&cardinality=' + cardinalityValue);
     }
     // ER relation selected
     else if (diagram[lastSelectedObject].symbolkind == symbolKind.erRelation) {

--- a/DuggaSys/diagram_forms.php
+++ b/DuggaSys/diagram_forms.php
@@ -128,7 +128,7 @@
   //form for lines
   else if($form == 'lineType') {
       $cardinality = $_GET['cardinality'];
-      if($cardinality == -1) {
+      if($cardinality == 1) {
         echo"
         Line type: </br>
         <select onchange=\"changeObjectAppearance('lineType');\" id='object_type'>
@@ -137,7 +137,7 @@
             <option value='Derived'>Derived</option>
         </select></br>
         ";
-      }else if($cardinality != 1) {
+      }else if($cardinality == 2) {
         echo"
         Line type: </br>
         <select onchange=\"changeObjectAppearance('lineType');\" id='object_type'>
@@ -153,7 +153,7 @@
           <option value='M'>M</option>
         </select><br/>
         ";
-      }else {
+      }else if ($cardinality == 3) {
         echo"
         Line type: </br>
         <select onchange=\"changeObjectAppearance('lineType');\" id='object_type'>


### PR DESCRIPTION
#7312 
This issue had to do with trying to set cardinality options for lines that doesn't have cardinality, therefore the error message. I changed so that cardinality options and line direction options are only set for the lines that have these options.