### PR TITLE
Komplettering-a17robda-7618

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4407,3 +4407,12 @@ function changeLineDirection() {
     }
     updateGraphics();
 }
+
+// Workaround for displaying the file selected with a span for changing button styling
+function loadWorkaround() {
+    $('#importFile').change(function() {
+        document.getElementById("importFileText").innerHTML = this.files[0].name;
+    });
+}
+
+// End of workaround

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -42,7 +42,7 @@
 </head>
 <!-- Reads the content from the js-files -->
 <!-- updateGraphics() must be last -->
-<body onload="initializeCanvas(); canvasSize(); loadDiagram(); setModeOnRefresh(); initToolbox(); updateGraphics();" style="overflow-y: hidden;">
+<body onload="initializeCanvas(); canvasSize(); loadDiagram(); setModeOnRefresh(); initToolbox(); updateGraphics(); loadWorkaround();" style="overflow-y: hidden;">
     <?php
         $noup = "SECTION";
         include '../Shared/navheader.php';
@@ -422,7 +422,9 @@
             <div class='table-wrap'>
                 <div class="importWrap">
                     <div>
-                        <input type="file" id="importFile" accept=".txt, text/plain" />
+                        <label for="importFile" class="import-submit-button">Browse...</label>
+                        <span id="importFileText">No file selected.</span>
+                        <input type="file" id="importFile" accept=".txt, text/plain" style="display: none"/>
                     </div>
                     <div id="importError" class="importError">
                         <span>Only .txt-files allowed</span>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5254,7 +5254,28 @@ textarea#mrkdwntxt {
   bottom: 0;
 }
 
+/* Import diagram extras for workaround to style input button in import */
 
+.import-submit-button {
+  display: inline-block;
+  background-color: var(--color-primary);
+  border: 0px;
+  width: 110px;
+  height: 30px;
+  color: #fff;
+  cursor: pointer;
+  margin: 8px 2px 4px 2px;
+  font-size: 14px;
+  transition: 0.1s background-color;
+  line-height: 30px;
+  border-radius: 5px;
+  text-align: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+}
+
+.import-submit-button:hover {
+  background-color: var(--color-primary-hover);
+}
 
 /* --------------================################================-------------- *
  *                               Edit file preview                              *


### PR DESCRIPTION
For #7618 Since it does not seem to be possible to style individual elements of the file input html tag, a workaround was created since it seemed to be the simplest way to keep the same functionality without major changes. By hiding the file input and attaching a visible label which is styled as the button it can be used to trigger the file picker when an user clicks on it. Then some JQuery is used to read the file picked when the file is changed and update a span next to the button to replace the text part of the file input that was removed in the workaround.
![importButtonFixed](https://user-images.githubusercontent.com/37792328/63019151-d805a380-be9a-11e9-8f20-2edb1c0bc1ca.png)
