### PR TITLE
Fixes issue 7847, closing appearance menu with escape then deleting objects with delete

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -382,6 +382,9 @@ function resetToolButtonsPressed() {
 
 function keyDownHandler(e) {
     var key = e.keyCode;
+    if(key == escapeKey && appearanceMenuOpen) {
+        closeAppearanceDialogMenu();
+    }
     if (appearanceMenuOpen) return;
     if ((key == deleteKey || key == backspaceKey)) {
         eraseSelectedObject(event);


### PR DESCRIPTION
If the appearance menu is closed with escape key you can now still delete objects with backspace or delete keys.