### PR TITLE
G4 2020 w14 issue#7812

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -9,6 +9,7 @@ var querystring = parseGet();
 var versions;
 var entries;
 var motd;
+var readonly;
 
 $(document).ready(function(){
     $('#startdate').datepicker({
@@ -237,18 +238,30 @@ function editVersion(cid, cname, ccode) {
 }
 
 function editSettings(){
-		if(motd!=="UNK") $("#motd").val(motd);
-		document.getElementById('editSettings').style.display = "flex";
+		const messageElement = document.getElementById('motd');
+		const readOnlyCheckbox = document.getElementById('readonly');
 
+		if(motd !== "UNK") {
+			messageElement.value = motd;
+		} 
+
+		if(readonly === 1) {
+			readOnlyCheckbox.checked = true;
+		} else if(readonly === 0) {
+			readOnlyCheckbox.checked = false;
+		}
+
+		document.getElementById('editSettings').style.display = "flex";
 }
 
 function updateSettings() {
-		const messageElement = document.getElementById("motd");
-		const readOnlyCheckbox = document.getElementById("readonly");
+		const messageElement = document.getElementById('motd');
+		const readOnlyCheckbox = document.getElementById('readonly');
 
-		let readonly = 0;
 		if(readOnlyCheckbox.checked) {
 			readonly = 1;
+		} else {
+			readonly = 0;
 		}
 
 		//Hide settings popup
@@ -411,7 +424,10 @@ function returnedCourse(data)
 	if (data['debug'] != "NONE!") {
 		alert(data['debug']);
 	}
-	motd=data["motd"]
+
+	motd=data["motd"];
+	readonly=parseInt(data["readonly"]);
+
 	if(motd!=="UNK"){
 		document.getElementById("servermsg").innerHTML=data["motd"];
 		document.getElementById("servermsgcontainer").style.display="flex";
@@ -420,7 +436,6 @@ function returnedCourse(data)
 	}
 
 	resetinputs();
-	console.log(data)
 	//resets all inputs
 }
 

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -243,17 +243,18 @@ function editSettings(){
 }
 
 function updateSettings() {
+		const messageElement = document.getElementById("motd");
+		const readOnlyCheckbox = document.getElementById("readonly");
 
-		var motd = $("#motd").val();
-		var readonly = 0;
-		if ($("#readonly").val() == "yes"){
+		let readonly = 0;
+		if(readOnlyCheckbox.checked) {
 			readonly = 1;
 		}
 
-		// Show dialog
-		$("#editSettings").css("display", "none");
+		//Hide settings popup
+		document.getElementById("editSettings").style.display = "none";
 
-		AJAXService("SETTINGS", {	motd : motd, readonly : readonly}, "COURSE");
+		AJAXService("SETTINGS", {motd: messageElement.value, readonly: readonly}, "COURSE");
 }
 
 function createVersion(){
@@ -419,6 +420,7 @@ function returnedCourse(data)
 	}
 
 	resetinputs();
+	console.log(data)
 	//resets all inputs
 }
 

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -109,7 +109,7 @@ $noup="NONE";
     		</div>
     		<div style='padding:5px;'>
     			<div class='inputwrapper'><span>Message of the day:</span><input class='textinput' type='text' id='motd' placeholder='Leave blank for no MOTD' /></div>
-    			<div class='inputwrapper'><span style='font-style:italic;color:rgba(0,0,0,0.6)'>Read Only:</span><input type="checkbox" name='readonly' id='readonly' value="no" title='Disables uploads/submits. Usefull for active backup servers.'></select></div>
+    			<div class='inputwrapper'><span style='font-style:italic;color:rgba(0,0,0,0.6)'>Read Only:</span><input type="checkbox" name='readonly' id='readonly' title='Disables uploads/submits. Usefull for active backup servers.'></select></div>
     		</div>
     		<div style='padding:5px;'>
     			<input class='submit-button' type='button' value='Save' title='Save changes' onclick='updateSettings();' />

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -548,7 +548,7 @@ if(!$query->execute()) {
 	$debug="Error reading settings\n".$error[2];
 }else{
 	$motd="UNK";
-	$readonly=false;
+	$readonly=0;
 	foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
 		$motd=$row["motd"];
 		$readonly=$row["readonly"];


### PR DESCRIPTION
Inserts the right value of read only to the database table settings based on the checkbox (0 -> unchecked, 1 -> checked). Before 0 was always inserted.
Made checkbox represent the previously made setting change by being checked (value in database 1) or unchecked (value in database 0) when settings popup is loaded.

-Test if the checkbox stays checked after page reload if saved as check and if it stays as unchecked if saved as unchecked. It is based on what is in the database so should not be a need to check in the database if it is correct there.