### PR TITLE
Fix: #7610 Shortcuts barely visible

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -269,25 +269,25 @@
                             <div class="drop-down-item">
                                 <div id="align-top-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick="align(event, 'top');">Top</span>
-                                    <i id="hotkey-Align-Top" class="hotKeys">Shift + ⇧ </i>
+                                    <i id="hotkey-Align-Top" class="hotKeys">Shift + ▲</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="align-right-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick="align(event, 'right');">Right</span>
-                                    <i id="hotkey-Align-Right" class="hotKeys">Shift + ⇨ </i>
+                                    <i id="hotkey-Align-Right" class="hotKeys">Shift + ►</i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="align-bottom-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick="align(event, 'bottom');">Bottom</span>
-                                    <i id="hotkey-Align-Bottom" class="hotKeys">Shift + ⇩ </i>
+                                    <i id="hotkey-Align-Bottom" class="hotKeys">Shift + ▼ </i>
                                 </div>
                             </div>
                             <div class="drop-down-item">
                                 <div id="align-left-item" class="drop-down-item-disabled">
                                     <span class="drop-down-option" onclick="align(event, 'left');">Left</span>
-                                    <i id="hotkey-Align-Left" class="hotKeys">Shift + ⇦ </i>
+                                    <i id="hotkey-Align-Left" class="hotKeys">Shift + ◄ </i>
                                 </div>
                             </div>
                             <div class="drop-down-divider">

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5593,7 +5593,3 @@ textarea#filecont {
 .resultedbuttons:hover {
   filter: brightness(1.2);
 }
-
-#arrow {
-  font-size: 150px;
-}

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5593,3 +5593,7 @@ textarea#filecont {
 .resultedbuttons:hover {
   filter: brightness(1.2);
 }
+
+#arrow {
+  font-size: 150px;
+}


### PR DESCRIPTION
Issue: #7610 

Changed arrows. This was the best option I could find that worked for all browsers and OS. Now it's more visible and user-friendly.