### PR TITLE
Hide copy button when box minimized

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1894,6 +1894,55 @@ function Play(event) {
 	}
 }
 
+function hideCopyButtons(templateid, boxid) {
+	var totalBoxes = getTotalBoxes(templateid);
+
+	for (var i = 1; i <= totalBoxes; i++) {
+		var copyBtn = document.querySelector('#box'+i+'wrapper #copyClipboard');
+		if (i !== boxid) {
+			copyBtn.style.display = "none";
+		} else {
+			copyBtn.style.display = "table-cell";
+		}
+	}
+}
+
+function showCopyButtons(templateid) {
+	var totalBoxes = getTotalBoxes(templateid);
+
+	for (var i = 1; i <= totalBoxes; i++) {
+		var copyBtn = document.querySelector('#box'+i+'wrapper #copyClipboard');
+		copyBtn.style.display = "table-cell";
+	}
+}
+
+function getTotalBoxes(template) {
+	var totalBoxes;
+	switch (template) {
+		case '10': totalBoxes = 1;
+		break;
+		case '1': 
+		//fall through
+		case '2': totalBoxes = 2;
+		break;
+		case '3': 
+		//fall through
+		case '4':
+		//fall through
+		case '8': totalBoxes = 3;
+		break;
+		case '5':
+		//fall through
+		case '6':
+		//fall through
+		case '7': totalBoxes = 4;
+		break;
+		case '9': totalBoxes = 5;
+		break;
+	}
+	return totalBoxes;
+}
+
 //-----------------------------------------------------------------------------
 // maximizeBoxes: Adding maximize functionality for the boxes
 //					Is called with onclick() by maximizeButton
@@ -1906,6 +1955,7 @@ function maximizeBoxes(boxid) {
 	var templateid = retData['templateid'];
 
 	getLocalStorageProperties(boxValArray);
+	hideCopyButtons(templateid, boxid);
 
 	//For template 1
 	if (templateid == 1) {
@@ -2224,6 +2274,7 @@ function hideMaximizeAndResetButton() {
 //reset boxes
 function resetBoxes() {
 	resizeBoxes("#div2", retData["templateid"]);
+	showCopyButtons(retData["templateid"]);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #7402 

Hides  this button:
![copybutton](https://user-images.githubusercontent.com/37792198/58182702-67415780-7cae-11e9-8ea3-1d019bcc182f.PNG)

For boxes that are 'minimized'