### PR TITLE
Fix for #6577: UML lines can now be moved

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3128,7 +3128,7 @@ function mousemoveevt(ev, t) {
                 // when in movearound mode or if the point doesn't belong to a selected object then don't display different pointer when hovering points
                 if (uimode != "MoveAround" && pointBelongsToObject) {
                     //Change cursor if you are hovering over a point and its not a line
-                    if(sel.attachedSymbol.symbolkind == symbolKind.line || sel.attachedSymbol.symbolkind == symbolKind.umlLine || sel.attachedSymbol.isLocked) {
+                    if(sel.attachedSymbol.symbolkind == symbolKind.line || sel.attachedSymbol.isLocked) {
                         //The point belongs to a umlLine or Line
                         canvas.style.cursor = "default";
                     } else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -817,7 +817,7 @@ diagram.closestPoint = function(mx, my) {
     var distance = 50000000;
     var point;
     let attachedSymbol;
-    this.filter(symbol => symbol.kind != kind.path && symbol.symbolkind != symbolKind.text).forEach(symbol => {
+    this.filter(symbol => symbol.kind != kind.path && symbol.symbolkind != symbolKind.text && symbol.symbolkind != symbolKind.umlLine).forEach(symbol => {
         [points[symbol.topLeft], points[symbol.bottomRight], {x:points[symbol.topLeft], y:points[symbol.bottomRight], fake:true}, {x:points[symbol.bottomRight], y:points[symbol.topLeft], fake:true}].forEach(corner => {
             var deltaX = corner.fake ? mx - corner.x.x : mx - corner.x;
             var deltaY = corner.fake ? my - corner.y.y : my - corner.y;
@@ -825,6 +825,19 @@ diagram.closestPoint = function(mx, my) {
             if (hypotenuseElevatedBy2 < distance) {
                 distance = hypotenuseElevatedBy2;
                 point = corner;
+                attachedSymbol = symbol;
+            }
+        });
+    });
+
+    this.filter(symbol => symbol.kind == kind.symbol && symbol.symbolkind == symbolKind.umlLine).forEach(symbol => {
+        symbol.draggablePoints.forEach(anchor => {            
+            var deltaX = mx - points[anchor].x;
+            var deltaY = my - points[anchor].y;
+            var hypotenuseElevatedBy2 = (deltaX * deltaX) + (deltaY * deltaY);
+            if (hypotenuseElevatedBy2 < distance) {
+                distance = hypotenuseElevatedBy2;
+                point = points[anchor];
                 attachedSymbol = symbol;
             }
         });

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1731,7 +1731,7 @@ function Symbol(kindOfSymbol) {
             }
             this.addAnchor(canvasToPixels(breakpointEndX).x, canvasToPixels(0, breakpointEndY).y);
             this.createDraggablePoints();
-        } else {
+        } else if (this.anchors.length > 0) {
             // These two anchors are fixed points
             points[this.anchors[0]].x = canvasToPixels(breakpointStartX).x;
             points[this.anchors[0]].y = canvasToPixels(0, breakpointStartY).y;

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1006,6 +1006,12 @@ function Symbol(kindOfSymbol) {
         var x2 = pixelsToCanvas(points[this.bottomRight].x).x;
         var y2 = pixelsToCanvas(0, points[this.bottomRight].y).y;
 
+        // Draggable UML line point
+        if (this.symbolkind == symbolKind.umlLine && this.draggablePoints.length > 1) {
+            var x3 = pixelsToCanvas(points[this.draggablePoints[0]].x).x;
+            var y3 = pixelsToCanvas(0, points[this.draggablePoints[0]].y).y;
+        }
+
         if (this.isLocked) {
             drawLock(this);
             if (this.isHovered || this.isLockHovered) {
@@ -1064,6 +1070,15 @@ function Symbol(kindOfSymbol) {
             ctx.arc(x2,y2,5 * diagram.getZoomValue(),0,2*Math.PI,false);
             ctx.fillStyle = '#F82';
             ctx.fill();
+
+            // Draggable UML line point
+            if (this.symbolkind == symbolKind.umlLine && this.draggablePoints.length > 0) {
+                ctx.beginPath();
+                ctx.arc(x3,y3,5 * diagram.getZoomValue(),0,2*Math.PI,false);
+                ctx.fillStyle = '#ccc';
+                ctx.fill();
+            }
+
             if (this.symbolkind != symbolKind.line && this.symbolkind != symbolKind.umlLine) {
                 ctx.beginPath();
                 ctx.arc(x1,y2,5 * diagram.getZoomValue(),0,2*Math.PI,false);

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1864,7 +1864,7 @@ function Symbol(kindOfSymbol) {
     // createDraggablePoints: dynamically create draggable points between every anchor
     //---------------------------------------------------------------
     this.createDraggablePoints = function() {
-        for (var i = 2; i < this.anchors.length; i++) { // i = depending on when to start creating draggable points
+        for (var i = 2; i < this.anchors.length - 1; i++) { // values depending on when to start and stop creating draggable points
             var firstAnchorPoint = this.anchors[i - 1];
             var secondAnchorPoint = this.anchors[i];
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1703,9 +1703,103 @@ function Symbol(kindOfSymbol) {
             }
             ctx.lineTo(x2, y2);
             ctx.stroke();
+        } else if (this.anchors.length == 0) {
+            this.addAnchor(canvasToPixels(breakpointStartX).x, canvasToPixels(0, breakpointStartY).y);
+
+            if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "up" || endLineDirection === "down")) {
+                if (x1 == x2) {
+                    this.addAnchor(canvasToPixels(breakpointStartX).x, canvasToPixels(0, breakpointStartY).y);
+                    this.addAnchor(canvasToPixels(breakpointEndX).x, canvasToPixels(0, breakpointEndY).y);
+                } else {
+                    this.addAnchor(canvasToPixels(breakpointStartX).x, canvasToPixels(0, middleBreakPointY).y);
+                    this.addAnchor(canvasToPixels(breakpointEndX).x, canvasToPixels(0, middleBreakPointY).y);
+                }
+            } else if ((startLineDirection === "left" || startLineDirection === "right") && (endLineDirection === "left" || endLineDirection === "right")) {
+                if (y1 == y2) {
+                    this.addAnchor(canvasToPixels(breakpointStartX).x, canvasToPixels(0, breakpointStartY).y);
+                    this.addAnchor(canvasToPixels(breakpointEndX).x, canvasToPixels(0, breakpointEndY).y);
+                } else {
+                    this.addAnchor(canvasToPixels(middleBreakPointX).x, canvasToPixels(0, breakpointStartY).y);
+                    this.addAnchor(canvasToPixels(middleBreakPointX).x, canvasToPixels(0, breakpointEndY).y);
+                }
+            } else if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "left" || endLineDirection === "right")) {
+                this.addAnchor(canvasToPixels(middleBreakPointX).x, canvasToPixels(0, middleBreakPointY).y);
+                this.addAnchor(canvasToPixels(breakpointEndX).x, canvasToPixels(0, breakpointEndY).y);
+            } else if ((startLineDirection === "right" || startLineDirection === "left") && (endLineDirection === "up" || endLineDirection === "down")) {
+                this.addAnchor(canvasToPixels(breakpointStartX).x, canvasToPixels(0, breakpointStartY).y);
+                this.addAnchor(canvasToPixels(middleBreakPointX).x, canvasToPixels(0, middleBreakPointY).y);
+            }
+            this.addAnchor(canvasToPixels(breakpointEndX).x, canvasToPixels(0, breakpointEndY).y);
+            this.createDraggablePoints();
         }
 
         this.drawUmlRelationLines(x1,y1,x2,y2, startLineDirection, endLineDirection);
+    }
+
+    //---------------------------------------------------------------
+    // addAnchor: create UML line anchor point
+    //---------------------------------------------------------------
+    this.addAnchor = function(anchorx, anchory) {
+        var newAnchor;
+        newAnchor = points.addPoint(anchorx, anchory, false);
+        this.anchors.push(newAnchor);
+    }
+
+    //---------------------------------------------------------------
+    // clearAnchors: remove all anchors from a UML line
+    //---------------------------------------------------------------
+    this.clearAnchors = function() {
+        for (var i = 0; i < this.anchors.length; i++) {
+            points[this.anchors[i]] = waldoPoint;
+        }
+        this.anchors = [];
+    }
+
+    //---------------------------------------------------------------
+    // addDraggablePoint: create UML line draggable point
+    //---------------------------------------------------------------
+    this.addDraggablePoint = function(dragpointx, dragpointy) {
+        var newDraggablePoint;
+        newDraggablePoint = points.addPoint(dragpointx, dragpointy, false);
+        this.draggablePoints.push(newDraggablePoint);
+    }
+
+    //---------------------------------------------------------------
+    // clearDraggablePoints: remove all draggable points from a UML line
+    //---------------------------------------------------------------
+    this.clearDraggablePoints = function() {
+        for (var i = 0; i < this.draggablePoints.length; i++) {
+            points[this.draggablePoints[i]] = waldoPoint;
+        }
+        this.draggablePoints = [];
+    }
+
+    //---------------------------------------------------------------
+    // createDraggablePoints: dynamically create draggable points between every anchor
+    //---------------------------------------------------------------
+    this.createDraggablePoints = function() {
+        for (var i = 2; i < this.anchors.length; i++) { // i = depending on when to start creating draggable points
+            var firstAnchorPoint = this.anchors[i - 1];
+            var secondAnchorPoint = this.anchors[i];
+
+            // Find X coordinate between anchor points
+            var newX = Math.abs(points[firstAnchorPoint].x - points[secondAnchorPoint].x) / 2;
+            if (points[firstAnchorPoint].x > points[secondAnchorPoint].x) {
+                newX += points[secondAnchorPoint].x;
+            } else {
+                newX += points[firstAnchorPoint].x;
+            }
+
+            // Find Y coordinate between anchor points
+            var newY = Math.abs(points[firstAnchorPoint].y - points[secondAnchorPoint].y) / 2;
+            if (points[firstAnchorPoint].y > points[secondAnchorPoint].y) {
+                newY += points[secondAnchorPoint].y;
+            } else {
+                newY += points[firstAnchorPoint].y;
+            }
+
+            this.addDraggablePoint(newX, newY);
+        }
     }
 
     //---------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1590,9 +1590,7 @@ function Symbol(kindOfSymbol) {
             } else if (canvasToPixels(0, y2).y == conobj2.br.y) {
                 endLineDirection = "down";
             }
-        } else if (connObjects.length == 1) {
-            console.log("test");
-            
+        } else if (connObjects.length == 1) {            
             // Check if line's end point matches any class diagram
             if (canvasToPixels(x2).x == conobj1.tl.x) {
                 endLineDirection = "left";
@@ -1650,60 +1648,62 @@ function Symbol(kindOfSymbol) {
             breakpointEndX = x2;
         }
 
-        // Start line
-        ctx.beginPath();
-        ctx.moveTo(x1, y1);
-
-        // Draw to start breakpoint based on direction
-        if (startLineDirection == "left") {
-            ctx.lineTo(breakpointStartX, breakpointStartY);
-        } else if (startLineDirection == "right") {
-            ctx.lineTo(breakpointStartX, breakpointStartY);
-        } else if (startLineDirection == "up") {
-            ctx.lineTo(breakpointStartX, breakpointStartY);
-        } else if (startLineDirection == "down") {
-            ctx.lineTo(breakpointStartX, breakpointStartY);
-        }
-
-        // Check if this is a recursive line (connects to a single object twice)
         if (connObjects.length == 1) {
-            if (x1 == x2) { // Make sure the line is drawn "out" of the symbol
-                if (startLineDirection === "right") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
-                else this.recursiveLineExtent = -Math.abs(this.recursiveLineExtent);
-                middleBreakPointX += this.recursiveLineExtent * zoomValue;
-            }else if (y1 == y2) {
-                if (startLineDirection === "down") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
-                else this.recursiveLineExtent = -Math.abs(this.recursiveLineExtent);
-                middleBreakPointY += this.recursiveLineExtent * zoomValue;
+            // Start line
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+
+            // Draw to start breakpoint based on direction
+            if (startLineDirection == "left") {
+                ctx.lineTo(breakpointStartX, breakpointStartY);
+            } else if (startLineDirection == "right") {
+                ctx.lineTo(breakpointStartX, breakpointStartY);
+            } else if (startLineDirection == "up") {
+                ctx.lineTo(breakpointStartX, breakpointStartY);
+            } else if (startLineDirection == "down") {
+                ctx.lineTo(breakpointStartX, breakpointStartY);
             }
-        }
 
-        if((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "up" || endLineDirection === "down")) {
-            ctx.lineTo(breakpointStartX, middleBreakPointY);
-            ctx.lineTo(middleBreakPointX, middleBreakPointY); // Mid point
-            ctx.lineTo(breakpointEndX, middleBreakPointY);
-        } else if((startLineDirection === "left" || startLineDirection === "right") && (endLineDirection === "left" || endLineDirection === "right")) {
-            ctx.lineTo(middleBreakPointX, breakpointStartY);
-            ctx.lineTo(middleBreakPointX, middleBreakPointY); // Mid point
-            ctx.lineTo(middleBreakPointX, breakpointEndY);
-        }  else if((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "left" || endLineDirection === "right")) {
-            ctx.lineTo(breakpointStartX, breakpointEndY);
-        }  else if((startLineDirection === "right" || startLineDirection === "left") && (endLineDirection === "up" || endLineDirection === "down")) {
-            ctx.lineTo(breakpointEndX, breakpointStartY);
-        }
+            // Check if this is a recursive line (connects to a single object twice)
+            if (connObjects.length == 1) {
+                if (x1 == x2) { // Make sure the line is drawn "out" of the symbol
+                    if (startLineDirection === "right") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
+                    else this.recursiveLineExtent = -Math.abs(this.recursiveLineExtent);
+                    middleBreakPointX += this.recursiveLineExtent * zoomValue;
+                } else if (y1 == y2) {
+                    if (startLineDirection === "down") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
+                    else this.recursiveLineExtent = -Math.abs(this.recursiveLineExtent);
+                    middleBreakPointY += this.recursiveLineExtent * zoomValue;
+                }
+            }
 
-        // Draw to end breakpoint based on direction
-        if (endLineDirection == "left") {
-            ctx.lineTo(breakpointEndX, breakpointEndY);
-        } else if (endLineDirection == "right") {
-            ctx.lineTo(breakpointEndX, breakpointEndY);
-        } else if (endLineDirection == "up") {
-            ctx.lineTo(breakpointEndX, breakpointEndY);
-        } else if (endLineDirection == "down") {
-            ctx.lineTo(breakpointEndX, breakpointEndY);
+            if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "up" || endLineDirection === "down")) {
+                ctx.lineTo(breakpointStartX, middleBreakPointY);
+                ctx.lineTo(middleBreakPointX, middleBreakPointY); // Mid point
+                ctx.lineTo(breakpointEndX, middleBreakPointY);
+            } else if ((startLineDirection === "left" || startLineDirection === "right") && (endLineDirection === "left" || endLineDirection === "right")) {
+                ctx.lineTo(middleBreakPointX, breakpointStartY);
+                ctx.lineTo(middleBreakPointX, middleBreakPointY); // Mid point
+                ctx.lineTo(middleBreakPointX, breakpointEndY);
+            } else if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "left" || endLineDirection === "right")) {
+                ctx.lineTo(breakpointStartX, breakpointEndY);
+            } else if ((startLineDirection === "right" || startLineDirection === "left") && (endLineDirection === "up" || endLineDirection === "down")) {
+                ctx.lineTo(breakpointEndX, breakpointStartY);
+            }
+
+            // Draw to end breakpoint based on direction
+            if (endLineDirection == "left") {
+                ctx.lineTo(breakpointEndX, breakpointEndY);
+            } else if (endLineDirection == "right") {
+                ctx.lineTo(breakpointEndX, breakpointEndY);
+            } else if (endLineDirection == "up") {
+                ctx.lineTo(breakpointEndX, breakpointEndY);
+            } else if (endLineDirection == "down") {
+                ctx.lineTo(breakpointEndX, breakpointEndY);
+            }
+            ctx.lineTo(x2, y2);
+            ctx.stroke();
         }
-        ctx.lineTo(x2, y2);
-        ctx.stroke();
 
         this.drawUmlRelationLines(x1,y1,x2,y2, startLineDirection, endLineDirection);
     }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -46,6 +46,10 @@ function Symbol(kindOfSymbol) {
     this.connectorLeft = [];
     this.connectorRight = [];
 
+    // UML line point arrays
+    this.anchors = [];          // Points that will not be manually manipulated
+    this.draggablePoints = [];  // Points that the user can move
+
     // Properties array that stores different kind of objects. Refer to the properties with "properties['fillColor']"
     this.properties = {
         'fillColor': settings.properties.fillColor,    // Change background colors on entities.
@@ -574,6 +578,31 @@ function Symbol(kindOfSymbol) {
         }
 
         return pointToLineDistance(points[this.topLeft], points[this.bottomRight], mx, my) < 11;
+    }
+
+    //--------------------------------------------------------------------
+    // UMLLineHover: returns if this line is hovered
+    //--------------------------------------------------------------------
+    this.UMLLineHover = function() {
+        var p1, p2;
+
+         // Check for hover in each section of the line
+        for(var i = 0; i < this.anchors.length - 1; i++){
+            p1 = this.anchors[i];
+            p2 = this.anchors[i+1];
+
+             if(Math.max(points[p1].x, points[p2].x) + tolerance > currentMouseCoordinateX && 
+               Math.min(points[p1].x, points[p2].x) - tolerance < currentMouseCoordinateX &&
+               Math.max(points[p1].y, points[p2].y) + tolerance > currentMouseCoordinateY && 
+               Math.min(points[p1].y, points[p2].y) - tolerance < currentMouseCoordinateY)
+            {
+                if(pointToLineDistance(points[p1], points[p2], currentMouseCoordinateX, currentMouseCoordinateY) < tolerance){
+                    return true;
+                }
+            }
+        }
+
+         return false;
     }
 
     //--------------------------------------------------------------------
@@ -2591,6 +2620,9 @@ function Path() {
     // checkForHover: Returns if the free draw object is clicked
     //--------------------------------------------------------------------
     this.checkForHover = function (mx, my) {
+        if(this.symbolkind == symbolKind.umlLine){
+            return this.UMLLineHover();
+        }
         setIsLockHovered(this, mx, my);
         return this.isClicked(mx, my);
     }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1563,8 +1563,8 @@ function Symbol(kindOfSymbol) {
         var startLineDirection = "";  // Which side of the class the line starts from
         var endLineDirection = "";    // Which side of the class the line ends in
 
-        var conobj1 = this.getConnectedObjects()[0].corners();
-        var conobj2 = this.getConnectedObjects()[1].corners();
+        let connObjects = this.getConnectedObjects();
+        var conobj1 = connObjects[0].corners();
 
         // Check if line's start point matches any class diagram
         if (canvasToPixels(x1).x == conobj1.tl.x) {
@@ -1577,15 +1577,19 @@ function Symbol(kindOfSymbol) {
             startLineDirection = "down";
         }
 
-        // Check if line's end point matches any class diagram
-        if (canvasToPixels(x2).x == conobj2.tl.x) {
-            endLineDirection = "left";
-        } else if (canvasToPixels(x2).x == conobj2.br.x) {
-            endLineDirection = "right";
-        } else if (canvasToPixels(0, y2).y == conobj2.tl.y) {
-            endLineDirection = "up";
-        } else if (canvasToPixels(0, y2).y == conobj2.br.y) {
-            endLineDirection = "down";
+        if (connObjects.length > 1) {
+            var conobj2 = this.getConnectedObjects()[1].corners();
+
+            // Check if line's end point matches any class diagram
+            if (canvasToPixels(x2).x == conobj2.tl.x) {
+                endLineDirection = "left";
+            } else if (canvasToPixels(x2).x == conobj2.br.x) {
+                endLineDirection = "right";
+            } else if (canvasToPixels(0, y2).y == conobj2.tl.y) {
+                endLineDirection = "up";
+            } else if (canvasToPixels(0, y2).y == conobj2.br.y) {
+                endLineDirection = "down";
+            }
         }
 
         // Default if something breaks
@@ -1647,17 +1651,16 @@ function Symbol(kindOfSymbol) {
 
         // Draw to start breakpoint based on direction
         if (startLineDirection == "left") {
-            ctx.lineTo(breakpointStartX, y1);
+            ctx.lineTo(breakpointStartX, breakpointStartY);
         } else if (startLineDirection == "right") {
-            ctx.lineTo(breakpointStartX, y1);
+            ctx.lineTo(breakpointStartX, breakpointStartY);
         } else if (startLineDirection == "up") {
-            ctx.lineTo(x1, breakpointStartY);
+            ctx.lineTo(breakpointStartX, breakpointStartY);
         } else if (startLineDirection == "down") {
-            ctx.lineTo(x1, breakpointStartY);
+            ctx.lineTo(breakpointStartX, breakpointStartY);
         }
 
         // Check if this is a recursive line (connects to a single object twice)
-        let connObjects = this.getConnectedObjects();
         if (connObjects.length == 1) {
             if (x1 == x2) { // Make sure the line is drawn "out" of the symbol
                 if (startLineDirection === "right") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
@@ -1686,13 +1689,13 @@ function Symbol(kindOfSymbol) {
 
         // Draw to end breakpoint based on direction
         if (endLineDirection == "left") {
-            ctx.lineTo(breakpointEndX, y2);
+            ctx.lineTo(breakpointEndX, breakpointEndY);
         } else if (endLineDirection == "right") {
-            ctx.lineTo(breakpointEndX, y2);
+            ctx.lineTo(breakpointEndX, breakpointEndY);
         } else if (endLineDirection == "up") {
-            ctx.lineTo(x2, breakpointEndY);
+            ctx.lineTo(breakpointEndX, breakpointEndY);
         } else if (endLineDirection == "down") {
-            ctx.lineTo(x2, breakpointEndY);
+            ctx.lineTo(breakpointEndX, breakpointEndY);
         }
         ctx.lineTo(x2, y2);
         ctx.stroke();

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1672,6 +1672,7 @@ function Symbol(kindOfSymbol) {
                 middleBreakPointY += this.recursiveLineExtent * zoomValue;
             }
 
+            // Draw rest of lineTos based on directions
             if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "up" || endLineDirection === "down")) {
                 ctx.lineTo(breakpointStartX, middleBreakPointY);
                 ctx.lineTo(middleBreakPointX, middleBreakPointY); // Mid point
@@ -1685,14 +1686,15 @@ function Symbol(kindOfSymbol) {
             } else if ((startLineDirection === "right" || startLineDirection === "left") && (endLineDirection === "up" || endLineDirection === "down")) {
                 ctx.lineTo(breakpointEndX, breakpointStartY);
             }
-
-            // Draw to end breakpoint based on direction
             ctx.lineTo(breakpointEndX, breakpointEndY);
             ctx.lineTo(x2, y2);
             ctx.stroke();
         } else if (this.anchors.length == 0) {
+            // This code is run once on regular UML lines and creates all anchors and draggable point(s)
+            //------------------------------------------------------------------------------------------
             this.addAnchor(canvasToPixels(breakpointStartX).x, canvasToPixels(0, breakpointStartY).y);
 
+            // Rules for anchors' starting positions
             if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "up" || endLineDirection === "down")) {
                 if (x1 == x2) {
                     this.addAnchor(canvasToPixels(breakpointStartX).x, canvasToPixels(0, breakpointStartY).y);

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1592,14 +1592,6 @@ function Symbol(kindOfSymbol) {
             }
         }
 
-        // Default if something breaks
-        if (startLineDirection === "") {
-            startLineDirection = "left";
-        }
-        if (endLineDirection === "") {
-            endLineDirection = "left";
-        }
-
         // Calculating the mid point between start and end
         if (x2 > x1) {
             middleBreakPointX = x1 + Math.abs(x2 - x1) / 2;

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1864,7 +1864,7 @@ function Symbol(kindOfSymbol) {
     // createDraggablePoints: dynamically create draggable points between every anchor
     //---------------------------------------------------------------
     this.createDraggablePoints = function() {
-        for (var i = 2; i < this.anchors.length - 1; i++) { // values depending on when to start and stop creating draggable points
+        for (var i = 2; i < this.anchors.length - 2; i++) { // values depending on when to start and stop creating draggable points
             var firstAnchorPoint = this.anchors[i - 1];
             var secondAnchorPoint = this.anchors[i];
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -872,6 +872,10 @@ function Symbol(kindOfSymbol) {
         privatePoints.push(this.bottomRight);
         privatePoints.push(this.middleDivider);
         privatePoints.push(this.centerPoint);
+        if (this.symbolkind == symbolKind.umlLine) {
+            privatePoints.push(this.anchors);
+            privatePoints.push(this.draggablePoints);
+        }
         return privatePoints;
     }
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1864,7 +1864,7 @@ function Symbol(kindOfSymbol) {
     // createDraggablePoints: dynamically create draggable points between every anchor
     //---------------------------------------------------------------
     this.createDraggablePoints = function() {
-        for (var i = 2; i < this.anchors.length - 1; i++) { // values depending on when to start and stop creating draggable points
+        for (var i = 2; i < this.anchors.length; i++) { // values depending on when to start and stop creating draggable points
             var firstAnchorPoint = this.anchors[i - 1];
             var secondAnchorPoint = this.anchors[i];
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1563,8 +1563,8 @@ function Symbol(kindOfSymbol) {
         var breakpointEndY = 0;       // Y Coordinate for end breakpoint
         var middleBreakPointX = 0;    // X Coordinate for mid point between line start and end
         var middleBreakPointY = 0;    // Y Coordinate for mid point between line start and end
-        var startLineDirection = "";  // Which side of the class the line starts from
-        var endLineDirection = "";    // Which side of the class the line ends in
+        var startLineDirection = "left";  // Which side of the class the line starts from
+        var endLineDirection = "left";    // Which side of the class the line ends in
 
         let connObjects = this.getConnectedObjects();
         var conobj1 = connObjects[0].corners();
@@ -1635,9 +1635,6 @@ function Symbol(kindOfSymbol) {
         } else if (startLineDirection == "down") {
             breakpointStartY = y1 + 35 * diagram.getZoomValue();
             breakpointStartX = x1;
-        } else {
-            breakpointStartX = x1;
-            breakpointStartY = y1;
         }
 
         if (endLineDirection == "left") {
@@ -1652,9 +1649,6 @@ function Symbol(kindOfSymbol) {
         } else if (endLineDirection == "down") {
             breakpointEndY = y2 + 35 * diagram.getZoomValue();
             breakpointEndX = x2;
-        } else {
-            breakpointEndX = x2;
-            breakpointEndY = y2;
         }
 
         if (connObjects.length == 1) {

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1563,6 +1563,39 @@ function Symbol(kindOfSymbol) {
         var startLineDirection = "";  // Which side of the class the line starts from
         var endLineDirection = "";    // Which side of the class the line ends in
 
+        var conobj1 = this.getConnectedObjects()[0].corners();
+        var conobj2 = this.getConnectedObjects()[1].corners();
+
+        // Check if line's start point matches any class diagram
+        if (canvasToPixels(x1).x == conobj1.tl.x) {
+            startLineDirection = "left";
+        } else if (canvasToPixels(x1).x == conobj1.br.x) {
+            startLineDirection = "right";
+        } else if (canvasToPixels(0, y1).y == conobj1.tl.y) {
+            startLineDirection = "up";
+        } else if (canvasToPixels(0, y1).y == conobj1.br.y) {
+            startLineDirection = "down";
+        }
+
+        // Check if line's end point matches any class diagram
+        if (canvasToPixels(x2).x == conobj2.tl.x) {
+            endLineDirection = "left";
+        } else if (canvasToPixels(x2).x == conobj2.br.x) {
+            endLineDirection = "right";
+        } else if (canvasToPixels(0, y2).y == conobj2.tl.y) {
+            endLineDirection = "up";
+        } else if (canvasToPixels(0, y2).y == conobj2.br.y) {
+            endLineDirection = "down";
+        }
+
+        // Default if something breaks
+        if (startLineDirection === "") {
+            startLineDirection = "left";
+        }
+        if (endLineDirection === "") {
+            endLineDirection = "left";
+        }
+
         // Calculating the mid point between start and end
         if (x2 > x1) {
             middleBreakPointX = x1 + Math.abs(x2 - x1) / 2;
@@ -1580,63 +1613,37 @@ function Symbol(kindOfSymbol) {
             middleBreakPointY = y1;
         }
 
+        if (startLineDirection == "left") {
+            breakpointStartX = x1 - 35 * diagram.getZoomValue();
+            breakpointStartY = y1;
+        } else if (startLineDirection == "right") {
+            breakpointStartX = x1 + 35 * diagram.getZoomValue();
+            breakpointStartY = y1;
+        } else if (startLineDirection == "up") {
+            breakpointStartY = y1 - 35 * diagram.getZoomValue();
+            breakpointStartX = x1;
+        } else if (startLineDirection == "down") {
+            breakpointStartY = y1 + 35 * diagram.getZoomValue();
+            breakpointStartX = x1;
+        }
+
+        if (endLineDirection == "left") {
+            breakpointEndX = x2 - 35 * diagram.getZoomValue();
+            breakpointEndY = y2;
+        } else if (endLineDirection == "right") {
+            breakpointEndX = x2 + 35 * diagram.getZoomValue();
+            breakpointEndY = y2;
+        } else if (endLineDirection == "up") {
+            breakpointEndY = y2 - 35 * diagram.getZoomValue();
+            breakpointEndX = x2;
+        } else if (endLineDirection == "down") {
+            breakpointEndY = y2 + 35 * diagram.getZoomValue();
+            breakpointEndX = x2;
+        }
+
         // Start line
         ctx.beginPath();
         ctx.moveTo(x1, y1);
-
-
-        // Check all symbols in diagram and see if anyone matches current line's points coordinate
-        for (var i = 0; i < diagram.length; i++) {
-            if (diagram[i].symbolkind == symbolKind.uml) { // filter UML class
-                var currentSymbol = diagram[i].corners();
-
-                // Check if line's start point matches any class diagram
-                if (x1 == pixelsToCanvas(currentSymbol.tl.x).x) {
-                    startLineDirection = "left";
-                    breakpointStartX = x1 - 30;
-                    breakpointStartY = y1;
-                } else if (x1 == pixelsToCanvas(currentSymbol.br.x).x) {
-                    startLineDirection = "right";
-                    breakpointStartX = x1 + 30;
-                    breakpointStartY = y1;
-                } else if (y1 == pixelsToCanvas(0, currentSymbol.tl.y).y) {
-                    startLineDirection = "up"
-                    breakpointStartY = y1 - 30;
-                    breakpointStartX = x1;
-                } else if (y1 == pixelsToCanvas(0, currentSymbol.br.y).y) {
-                    startLineDirection = "down"
-                    breakpointStartY = y1 + 30;
-                    breakpointStartX = x1;
-                }
-
-                // Check if line's end point matches any class diagram
-                if (x2 == pixelsToCanvas(currentSymbol.tl.x).x) {
-                    endLineDirection = "left";
-                    breakpointEndX = x2 - 30;
-                    breakpointEndY = y2;
-                } else if (x2 == pixelsToCanvas(currentSymbol.br.x).x) {
-                    endLineDirection = "right";
-                    breakpointEndX = x2 + 30;
-                    breakpointEndY = y2;
-                } else if (y2 == pixelsToCanvas(0, currentSymbol.tl.y).y) {
-                    endLineDirection = "up"
-                    breakpointEndY = y2 - 30;
-                    breakpointEndX = x2;
-                } else if (y2 == pixelsToCanvas(0, currentSymbol.br.y).y) {
-                    endLineDirection = "down"
-                    breakpointEndY = y2 + 30;
-                    breakpointEndX = x2;
-                }
-
-                // If start and end points are too close to each other, set breakpoints to same as start and end points
-                if((Math.abs(x1 - x2) < 60) || (Math.abs(y1 - y2) < 60)) {
-                    breakpointStartX = x1;
-                    breakpointStartY = y1;
-                    breakpointEndX = x2;
-                    breakpointEndY = y2;
-                }
-            }
-        }
 
         // Draw to start breakpoint based on direction
         if (startLineDirection == "left") {

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1632,6 +1632,9 @@ function Symbol(kindOfSymbol) {
         } else if (startLineDirection == "down") {
             breakpointStartY = y1 + 35 * diagram.getZoomValue();
             breakpointStartX = x1;
+        } else {
+            breakpointStartX = x1;
+            breakpointStartY = y1;
         }
 
         if (endLineDirection == "left") {
@@ -1646,23 +1649,16 @@ function Symbol(kindOfSymbol) {
         } else if (endLineDirection == "down") {
             breakpointEndY = y2 + 35 * diagram.getZoomValue();
             breakpointEndX = x2;
+        } else {
+            breakpointEndX = x2;
+            breakpointEndY = y2;
         }
 
         if (connObjects.length == 1) {
             // Start line
             ctx.beginPath();
             ctx.moveTo(x1, y1);
-
-            // Draw to start breakpoint based on direction
-            if (startLineDirection == "left") {
-                ctx.lineTo(breakpointStartX, breakpointStartY);
-            } else if (startLineDirection == "right") {
-                ctx.lineTo(breakpointStartX, breakpointStartY);
-            } else if (startLineDirection == "up") {
-                ctx.lineTo(breakpointStartX, breakpointStartY);
-            } else if (startLineDirection == "down") {
-                ctx.lineTo(breakpointStartX, breakpointStartY);
-            }
+            ctx.lineTo(breakpointStartX, breakpointStartY);
 
             // Check if this is a recursive line (connects to a single object twice)
             if (connObjects.length == 1) {
@@ -1692,15 +1688,7 @@ function Symbol(kindOfSymbol) {
             }
 
             // Draw to end breakpoint based on direction
-            if (endLineDirection == "left") {
-                ctx.lineTo(breakpointEndX, breakpointEndY);
-            } else if (endLineDirection == "right") {
-                ctx.lineTo(breakpointEndX, breakpointEndY);
-            } else if (endLineDirection == "up") {
-                ctx.lineTo(breakpointEndX, breakpointEndY);
-            } else if (endLineDirection == "down") {
-                ctx.lineTo(breakpointEndX, breakpointEndY);
-            }
+            ctx.lineTo(breakpointEndX, breakpointEndY);
             ctx.lineTo(x2, y2);
             ctx.stroke();
         } else if (this.anchors.length == 0) {

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1731,6 +1731,109 @@ function Symbol(kindOfSymbol) {
             }
             this.addAnchor(canvasToPixels(breakpointEndX).x, canvasToPixels(0, breakpointEndY).y);
             this.createDraggablePoints();
+        } else {
+            // These two anchors are fixed points
+            points[this.anchors[0]].x = canvasToPixels(breakpointStartX).x;
+            points[this.anchors[0]].y = canvasToPixels(0, breakpointStartY).y;
+            points[this.anchors[3]].x = canvasToPixels(breakpointEndX).x;
+            points[this.anchors[3]].y = canvasToPixels(0, breakpointEndY).y;
+
+            // Set coordinates for anchors based on where the draggable point is positioned
+            if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "up" || endLineDirection === "down")) {
+                if (x1 == x2) {
+                    points[this.anchors[1]].x = points[this.draggablePoints[0]].x;
+                    points[this.anchors[1]].y = canvasToPixels(0, breakpointStartY).y;
+                    points[this.anchors[2]].x = points[this.draggablePoints[0]].x;
+                    points[this.anchors[2]].y = canvasToPixels(0, breakpointEndY).y;
+                } else {
+                    points[this.anchors[1]].x = canvasToPixels(breakpointStartX).x;
+                    points[this.anchors[1]].y = points[this.draggablePoints[0]].y;
+                    points[this.anchors[2]].x = canvasToPixels(breakpointEndX).x;
+                    points[this.anchors[2]].y = points[this.draggablePoints[0]].y;
+                }
+            } else if ((startLineDirection === "left" || startLineDirection === "right") && (endLineDirection === "left" || endLineDirection === "right")) {
+                if (y1 == y2) {
+                    points[this.anchors[1]].x = canvasToPixels(breakpointStartX).x;
+                    points[this.anchors[1]].y = points[this.draggablePoints[0]].y;
+                    points[this.anchors[2]].x = canvasToPixels(breakpointEndX).x;
+                    points[this.anchors[2]].y = points[this.draggablePoints[0]].y;
+                } else {
+                    points[this.anchors[1]].x = canvasToPixels(breakpointStartX).x;
+                    points[this.anchors[1]].y = points[this.draggablePoints[0]].y;
+                    points[this.anchors[2]].x = canvasToPixels(breakpointEndX).x;
+                    points[this.anchors[2]].y = points[this.draggablePoints[0]].y;
+                }
+            } else if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "left" || endLineDirection === "right")) {
+                points[this.anchors[1]].x = canvasToPixels(breakpointStartX).x;
+                points[this.anchors[1]].y = points[this.draggablePoints[0]].y;
+                points[this.anchors[2]].x = canvasToPixels(breakpointEndX).x;
+                points[this.anchors[2]].y = points[this.draggablePoints[0]].y;
+            } else if ((startLineDirection === "right" || startLineDirection === "left") && (endLineDirection === "up" || endLineDirection === "down")) {
+                points[this.anchors[1]].x = canvasToPixels(breakpointStartX).x;
+                points[this.anchors[1]].y = points[this.draggablePoints[0]].y;
+                points[this.anchors[2]].x = canvasToPixels(breakpointEndX).x;
+                points[this.anchors[2]].y = points[this.draggablePoints[0]].y;
+            }
+
+            // Prevent from moving point so lines draw back into the UML class
+            if ((startLineDirection === "up" && points[this.anchors[1]].y > canvasToPixels(0, breakpointStartY).y)
+                || (startLineDirection === "down" && points[this.anchors[1]].y < canvasToPixels(0, breakpointStartY).y)) {
+                points[this.anchors[1]].y = canvasToPixels(0, breakpointStartY).y;
+                points[this.anchors[2]].y = canvasToPixels(0, breakpointStartY).y;
+            } else if ((startLineDirection === "left" && points[this.anchors[1]].x > canvasToPixels(breakpointStartX).x)
+                || (startLineDirection === "right" && points[this.anchors[1]].x < canvasToPixels(breakpointStartX).x)) {
+                points[this.anchors[1]].x = canvasToPixels(breakpointStartX).x;
+                points[this.anchors[2]].x = canvasToPixels(breakpointStartX).x;
+            }
+
+            if ((endLineDirection === "up" && points[this.anchors[2]].y > canvasToPixels(0, breakpointEndY).y)
+                || (endLineDirection === "down" && points[this.anchors[2]].y < canvasToPixels(0, breakpointEndY).y)) {
+                points[this.anchors[1]].y = canvasToPixels(0, breakpointEndY).y;
+                points[this.anchors[2]].y = canvasToPixels(0, breakpointEndY).y;
+            } else if ((endLineDirection === "left" && points[this.anchors[2]].x > canvasToPixels(breakpointEndX).x)
+                || (endLineDirection === "down" && points[this.anchors[2]].x < canvasToPixels(breakpointEndX).x)) {
+                points[this.anchors[1]].x = canvasToPixels(breakpointEndX).x;
+                points[this.anchors[2]].x = canvasToPixels(breakpointEndX).x;
+            }
+
+            // Only move draggable points on one axis based on line direction
+            if (points[this.anchors[1]].x == points[this.anchors[2]].x) {
+                // You can only move the point left and right
+                if (points[this.anchors[2]].y > points[this.anchors[1]].y) { // If second anchor is lower (on canvas) than first anchor
+                    points[this.draggablePoints[0]].y = points[this.anchors[1]].y + Math.abs(points[this.anchors[1]].y - points[this.anchors[2]].y) / 2;
+                } else if (points[this.anchors[1]].y > points[this.anchors[2]].y) { // If first anchor is lower (on canvas) than second anchor
+                    points[this.draggablePoints[0]].y = points[this.anchors[2]].y + Math.abs(points[this.anchors[1]].y - points[this.anchors[2]].y) / 2;
+                } else {
+                    points[this.draggablePoints[0]].y = points[this.anchors[1]].y;
+                }
+
+                if (points[this.draggablePoints[0]].x < points[this.anchors[1]].x || points[this.draggablePoints[0]].x > points[this.anchors[1]].x) {
+                    points[this.draggablePoints[0]].x = points[this.anchors[1]].x;
+                }
+            } else if (points[this.anchors[1]].y == points[this.anchors[2]].y) {
+                // You can only move the point up and down
+                if (points[this.anchors[2]].x > points[this.anchors[1]].x) { // If second anchor is more to the right than first anchor
+                    points[this.draggablePoints[0]].x = points[this.anchors[1]].x + Math.abs(points[this.anchors[1]].x - points[this.anchors[2]].x) / 2;
+                } else if (points[this.anchors[1]].x > points[this.anchors[2]].x) { // If first anchor is more to the right than second anchor
+                    points[this.draggablePoints[0]].x = points[this.anchors[2]].x + Math.abs(points[this.anchors[1]].x - points[this.anchors[2]].x) / 2;
+                } else {
+                    points[this.draggablePoints[0]].x = points[this.anchors[1]].x;
+                }
+
+                if (points[this.draggablePoints[0]].y < points[this.anchors[1]].y || points[this.draggablePoints[0]].y > points[this.anchors[1]].y) {
+                    points[this.draggablePoints[0]].y = points[this.anchors[1]].y;
+                }
+            }
+
+            // Start line
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.lineTo(pixelsToCanvas(points[this.anchors[0]].x).x, pixelsToCanvas(0, points[this.anchors[0]].y).y);
+            ctx.lineTo(pixelsToCanvas(points[this.anchors[1]].x).x, pixelsToCanvas(0, points[this.anchors[1]].y).y);
+            ctx.lineTo(pixelsToCanvas(points[this.anchors[2]].x).x, pixelsToCanvas(0, points[this.anchors[2]].y).y);
+            ctx.lineTo(pixelsToCanvas(points[this.anchors[3]].x).x, pixelsToCanvas(0, points[this.anchors[3]].y).y);
+            ctx.lineTo(x2, y2);
+            ctx.stroke();
         }
 
         this.drawUmlRelationLines(x1,y1,x2,y2, startLineDirection, endLineDirection);

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1569,7 +1569,7 @@ function Symbol(kindOfSymbol) {
         let connObjects = this.getConnectedObjects();
         var conobj1 = connObjects[0].corners();
 
-        // Check if line's start point matches any class diagram
+        // Check if line's start point matches coordinates of any UML class symbols
         if (canvasToPixels(x1).x == conobj1.tl.x) {
             startLineDirection = "left";
         } else if (canvasToPixels(x1).x == conobj1.br.x) {
@@ -1582,8 +1582,7 @@ function Symbol(kindOfSymbol) {
 
         if (connObjects.length > 1) {
             var conobj2 = this.getConnectedObjects()[1].corners();
-
-            // Check if line's end point matches any class diagram
+            // Check if line's end point matches coordinates of any UML class symbols
             if (canvasToPixels(x2).x == conobj2.tl.x) {
                 endLineDirection = "left";
             } else if (canvasToPixels(x2).x == conobj2.br.x) {
@@ -1594,7 +1593,7 @@ function Symbol(kindOfSymbol) {
                 endLineDirection = "down";
             }
         } else if (connObjects.length == 1) {            
-            // Check if line's end point matches any class diagram
+            // If line is recursive, use the same object for end line direction as start
             if (canvasToPixels(x2).x == conobj1.tl.x) {
                 endLineDirection = "left";
             } else if (canvasToPixels(x2).x == conobj1.br.x) {
@@ -1623,6 +1622,7 @@ function Symbol(kindOfSymbol) {
             middleBreakPointY = y1;
         }
 
+        // Set breakpoint coordinates based on line directions
         if (startLineDirection == "left") {
             breakpointStartX = x1 - 35 * diagram.getZoomValue();
             breakpointStartY = y1;
@@ -1651,23 +1651,21 @@ function Symbol(kindOfSymbol) {
             breakpointEndX = x2;
         }
 
-        if (connObjects.length == 1) {
+        if (connObjects.length == 1) { // If line is recursive, in place to skip anchors
             // Start line
             ctx.beginPath();
             ctx.moveTo(x1, y1);
             ctx.lineTo(breakpointStartX, breakpointStartY);
 
             // Check if this is a recursive line (connects to a single object twice)
-            if (connObjects.length == 1) {
-                if (x1 == x2) { // Make sure the line is drawn "out" of the symbol
-                    if (startLineDirection === "right") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
-                    else this.recursiveLineExtent = -Math.abs(this.recursiveLineExtent);
-                    middleBreakPointX += this.recursiveLineExtent * zoomValue;
-                } else if (y1 == y2) {
-                    if (startLineDirection === "down") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
-                    else this.recursiveLineExtent = -Math.abs(this.recursiveLineExtent);
-                    middleBreakPointY += this.recursiveLineExtent * zoomValue;
-                }
+            if (x1 == x2) { // Make sure the line is drawn "out" of the symbol
+                if (startLineDirection === "right") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
+                else this.recursiveLineExtent = -Math.abs(this.recursiveLineExtent);
+                middleBreakPointX += this.recursiveLineExtent * zoomValue;
+            } else if (y1 == y2) {
+                if (startLineDirection === "down") this.recursiveLineExtent = Math.abs(this.recursiveLineExtent);
+                else this.recursiveLineExtent = -Math.abs(this.recursiveLineExtent);
+                middleBreakPointY += this.recursiveLineExtent * zoomValue;
             }
 
             if ((startLineDirection === "up" || startLineDirection === "down") && (endLineDirection === "up" || endLineDirection === "down")) {

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -548,7 +548,7 @@ function Symbol(kindOfSymbol) {
     // checkForHover: Returns line distance to segment object e.g. line objects (currently only relationship markers)
     //--------------------------------------------------------------------
     this.checkForHover = function (mx, my) {
-        if(this.symbolkind == symbolKind.umlLine){
+        if(this.symbolkind == symbolKind.umlLine && this.isRecursiveLine == false){
             return this.UMLLineHover();
         }
         setIsLockHovered(this, mx, my);

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1591,6 +1591,8 @@ function Symbol(kindOfSymbol) {
                 endLineDirection = "down";
             }
         } else if (connObjects.length == 1) {
+            console.log("test");
+            
             // Check if line's end point matches any class diagram
             if (canvasToPixels(x2).x == conobj1.tl.x) {
                 endLineDirection = "left";

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -752,6 +752,10 @@ function Symbol(kindOfSymbol) {
     // erase: attempts to erase object completely from canvas
     //--------------------------------------------------------------------
     this.erase = function () {
+        if (this.symbolkind == symbolKind.umlLine) {
+            this.clearAnchors();
+            this.clearDraggablePoints();
+        }
         this.movePoints();
         this.emptyConnectors();
     }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1864,7 +1864,7 @@ function Symbol(kindOfSymbol) {
     // createDraggablePoints: dynamically create draggable points between every anchor
     //---------------------------------------------------------------
     this.createDraggablePoints = function() {
-        for (var i = 2; i < this.anchors.length - 2; i++) { // values depending on when to start and stop creating draggable points
+        for (var i = 2; i < this.anchors.length - 1; i++) { // values depending on when to start and stop creating draggable points
             var firstAnchorPoint = this.anchors[i - 1];
             var secondAnchorPoint = this.anchors[i];
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1014,7 +1014,7 @@ function Symbol(kindOfSymbol) {
         var y2 = pixelsToCanvas(0, points[this.bottomRight].y).y;
 
         // Draggable UML line point
-        if (this.symbolkind == symbolKind.umlLine && this.draggablePoints.length > 1) {
+        if (this.symbolkind == symbolKind.umlLine && this.draggablePoints.length > 0) {
             var x3 = pixelsToCanvas(points[this.draggablePoints[0]].x).x;
             var y3 = pixelsToCanvas(0, points[this.draggablePoints[0]].y).y;
         }
@@ -1868,7 +1868,7 @@ function Symbol(kindOfSymbol) {
     // createDraggablePoints: dynamically create draggable points between every anchor
     //---------------------------------------------------------------
     this.createDraggablePoints = function() {
-        for (var i = 2; i < this.anchors.length; i++) { // values depending on when to start and stop creating draggable points
+        for (var i = 2; i < this.anchors.length - 1; i++) { // values depending on when to start and stop creating draggable points
             var firstAnchorPoint = this.anchors[i - 1];
             var secondAnchorPoint = this.anchors[i];
 

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -548,6 +548,9 @@ function Symbol(kindOfSymbol) {
     // checkForHover: Returns line distance to segment object e.g. line objects (currently only relationship markers)
     //--------------------------------------------------------------------
     this.checkForHover = function (mx, my) {
+        if(this.symbolkind == symbolKind.umlLine){
+            return this.UMLLineHover();
+        }
         setIsLockHovered(this, mx, my);
         if (this.symbolkind == symbolKind.line) {
             return this.linehover(mx, my);
@@ -2839,9 +2842,6 @@ function Path() {
     // checkForHover: Returns if the free draw object is clicked
     //--------------------------------------------------------------------
     this.checkForHover = function (mx, my) {
-        if(this.symbolkind == symbolKind.umlLine){
-            return this.UMLLineHover();
-        }
         setIsLockHovered(this, mx, my);
         return this.isClicked(mx, my);
     }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1590,6 +1590,17 @@ function Symbol(kindOfSymbol) {
             } else if (canvasToPixels(0, y2).y == conobj2.br.y) {
                 endLineDirection = "down";
             }
+        } else if (connObjects.length == 1) {
+            // Check if line's end point matches any class diagram
+            if (canvasToPixels(x2).x == conobj1.tl.x) {
+                endLineDirection = "left";
+            } else if (canvasToPixels(x2).x == conobj1.br.x) {
+                endLineDirection = "right";
+            } else if (canvasToPixels(0, y2).y == conobj1.tl.y) {
+                endLineDirection = "up";
+            } else if (canvasToPixels(0, y2).y == conobj1.br.y) {
+                endLineDirection = "down";
+            }
         }
 
         // Calculating the mid point between start and end


### PR DESCRIPTION
Main issue: https://github.com/HGustavs/LenaSYS/issues/6577
Also solves: https://github.com/HGustavs/LenaSYS/issues/7036

UML lines are now created with anchors (line kinks/corners) and one "draggable point" which is used to manipulate the line. 

Hovering over just the line to select it also works now. 

There are still a few issues but nothing that majorly breaks the line:
- In other zoom views than 100%, startLineDirection and endLineDirection is default "left". This might (probably) be a problem with getConnectedObjects() and how it works with coordinates.
- Currently there is only one draggable point and you can only move the line up and down because of the difficulty of implementing the functionality all at once.