### PR TITLE
Added tree support for codeviewer

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1092,7 +1092,7 @@ function tokenize(instring, inprefix, insuffix) {
 	while (currentCharacter) { // currentCharacter == first character in each word
 		from = i;
 		if (currentCharacter <= ' ') { // White space and carriage return
-			if ((currentCharacter == '\n') || (currentCharacter == '\r') || (currentCharacter == '')) {
+ 			if ((currentCharacter == '\n') || (currentCharacter == '\r') || (currentCharacter == '')) {
 				maketoken('newline', "", i, i, row);
 				currentStr = "";
 				row++;
@@ -1100,16 +1100,13 @@ function tokenize(instring, inprefix, insuffix) {
 				currentStr = currentCharacter;
 			}
 
-			i++;
+			i++; 
 			while (true) {
 				currentCharacter = instring.charAt(i);
 				if (currentCharacter > ' ' || !currentCharacter) break;
 				if ((currentCharacter == '\n') || (currentCharacter == '\r') || (currentCharacter == '')) {
 					maketoken('whitespace', currentStr, from, i, row);
-					maketoken('newline', "", i, i, row);
 					currentStr = "";
-					// White space Row (so we get one white space token for each new row) also increase row number
-					row++;
 				} else {
 					currentStr += currentCharacter;
 				}
@@ -1810,36 +1807,36 @@ function createBlocks(ranges, boxid) {
 			button.classList.toggle('open-block');
 			button.classList.toggle('closed-block');
 			var rowsInBlock = Array(ranges[button.id][1] - ranges[button.id][0]).fill().map((_, idx) => ranges[button.id][0] + idx);
-			if (button.classList.contains('closed-block')) {
-				hideRows(rowsInBlock, button);
-			} else {
-				showRows(rowsInBlock, button);
-			}
-		})
+			toggleRows(rowsInBlock, button);
+		});
 	}
 }
 
-function hideRows(rows, button) {
+function toggleRows(rows, button) {
 	var baseRow = button.parentNode;
 	var wrapper = baseRow.parentNode;
 	var box = wrapper.parentNode;
 	var numbers = [...box.querySelectorAll('.codeborder div')];
+	var display;
+	var ellipses = document.createElement('span');
+	ellipses.classList.add('blockEllipses');
+	ellipses.innerHTML = ' ...';
+
+	if (button.classList.contains('closed-block')) {
+		display = 'none';
+		baseRow.appendChild(ellipses);
+	} else {
+		display = 'block';
+		ellipses = baseRow.querySelector('.blockEllipses');
+		baseRow.removeChild(ellipses);
+	}
+	
 	for (var i = 1; i < rows.length; i++) {
-		wrapper.querySelector("div[id$='"+rows[i]+"']").style.display = 'none';
-		numbers[rows[i] - 1].style.display = 'none';
+		wrapper.querySelector("div[id$='"+rows[i]+"']").style.display = display;
+		numbers[rows[i] - 1].style.display = display;
 	}
 }
 
-function showRows(rows, button) {
-	var baseRow = button.parentNode;
-	var wrapper = baseRow.parentNode;
-	var box = wrapper.parentNode;
-	var numbers = [...box.querySelectorAll('.codeborder div')];
-	for (var i = 1; i < rows.length; i++) {
-		wrapper.querySelector("div[id$='"+rows[i]+"']").style.display = 'block';
-		numbers[rows[i] - 1].style.display = 'block';
-	}
-}
 
 //----------------------------------------------------------------------------------
 // createCodeborder: function to create a border with line numbers

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -266,7 +266,8 @@ function returned(data) {
 
 	var ranges = getBlockRanges(allBlocks);
 	for (var i = 0; i < Object.keys(ranges).length; i++) {
-		createBlocks(ranges[i+1], i+1);
+		var boxid = Object.keys(ranges)[i];
+		createBlocks(ranges[boxid], boxid);
 	}
 
 	//hides maximize button if not supported

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2130,6 +2130,7 @@ function minimizeBoxes(boxid) {
 			alignBoxesHeight2boxes(boxValArray, 2, 1);
 		}
 	}
+}
 
 function hideCopyButtons(templateid, boxid) {
 	var totalBoxes = getTotalBoxes(templateid);

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -844,7 +844,7 @@
       min-width: 11px;
       display: inline-block;
       text-align: center;
-      line-height: 11px;
+      line-height: 8px;
       max-height: 11px;
       -webkit-box-sizing:border-box;
       -moz-box-sizing:border-box;

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -839,3 +839,26 @@
     margin-right: auto;
     width: 30% !important;
   }
+
+  .blockBtnSlot {
+      min-width: 12px;
+      display: inline-block;
+      text-align: center;
+      line-height: 12px;
+      font-size: 10pt;
+  }
+  .blockBtnSlot.open-block::before {
+      content: '-';
+  }
+  .blockBtnSlot.closed-block::before {
+      content: '+';
+  }
+  .blockBtnSlot.occupied {
+    border: 1px solid black;
+    border-radius: 50%;
+    cursor: pointer;
+  }
+  .blockBtnSlot.occupied:hover {
+    background: var(--color-primary);
+    color: #fff;
+  }

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -841,11 +841,15 @@
   }
 
   .blockBtnSlot {
-      min-width: 12px;
+      min-width: 11px;
       display: inline-block;
       text-align: center;
-      line-height: 12px;
-      font-size: 10pt;
+      line-height: 11px;
+      max-height: 11px;
+      -webkit-box-sizing:border-box;
+      -moz-box-sizing:border-box;
+      -ms-box-sizing:border-box;
+      box-sizing:border-box;
   }
   .blockBtnSlot.open-block::before {
       content: '-';
@@ -854,11 +858,14 @@
       content: '+';
   }
   .blockBtnSlot.occupied {
-    border: 1px solid black;
+    border: 1px  solid black;
     border-radius: 50%;
     cursor: pointer;
   }
   .blockBtnSlot.occupied:hover {
     background: var(--color-primary);
     color: #fff;
+  }
+  .blockEllipses {
+      font-weight: bold;
   }


### PR DESCRIPTION
Fixes #470 

![tree](https://user-images.githubusercontent.com/37792198/58299398-60fec880-7ddf-11e9-9ae5-76157f031411.gif)


Collapses and restores blocks (only works on { } blocks). Could maybe hide the buttons until the user hovers over the row if that is something we want.