### PR TITLE
Fixed the fab buttons on the "files" page in mobile view from issue #8072

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -646,12 +646,14 @@ $(document).mouseup(function (e) {
     }
 });
 
-$(document).on("touchstart", function (e) {
+$(document).ready(function(){
+$("#fabBtn").on("touchstart", function (e) {
     if ($(e.target).parents(".fixed-action-button").length !== 0 && $(e.target).parents(".fab-btn-list").length === 0) {
         e.preventDefault();
     }
-
+$("#fab-btn-list").show();
     TouchFABDown(e);
+});
 });
 
 $(document).on("touchend", function (e) {

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -238,7 +238,7 @@ $codeLinkQuery->execute();
 <!--Fab-button-->
 <div class="fixed-action-button" id="fabButton">
     <a class="btn-floating fab-btn-lg noselect" id="fabBtn">+</a>
-    <ol class="fab-btn-list" style="margin: 0; padding: 0; display: none;" reversed>
+    <ol class="fab-btn-list" style="margin: 0; padding: 0; display: none;" reversed id='fab-btn-list'>
 	
         <li>
             <a id="emptyFabBtn" class="btn-floating fab-btn-sm scale-transition scale-out" data-tooltip='Add Dummy Empty File'>


### PR DESCRIPTION
Fixed the fab buttons on the files page in mobile view so that they show up when you press the +. You also need to _only_ press the +, and not anywhere on the screen.

You can still **close** the fab buttons by clicking on the background but that is not an issue as it's usually how things are on mobile.

