### PR TITLE
Fix for #7204: Only open "Change Appearance" menu if 1 object is selected

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3723,7 +3723,7 @@ function showMenu() {
 //----------------------------------------------------------------------
 
 function openAppearanceDialogMenu() {
-    if (selected_objects.length == 0 || diagram[lastSelectedObject].isLocked) {
+    if (selected_objects.length != 1 || diagram[lastSelectedObject].isLocked) {
         return;
     }
     $(".loginBox").draggable();
@@ -4082,7 +4082,7 @@ function objectAppearanceMenu(form) {
 }
 
 //----------------------------------------------------------------------
-// changeObjectAppearance: USES DIALOG TO CHANGE OBJECT APPEARANC
+// changeObjectAppearance: USES DIALOG TO CHANGE OBJECT APPEARANCE
 //----------------------------------------------------------------------
 
 function changeObjectAppearance(object_type) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3723,7 +3723,7 @@ function showMenu() {
 //----------------------------------------------------------------------
 
 function openAppearanceDialogMenu() {
-    if (diagram[lastSelectedObject].isLocked) {
+    if (selected_objects.length == 0 || diagram[lastSelectedObject].isLocked) {
         return;
     }
     $(".loginBox").draggable();


### PR DESCRIPTION
Previously the console would print an error if the "Change Appearance" button was clicked with either no objects or more than 1 object selected. 

