### PR TITLE
Changed markdown.js

### DIFF
--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -117,7 +117,7 @@ function parseMarkdown(inString)
             specialBlockStart=false;
             workstr='<div class="console"><pre>'+workstr.substr(3)+'</pre></div>';
         }else if(workstr !== "") {
-            workstr=parseLineByLine(workstr.replace(/^[\&{3}]|[\@{3}]/gm, ''));
+            workstr=parseLineByLine(workstr.replace(/^\&{3}|\@{3}/gm, ''));
             specialBlockStart=true;
         }
         str+=workstr;


### PR DESCRIPTION
Changed a faulty regEx so it does not match with the characters '3' , '{' and '}'.

Co-Authored-By: a16vikva <a16vikva@users.noreply.github.com>

![bild](https://user-images.githubusercontent.com/49142342/78552732-51764b80-7808-11ea-821c-fd3d08e3bbf5.png)

The screenshot shows the ordered list now working in markdown preview on the fileed.php page. 