### PR TITLE
[Fixed] Change the Global Appearance Functionality #7222

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3531,7 +3531,7 @@ function mouseupevt(ev) {
         }
     }
 
-    // Sets the Global Apperance settings for each object
+    // Sets the Global Appearance settings for each object
     if (lastSelectedObject >= 0) {
         diagram[lastSelectedObject].properties['lineWidth'] = getLineThickness();
         diagram[lastSelectedObject].properties['fontColor'] = getFontColor();
@@ -3750,7 +3750,7 @@ function dimDialogMenu(dim) {
 }
 
 //----------------------------------------------------------------------
-// loadFormIntoElement: Loads the menu which is used to change apperance of ER and free draw objects.
+// loadFormIntoElement: Loads the menu which is used to change appearance of ER and free draw objects.
 //----------------------------------------------------------------------
 
 function loadFormIntoElement(element, dir) {
@@ -3773,7 +3773,7 @@ function loadFormIntoElement(element, dir) {
                 document.getElementById('figureOpacity').value = (diagram[lastSelectedObject].opacity * 100);
                 setSelectedOption('LineColor', diagram[lastSelectedObject].properties['strokeColor']);
             } else {
-                // should only occur when changing global apperance
+                // should only occur when changing global appearance
                 document.getElementById('line-thickness').value = getLineThickness();
             }
         }
@@ -3782,7 +3782,7 @@ function loadFormIntoElement(element, dir) {
 }
 
 //----------------------------------------------------------------------
-// The following functions are used to get Global Apperance changes
+// The following functions are used to get Global Appearance changes
 //----------------------------------------------------------------------
 
 // Return the line thickness of one of the current objects in the diagram
@@ -3932,7 +3932,7 @@ function loadTextForm(element, dir) {
 }
 
 //----------------------------------------------------------------------
-// setSelectedOption: used to implement the changes to apperances that has been made
+// setSelectedOption: used to implement the changes to appearances that has been made
 //----------------------------------------------------------------------
 
 function setSelectedOption(type, value) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3505,7 +3505,7 @@ function mouseupevt(ev) {
             setTargetedForSymbolGroup(diagram[lastSelectedObject], true);
         }
     } else if (uimode == "CreateUMLLine" && md == mouseState.boxSelectOrCreateMode) {
-        //Code for making a line, if start and end object are different, except attributes and if no object is text
+        // Code for making a line, if start and end object are different, except attributes and if no object is text
         if((symbolStartKind != symbolEndKind || (symbolStartKind == symbolKind.erAttribute && symbolEndKind == symbolKind.erAttribute)
         || symbolStartKind == symbolKind.uml && symbolEndKind == symbolKind.uml) && (symbolStartKind != symbolKind.umlLine && symbolEndKind != symbolKind.umlLine)
         && (symbolStartKind != symbolKind.text && symbolEndKind != symbolKind.text) && okToMakeLine) {
@@ -3530,7 +3530,8 @@ function mouseupevt(ev) {
             updateGraphics();
         }
     }
-    // set the linewidth for the created object
+
+    // Sets the Global Apperance settings for each object
     if (lastSelectedObject >= 0) {
         diagram[lastSelectedObject].properties['lineWidth'] = getLineThickness();
         diagram[lastSelectedObject].properties['fontColor'] = getFontColor();
@@ -3538,8 +3539,8 @@ function mouseupevt(ev) {
         diagram[lastSelectedObject].properties['strokeColor'] = getStrokeColor();
         diagram[lastSelectedObject].properties['symbolColor'] = getFillColor();
         diagram[lastSelectedObject].properties['sizeOftext'] = getTextSize();
+        diagram[lastSelectedObject].fillColor = getFillColor();
     }
-
 
     //when symbol is er relation then don't assign variables since it's already done earlier when creating points
     if (diagramObject && diagramObject.symbolkind != symbolKind.erRelation) {
@@ -3774,63 +3775,67 @@ function loadFormIntoElement(element, dir) {
             } else {
                 // should only occur when changing global apperance
                 document.getElementById('line-thickness').value = getLineThickness();
-                document.getElementById('fontColor').value = getFontColor();
-                document.getElementById('font').value = getFont();
-                document.getElementById('strokeColor').value = getStrokeColor();
-                document.getElementById('symbolColor').value = getFillColor();
-                document.getElementById('sizeOftext').value = getTextSize();
             }
         }
     }
     file.send();
 }
 
