### PR TITLE
#Issue 7029 Fixed cursor on hovering points when drawLine is selected

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3057,7 +3057,10 @@ function mousemoveevt(ev, t) {
                         //The point belongs to a umlLine or Line
                         canvas.style.cursor = "default";
                     } else {
-                        canvas.style.cursor = "url('../Shared/icons/hand_move.cur'), auto";
+                        // Should not change when drawing a line.
+                        if (uimode != "CreateLine") {
+                            canvas.style.cursor = "url('../Shared/icons/hand_move.cur'), auto";
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Issue #7029. Fixed so that the cursor no longer changes while hovering over the points for the objects on the canvas while drawLine is selected.