### PR TITLE
Implemented refreshing of session cookies when user is active - G1-2020-W16-#7507

### DIFF
--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -130,6 +130,13 @@ Testing Link:
 					
 				}
 			}
+			else{
+				// refreshes session cookies, thereby extending the time before users sees the alert or get logged out
+				// refreshes takes place when navigating to codeviewer.php, courseed.php, and sectioned.php 
+				setcookie("sessionEndTime", "expireC", time() + 2700, "/"); // Alerts user in 45min
+				setcookie("sessionEndTimeLogOut", "expireC", time() + 3600, "/"); // Ends session in 60min, user gets logged out
+			}
+			
 			//	FOR TESTING:	uncomment line below to see log output of #username, 
 			//echo "<script>console.log('Debug Objects: " . $_COOKIE["cookie_guest"] . "' );</script>";
 

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -27,6 +27,12 @@ if($userid == "00"){
 		
 	}
 }
+else{
+	// refreshes session cookies, thereby extending the time before users sees the alert or get logged out
+	// refreshes takes place when navigating to codeviewer.php, courseed.php, and sectioned.php
+	setcookie("sessionEndTime", "expireC", time() + 2700, "/"); // Alerts user in 45min
+	setcookie("sessionEndTimeLogOut", "expireC", time() + 3600, "/"); // Ends session in 60min, user gets logged out
+}
 
 ?>
 <!DOCTYPE html>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -20,6 +20,12 @@
 			
 		}
 	}
+	else{
+		// refreshes session cookies, thereby extending the time before users sees the alert or get logged out
+		// refreshes takes place when navigating to codeviewer.php, courseed.php, and sectioned.php
+		setcookie("sessionEndTime", "expireC", time() + 2700, "/"); // Alerts user in 45min
+		setcookie("sessionEndTimeLogOut", "expireC", time() + 3600, "/"); // Ends session in 60min, user gets logged out
+	}
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
The issue https://github.com/HGustavs/LenaSYS/issues/7507 wanted a solution to prevent the alert being triggered even though the user is active on the site. 

![Screenshot 2020-04-14 at 13 42 43](https://user-images.githubusercontent.com/62876614/79221460-25854680-7e56-11ea-9634-94a7e331a3ce.png)

To solve this the session cookies which holds the time when the alert is suppose to trigger instead now gets refreshed by the user navigating the site. Refreshes takes place when navigating to codeviewer.php, courseed.php, and sectioned.php.
![Screenshot 2020-04-14 at 13 48 02](https://user-images.githubusercontent.com/62876614/79221722-9cbada80-7e56-11ea-89b1-d9c0f7456973.png)

 