### PR TITLE
Added selection menu for course local image files in markdown editor - G1 2020 w15 #4744

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -3,7 +3,12 @@ session_start();
 include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 pdoConnect();
+
+$query = $pdo->prepare( "SELECT filename FROM fileLink");     
+$query->execute();      
+
 ?>
+
 
 <!DOCTYPE html>
 <html>
@@ -133,11 +138,25 @@ pdoConnect();
                         <span class="markdown-icons" onclick="codeBlockText()" title="CodeBlock">&#10065;</span>
                         <span class="markdown-icons" onclick="lists()" title="lists"><img src="../Shared/icons/list-symbol.svg"></span>
 
+                      
+
                         <span class="markdown-icons" onclick="linkYoutube()" title="link Youtube"><b>Yt</b></span>
                         <span class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</span>
                         <span class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></span>
                         <span class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></span>
                         <span class="markdown-icons headerType" id="headerIcon" title="Header">aA&#9663;</span>
+
+                        <select name=";" onchange="pickFile(this.options[this.selectedIndex].value);" >
+                        <option value='$fileName'>Choose file</option>
+                        <?php
+                            while($row = $query->FETCH(PDO::FETCH_ASSOC)){  
+                                $fileName = $row['filename'];
+                                if(preg_match('/(\.jpg|\.png|\.bmp)$/i', $fileName)){              
+                                    echo "<option value='$fileName'>$fileName</option>";     
+                                }   
+                            } 
+                        ?>
+                        </select>
 
                         <div class="selectHeader" id="select-header">
                             <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>
@@ -147,6 +166,9 @@ pdoConnect();
                             <span id="headerType5" onclick="selected();headerVal5()" value="H5">Header 5</span>
                             <span id="headerType6" onclick="selected();headerVal6()" value="H6">Header 6</span>
                         </div>
+
+
+
                         </div>
                         <div class="markText">
                             <textarea id="mrkdwntxt" style="font-family:monospace;" oninput="updatePreview(this.value)" name="markdowntext"></textarea>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -1,10 +1,19 @@
 <?php
-session_start();
+
 include_once "../../coursesyspw.php";
+include_once "../Shared/basic.php";
 include_once "../Shared/sessions.php";
+
+// Connect to database and start session
+session_start();
 pdoConnect();
 
-$query = $pdo->prepare( "SELECT filename FROM fileLink");     
+$cid = getOPG('courseid');
+
+echo("<script>console.log('PHP: " . $cid . "');</script>");
+
+$query = $pdo->prepare( "SELECT filename, cid FROM fileLink WHERE cid=:cid;");
+$query->bindParam(':cid', $cid);
 $query->execute();      
 
 ?>
@@ -146,13 +155,16 @@ $query->execute();
                         <span class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></span>
                         <span class="markdown-icons headerType" id="headerIcon" title="Header">aA&#9663;</span>
 
-                        <select name=";" onchange="pickFile(this.options[this.selectedIndex].value);" >
-                        <option value='$fileName'>Choose file</option>
+                        <select name=";" onchange="chooseFile(this.options[this.selectedIndex].value);" >
+                        <option value='defaultOption'>Choose file</option>
                         <?php
                             while($row = $query->FETCH(PDO::FETCH_ASSOC)){  
                                 $fileName = $row['filename'];
+                                $cid = $row['cid'];
+                                $fileInfo = $fileName . ',' . $cid;
                                 if(preg_match('/(\.jpg|\.png|\.bmp)$/i', $fileName)){              
-                                    echo "<option value='$fileName'>$fileName</option>";     
+                                    echo "<option value='$fileInfo'>$fileName</option>"; 
+
                                 }   
                             } 
                         ?>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5283,7 +5283,8 @@ textarea#mrkdwntxt {
 
 #imgIcon,
 #headerIcon {
-  margin-left: 4px;
+  margin-left: 2px;
+  margin-right: 10px;
 }
 
 

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -541,6 +541,15 @@ function boldText() {
     updatePreview(txtarea.value);
 }
 
