### PR TITLE
Fixed so that swedish characters are loaded correctly, issue #7839

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -117,7 +117,7 @@ function selectCourse(cid, coursename, coursecode, visi, vers, edvers)
 	// Convert representation of swedish letters
 	var tempCoursename = coursename;
 	tempCoursename = tempCoursename.replace(/&Aring;/g, "Å");
-	tempCoursename = tempCoursename.replace(/&aring;/g, "a");
+	tempCoursename = tempCoursename.replace(/&aring;/g, "å");
 	tempCoursename = tempCoursename.replace(/&Auml;/g, "Ä");
 	tempCoursename = tempCoursename.replace(/&auml;/g, "ä");
 	tempCoursename = tempCoursename.replace(/&Ouml;/g, "Ö");

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -114,9 +114,17 @@ function selectCourse(cid, coursename, coursecode, visi, vers, edvers)
 	$(".item").css("box-shadow", "none");
 	$(".item").css("background", "#fff");
 
+	// Convert representation of swedish letters
+	var tempCoursename = coursename;
+	tempCoursename = tempCoursename.replace(/&Aring;/g, "Å");
+	tempCoursename = tempCoursename.replace(/&aring;/g, "a");
+	tempCoursename = tempCoursename.replace(/&Auml;/g, "Ä");
+	tempCoursename = tempCoursename.replace(/&auml;/g, "ä");
+	tempCoursename = tempCoursename.replace(/&Ouml;/g, "Ö");
+	tempCoursename = tempCoursename.replace(/&ouml;/g, "ö");
 
 	// Set Name
-	$("#coursename").val(coursename);
+	$("#coursename").val(tempCoursename);
 	// Set Cid
 	$("#cid").val(cid);
 	// Set Code


### PR DESCRIPTION
Updated function for selecting course to also convert to swedish when selecting. Can be tested by editing courses on homepage and giving them names with the letters ÅÄÖåäö. 