### PR TITLE
Removed unnecessary scrollbar in ResultEditor.

### DIFF
--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -107,7 +107,7 @@ pdoConnect();
 			<div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 
-		<div id="MarkCont" style="position: absolute; left:4px; width: 99%; top:34px; bottom:4px; border:2px inset #aaa;background:#bbb; overflow:scroll;"> </div>
+		<div id="MarkCont" style="position: absolute; left:4px; width: 99%; top:34px; bottom:4px; border:2px inset #aaa;background:#bbb;"> </div>
 		<div id="toggleGrade">
 		<div id='markMenuPlaceholder'></div>
 		<div id="teacherFeedbackTable"></div>


### PR DESCRIPTION
Removed inline css for scroll on MarkCont-element. Now uses value from style.css (scroll: auto).

This makes the scrollbar only appear when scrolling is needed (before it would be displayed by default).

Solves #7448.