### PR TITLE
Fixes issue 7847, closing apperance menu with escape locks delete and backspace

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -385,6 +385,9 @@ function resetToolButtonsPressed() {
 
 function keyDownHandler(e) {
     var key = e.keyCode;
+    if(key == escapeKey && appearanceMenuOpen) {
+        toggleApperanceElement();
+    }
     if (appearanceMenuOpen) return;
     if ((key == deleteKey || key == backspaceKey)) {
         eraseSelectedObject(event);


### PR DESCRIPTION
When you close the menu to edit the appearance of an UML-element with the escape key, it is now possible to delete an object with the delete or backspace keys.