### PR TITLE
Fix for styling in import-dialog issue#7618 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1640,6 +1640,17 @@ function importFile() {
     reader.readAsText(file, "UTF-8");
 }
 
+//-------------------------------------------------------
+// Change name of label to filename when importing file
+//-------------------------------------------------------
+
+$(document).ready(function(){
+        $('.import-file-button').change(function(e){
+            var fileName = e.target.files[0].name;
+          $('#importLabel').text(fileName);
+        });
+    });
+
 //---------------------------------------------------
 // canvasSize: Function that is used for the resize
 //             Making the page more responsive

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -38,7 +38,6 @@ AJAXService("get", {}, "DIAGRAM");
 //           A diagram object could for instance be a path, or a symbol
 //--------------------------------------------------------------------
 
-//TEST
 
 var diagram = [];
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -38,7 +38,6 @@ AJAXService("get", {}, "DIAGRAM");
 //           A diagram object could for instance be a path, or a symbol
 //--------------------------------------------------------------------
 
-
 var diagram = [];
 
 var settings = {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -38,6 +38,8 @@ AJAXService("get", {}, "DIAGRAM");
 //           A diagram object could for instance be a path, or a symbol
 //--------------------------------------------------------------------
 
+//TEST
+
 var diagram = [];
 
 var settings = {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -559,7 +559,8 @@
             <div class='table-wrap'>
                 <div class="importWrap">
                     <div>
-                        <input type="file" id="importFile" accept=".txt, text/plain" />
+                        <input type="file" class="import-file-button" id="importFile" accept=".txt, text/plain" />
+                        <label for="importFile" class="custom-file-upload">Choose file</label>
                     </div>
                     <div id="importError" class="importError">
                         <span>Only .txt-files allowed</span>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -560,7 +560,7 @@
                 <div class="importWrap">
                     <div>
                         <input type="file" class="import-file-button" id="importFile" accept=".txt, text/plain" />
-                        <label for="importFile" class="custom-file-upload">Choose file</label>
+                        <label for="importFile" id="importLabel" class="submit-button custom-file-upload">Choose a file</label>
                     </div>
                     <div id="importError" class="importError">
                         <span>Only .txt-files allowed</span>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5283,12 +5283,17 @@ textarea#mrkdwntxt {
 }
 
 .importDiagram .import-file-button {
-    width: 0.1px;
-	height: 0.1px;
-	opacity: 0;
-	overflow: hidden;
-	position: absolute;
-	z-index: -1;
+  width: 0.1px;
+  height: 0.1px;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  z-index: -1;
+}
+
+.import-file-button + label {
+  float: left;
+  border-radius: 4px;
 }
 
 .multiselect-group {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5282,6 +5282,14 @@ textarea#mrkdwntxt {
   padding: 0 15px;
 }
 
+.importDiagram .import-file-button {
+    width: 0.1px;
+	height: 0.1px;
+	opacity: 0;
+	overflow: hidden;
+	position: absolute;
+	z-index: -1;
+}
 
 .multiselect-group {
   width: 112px;


### PR DESCRIPTION
Styling fixed for the input type="file" button. The button "Välj fil" now has the same styling as all the other buttons. When selecting a file the labeltext changes to the filename. 

Before:

![Screenshot_4](https://user-images.githubusercontent.com/49142301/79217303-ed2e3a00-7e4e-11ea-8de8-08c77d13e6fb.png)

After:

![Screenshot_6](https://user-images.githubusercontent.com/49142301/79217352-07681800-7e4f-11ea-855f-01a510df0d0d.png)

