### PR TITLE
G2 2020 w14 #7795

### DIFF
--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -737,7 +737,7 @@ $courseteachers=array();
 if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid))) {
 	$query = $pdo->prepare("
     SELECT DISTINCT examiner
-    FROM user_course where cid=$cid;
+    FROM user_course where cid=:cid;
   ");
 	$query->bindParam(':cid', $cid);
 	if(!$query->execute()){


### PR DESCRIPTION
Resolves an issue with a database search query error while visting the Result Editor while logged in.

This resolves #7795 