### PR TITLE
G4 2020 w15 issue#7647

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3591,6 +3591,8 @@ function mouseupevt(ev) {
                     if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) >= 2) okToMakeLine = false;
                 }else if (symbolEndKind == symbolKind.erRelation && symbolStartKind == symbolKind.erEntity) {
                     if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) >= 2) okToMakeLine = false;
+                }else if (symbolEndKind == symbolKind.erRelation && symbolStartKind == symbolKind.erAttribute) {
+                    if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) > 0) okToMakeLine = false;
                 }else if (symbolEndKind == symbolKind.erRelation && symbolStartKind == symbolKind.erRelation) {
                     okToMakeLine = false;
                 }else if ((symbolEndKind == symbolKind.uml && symbolStartKind != symbolKind.uml) || (symbolEndKind != symbolKind.uml && symbolStartKind == symbolKind.uml)) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3593,6 +3593,8 @@ function mouseupevt(ev) {
                     if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) >= 2) okToMakeLine = false;
                 }else if (symbolEndKind == symbolKind.erRelation && symbolStartKind == symbolKind.erAttribute) {
                     if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) > 0) okToMakeLine = false;
+                }else if (symbolEndKind == symbolKind.erAttribute && symbolStartKind == symbolKind.erRelation) {
+                    if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) > 0) okToMakeLine = false;
                 }else if (symbolEndKind == symbolKind.erRelation && symbolStartKind == symbolKind.erRelation) {
                     okToMakeLine = false;
                 }else if ((symbolEndKind == symbolKind.uml && symbolStartKind != symbolKind.uml) || (symbolEndKind != symbolKind.uml && symbolStartKind == symbolKind.uml)) {


### PR DESCRIPTION
As of before fix, several lines could be drawn between the same attribute and the same relation. 

In diagram.php it should be impossible to draw multiple line between the same attribute and the same relation. This might be hard to test since the lines are placed in the same position. Before when the user drew multiple lines between the same relation and attribute the lines were lumped together. The picture below illustrates this.

![Screenshot_4](https://user-images.githubusercontent.com/49142301/78645359-b89f0900-78b7-11ea-8d11-09be906ee99c.png)

Now it should look more like the picture below even when the user tries to add more lines.

![Screenshot_5](https://user-images.githubusercontent.com/49142301/78645462-d8363180-78b7-11ea-8e4f-0bd309158d34.png)
