### PR TITLE
Fixed lines between relations and entities issue#6209

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1164,7 +1164,7 @@ diagram.sortConnectors = function() {
 diagram.updateQuadrants = function() {
     for (var i = 0; i < diagram.length; i++) {
         if (diagram[i].symbolkind == symbolKind.erEntity || diagram[i].symbolkind == symbolKind.erRelation || diagram[i].symbolkind == symbolKind.uml) {
-            if(diagram[i].quadrants()) break;
+            if(diagram[i].quadrants(diagram[i].symbolkind)) /*break*/;
         }
     }
 }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -128,7 +128,7 @@ function Symbol(kindOfSymbol) {
     //--------------------------------------------------------------------
     // quadrants: Iterates over all relation ends and checks if any need to change quadrants
     //--------------------------------------------------------------------
-    this.quadrants = function () {
+    this.quadrants = function (kind) {
         // Fix right connector box (1)
         var changed = false;
         var i = 0;
@@ -218,6 +218,34 @@ function Symbol(kindOfSymbol) {
                 i++;
             }
         }
+        // Fixes lines when thes same entity connects to a relation twice     
+        if (kind == symbolKind.erRelation){
+            if (this.connectorTop.length == 2){
+                changed = true;
+                conn = this.connectorTop.splice(0, 2);
+                this.connectorLeft.push(conn[1]);
+                this.connectorRight.push(conn[0]);
+            }
+            else if (this.connectorBottom.length == 2){
+                changed = true;
+                conn = this.connectorBottom.splice(0, 2);
+                this.connectorLeft.push(conn[1]);
+                this.connectorRight.push(conn[0]);
+            }            
+            else if (this.connectorLeft.length == 2){
+                changed = true;
+                conn = this.connectorLeft.splice(0, 2);
+                this.connectorTop.push(conn[1]);
+                this.connectorBottom.push(conn[0]);
+            }
+            else if (this.connectorRight.length == 2){
+                changed = true;
+                conn = this.connectorRight.splice(0, 2);
+                this.connectorTop.push(conn[0]);
+                this.connectorBottom.push(conn[1]);
+            }
+        }
+
         return changed;
     }
 


### PR DESCRIPTION
Made it so when an entity has a recursive relation with itself the lines appear on the sides instead of on the same edge of the relation. This should make cardinalities collide less.
Should look like this: 
![image](https://user-images.githubusercontent.com/62876581/78780645-3ab62d00-799f-11ea-97af-44af319a990a.png)
It should work from all directions and when moving the objects around. 
Closes#6209
