### PR TITLE
Fixes issue#7728, spacing in UML appearance menu

### DIFF
--- a/DuggaSys/diagram_forms.php
+++ b/DuggaSys/diagram_forms.php
@@ -54,13 +54,13 @@
   }
   //form for classes
   else if($form == 'classType') {
-      echo'Class name: </br>
+      echo'<label style="display:inline-block; margin-top: 10px; margin-bottom: 5px"; for=\'nametext\'>Class name:</label></br>
       <input onkeyup="changeObjectAppearance(\'classType\');" id=\'nametext\' type=\'text\'></br>
 
-      Attributes:<br>
+      <label style="display:inline-block; margin-top: 10px"; for="UMLAttributes">Attributes:</label><br>
       <textarea onkeyup="changeObjectAppearance(\'classType\');" id="UMLAttributes" class="UMLTextarea" style="height:100px; resize:none"></textarea><br>
 
-      Operations:<br>
+      <label style="display:inline-block; margin-top: 10px"; for="UMLOperations">Operations:</label><br>
       <textarea onkeyup="changeObjectAppearance(\'classType\');" id="UMLOperations" class="UMLTextarea" style="height:100px; resize:none"></textarea><br>
 
       <button type=\'submit\' class=\'submit-button\' onclick="SaveState(); changeObjectAppearance(\'classType\'); closeAppearanceDialogMenu();" style=\'float: none; display: block; margin: 10px auto;\'>Ok</button>


### PR DESCRIPTION
Adding labels allowed for styling of the text (adding margins). There is now more space between the different elements. The labels also help screen readers and allows you to click the text instead of the box to focus on the input-textbox. 
![Anteckning 2020-04-08 105234](https://user-images.githubusercontent.com/62878096/78764519-f5860100-7986-11ea-84c7-b26653062db6.png)

