### PR TITLE
Fix for #7500: Disable menus that don't meet the requirements for use

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -517,7 +517,8 @@ function canvasToPixels(pixelX = 0, pixelY = 0) {
 // Move selected objects to front of canvas
 //-----------------------------------------
 
-function moveToFront() {
+function moveToFront(event) {
+    event.stopPropagation();
     let front = [];
     let back = [];
     let diagramLength = diagram.length;
@@ -543,7 +544,8 @@ function moveToFront() {
 // Move selected objects to back of canvas
 //-----------------------------------------
 
-function moveToBack() {
+function moveToBack(event) {
+    event.stopPropagation();
     let front = [];
     let back = [];
     let diagramLength = diagram.length;
@@ -1516,7 +1518,7 @@ function toggleA4Orientation(event) {
 //-----------------------------------------------------------------------------------
 // When an item is selected, enable all options related to having an object selected
 //-----------------------------------------------------------------------------------
-
+var selectedItems = false;
 function enableSelectedItemOptions() {
       if (selected_objects.length > 0) {
         $("#change-appearance-item").removeClass("drop-down-item drop-down-item-disabled");
@@ -1635,7 +1637,8 @@ function updateGraphics() {
 // resetViewToOrigin: moves the view to origo based on movement done in the canvas
 //---------------------------------------------------------------------------------
 
-function resetViewToOrigin(){
+function resetViewToOrigin(event){
+    event.stopPropagation();
     origoOffsetX = 0;
     origoOffsetY = 0;
     updateGraphics();
@@ -1742,13 +1745,8 @@ function changeLoginBoxTitleAppearance() {
 // Ends up with erasing all selected objects
 //---------------------------------------------------
 
-function eraseSelectedObject() {
-    //Issue: Need to remove the crosses
-    if(selected_objects.length == 0) {
-        showMenu().innerHTML = "No item selected<type='text'>";
-        changeLoginBoxTitleDelete();
-        $(".loginBox").draggable();
-    }
+function eraseSelectedObject(event) {
+    event.stopPropagation();
     for(var i = 0; i < selected_objects.length; i++) {
         eraseObject(selected_objects[i]);
     }
@@ -3924,11 +3922,15 @@ function showMenu() {
 //  openAppearanceDialogMenu: Opens the dialog menu for appearance.
 //----------------------------------------------------------------------
 
-function openAppearanceDialogMenu() {
+function openAppearanceDialogMenu(event) {
+    event.stopPropagation();
     for(var i = 0; i < selected_objects.length; i++){
         if (selected_objects[i].isLocked) {
             return;
         }
+    }
+    if (selected_objects.length == 0) {
+        return;
     }
     $(".loginBox").draggable();
     var form = showMenu();
@@ -4208,7 +4210,8 @@ function setSelectedOption(type, value) {
 // globalAppearanceMenu: open a menu to change appearance on all entities.
 //----------------------------------------------------------------------
 
-function globalAppearanceMenu() {
+function globalAppearanceMenu(event) {
+    event.stopPropagation();
     globalAppearanceValue = 1;
     $(".loginBox").draggable();
     var form = showMenu();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -49,7 +49,7 @@ var settings = {
         Text: 0,
     },
 
-    properties: {        
+    properties: {
         fillColor: '#ffffff',                         // Change background colors on entities.
         strokeColor: '#000000',                       // Change standard line color.
         fontColor: '#000000',                         // Change the color of the font.
@@ -579,7 +579,7 @@ function cancelFreeDraw() {
         md = mouseState.empty;      //Prevents the dashed line box, when drawing a square, to appear immediately
         updateGraphics();
     }
-    
+
 }
 
 //----------------------------------------------------------------------
@@ -1513,6 +1513,46 @@ function toggleA4Orientation(event) {
     updateGraphics();
 }
 
+//-----------------------------------------------------------------------------------
+// When an item is selected, enable all options related to having an object selected
+//-----------------------------------------------------------------------------------
+
+function enableSelectedItemOptions() {
+      if (selected_objects.length > 0) {
+        $("#change-appearance-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#move-selected-front-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#move-selected-back-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#lock-selected-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#delete-object-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#group-objects-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#ungroup-objects-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#align-top-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#align-right-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#align-bottom-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#align-left-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#horizontal-c-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#vertical-c-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#distribute-horizontal-item").removeClass("drop-down-item drop-down-item-disabled");
+        $("#distribute-vertical-item").removeClass("drop-down-item drop-down-item-disabled");
+      } else {
+        $("#change-appearance-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#move-selected-front-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#move-selected-back-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#lock-selected-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#delete-object-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#group-objects-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#ungroup-objects-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#align-top-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#align-right-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#align-bottom-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#align-left-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#horizontal-c-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#vertical-c-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#distribute-horizontal-item").addClass("drop-down-item drop-down-item-disabled");
+        $("#distribute-vertical-item").addClass("drop-down-item drop-down-item-disabled");
+    }
+}
+
 //----------------------------------------------------
 // openImportDialog: Opens the dialog menu for import
 //----------------------------------------------------
@@ -1752,7 +1792,7 @@ $(document).ready(function() {
 
 function setTextSizeEntity() {
     for(var i = 0; i < selected_objects.length; i++){
-        selected_objects[i].properties['sizeOftext'] = document.getElementById('TextSize').value;        
+        selected_objects[i].properties['sizeOftext'] = document.getElementById('TextSize').value;
     }
 }
 
@@ -2211,6 +2251,7 @@ function reWrite() {
             document.getElementById("selectDiv").style.minWidth = '10%';
         }
     }
+    enableSelectedItemOptions();
 }
 
 //----------------------------------------
@@ -2698,7 +2739,7 @@ function globalFillColor() {
     for (var i = 0; i < diagram.length; i++) {
         if (diagram[i].kind == kind.symbol && (diagram[i].symbolkind == symbolKind.erAttribute || diagram[i].symbolkind == symbolKind.erEntity || diagram[i].symbolkind == symbolKind.erRelation || diagram[i].symbolkind == symbolKind.uml)) {
             diagram[i].properties['fillColor'] = settings.properties.fillColor;
-        } else { 
+        } else {
             diagram[i].fillColor = settings.properties.fillColor;
         }
     }
@@ -3964,7 +4005,7 @@ function loadFormIntoElement(element, dir) {
     var file = new XMLHttpRequest();
     var lastSelected = selected_objects[selected_objects.length - 1];
     var names = "";
-    var properties; 
+    var properties;
 
     if(dir == "diagram_forms.php?form=globalType"){
         properties = settings.properties;

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -158,24 +158,24 @@
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='globalAppearanceMenu();'>Global Appearance</span>
+                                <span class="drop-down-option" onclick='globalAppearanceMenu(event);'>Global Appearance</span>
                             </div>
                             <div class="drop-down-item">
                                 <div id="change-appearance-item" class="drop-down-item-disabled">
-                                    <span class="drop-down-option" onclick='openAppearanceDialogMenu();'>Change Appearance</span>
+                                    <span class="drop-down-option" onclick='openAppearanceDialogMenu(event);'>Change Appearance</span>
                                 </div>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
                                 <div id="move-selected-front-item" class="drop-down-item-disabled">
-                                    <span class="drop-down-option" onclick='moveToFront()'>Move selected to front</span>
+                                    <span class="drop-down-option" onclick='moveToFront(event)'>Move selected to front</span>
                                     <i id="hotkey-front" class="hotKeys">Shift + 1</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="move-selected-back-item" class="drop-down-item-disabled">
-                                    <span class="drop-down-option" onclick='moveToBack()'>Move selected to back</span>
+                                    <span class="drop-down-option" onclick='moveToBack(event)'>Move selected to back</span>
                                     <i id="hotkey-back" class="hotKeys">Shift + 2</i>
                                 </div>
                             </div>
@@ -189,7 +189,7 @@
                             </div>
                             <div class="drop-down-item">
                                 <div id="delete-object-item" class="drop-down-item-disabled">
-                                    <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
+                                    <span class="drop-down-option" onclick='eraseSelectedObject(event);'>Delete Object</span>
                                     <i id="hotkey-delete" class="hotKeys">Delete/Backspace</i>
                                 </div>
                             </div>
@@ -208,7 +208,7 @@
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='resetViewToOrigin();'>Reset view to origin</span>
+                                <span class="drop-down-option" onclick='resetViewToOrigin(event);'>Reset view to origin</span>
                                 <i id="hotkey-resetView" class="hotKeys">Shift + O</i>
                             </div>
                         </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -161,35 +161,49 @@
                                 <span class="drop-down-option" onclick='globalAppearanceMenu();'>Global Appearance</span>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='openAppearanceDialogMenu();'>Change Appearance</span>
+                                <div id="change-appearance-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick='openAppearanceDialogMenu();'>Change Appearance</span>
+                                </div>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='moveToFront()'>Move selected to front</span>
-                                <i id="hotkey-front" class="hotKeys">Shift + 1</i>
+                                <div id="move-selected-front-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick='moveToFront()'>Move selected to front</span>
+                                    <i id="hotkey-front" class="hotKeys">Shift + 1</i>
+                                </div>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='moveToBack()'>Move selected to back</span>
-                                <i id="hotkey-back" class="hotKeys">Shift + 2</i>
+                                <div id="move-selected-back-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick='moveToBack()'>Move selected to back</span>
+                                    <i id="hotkey-back" class="hotKeys">Shift + 2</i>
+                                </div>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='lockSelected(event)'>Lock/Unlock selected</span>
-                                <i id="hotkey-lock" class="hotKeys">Shift + X</i>
+                                <div id="lock-selected-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick='lockSelected(event)'>Lock/Unlock selected</span>
+                                    <i id="hotkey-lock" class="hotKeys">Shift + X</i>
+                                </div>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
-                                <i id="hotkey-delete" class="hotKeys">Delete/Backspace</i>
+                                <div id="delete-object-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick='eraseSelectedObject();'>Delete Object</span>
+                                    <i id="hotkey-delete" class="hotKeys">Delete/Backspace</i>
+                                </div>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='addGroupToSelected(event)'>Group objects</span>
+                                <div id="group-objects-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick='addGroupToSelected(event)'>Group objects</span>
+                                </div>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick='removeGroupFromSelected(event)'>Ungroup objects</span>
+                                <div id="ungroup-objects-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick='removeGroupFromSelected(event)'>Ungroup objects</span>
+                                </div>
                             </div>
                             <div class="drop-down-divider">
                             </div>
@@ -253,28 +267,40 @@
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick="align(event, 'top');">Top</span>
-                                <i id="hotkey-Align-Top" class="hotKeys">Shift + ⇧ </i>
+                                <div id="align-top-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick="align(event, 'top');">Top</span>
+                                    <i id="hotkey-Align-Top" class="hotKeys">Shift + ⇧ </i>
+                                </div>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick="align(event, 'right');">Right</span>
-                                <i id="hotkey-Align-Right" class="hotKeys">Shift + ⇨ </i>
+                                <div id="align-right-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick="align(event, 'right');">Right</span>
+                                    <i id="hotkey-Align-Right" class="hotKeys">Shift + ⇨ </i>
+                                </div>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick="align(event, 'bottom');">Bottom</span>
-                                <i id="hotkey-Align-Bottom" class="hotKeys">Shift + ⇩ </i>
+                                <div id="align-bottom-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick="align(event, 'bottom');">Bottom</span>
+                                    <i id="hotkey-Align-Bottom" class="hotKeys">Shift + ⇩ </i>
+                                </div>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick="align(event, 'left');">Left</span>
-                                <i id="hotkey-Align-Left" class="hotKeys">Shift + ⇦ </i>
+                                <div id="align-left-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick="align(event, 'left');">Left</span>
+                                    <i id="hotkey-Align-Left" class="hotKeys">Shift + ⇦ </i>
+                                </div>
                             </div>
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick="align(event, 'horizontalCenter');">Horizontal center</span>
+                                <div id="horizontal-c-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick="align(event, 'horizontalCenter');">Horizontal center</span>
+                                </div>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick="align(event, 'verticalCenter');">Vertical center</span>
+                                <div id="vertical-c-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick="align(event, 'verticalCenter');">Vertical center</span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -282,10 +308,14 @@
                         <span class="drop-down-label">Distribute</span>
                         <div class="drop-down">
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick="distribute(event, 'horizontally');">Horizontal</span>
+                                <div id="distribute-horizontal-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick="distribute(event, 'horizontally');">Horizontal</span>
+                                </div>
                             </div>
                             <div class="drop-down-item">
-                                <span class="drop-down-option" onclick="distribute(event, 'vertically');">Vertical</span>
+                                <div id="distribute-vertical-item" class="drop-down-item-disabled">
+                                    <span class="drop-down-option" onclick="distribute(event, 'vertically');">Vertical</span>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
**Co-Author: @a16jenja** 
Issue: #7500

Disable menus that don't meet the requirements for use. 
Also, prevent all menu items to collapse when clicking at them.

As we see it the menu item "Global appearance" should be able to be clicked at even when no symbols are selected. The user should be in our opinion, be able to set all the customization before starting to draw the diagram. That's why we made no changes to it. Let us know your thoughts on this @a14oscna. 
