### PR TITLE
Simple fix for move icon being slightly off center in firefox, issue #7621

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2012,7 +2012,8 @@ div.submit-button:disabled {
 #moveButton {
   z-index: 2;
   position: absolute;
-  right: 10px;
+  right: 12px;
+  top: 85px;
   border-radius: 0px;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2012,6 +2012,7 @@ div.submit-button:disabled {
 #moveButton {
   z-index: 2;
   position: absolute;
+  right: 10px;
   border-radius: 0px;
 }
 


### PR DESCRIPTION
See issue for picture of how it looked before.