### PR TITLE
G4 2020 w17 issue#8127

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3992,6 +3992,24 @@ function deactivateMovearound() {
 }
 
 //----------------------------------------------------------------------
+// toggleCameraView: Enter camera view by clicking option in menu.
+//----------------------------------------------------------------------
+
+function toggleCameraView(){
+    event.stopPropagation();
+    if (spacebarKeyPressed) {
+        spacebarKeyPressed = false;
+        setCheckbox($(".drop-down-option:contains('Move camera')"), spacebarKeyPressed);
+        
+    } else {
+        spacebarKeyPressed = true;
+        setCheckbox($(".drop-down-option:contains('Move camera')"), spacebarKeyPressed);
+    }
+    updateGraphics();
+    activateMovearound();
+}
+
+//----------------------------------------------------------------------
 // clickOutsideDialogMenu: Closes the dialog menu when click is done outside box.
 //----------------------------------------------------------------------
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3999,11 +3999,9 @@ function toggleCameraView(){
     event.stopPropagation();
     if (spacebarKeyPressed) {
         spacebarKeyPressed = false;
-        setCheckbox($(".drop-down-option:contains('Move camera')"), spacebarKeyPressed);
         
     } else {
         spacebarKeyPressed = true;
-        setCheckbox($(".drop-down-option:contains('Move camera')"), spacebarKeyPressed);
     }
     updateGraphics();
     activateMovearound();

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -344,11 +344,9 @@
                     <div class="menu-drop-down">
                         <span class="drop-down-label" tabindex="0">Help</span>
                         <div class="drop-down">
-                            <div class="drop-down-text-non-clickable" tabindex="0">
-                                <span class="drop-down-option">Move camera</span>
-                                <div id="hotkey-space" class="hotKeys">
-                                    <i>Blankspace</i>
-                                </div>
+                            <div class="drop-down-item" tabindex="0">
+                                <span class="drop-down-option" onclick="toggleCameraView(event)">Move camera</span>
+                                <i id="hotkey-space" class="hotKeys">Blankspace</i>
                             </div>
                             <div class="drop-down-divider">
                             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -345,7 +345,7 @@
                         <span class="drop-down-label" tabindex="0">Help</span>
                         <div class="drop-down">
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="toggleCameraView(event)">Move camera</span>
+                                <span class="drop-down-option" onclick="toggleCameraView(event);">Move camera</span>
                                 <i id="hotkey-space" class="hotKeys">Blankspace</i>
                             </div>
                             <div class="drop-down-divider">


### PR DESCRIPTION
Added functionality for menu item "Camera view" so uou can now enter camera mode without using keyboard shortcuts. Ready for testing