### PR TITLE
Changed the right margin of menu icon, fix for issue #7657

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -671,7 +671,7 @@ header td {
 }
 
 .navButt {
-  width: 32px;
+  width: 29px;
   vertical-align: middle;
   margin-top: 9px;
 }
@@ -779,7 +779,7 @@ div .navButt:hover {
 
 
 
-}
+
 
 /* --------------================################================-------------- *
  *                                   Dialog Box                                 *
@@ -3666,7 +3666,7 @@ table.navheader td.menuButton {
 }
 
 table.navheader div.menuButton {
-  margin-right: 10px;
+  margin-right: 8px;
   pointer-events: auto;
   display: inline-block;
   opacity: 1.0;

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -60,7 +60,7 @@
 							echo "    </div>";
 							echo "</td>";
 							
-							echo "<td class='newVers' style='display: inline-block;margin-right:2px;'>";
+							echo "<td class='newVers' style='display: inline-block;margin-right:16px;'>";
 							echo "    <div class='newVers menuButton'>";
               echo "      <img id='versionPlus' value='New version' class='navButt' title='Create a new version of this course' onclick='showCreateVersion();' src='../Shared/icons/PlusS.svg'>";
 							echo "    </div>";


### PR DESCRIPTION
Changed the right margin of menu icon so that there's a clearer difference to add clarity and separation.

Also made the icons slightly smaller.

![image](https://user-images.githubusercontent.com/49142028/79435114-8e43fe80-7fcf-11ea-9ba2-c12634954e0e.png)
