### PR TITLE
Komplettering-a17robda-7718

### DIFF
--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -77,7 +77,7 @@
   <div class="loginBox">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideFeedbackPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/DuggaSys/templates/html_css_dugga_light.html
+++ b/DuggaSys/templates/html_css_dugga_light.html
@@ -71,7 +71,7 @@
 <div id="feedbackBox" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
     <div class='loginBoxheader'>
         <h3>Feedback Log</h3>
-        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
+        <div class='cursorPointer' onclick="hideFeedbackPopup()">x</div>
     </div>
     <div class="table-wrap" id="feedbackTable">
         <table>

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1070,6 +1070,12 @@ function hideReceiptPopup()
 	//$("#overlay").css("display","none");
 }
 
+function hideFeedbackPopup()
+{
+	$("#feedbackBox").css("display", "none");
+	//$("#overlay").css("display","none");
+}
+
 function hideDuggaStatsPopup()
 {
 	$("#duggaStats").css("display", "none");


### PR DESCRIPTION
Fix for #7718. Makes it possible to close the feedback box on CSS duggas in showdugga.php. Possible discrepancies in other duggas aswell with the closing function and ID's on divs. But since they have a different structure I did not change their onclick functions on X button.