### PR TITLE
Fixed issue for branch: G1-2020-W17-ISSUE#4048

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1173,7 +1173,6 @@ function sessionExpireMessage() {
 
 			if (document.cookie.indexOf('sessionEndTime=expireC') == -1){
 				$(".expiremessagebox").css("display","block");
-
 				clearInterval(intervalId);
 			}
 
@@ -1195,6 +1194,7 @@ function sessionExpireLogOut() {
 	function checkIfExpired() {
 
 			if (document.cookie.indexOf('sessionEndTimeLogOut=expireC') == -1){
+				$(".expiremessagebox").css("display","none");
 				$(".endsessionmessagebox").css("display","block");
 				processLogout();
 				clearInterval(intervalId);


### PR DESCRIPTION
In this issue they complained that the "expiremessagebox" was covered by "endsessionmessagebox" as seen below.
![image](https://user-images.githubusercontent.com/62876625/79325166-026b9d00-7f11-11ea-8e60-d3bc995c551f.png)

Now with the added code it looks like the GIF below instead which solves the "weird" boxes. 
![392ef1256c66a1b9798b209294ea161f](https://user-images.githubusercontent.com/62876625/79325528-99d0f000-7f11-11ea-80d8-2c1f70390f40.gif)

