### PR TITLE
Fix for #7599. Enabled "Add text" shortcut for every mode in diagram

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -466,7 +466,7 @@ function keyDownHandler(e) {
       document.getElementById("relationbutton").click();
     } else if (shiftIsClicked && key == cKey && targetMode == "UML") {
       document.getElementById("classbutton").click();
-    } else if (shiftIsClicked && key == tKey && targetMode == "ER") {
+    } else if (shiftIsClicked && key == tKey) {
       document.getElementById("drawtextbutton").click();
     } else if (shiftIsClicked && key == fKey) {
       document.getElementById("drawfreebutton").click();


### PR DESCRIPTION
Previously the Shift+T shortcut only activated under the ER mode. Now it activates under every mode. 

Fix for #7599 