### PR TITLE
Solved issue#7664, UML-diagram line problem

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3618,6 +3618,7 @@ function mouseupevt(ev) {
         //Check if you release on canvas or try to draw a line from entity to entity
         if (markedObject == -1 || diagram[lineStartObj].symbolkind == symbolKind.erEntity && diagram[markedObject].symbolkind == symbolKind.erEntity) {
             md = mouseState.empty;
+            uimode = "CreateLine";
         }else {
             //Get which kind of symbol mouseupevt execute on
             symbolEndKind = diagram[markedObject].symbolkind;


### PR DESCRIPTION
Drawing a UML-line changes uimode to "CreateUMLLine", but if the line is not drawn uimode is never changed back to "ChangeLine" and thus does not pass any checks until the button is pressed again and uimode is changed back. This was solved by simply adding the line "uimode = "CreateLine";" where the check occurs if the line is drawn to an empty spot. This enables you to draw a new line to another class.