### PR TITLE
G4 2020 w15 issue#7653

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2128,14 +2128,14 @@ function Symbol(kindOfSymbol) {
     //---------------------------------------------------------
     this.getTextX = function(x1, midX, x2) {
         var textX = 0;
-        if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Large') textX = x1 + 70;
-        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Large') textX = x2 - 70;
-        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Medium') textX = x1 + 43;
-        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Medium') textX = x2 - 43;
-        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Small') textX = x1 + 30;
-        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Small') textX = x2 - 30;
-        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Tiny') textX = x1 + 22;
-        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Tiny') textX = x2 - 22;
+        if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Large') textX = x1 + 70 * diagram.getZoomValue();
+        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Large') textX = x2 - 70 * diagram.getZoomValue();
+        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Medium') textX = x1 + 43 * diagram.getZoomValue();
+        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Medium') textX = x2 - 43 * diagram.getZoomValue();
+        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Small') textX = x1 + 30 * diagram.getZoomValue();
+        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Small') textX = x2 - 30 * diagram.getZoomValue();
+        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Tiny') textX = x1 + 22 * diagram.getZoomValue();
+        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Tiny') textX = x2 - 22 * diagram.getZoomValue();
         else textX = midX;
         return textX;
     }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2128,8 +2128,14 @@ function Symbol(kindOfSymbol) {
     //---------------------------------------------------------
     this.getTextX = function(x1, midX, x2) {
         var textX = 0;
-        if (this.properties['textAlign'] == "start") textX = x1 + 10;
-        else if (this.properties['textAlign'] == "end") textX = x2 - 10;
+        if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Large') textX = x1 + 70;
+        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Large') textX = x2 - 70;
+        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Medium') textX = x1 + 43;
+        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Medium') textX = x2 - 43;
+        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Small') textX = x1 + 30;
+        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Small') textX = x2 - 30;
+        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Tiny') textX = x1 + 22;
+        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Tiny') textX = x2 - 22;
         else textX = midX;
         return textX;
     }


### PR DESCRIPTION
Aligning text left/right makes text go outside of the text box. When creating a textobject in diagram.php you should now be able to align the text left, center and right without the text going outside of the textbox. This should work for all font-sizes. 

What the issue forgot to mention is that text-alignment is affected by the zoom function. This issue should also be resolved. The text should not change position depended on the zoom.

Before: 

![Screenshot_7](https://user-images.githubusercontent.com/49142301/78664724-e181c700-78d4-11ea-975b-cbd1619ef548.png)

After: 

![Screenshot_6](https://user-images.githubusercontent.com/49142301/78664733-e6467b00-78d4-11ea-9a37-18655213b931.png)


