### PR TITLE
Fixed hiding of copy button when clicking minimize

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2108,6 +2108,7 @@ function minimizeBoxes(boxid) {
 	var parentDiv = document.getElementById("div2");
 	var boxValArray = initResizableBoxValues(parentDiv);
 	var templateid = retData['templateid'];
+	document.querySelector('#box'+boxid+'wrapper #copyClipboard').style.display = 'none';
 
 	getLocalStorageProperties(boxValArray);
 


### PR DESCRIPTION
Clicking minimize wouldn't hide the copy button, now does. Note that the minimize button only appears on template 1 and 2