### PR TITLE
fix ISSUE#7531 Eventlistener moved from diagram.php to diagram.js

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -387,6 +387,7 @@ function resetToolButtonsPressed() {
 //--------------------------------------------------------------------
 
 function keyDownHandler(e) {
+    clickEnterOnDialogMenu();
     var key = e.keyCode;
     if(key == escapeKey && appearanceMenuOpen) {
         toggleApperanceElement();

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -35,8 +35,6 @@
             $(".drop-down-item").click(function() {
                 $(this).closest(".drop-down").hide();
             });
-
-            window.addEventListener('keypress', clickEnterOnDialogMenu);
         });
     </script>
 </head>


### PR DESCRIPTION
Functionality should be the same as before. When you click the "Enter"-button in an appearance menu that's either a attribute, entity, relation or draw free object the menu should close. 