-// return the line thickness of one of the current objects in the diagram or else return the standard value: 2
+//----------------------------------------------------------------------
+// The following functions are used to get Global Apperance changes
+//----------------------------------------------------------------------
+
+// Return the line thickness of one of the current objects in the diagram
 function getLineThickness() {
     if (diagram.length > 0){
         return value = diagram[0].properties['lineWidth'];
     } else {
-        return 2;
+        return diagram[0].properties['lineWidth'];
     }
 }
 
+// Returns the font color of the objects in the diagram
 function getFontColor() {
     if (diagram.length > 0){
         return value = diagram[0].properties['fontColor'];
     } else {
-        return '#000000';
+        return diagram[0].properties['fontColor'];
     }
 }
 
+// Returns the font of the objects in the diagram
 function getFont() {
     if (diagram.length > 0){
         return value = diagram[0].properties['font'];
     } else {
-        return 'Arial';
+        return diagram[0].properties['font'];
     }
 }
 
+// Returns the stroke color of the objects in the diagram
 function getStrokeColor() {
     if (diagram.length > 0){
         return value = diagram[0].properties['strokeColor'];
     } else {
-        return '#000000';
+        return diagram[0].properties['strokeColor'];
     }
 }
 
+// Returns the fill color of the objects in the diagram
 function getFillColor() {
     if (diagram.length > 0){
         return value = diagram[0].properties['symbolColor'];
     } else {
-        return '#ffffff';
+        return diagram[0].properties['symbolColor'];
     }
 }
 
