### PR TITLE
Inconsistensies with positioning and naming of certain headings fixed

### DIFF
--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -31,7 +31,7 @@
 		<div id="headerContent"> <!-- A div to place header content. -->
 			<?php
 				echo "<div class='titles' style='padding-top:10px;'>";
-				echo "<h1 style='flex:1;text-align:center;'>Access</h1>";
+				echo "<h1 style='flex:1;text-align:start;'>Access Database Editor</h1>";
 			?>
 			</div>
 			<div id='searchBarMobile' style='test-align:right;margin-bottom:15px;'>

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -610,7 +610,7 @@ function returnedDugga(data) {
 
 				/* Page title */
 				content += "<div class='titles' style='padding-top:10px;'>"
-						content += "<h1 style='flex:1;text-align:center;'>Tests</h1>"
+						content += "<h1 style='flex:1;text-align:start;'>Dugga Modifications Editor</h1>"
 				content += "</div>"
 
 		}

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -57,7 +57,7 @@ $codeLinkQuery->execute();
             </button>
         </div>
         <div class='titles' style='padding-top:10px;'>
-            <h1 style='flex:1;text-align:center;'>Files</h1>
+			<h1 style='flex:1;text-align:center;'>Files</h1>
         </div>
         <div style='display:flex;justify-content:space-between;align-items:flex-end;'>
             <div style='display:flex;flex-wrap:wrap;'>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -57,7 +57,7 @@ $codeLinkQuery->execute();
             </button>
         </div>
         <div class='titles' style='padding-top:10px;'>
-			<h1 style='flex:1;text-align:center;'>Files</h1>
+			<h1 style='flex:1;text-align:start;'>File Editor</h1>
         </div>
         <div style='display:flex;justify-content:space-between;align-items:flex-end;'>
             <div style='display:flex;flex-wrap:wrap;'>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -57,7 +57,7 @@ $codeLinkQuery->execute();
             </button>
         </div>
         <div class='titles' style='padding-top:10px;'>
-			<h1 style='flex:1;text-align:start;'>File Editor</h1>
+            <h1 style='flex:1;text-align:center;'>Files</h1>
         </div>
         <div style='display:flex;justify-content:space-between;align-items:flex-end;'>
             <div style='display:flex;flex-wrap:wrap;'>


### PR DESCRIPTION
The headings in fileed, duggaed and accessed have been positoned to the left and had their names changed to be consistent with other headings' positioning and naming conventions.


Co-Authored-By: a17pioja <a17pioja@users.noreply.github.com>
Co-Authored-By: a18ismca<a18ismca@users.noreply.github.com>