### PR TITLE
Fixes issue #7531

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4005,22 +4005,6 @@ function clickOutsideDialogMenu(ev) {
     });
 }
 
-//----------------------------------------------------------------------
-// clickEnterOnDialogMenu: Closes the dialog menu when the enter button is pressed.
-//----------------------------------------------------------------------
-
-function clickEnterOnDialogMenu(ev) {
-    $(document).keypress(function (ev) {
-        if (ev.which == 13 && appearanceMenuOpen && !classAppearanceOpen && !textAppearanceOpen) {
-            globalappearanceMenuOpen = false;
-            toggleApperanceElement();
-            // Is called in the separate appearance php-files at the buttons.
-            // Called here since an enter press doesn't relate to any element
-            setObjectProperties();
-        }
-    });
-}
-
 function toggleApperanceElement(show = false) {
     const appearanceElement = document.getElementById("appearance");
     if(show) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -387,6 +387,7 @@ function resetToolButtonsPressed() {
 //--------------------------------------------------------------------
 
 function keyDownHandler(e) {
+    clickEnterOnDialogMenu();
     var key = e.keyCode;
     if(key == escapeKey && appearanceMenuOpen) {
         toggleApperanceElement();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -387,7 +387,6 @@ function resetToolButtonsPressed() {
 //--------------------------------------------------------------------
 
 function keyDownHandler(e) {
-    clickEnterOnDialogMenu();
     var key = e.keyCode;
     if(key == escapeKey && appearanceMenuOpen) {
         toggleApperanceElement();
@@ -4335,4 +4334,15 @@ function getGroupsByType(type) {
         const types = group.dataset.types.split(",");
         return types.includes(type.toString());
     });
+}
+
+//Shoud simulate button click or enter click in appearance menu to save and close
+function submitAppearanceForm() {
+    if(globalappearanceMenuOpen) {
+        setGlobalProperties();
+    } else {
+        setObjectProperties();
+    }
+    SaveState();
+    toggleApperanceElement();
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -390,6 +390,8 @@ function keyDownHandler(e) {
     var key = e.keyCode;
     if(key == escapeKey && appearanceMenuOpen) {
         toggleApperanceElement();
+    } else if(key == enterKey && appearanceMenuOpen && !classAppearanceOpen && !textAppearanceOpen) {
+        submitAppearanceForm();
     }
     if (appearanceMenuOpen) return;
     if ((key == deleteKey || key == backspaceKey)) {
@@ -4297,11 +4299,7 @@ function initAppearanceForm() {
                 }
             } else if(element.tagName === "INPUT" || element.tagName === "TEXTAREA") {
                 if(element.type === "submit") {
-                    element.addEventListener("click", () => {
-                        SaveState();
-                        setObjectProperties();
-                        toggleApperanceElement();
-                    });
+                    element.addEventListener("click", submitAppearanceForm);
                 } else {
                     element.addEventListener("input", setObjectProperties);
                 }

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -35,8 +35,6 @@
             $(".drop-down-item").click(function() {
                 $(this).closest(".drop-down").hide();
             });
-
-            window.addEventListener('keypress', clickEnterOnDialogMenu);
         });
     </script>
 </head>


### PR DESCRIPTION
Made a general function for submitting the appearance form to simulate enter click and button click. Only these two ways of closing the appearnce menu should save the state as of now. Removed old jQuery eventlistener and merged this check into the keyDownHandler vanilla JavaScript eventlistener.