+// Returns the text size of the objects in the diagram
 function getTextSize() {
     if (diagram.length > 0){
         return value = diagram[0].properties['sizeOftext'];
     } else {
-        return 'Tiny';
+        return diagram[0].properties['sizeOftext'];
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3533,7 +3533,11 @@ function mouseupevt(ev) {
     // set the linewidth for the created object
     if (lastSelectedObject >= 0) {
         diagram[lastSelectedObject].properties['lineWidth'] = getLineThickness();
+        diagram[lastSelectedObject].properties['fontColor'] = getFontColor();
+        diagram[lastSelectedObject].properties['font'] = getFont();
+        diagram[lastSelectedObject].properties['strokeColor'] = getStrokeColor();
     }
+
 
     //when symbol is er relation then don't assign variables since it's already done earlier when creating points
     if (diagramObject && diagramObject.symbolkind != symbolKind.erRelation) {
@@ -3768,6 +3772,9 @@ function loadFormIntoElement(element, dir) {
             } else {
                 // should only occur when changing global apperance
                 document.getElementById('line-thickness').value = getLineThickness();
+                document.getElementById('fontColor').value = getFontColor();
+                document.getElementById('font').value = getFont();
+                document.getElementById('strokeColor').value = getStrokeColor();
             }
         }
     }
@@ -3780,6 +3787,30 @@ function getLineThickness() {
         return value = diagram[0].properties['lineWidth'];
     } else {
         return 2;
+    }
+}
+
+function getFontColor() {
+    if (diagram.length > 0){
+        return value = diagram[0].properties['fontColor'];
+    } else {
+        return '#000000';
+    }
+}
+
+function getFont() {
+    if (diagram.length > 0){
+        return value = diagram[0].properties['font'];
+    } else {
+        return 'Arial';
+    }
+}
+
+function getStrokeColor() {
+    if (diagram.length > 0){
+        return value = diagram[0].properties['strokeColor'];
+    } else {
+        return '#000000';
     }
 }
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -819,7 +819,7 @@ function Symbol(kindOfSymbol) {
         privatePoints.push(this.centerPoint);
         return privatePoints;
     }
-    
+
     //-----------------------------------------------------------------------
     // isLineType: Checks if this is a line (ER or UML)
     //-----------------------------------------------------------------------
@@ -827,7 +827,7 @@ function Symbol(kindOfSymbol) {
         return this.symbolkind === symbolKind.line ||
                 this.symbolkind === symbolKind.umlLine;
     }
-    
+
     //----------------------------------------------------------------
     // getConnectedObjects: returns an array with the objects that a specific line is connected to,
     //                      function is used on line objects
@@ -1320,7 +1320,7 @@ function Symbol(kindOfSymbol) {
 
     this.drawEntity = function(x1, y1, x2, y2) {
         ctx.fillStyle = this.properties['symbolColor'];
-        
+
         if (this.properties['key_type'] == "Weak") {
             this.drawWeakEntity(x1, y1, x2, y2);
             setLinesConnectedToRelationsToForced(x1, y1, x2, y2);
@@ -2109,7 +2109,7 @@ function drawLockedTooltip(symbol) {
     var yOffset = 13;
     // Different size when hovering the lock itself and the entity, for displaying different amount of text
     var ySize = symbol.isLockHovered ? 34 : 16;
-    var xSize = 85; 
+    var xSize = 85;
     // Draw tooltip background
     ctx.fillStyle = "#f5f5f5";
     ctx.fillRect(position.x, position.y + yOffset * diagram.getZoomValue(), xSize * diagram.getZoomValue(), ySize * diagram.getZoomValue());
@@ -2368,7 +2368,7 @@ function Path() {
             if (this.group != 0){
                 drawGroup(this);
             }
-    
+
             // Assign stroke style, color, transparency etc
             var shouldFill = true;
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -819,7 +819,7 @@ function Symbol(kindOfSymbol) {
         privatePoints.push(this.centerPoint);
         return privatePoints;
     }
-
+    
     //-----------------------------------------------------------------------
     // isLineType: Checks if this is a line (ER or UML)
     //-----------------------------------------------------------------------
@@ -827,7 +827,7 @@ function Symbol(kindOfSymbol) {
         return this.symbolkind === symbolKind.line ||
                 this.symbolkind === symbolKind.umlLine;
     }
-
+    
     //----------------------------------------------------------------
     // getConnectedObjects: returns an array with the objects that a specific line is connected to,
     //                      function is used on line objects
@@ -1027,11 +1027,16 @@ function Symbol(kindOfSymbol) {
     //---------------------------------------------------------
     this.drawUML = function(x1, y1, x2, y2) {
         var midy = pixelsToCanvas(0, points[this.middleDivider].y).y;
+        this.properties['textSize'] = '14';
+        this.properties['strokeColor'] = '#000000';
+        this.properties['fontColor'] = '#000000';
+        this.properties['lineWidth'] = 2;
         ctx.font = "bold " + parseInt(this.properties['textSize']) + "px Arial";
 
         // Clear Class Box
-        ctx.fillStyle = this.properties['symbolColor'];
+        ctx.fillStyle = '#ffffff';
         ctx.lineWidth = this.properties['lineWidth'] * diagram.getZoomValue();
+
         // Box
         ctx.beginPath();
         ctx.moveTo(x1, y1);
@@ -1049,7 +1054,6 @@ function Symbol(kindOfSymbol) {
         ctx.fill();
         ctx.stroke();
         ctx.clip();
-
         ctx.fillStyle = this.properties['fontColor'];
         // Write Class Name
         ctx.textAlign = "center";
@@ -1091,10 +1095,32 @@ function Symbol(kindOfSymbol) {
             drawOval(x1 - 7 * diagram.getZoomValue(), y1 - 7 * diagram.getZoomValue(), x2 + 7 * diagram.getZoomValue(), y2 + 7 * diagram.getZoomValue());
             ctx.stroke();
             drawOval(x1, y1, x2, y2);
+            // Makes sure that the stroke color can not be white
+            if (this.properties['strokeColor'] == '#ffffff') {
+                this.properties['strokeColor'] = '#000000';
+            }
+            // Make sure that the font color is always able to be seen.
+            // Symbol and Font color should therefore not be the same
+            if (this.properties['fontColor'] == this.properties['symbolColor']) {
+                if (this.properties['symbolColor'] == '#000000') {
+                    this.properties['fontColor'] = '#ffffff';
+                } else {
+                    this.properties['fontColor'] = '#000000';
+                }
+            }
         // Drawing a normal attribute
         } else {
             drawOval(x1, y1, x2, y2);
             ctx.fill();
+            // Make sure that the font color is always able to be seen.
+            // Symbol and Font color should therefore not be the same
+            if (this.properties['fontColor'] == this.properties['symbolColor']) {
+                if (this.properties['symbolColor'] == '#000000') {
+                    this.properties['fontColor'] = '#ffffff';
+                } else {
+                    this.properties['fontColor'] = '#000000';
+                }
+            }
         }
         ctx.clip();
 
@@ -1308,7 +1334,7 @@ function Symbol(kindOfSymbol) {
             this.properties['strokeColor'] = '#000000';
         }
         // Make sure that the font color is always able to be seen.
-        //Symbol and Font color should therefore not be the same
+        // Symbol and Font color should therefore not be the same
         if (this.properties['fontColor'] == this.properties['symbolColor']) {
             if (this.properties['symbolColor'] == '#000000') {
                 this.properties['fontColor'] = '#ffffff';
@@ -1320,7 +1346,6 @@ function Symbol(kindOfSymbol) {
 
     this.drawEntity = function(x1, y1, x2, y2) {
         ctx.fillStyle = this.properties['symbolColor'];
-
         if (this.properties['key_type'] == "Weak") {
             this.drawWeakEntity(x1, y1, x2, y2);
             setLinesConnectedToRelationsToForced(x1, y1, x2, y2);
@@ -1335,9 +1360,15 @@ function Symbol(kindOfSymbol) {
         ctx.lineTo(x1, y1);
         ctx.closePath();
         ctx.fill();
+        if (this.properties['fontColor'] == this.properties['symbolColor']) {
+            if (this.properties['symbolColor'] == '#000000') {
+                this.properties['fontColor'] = '#ffffff';
+            } else {
+                this.properties['fontColor'] = '#000000';
+            }
+        }
         ctx.clip();
         ctx.stroke();
-
         ctx.fillStyle = this.properties['fontColor'];
 
         if(ctx.measureText(this.name).width >= (x2-x1) - 5) {
@@ -1397,6 +1428,8 @@ function Symbol(kindOfSymbol) {
     }
 
     this.drawUMLLine = function(x1, y1, x2, y2) {
+        this.properties['strokeColor'] = '#000000';
+        this.properties['lineWidth'] = 2;
         //Checks if there is cardinality set on this object
         if(this.cardinality[0].value != "" && this.cardinality[0].value != null) {
             //Updates x and y position
@@ -1825,10 +1858,20 @@ function Symbol(kindOfSymbol) {
         ctx.lineTo(midx, y1);
         ctx.closePath();
         ctx.fill();
+        // Make sure that the font color is always able to be seen.
+        // Symbol and Font color should therefore not be the same
+        if (this.properties['fontColor'] == this.properties['symbolColor']) {
+            if (this.properties['symbolColor'] == '#000000') {
+                this.properties['fontColor'] = '#ffffff';
+            } else {
+                this.properties['fontColor'] = '#000000';
+            }
+        }
         ctx.clip();
         ctx.stroke();
 
         ctx.fillStyle = this.properties['fontColor'];
+        
         if(ctx.measureText(this.name).width >= (x2-x1) - 12) {
             ctx.textAlign = "start";
             ctx.fillText(this.name, x1 + 10 , (y1 + ((y2 - y1) * 0.5)));
@@ -1851,11 +1894,12 @@ function Symbol(kindOfSymbol) {
             ctx.rect(x1, y1, x2-x1, y2-y1);
             ctx.stroke();
         }
-        this.properties['textSize'] = this.getFontsize();
-
+        
         ctx.fillStyle = this.properties['fontColor'];
         ctx.textAlign = this.textAlign;
-
+        this.properties['textSize'] = this.getFontsize();
+        this.properties['font'] = getFont();
+        this.properties['fontColor'] = getFontColor();
         for (var i = 0; i < this.textLines.length; i++) {
             ctx.fillText(this.textLines[i].text, this.getTextX(x1, midx, x2), y1 + (this.properties['textSize'] * 1.7) / 2 + (this.properties['textSize'] * i));
         }
@@ -1985,7 +2029,6 @@ function Symbol(kindOfSymbol) {
 				strokeWidth = this.properties['lineWidth'] * 3 * diagram.getZoomValue();
 				svgStyle = "stroke:"+this.properties['strokeColor']+"; stroke-width:"+strokeWidth+";";
 				str += "<line "+svgPos+" style='"+svgStyle+"' />";
-
 				// Thin line used to divide thick line into two lines
 				strokeWidth = this.properties['lineWidth'] * diagram.getZoomValue();
 				svgStyle = "stroke:#fff; stroke-width:"+strokeWidth+";";
@@ -2109,7 +2152,7 @@ function drawLockedTooltip(symbol) {
     var yOffset = 13;
     // Different size when hovering the lock itself and the entity, for displaying different amount of text
     var ySize = symbol.isLockHovered ? 34 : 16;
-    var xSize = 85;
+    var xSize = 85; 
     // Draw tooltip background
     ctx.fillStyle = "#f5f5f5";
     ctx.fillRect(position.x, position.y + yOffset * diagram.getZoomValue(), xSize * diagram.getZoomValue(), ySize * diagram.getZoomValue());
@@ -2167,6 +2210,7 @@ this.drawOval = function (x1, y1, x2, y2) {
     this.isOval = true;
     var middleX = x1 + ((x2 - x1) * 0.5);
     var middleY = y1 + ((y2 - y1) * 0.5);
+
     ctx.beginPath();
     ctx.moveTo(x1, middleY);
     ctx.quadraticCurveTo(x1, y1, middleX, y1);
@@ -2368,7 +2412,7 @@ function Path() {
             if (this.group != 0){
                 drawGroup(this);
             }
-
+    
             // Assign stroke style, color, transparency etc
             var shouldFill = true;
 
@@ -2708,6 +2752,7 @@ function figureFreeDraw() {
         startPosition = p2;
         isFirstPoint = false;
     } else {
+
         // Read and set the values for p1 and p2
         p1 = p2;
         if (activePoint != null) {
@@ -2728,12 +2773,14 @@ function figureFreeDraw() {
             figurePath.addsegment(1, p1, p2);
             md = mouseState.empty; // To prevent selectbox spawn when clicking out of freedraw mode
             diagram.push(figurePath);
+
             figurePath.figureType = "Free";
             selected_objects.push(figurePath);
             lastSelectedObject = diagram.length - 1;
             figurePath.properties['lineWidth'] = getLineThickness();
-            properties['symbolColor'] = getFillColor();
-            properties['sizeOftext'] = getTextSize();
+            figurePath.fillColor = getFillColor();
+            figurePath.properties['strokeColor'] = getStrokeColor();
+
             cleanUp();
             SaveState();
         } else {
@@ -2746,6 +2793,7 @@ function figureFreeDraw() {
             numberOfPointsInFigure++;
         }
     }
+
 }
 
 function endFreeDraw(){
@@ -2774,6 +2822,7 @@ function endFreeDraw(){
     figurePath.figureType = "Free";
     selected_objects.push(figurePath);
     lastSelectedObject = diagram.length - 1;
+
     cleanUp();
     SaveState();
 }


### PR DESCRIPTION
#7222 
The issue does now appear to be solved. There may be combinations that we have not thought about so be thorough when testing to try and find the edge cases where this may fail.

However, none were found before making this pull-request so hopefully, this works fine.

All of these attributes can now be used in Global Appearance to set the settings for current objects, and the settings for future objects to be drawn:
_Font family
Font color
Text size
Fill color
Stroke color
Line thickness_

UML objects are intentionally excluded