### PR TITLE
Added ajax error handling for codeviewer

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -62,6 +62,13 @@ function setup() {
 	}
 }
 
+
+function returnedError(error) {
+	if (error.responseText) {
+		document.querySelector('#div2').innerHTML += " and show them this message:<br><br>"+error.responseText;
+	}
+}
+
 //-----------------------------------------------------------------
 // returned: Fetches returned data from all sources
 //-----------------------------------------------------------------

--- a/DuggaSys/codeviewerService.php
+++ b/DuggaSys/codeviewerService.php
@@ -539,6 +539,18 @@
             'courseid' => $courseId,
             'courseversion' => $courseVersion
 		);
+		
+		function checkForEncodingError($data) {
+			if (json_encode($data) === false) {
+				throw new Exception( json_last_error_msg() );
+			} 
+		}
+		try {
+			checkForEncodingError($array);
+		} catch (Exception $e)  {
+			echo $e;
+			die;
+		}
 		echo json_encode($array);
 	}else{
 		$debug = "Debug: Error occur at line " . __LINE__ . " in file " . __FILE__ . ". There are no examples or the ID of example is incorrect.\n";

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -787,7 +787,8 @@ function AJAXService(opt,apara,kind)
 				type: "POST",
 				data: "opt="+opt+para,
 				dataType: "json",
-				success: returned
+				success: returned,
+				error: returnedError
 			});
 	}else if(kind=="BOXCONTENT"){
 		$.ajax({


### PR DESCRIPTION
Fix #7381

Now throws this error:
![errorthrown](https://user-images.githubusercontent.com/37792198/58248841-85b25c00-7d5d-11e9-8ee6-4e3ff4a8c6c9.PNG)
