### PR TITLE
fix ISSUE#7147 New border when buttons selected

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1963,7 +1963,7 @@ div.submit-button:disabled {
   justify-content: center;
   align-items: center;
   border-radius: 8px;
-  border: none;
+  border: 1px solid #614875;
   margin: 5px auto;
   transition: 0.25s background-color;
   display: inline;
@@ -1973,6 +1973,10 @@ div.submit-button:disabled {
 
 .buttonsStyle:hover {
   background-color: var(--color-primary-hover);
+}
+
+.buttonsStyle:focus {
+  outline:0;
 }
 
 .buttonsStyle img,


### PR DESCRIPTION
Buttons now have a border with same color as the background color. When a button is selected and the background color change, the border will become visable.

Before: 

![Screenshot_16](https://user-images.githubusercontent.com/49142301/79336030-4d8eab80-7f23-11ea-942c-5ffea787b3eb.png)

After: 

![Screenshot_17](https://user-images.githubusercontent.com/49142301/79336052-52ebf600-7f23-11ea-9b7b-f7bf0813036c.png)

