### PR TITLE
Komplettering-a17robda-7657

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -49,7 +49,7 @@
                             <img id='versionCog' class="navButt" title='Edit the selected version' onclick=showEditVersion(); src='../Shared/icons/CogwheelWhite.svg'>
 						</div>
 					</td>
-					<td class='newVers' style='display: inline-block;margin-right:2px;'>
+					<td class='newVers' style='display: inline-block;margin-right:15px;'>
 						<div class='newVers menuButton'>
                             <img id='versionPlus' value='New version' class="navButt" title='Create a new version of this course' onclick='showCreateVersion();' src='../Shared/icons/PlusS.svg'>
 						</div>

--- a/Shared/SortableTableLibrary/style.css
+++ b/Shared/SortableTableLibrary/style.css
@@ -567,7 +567,7 @@ header td {
 }
 
 .navButt {
-  width:32px;
+  width: 32px;
   vertical-align: middle;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -666,7 +666,7 @@ header td {
 }
 
 .navButt {
-  width: 32px;
+  width: 28px;
   vertical-align: middle;
 }
 
@@ -3593,7 +3593,7 @@ table.navheader td.menuButton {
 }
 
 table.navheader div.menuButton {
-  margin-right: 10px;
+  margin-right: 14px;
   pointer-events: auto;
   display: inline-block;
   opacity: 1.0;


### PR DESCRIPTION
Fix for #7657 and #7619. Separated icons and added more padding between them plus made them smaller to match the previous icons.
Before:
![navbarbefore](https://user-images.githubusercontent.com/37792328/59761253-98547e00-9294-11e9-95c1-1f7660f55c0a.png)
After:
![navbarafter](https://user-images.githubusercontent.com/37792328/59761263-9e4a5f00-9294-11e9-9260-6f7f2a1f4c31.png)
