### PR TITLE
State is now saved when distribute function is used

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2642,6 +2642,7 @@ function distribute(event, axis) {
     // There is a posibility for more types
     updateGraphics();
     hashFunction();
+    SaveState();
 }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
The state of the canvas is now saved when the distribute function is used.

Result of this is that the canvas should save the changes after distributing the objects and the user refreshes quickly after.