### PR TITLE
Fixed issue #6634: Problem with selecting object after using right-click-move

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -202,18 +202,6 @@ const leftMouseClick = 0;
 const scrollClick = 1;
 const rightMouseClick = 2;
 
-// This bool is used so the contextmenu will be hidden on mouse drag, and shown on right mouse click.
-var dragDistanceReached = true;
-
-// Hides the context menu. Needed in order to be able to right click and drag to move the camera.
-window.addEventListener('contextmenu', function (e) {
-        if (dragDistanceReached) {
-            e.preventDefault();
-        }
-    },
-    false
-);
-
 // This block of the code is used to handel keyboard input;
 window.addEventListener("keydown", this.keyDownHandler);
 
@@ -2020,7 +2008,7 @@ function reWrite() {
         + "X=" + decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)
         + " & Y=" + decimalPrecision(currentMouseCoordinateY, 0).toFixed(0) + " | Top-left Corner(" + Math.round(origoOffsetX / zoomValue) + ", " + Math.round(origoOffsetY / zoomValue) + " ) </p>";
         document.getElementById("valuesCanvas").style.display = 'block';
-        
+
         //If you're using smaller screens in dev-mode then the coord-bar & zoom-bar will scale.
         var smallerScreensDev = window.matchMedia("(max-width: 745px)");
         if (smallerScreensDev.matches) {
@@ -2862,16 +2850,11 @@ function mousemoveevt(ev, t) {
             ||
             (diffY > deltaY) || (diffY < -deltaY)
         ) {
-            dragDistanceReached = true;
             // Entering MoveAround mode
             if (uimode != "MoveAround") {
                 activateMovearound();
             }
             updateGraphics();
-        }
-        else {
-            // If click event is needed, it goes in here.
-            dragDistanceReached = false;
         }
     }
 
@@ -3173,7 +3156,6 @@ function mousedownevt(ev) {
         if (typeof InitPageX == 'undefined' && typeof InitPageY == 'undefined') {
             InitPageX = ev.pageX;
             InitPageY = ev.pageY;
-            dragDistanceReached = false;
         }
     }
 
@@ -3210,7 +3192,6 @@ function mousedownevt(ev) {
     } else {
         md = mouseState.boxSelectOrCreateMode; // Box select or Create mode.
         if(ev.button == rightMouseClick && uimode == "CreateFigure"){
-            dragDistanceReached = true;
             endFreeDraw();
         }
         if (uimode != "MoveAround" && !ctrlIsClicked) {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -338,7 +338,7 @@
                     <img src="../Shared/icons/diagram_move_arrows.svg">
                 </button>
             </div>
-            <div id="canvasDiv" style = "margin-left: 52px">
+            <div id="canvasDiv" style = "margin-left: 52px" oncontextmenu="return false;">
             </div>
             <div id="consoleDiv">
                 <!--


### PR DESCRIPTION
Issue: #6634 
Related issue: #6726 
**Co-Author: @a17jacsv**

Removed old solution and disabled contextmenu when right-clicking on the canvas. It should work on both mac and pc now as we have tested it on a different kind. Removed some unnecessary code as well.