### PR TITLE
Fix for MYSQL_VERSION constant already defined, issue #7868

### DIFF
--- a/Shared/database.php
+++ b/Shared/database.php
@@ -45,7 +45,9 @@ function pdoConnect()
 	global $pdo;
 	try {
 		$pdo = new PDO('mysql:host='.DB_HOST.';dbname='.DB_NAME.';charset=utf8',DB_USER,DB_PASSWORD);
-		define("MYSQL_VERSION",$pdo->query('select version()')->fetchColumn());
+		if(!defined("MYSQL_VERSION")) {
+			define("MYSQL_VERSION",$pdo->query('select version()')->fetchColumn());
+		}
 	} catch (PDOException $e) {
 		echo "Failed to get DB handle: " . $e->getMessage() . "</br>";
 		exit;


### PR DESCRIPTION
Fixed the issue where MYSQL_VERSION could be defined more than once when connecting to database. A constant should only be declared once.