### PR TITLE
Komplettering-a17robda-7448

### DIFF
--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -123,7 +123,7 @@ pdoConnect();
 			<div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 
-		<div id="MarkCont" style="position: absolute; left:4px; width: 99%; top:34px; bottom:4px; border:2px inset #aaa;background:#bbb; overflow:scroll;"> </div>
+		<div id="MarkCont" style="position: absolute; left:4px; width: 99%; top:34px; bottom:4px; border:2px inset #aaa;background:#bbb; overflow:auto;"> </div>
 		<div id="toggleGrade">
 		<div id='markMenuPlaceholder'></div>
 		<div id="teacherFeedbackTable"></div>


### PR DESCRIPTION
For #7448. Changes overflow to auto to not have visible scrollbars by default unless the content is overflowing.