### PR TITLE
G1-2020-W17-ISSUE#7955

### DIFF
--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -200,8 +200,7 @@ function isOrderdList(item) {
 // CHeck if its a table
 function isTable(item) {
     // return true if space followed by a pipe-character and have closing pipe-character
-    //return /^\s*\|\s*(.*)\|/gm.test(item);
-    return false;
+    return /^\s*\|\s*(.*)\|/gm.test(item);
 }
 // The creation and destruction of lists
 function handleLists(currentLine, prevLine, nextLine) {


### PR DESCRIPTION
Removed commented out code so that markdown would recognize that a table is created.
![bild](https://user-images.githubusercontent.com/49142342/79441032-03670200-7fd7-11ea-8468-c4c75b3448de.png)
Alignment now works and it works together with lists (both unordered and ordered). It follows standard markdown syntax for tables.