### PR TITLE
CodeViewer: Hides Copy button when there isnt room for it

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -914,7 +914,7 @@ $(window).resize(function () {
 	var windowHeight = $(window).height();
 	textHeight = windowHeight - 50;
 	$("#table-scroll").css("height", textHeight);
-
+	hideCopyButton();
 });
 
 document.addEventListener("drop", function (e) {
@@ -1915,20 +1915,6 @@ function Play(event) {
 	}
 }
 
-function hideCopyButtons(templateid, boxid) {
-	var totalBoxes = getTotalBoxes(templateid);
-
-	for (var i = 1; i <= totalBoxes; i++) {
-		var copyBtn = document.querySelector('#box'+i+'wrapper #copyClipboard');
-
-		if (i !== boxid) {
-			copyBtn.style.display = "none";
-		} else {
-			copyBtn.style.display = "table-cell";
-		}
-	}
-}
-
 function showCopyButtons(templateid) {
 	var totalBoxes = getTotalBoxes(templateid);
 
@@ -1965,7 +1951,7 @@ function getTotalBoxes(template) {
 	return totalBoxes;
 }
 
-function testHideCoopyButton() {
+function hideCopyButton() {
 	var boxWidth;
 	var templateid = retData['templateid'];
 
@@ -1975,6 +1961,9 @@ function testHideCoopyButton() {
 		if(boxWidth <= 230){
 			copyButton = document.getElementById("box" + i + "wrapper").getElementsByClassName("copybutton")[0];
 			copyButton.style.display = 'none';
+		}else{
+			copyButton = document.getElementById("box" + i + "wrapper").getElementsByClassName("copybutton")[0];
+			copyButton.style.display = 'block';
 		}
 	}
 }
@@ -1991,7 +1980,6 @@ function maximizeBoxes(boxid) {
 	var templateid = retData['templateid'];
 
 	getLocalStorageProperties(boxValArray);
-	hideCopyButtons(templateid, boxid);
 
 	//For template 1
 	if (templateid == 1) {
@@ -2296,6 +2284,8 @@ function maximizeBoxes(boxid) {
 			alignBoxesHeight3boxes(boxValArray, 2, 1, 3);
 		}
 	}
+	
+	hideCopyButton();
 }
 
 //hide maximizeButton
@@ -2478,8 +2468,6 @@ function resizeBoxes(parent, templateId) {
 				$('iframe').css('pointer-events', 'auto');
 			}
 		});
-
-		testHideCoopyButton();
 
 	} else if (templateId == 6) {
 
@@ -2699,8 +2687,8 @@ function resizeBoxes(parent, templateId) {
 		});
 
 	}
-
 	
+	hideCopyButton();
 };
 
 //----------------------------------------------------------------------------------

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1920,6 +1920,7 @@ function hideCopyButtons(templateid, boxid) {
 
 	for (var i = 1; i <= totalBoxes; i++) {
 		var copyBtn = document.querySelector('#box'+i+'wrapper #copyClipboard');
+
 		if (i !== boxid) {
 			copyBtn.style.display = "none";
 		} else {
@@ -1962,6 +1963,20 @@ function getTotalBoxes(template) {
 		break;
 	}
 	return totalBoxes;
+}
+
+function testHideCoopyButton() {
+	var boxWidth;
+	var templateid = retData['templateid'];
+
+	for(var i = 1; i <= getTotalBoxes(templateid); i++){
+		boxWidth = $("#box" + i + "wrapper").width();
+		console.log(boxWidth);
+		if(boxWidth <= 230){
+			hideCopyButtons(templateid, "box" + i.toString);
+			console.log("seems to work");
+		}
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -2463,6 +2478,9 @@ function resizeBoxes(parent, templateId) {
 				$('iframe').css('pointer-events', 'auto');
 			}
 		});
+
+		testHideCoopyButton();
+
 	} else if (templateId == 6) {
 
 		getLocalStorageProperties(templateId, boxValArray);
@@ -2681,6 +2699,8 @@ function resizeBoxes(parent, templateId) {
 		});
 
 	}
+
+	
 };
 
 //----------------------------------------------------------------------------------

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1973,8 +1973,8 @@ function testHideCoopyButton() {
 		boxWidth = $("#box" + i + "wrapper").width();
 		console.log(boxWidth);
 		if(boxWidth <= 230){
-			hideCopyButtons(templateid, "box" + i.toString);
-			console.log("seems to work");
+			copyButton = document.getElementById("box" + i + "wrapper").getElementsByClassName("copybutton")[0];
+			copyButton.style.display = 'none';
 		}
 	}
 }

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1951,13 +1951,13 @@ function getTotalBoxes(template) {
 	return totalBoxes;
 }
 
+// Hides the copy button when there isnt enugh room for it
 function hideCopyButton() {
 	var boxWidth;
 	var templateid = retData['templateid'];
 
 	for(var i = 1; i <= getTotalBoxes(templateid); i++){
 		boxWidth = $("#box" + i + "wrapper").width();
-		console.log(boxWidth);
 		if(boxWidth <= 230){
 			copyButton = document.getElementById("box" + i + "wrapper").getElementsByClassName("copybutton")[0];
 			copyButton.style.display = 'none';
@@ -2284,7 +2284,6 @@ function maximizeBoxes(boxid) {
 			alignBoxesHeight3boxes(boxValArray, 2, 1, 3);
 		}
 	}
-	
 	hideCopyButton();
 }
 

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1958,7 +1958,7 @@ function hideCopyButton() {
 
 	for(var i = 1; i <= getTotalBoxes(templateid); i++){
 		boxWidth = $("#box" + i + "wrapper").width();
-		if(boxWidth <= 230){
+		if(boxWidth <= 310){
 			copyButton = document.getElementById("box" + i + "wrapper").getElementsByClassName("copybutton")[0];
 			copyButton.style.display = 'none';
 		}else{


### PR DESCRIPTION
The copy button will get hidden when the box reaches a certain width threshold. Also removed the old functionality added in this PR: #7416 as it is now obsolete with this pull request

Fixing issue: #7434