### PR TITLE
Changed justify-content to center. #7400

### DIFF
--- a/DuggaSys/templates/dugga4.html
+++ b/DuggaSys/templates/dugga4.html
@@ -1,4 +1,4 @@
-<div id="container" style="display:flex; justify-content:flex-end;">
+<div id="container" style="display:flex; justify-content:center;">
     <div id='duggaInfoBox2' style="inline-block; width:300px;">
       
           <div class='loginBoxheader'>


### PR DESCRIPTION
Changed justify-content: flex-end to center. To make the container to the center instead of being on the right.

Co-Authored-By: b18jonli <b18jonli@users.noreply.github.com>
<img width="1280" alt="Screenshot 2020-04-14 at 14 20 42" src="https://user-images.githubusercontent.com/49142649/79224311-27053d80-7e5b-11ea-9dfc-73956c206596.png">
