### PR TITLE
Added way to remove examples

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -69,6 +69,10 @@ function setup() {
 function returned(data) {
 	retData = data;
 
+	if (retData['deleted']) {
+		window.location.href = 'sectioned.php?courseid='+courseid+'&coursevers='+cvers;
+	}
+
 	if (retData['writeaccess'] == "w") {
 		document.getElementById('fileedButton').onclick = new Function("navigateTo('/fileed.php','?cid=" + courseid + "&coursevers=" + cvers + "');");
 		document.getElementById('fileedButton').style = "display:table-cell;";
@@ -455,6 +459,20 @@ function updateExample() {
 	}
 
 	$("#editExampleContainer").css("display", "none");
+}
+
+function removeExample() {
+	var courseid = querystring['courseid'];
+	var cvers = querystring['cvers'];
+	var exampleid = querystring['exampleid'];
+	var lid = querystring['lid'];
+
+	AJAXService("DELEXAMPLE", {
+		courseid: courseid,
+		cvers: cvers,
+		exampleid: exampleid,
+		lid: lid
+	}, "CODEVIEW");
 }
 
 //----------------------------------------------------------------------------------

--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -255,7 +255,7 @@ Testing Link:
 								<td>Important Words:(No spaces)<input class='form-control textinput' type='text' id='impword' placeholder="<Important word>" /><input style="width:32px; float:none; margin-left:5px; margin-top:0px;" class='submit-button' type='button' value='+' onclick='editImpWords("+");' /><select style="float:none;" id='impwords'><input style="width:32px; float:none; margin-left:5px; margin-top:0px;" class='submit-button' type='button' value='-' onclick='editImpWords("-");' /></select></td>
 							</tr>
 							<tr>
-								<td></td>
+								<td><input class='submit-button' type='button' value='Remove' onclick='removeExample();' /></td>
 								<td align='right'><input class='submit-button' type='button' value='Save' onclick='updateExample();' /></td>
 							</tr>
 						</table>

--- a/DuggaSys/codeviewerService.php
+++ b/DuggaSys/codeviewerService.php
@@ -278,6 +278,51 @@
 
 				echo json_encode(array('title' => $boxTitle, 'id' => $boxId));
 				return;
+			} else if (strcmp('DELEXAMPLE', $opt) === 0) {
+
+				$query1 = $pdo->prepare("DELETE FROM box WHERE exampleid=:exampleid;");
+				$query1->bindValue(':exampleid', $exampleId);				
+
+				$query2 = $pdo->prepare("DELETE FROM improw WHERE exampleid=:exampleid;");
+				$query2->bindValue(':exampleid', $exampleId);				
+
+				$query3 = $pdo->prepare("DELETE FROM impwordlist WHERE exampleid=:exampleid;");
+				$query3->bindValue(':exampleid', $exampleId);				
+
+				$query4 = $pdo->prepare("DELETE FROM codeexample WHERE exampleid=:exampleid;");
+				$query4->bindValue(':exampleid', $exampleId);
+			
+				$query5 = $pdo->prepare("DELETE FROM listentries WHERE lid=:lid;");
+				$lid = getOP('lid');
+				$query5->bindValue(':lid', $lid);
+
+				if(!$query1->execute()) {
+						$error = $query1->errorInfo();
+						echo (json_encode(array('writeaccess' => 'w', 'debug' => $error[2])));
+						return;
+				}
+				if(!$query2->execute()) {
+					$error = $query2->errorInfo();
+					echo (json_encode(array('writeaccess' => 'w', 'debug' => $error[2])));
+					return;
+				}
+				if(!$query3->execute()) {
+					$error = $query3->errorInfo();
+					echo (json_encode(array('writeaccess' => 'w', 'debug' => $error[2])));
+					return;
+				}
+				if(!$query4->execute()) {
+					$error = $query4->errorInfo();
+					echo (json_encode(array('writeaccess' => 'w', 'debug' => $error[2])));
+					return;
+				}
+				if(!$query5->execute()) {
+					$error = $query5->errorInfo();
+					echo (json_encode(array('writeaccess' => 'w', 'debug' => $error[2])));
+					return;
+				}
+				echo (json_encode(array('deleted' => true, 'debug' => $debug)));
+				return;
 			}
 		}
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -841,7 +841,8 @@ function returnedSection(data) {
           var param = {
             'exampleid': item['link'],
             'courseid': querystring['courseid'],
-            'cvers': querystring['coursevers']
+            'cvers': querystring['coursevers'],
+            'lid': item['lid']
           };
           str += "<div class='ellipsis nowrap'><span>" + makeanchor("codeviewer.php", hideState, "margin-left:8px;", item['entryname'], false, param) + "</span></div>";
         } else if (itemKind == 3) {


### PR DESCRIPTION
Fixes #1009 

To do this: go to a code example, click the cog wheel, click remove. You should be redirected to the section page, and the code example should be gone.

This will delete everything from several tables with the exampleid in question, but I'm sure this can be done more elegantly if we add `ON DELETE CASCADE` to the `box`, `improw`, and `impwordlist `tables.