### PR TITLE
G4-2020-W15-ISSUE#7868

### DIFF
--- a/Shared/database.php
+++ b/Shared/database.php
@@ -45,7 +45,9 @@ function pdoConnect()
 	global $pdo;
 	try {
 		$pdo = new PDO('mysql:host='.DB_HOST.';dbname='.DB_NAME.';charset=utf8',DB_USER,DB_PASSWORD);
-		define("MYSQL_VERSION",$pdo->query('select version()')->fetchColumn());
+		if(!defined("MYSQL_VERSION")) {
+			define("MYSQL_VERSION",$pdo->query('select version()')->fetchColumn());
+		}
 	} catch (PDOException $e) {
 		echo "Failed to get DB handle: " . $e->getMessage() . "</br>";
 		exit;


### PR DESCRIPTION
Fixed so notice saying "MYSQL_VERSION already defined" in #7868 can not appear and break design by checking if global variable already defined or not and only defining it if it is not defined.

-Test if notice "MYSQL_VERSION not defined" can appear.