### PR TITLE
solution for fileinfo extension

### DIFF
--- a/DuggaSys/filereceive.php
+++ b/DuggaSys/filereceive.php
@@ -150,8 +150,16 @@ if ($storefile) {
 
             $temp = explode(".", $filea["name"]);
             $extension = end($temp); //stores the file type
-            // Determine file MIME-type
-            $filetype = mime_content_type($filea["tmp_name"]);
+
+           
+            $filetype = "";
+            if (function_exists('mime_content_type'))
+                // Determine file MIME-type
+                $filetype = mime_content_type($filea["tmp_name"]);
+            else
+                // Use the file type given at upload because the extension "fileinfo" has not been enabled in php.ini
+                $filetype = $filea['type'];
+            
             if (array_key_exists($extension, $allowedExtensions)) {
                 //  if file type is allowed, continue the uploading process.
 


### PR DESCRIPTION
Now checks if the `fileinfo` extension is enabled by checking if the function exists, if it doesnt it uses the file type given on upload. This stops the application from breaking on a new system without the right `php.ini` settings.