### PR TITLE
Prevented long MOTD to be half shown after change

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1594,11 +1594,13 @@ function generateTimeSheetOptions(course, moment, selected) {
 //----------------------------------------------------------------------------------
 
 function hideServerMessage() {
-	$("#servermsgcontainer").animate({ opacity: 0, top: 0 }, 200, "easeInOutSine");
-	setTimeout(function () {
-		$("#servermsgcontainer").css("display", "none");
-		$("#servermsgcontainer").css("opacity", "1");
-	}, 200);
+	const $containerHeight = $("#servermsgcontainer");
+	$containerHeight.animate({ 
+		opacity: 0, 
+		top: -$containerHeight.outerHeight() 
+	}, 200, "easeInOutSine", () => {
+		$containerHeight.css(opacity, 1);
+	});
 }
 
 function hideCookieMessage() {


### PR DESCRIPTION
Fixes #7789.
Prevents message of the day from showing after administrator changed the message.
Before, the message relied on being one row as it would appear behind the header. On small screens, there is a big risk of the message being multiple rows making it show parts of it below the header.
Uses the height of element when button is clicked to force it outside the screen with the right amount of pixels.
Function returnedCourse in courseed.js will be called whenever a change is made in courseed, which will automatically show the message again even if hidden before. This is because same function is used to show the right things when site is loaded. This workaround prevents it from appearing.