### PR TITLE
komplettering-c17alepe-7743

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -140,6 +140,7 @@ h3 {
 
 .instructions-container h3 {
   border-bottom: none;
+  margin: 6px 0px 6px 0px;
 }
 
 h4 {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38323901/61622036-51cbb800-ac74-11e9-9ec5-09dd8a376476.png)

fixes the margin for h3 inside .instructions-container classes

#7743