### PR TITLE
Reimplemented old issue that disappeared in weekly merge #7784

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -614,6 +614,7 @@ function returnedSection(data) {
       document.querySelector(".course-dropdown-div").style.display = "none";
       document.querySelector("td.editVers").style.display = "none";
       document.querySelector("td.newVers").style.display = "none";
+      document.querySelector("td.coursePage").style.display = "none";
 
       // Show addElement Button
       document.getElementById("addElement").style.display = "Block";

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -89,6 +89,31 @@
 							echo "      </a>";
 							echo "    </div>";
 							echo "</td>";
+
+							include_once "../Shared/database.php";
+							pdoConnect();	
+							$query = $pdo->query("SELECT versname, coursecode FROM vers WHERE cid=".$_SESSION['courseid']."");
+							$fetch = $query->fetch();
+							$result['coursecode'] = $fetch['coursecode'];
+							$result['versname'] = $fetch['versname'];
+
+							// Changes format from 'HT20' to numbers to create the URL
+							$array = explode("T", $result['versname']);
+							$array[0]; 
+							$year = "20";
+							$year .= $array[1];
+							if ($array[0] = "H")
+							  $term = 2;
+							else if ($array[0] = "V")
+								$term = 1;
+
+							echo "<td class='coursePage' style='display: inline-block;'>";
+							echo "    <div class='course menuButton'>";
+							echo " 		<a href='https://personal.his.se/utbildning/kurs/?semester=".$year.$term."&coursecode=".$result['coursecode']."'>";
+              echo "        <img id='courseIMG' value='Course' class='navButt' title='Course page for ".$result['coursecode']."' src='../Shared/icons/coursepage_button.svg'>";
+							echo "		</a>";
+							echo "    </div>";
+							echo "</td>";
 						
 							echo "<td class='access menuButton' style='display: inline-block;'>";
 							echo "    <div class='access menuButton'>";


### PR DESCRIPTION
Old code that was lost reimplemented. There should be a button in the header for courses that look like this (Can only be seen as teacher):
![image](https://user-images.githubusercontent.com/62876581/79201717-c82ecc80-7e38-11ea-884e-9ac144633de4.png)
The button should lead to an external teacher site for the course.