### PR TITLE
Fab button mobile view fix for ISSUE#7871

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1362,7 +1362,7 @@ $(document).mouseup(function (e) {
   }
 });
 
-$(document).on("touchstart", function (e) {
+$(fabBtn).on("touchstart", function (e) {
   if ($(e.target).parents(".fixed-action-button").length !== 0 && $(e.target).parents(".fab-btn-list").length === 0) {
     e.preventDefault();
   }


### PR DESCRIPTION
You can no longer open the fab button menu when pressing on the background in mobile view. You have to press the "+" button.  

Closing#7871