### PR TITLE
#7886 Fix problem were HTML encoded letters got into the database.

### DIFF
--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -61,6 +61,14 @@ if(checklogin() && $hasAccess) {
 
 	if(strcmp($opt,"UPDATE")==0){
 
+		//Replaces the HTML enconding to orignial latin letters åäö
+		$val = str_replace("&aring;","å",$val);
+		$val = str_replace("&Aring;","Å",$val);
+		$val = str_replace("&auml;","ä",$val);
+		$val = str_replace("&Auml;","Ä",$val);
+		$val = str_replace("&ouml;","ö",$val);
+		$val = str_replace("&Ouml;","Ö",$val);
+
 		// User Table Updates
 		if($prop=="firstname"){
 				$query = $pdo->prepare("UPDATE user SET firstname=:firstname WHERE uid=:uid;");


### PR DESCRIPTION
Added string replacers to change the HTML encoded letters back to the original latin letters "åäö" before updating the database.

Co-Authored-By: a18matna <a18matna@users.noreply.github.com>