### PR TITLE
Fixed issue where "Result" does not follow the horizontal scroll

### DIFF
--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -45,10 +45,11 @@ pdoConnect();
   ?>
   <!-- content START -->
 	<div id="content">
-		<div class="titles" style="justify-content:center;">
+		
+    <div id="resultedFormContainer">
+	<div class="titles" style="justify-content:center;">
 			<h1>Result</h1>
     </div>
-    <div id="resultedFormContainer">
       <div id="ladexportContainer">
       <div class="resultedFormsFlex">
         <label>Delkurs</label>


### PR DESCRIPTION
By moving the div "titles" from outside the div "resultedFormContainer" to inside, the issue where the H1-tag "Result" dissapears is fixed and now follows the scroll.

![image](https://user-images.githubusercontent.com/49142704/79226399-9df00580-7e5e-11ea-8a6a-a89f27ba3ca0.png)
