### PR TITLE
An option has been added to download the diagram in A4 size

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -135,6 +135,9 @@
                                     <div class="export-drop-down-item" tabindex="0">
                                         <a class="drop-down-option" id="picid">Export Picture</a>
                                     </div>
+                                    <div class="export-drop-down-item" tabindex="0">
+                                        <a class="drop-down-option" id="svgidA4" onclick='ExportSVGA4(this);'>Export as A4 size(SVG)</a>
+                                    </div>
                                 </div>
                             </div>
                             <div class="drop-down-divider">

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -329,9 +329,9 @@ function ExportSVG(el) {
 }
 
 function ExportSVGA4(el) {
-    const pixelsPerMillimeter = 3.781 * zoomValue;
-    a4Width = 210 * pixelsPerMillimeter;
-    a4Height = 297 * pixelsPerMillimeter;
+    const pixelsPerMillimeter = 3.781;
+    const a4Width = 210 * pixelsPerMillimeter;
+    const a4Height = 297 * pixelsPerMillimeter;
     if(A4Orientation == "landscape"){
         temp = a4Width;
         a4Width = a4Height;

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -328,6 +328,28 @@ function ExportSVG(el) {
     el.setAttribute("download", "diagram.svg");
 }
 
+function ExportSVGA4(el) {
+    const pixelsPerMillimeter = 3.781;
+    a4Width = 210 * pixelsPerMillimeter;
+    a4Height = 297 * pixelsPerMillimeter;
+    if(A4Orientation == "landscape"){
+        temp = a4Width;
+        a4Width = a4Height;
+        a4Height = temp
+        //downloads file with swapped height and width for landscape oriented A4
+    }
+    var svgstr = "";
+    var width = a4Width, height = a4Height;
+    svgstr += "<svg width='"+width+"' height='"+height+"' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'>";
+    svgstr += gridToSVG(width, height);
+    svgstr += diagramToSVG();
+    svgstr += "</svg>";
+    var data = "text/json;charset=utf-8," + encodeURIComponent(svgstr);
+    el.setAttribute("class", 'icon-download');
+    el.setAttribute("href", "data:" + data);
+    el.setAttribute("download", "diagram.svg");
+}
+
 //------------------------------------------------
 // used when exporting the file as a .png image.
 //------------------------------------------------

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -329,9 +329,9 @@ function ExportSVG(el) {
 }
 
 function ExportSVGA4(el) {
-    const pixelsPerMillimeter = 3.781;
-    const a4Width = 210 * pixelsPerMillimeter;
-    const a4Height = 297 * pixelsPerMillimeter;
+    const pixelsPerMillimeter = 3.781 * zoomValue;
+    a4Width = 210 * pixelsPerMillimeter;
+    a4Height = 297 * pixelsPerMillimeter;
     if(A4Orientation == "landscape"){
         temp = a4Width;
         a4Width = a4Height;

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -329,7 +329,7 @@ function ExportSVG(el) {
 }
 
 function ExportSVGA4(el) {
-    const pixelsPerMillimeter = 3.781;
+    const pixelsPerMillimeter = 3.781 * zoomValue;
     a4Width = 210 * pixelsPerMillimeter;
     a4Height = 297 * pixelsPerMillimeter;
     if(A4Orientation == "landscape"){

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -329,7 +329,7 @@ function ExportSVG(el) {
 }
 
 function ExportSVGA4(el) {
-    const pixelsPerMillimeter = 3.781 * zoomValue;
+    const pixelsPerMillimeter = 3.781;
     a4Width = 210 * pixelsPerMillimeter;
     a4Height = 297 * pixelsPerMillimeter;
     if(A4Orientation == "landscape"){


### PR DESCRIPTION
A export option has been added to export the diagram in a4 format. The issue was assumed to be solved as HGustavs comment above mentions "Svg export with limit to certain page/coordinate combo". Solution does also download the appropriate oriantation(portrait, landscape) depending on what option has been selected in the view options(Display virtual A4 -> Toggle A4 oriantation).

This solution only downloads the first A4(top left) in the canvas since including more would break the A4 format and make the A4 format export pointless.