### PR TITLE
Komplettering-a17robda-7618

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4407,3 +4407,12 @@ function changeLineDirection() {
     }
     updateGraphics();
 }
+
+// Workaround for displaying the file selected with a span for changing button styling
+function loadWorkaround() {
+    $('#importFile').change(function() {
+        document.getElementById("importFileText").innerHTML = this.files[0].name;
+    });
+}
+
+// End of workaround

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -42,7 +42,7 @@
 </head>
 <!-- Reads the content from the js-files -->
 <!-- updateGraphics() must be last -->
-<body onload="initializeCanvas(); canvasSize(); loadDiagram(); setModeOnRefresh(); initToolbox(); updateGraphics();" style="overflow-y: hidden;">
+<body onload="initializeCanvas(); canvasSize(); loadDiagram(); setModeOnRefresh(); initToolbox(); updateGraphics(); loadWorkaround();" style="overflow-y: hidden;">
     <?php
         $noup = "SECTION";
         include '../Shared/navheader.php';
@@ -422,7 +422,9 @@
             <div class='table-wrap'>
                 <div class="importWrap">
                     <div>
-                        <input type="file" id="importFile" accept=".txt, text/plain" />
+                        <label for="importFile" class="import-submit-button">Browse...</label>
+                        <span id="importFileText">No file selected.</span>
+                        <input type="file" id="importFile" accept=".txt, text/plain" style="display: none"/>
                     </div>
                     <div id="importError" class="importError">
                         <span>Only .txt-files allowed</span>

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -478,12 +478,7 @@ function clickResult(cid, vers, moment, qfile, firstname, lastname, uid, submitt
 
 function toggleGradeBox(){
 	var toggleGrade = document.getElementById('toggleGrade');
-	var width = toggleGrade.offsetWidth;
-
-	$('#toggleGrade').animate({width: 'toggle'});
-	if(width <= 0){
-		toggleGrade.style.position = 'absolute';
-	}
+	$('#toggleGrade').animate({opacity: 'toggle'}, 200);
 }
 
 function changeGrade(newMark, gradesys, cid, vers, moment, uid, mark, ukind, qvariant, qid, gradeExpire, feedbackText) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -477,7 +477,6 @@ function clickResult(cid, vers, moment, qfile, firstname, lastname, uid, submitt
 }
 
 function toggleGradeBox(){
-	var toggleGrade = document.getElementById('toggleGrade');
 	$('#toggleGrade').animate({opacity: 'toggle'}, 200);
 }
 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -34,6 +34,7 @@ h4{font-family: Calibri,sans-serif;font-size:1.2em; color: #000;}
 
 #toggleGrade {
 	display: none;
+	position: absolute;
 	background:#bbb;
 	width: 60%;
 	top: 25%;

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -35,7 +35,9 @@ h4{font-family: Calibri,sans-serif;font-size:1.2em; color: #000;}
 #toggleGrade {
 	display: none;
 	background:#bbb;
-	width: 80%;
+	width: 60%;
+	top: 25%;
+	left: 20%;
 	border: 2px solid var(--color-border);
 }
 #gradeBtn {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5254,7 +5254,28 @@ textarea#mrkdwntxt {
   bottom: 0;
 }
 
+/* Import diagram extras for workaround to style input button in import */
 
+.import-submit-button {
+  display: inline-block;
+  background-color: var(--color-primary);
+  border: 0px;
+  width: 110px;
+  height: 30px;
+  color: #fff;
+  cursor: pointer;
+  margin: 8px 2px 4px 2px;
+  font-size: 14px;
+  transition: 0.1s background-color;
+  line-height: 30px;
+  border-radius: 5px;
+  text-align: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+}
+
+.import-submit-button:hover {
+  background-color: var(--color-primary-hover);
+}
 
 /* --------------================################================-------------- *
  *                               Edit file preview                              *


### PR DESCRIPTION
For #7618 Since it does not seem to be possible to style the individual components of the input file element in HTML a workaround was created to preserve the original function. By hiding the input element and creating a label for said input field it can be used to style the button since clicking the label will activate the file input. By using JQuery to detect when said file input has changed we can update a span element that would simulate the original text label we removed in the workaround.
![importButtonFixed](https://user-images.githubusercontent.com/37792328/63016955-4a738500-be95-11e9-91ee-4ee01f1505be.png)
