### PR TITLE
Changed it so chrome also zooms in steps of 10% #7614

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2963,7 +2963,9 @@ function changeZoom(zoomValue, event) {
 //-----------------------
 
 function scrollZoom(event) {
-    var wheelZoom = 124;
+    // deltaY is different for different browsers so 
+    // wheelZoom might need to be changed in the future
+    var wheelZoom = 99;
     var mousePadZoom = 5;
 
     if(event.mozInputSource){


### PR DESCRIPTION
Chrome should also zoom in steps of 10% when scrolling in the diagram now.