+function pickFile(selectedFile){
+    this.setCarotPosition();
+    var finText = txtarea.value.substring(0, start) + selectedFile + sel  + txtarea.value.substring(end);
+    txtarea.value = finText;
+    txtarea.foucs();
+    txtarea.selcetionEnd= end + 2;
+    updatePreview(txtarea.value);
+}
+
 function linkYoutube(){
     this.setCarotPosition();
     var finText = txtarea.value.substring(0, start) + '[YOUTUBE:' + 'IDNUM,WIDTH,LENGTH' + sel + ']' + txtarea.value.substring(end);

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -541,12 +541,12 @@ function chooseFile(selectedFile){
     var fileName = fields[0];
     var cid = fields[1];
     if(fileName !== "defaultOption"){
-    this.setCarotPosition();
-    var finText = txtarea.value.substring(0, start) + '|||' + '../courses/' + cid + '/' +  fileName + ', thumbnail in width px here,  full width here' + sel + '|||'  + txtarea.value.substring(end);
-    txtarea.value = finText;
-    txtarea.foucs();
-    txtarea.selcetionEnd= end + 12;
-    updatePreview(txtarea.value);
+        this.setCarotPosition();
+        var finText = txtarea.value.substring(0, start) + '|||' + '../courses/' + cid + '/' +  fileName + ', thumbnail in width px here,  full width here' + sel + '|||'  + txtarea.value.substring(end);
+        txtarea.value = finText;
+        txtarea.foucs();
+        txtarea.selcetionEnd= end + 12;
+        updatePreview(txtarea.value);
     }
 }
 

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -541,13 +541,18 @@ function boldText() {
     updatePreview(txtarea.value);
 }
 
-function pickFile(selectedFile){
+function chooseFile(selectedFile){
+    var fields = selectedFile.split(',');
+    var fileName = fields[0];
+    var cid = fields[1];
+    if(fileName !== "defaultOption"){
     this.setCarotPosition();
-    var finText = txtarea.value.substring(0, start) + '|||' + '../testfiles/' +selectedFile + ', thumbnail in width px here,  full width here' + sel + '|||'  + txtarea.value.substring(end);
+    var finText = txtarea.value.substring(0, start) + '|||' + '../courses/' + cid + '/' +  fileName + ', thumbnail in width px here,  full width here' + sel + '|||'  + txtarea.value.substring(end);
     txtarea.value = finText;
     txtarea.foucs();
     txtarea.selcetionEnd= end + 12;
     updatePreview(txtarea.value);
+    }
 }
 
 function linkYoutube(){

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -543,10 +543,10 @@ function boldText() {
 
 function pickFile(selectedFile){
     this.setCarotPosition();
-    var finText = txtarea.value.substring(0, start) + selectedFile + sel  + txtarea.value.substring(end);
+    var finText = txtarea.value.substring(0, start) + '|||' + '../testfiles/' +selectedFile + ', thumbnail in width px here,  full width here' + sel + '|||'  + txtarea.value.substring(end);
     txtarea.value = finText;
     txtarea.foucs();
-    txtarea.selcetionEnd= end + 2;
+    txtarea.selcetionEnd= end + 12;
     updatePreview(txtarea.value);
 }
 


### PR DESCRIPTION
The solution retrieves the files corresponding with the course which the users is currently navigated to, these are shown in the menu. The files are retrieved from the database. 
![Screenshot 2020-04-05 at 23 29 06](https://user-images.githubusercontent.com/62876614/78539438-da828800-77f2-11ea-814b-27f2e4a374ae.png)

Once selected the following text below will be created. The file path created point toward the location where all files are created(not working in our version), i.e. directly under lenaSYS in the directory courses. Is the courses directory each course get their own directory which are named according to the course id. The png file shown in the example below belongs to the course with the course id 2. Which can be seen in the file path.
![Screenshot 2020-04-05 at 23 18 31](https://user-images.githubusercontent.com/62876614/78539444-dd7d7880-77f2-11ea-9595-581917913413.png)

