### PR TITLE
A4 dashed in all zoom modes

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1306,7 +1306,7 @@ function drawVirtualA4() {
 
     ctx.save();
     ctx.strokeStyle = "black"
-    ctx.setLineDash([10]);
+    ctx.setLineDash([10 * (pixelsPerMillimeter / 3)]);
     
     if(A4Orientation == "portrait") {           // Draw A4 sheets in portrait mode
         for (var i = 0; i < a4Rows; i++) {


### PR DESCRIPTION
Fixes #7675

Before when zooming, the A4 dashed lines when using "Display virtual A4" would be inconsistent and sometimes connect to a solid line. This fixes that issue by using the pixelsPerMillimeter value.