### PR TITLE
G1 2020 w17 issue#8094

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -208,7 +208,7 @@ function returned(data) {
 			for (j = 0; j < important.length; j++) {
 				//Prevent important word spans to be created for HTML events.
 				if(htmlEventArray.includes(important[j])){
-					var sstr ="";
+					var sstr = important[j];
 				}else{
 					var sstr = "<span id='IWW' class='impword' onclick='popupDocumentation(\"" + important[j] + "\", \"unspecified\");' onmouseout='highlightKeyword(\"" + important[j] + "\")' onmouseover='highlightKeyword(\"" + important[j] + "\")'>" + important[j] + "</span>";
 				}

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -206,7 +206,12 @@ function returned(data) {
 			// Highlight important words
 			important = retData.impwords;
 			for (j = 0; j < important.length; j++) {
-				var sstr = "<span id='IWW' class='impword' onclick='popupDocumentation(\"" + important[j] + "\", \"unspecified\");' onmouseout='highlightKeyword(\"" + important[j] + "\")' onmouseover='highlightKeyword(\"" + important[j] + "\")'>" + important[j] + "</span>";
+				//Prevent important word spans to be created for HTML events.
+				if(htmlEventArray.includes(important[j])){
+					var sstr ="";
+				}else{
+					var sstr = "<span id='IWW' class='impword' onclick='popupDocumentation(\"" + important[j] + "\", \"unspecified\");' onmouseout='highlightKeyword(\"" + important[j] + "\")' onmouseover='highlightKeyword(\"" + important[j] + "\")'>" + important[j] + "</span>";
+				}
 				//Interpret asterisks in important word as literals and not as character with special meaning
 				if (important[j].indexOf('*') != -1) {
 					important[j] = important[j].replace(/\*/g, "&#42;");
@@ -882,6 +887,7 @@ function highlightHtml(otherTag, thisTag) {
 
 //Array containing HTML attributes. Needs to be filled with a complete list of attributes, the array contains only the most common ones for now.
 htmlAttrArray = new Array('action', 'class', 'disabled', 'href', 'id', 'rel', 'src', 'style', 'title', 'type');
+htmlEventArray = new Array('onclick', 'onmouseout', 'onmouseleave', 'onmouseover', 'onmouseenter','onload', 'onkeydown','onkeyup','onkeypress','oninput');
 
 //----------------------------------------------------------------------------------
 // 	popupDocumentation: Creates a pop-up window containing relevant documentation to a

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -206,12 +206,7 @@ function returned(data) {
 			// Highlight important words
 			important = retData.impwords;
 			for (j = 0; j < important.length; j++) {
-				//Prevent important word spans to be created for HTML events.
-				if(htmlEventArray.includes(important[j])){
-					var sstr ="";
-				}else{
-					var sstr = "<span id='IWW' class='impword' onclick='popupDocumentation(\"" + important[j] + "\", \"unspecified\");' onmouseout='highlightKeyword(\"" + important[j] + "\")' onmouseover='highlightKeyword(\"" + important[j] + "\")'>" + important[j] + "</span>";
-				}
+				var sstr = "<span id='IWW' class='impword' onclick='popupDocumentation(\"" + important[j] + "\", \"unspecified\");' onmouseout='highlightKeyword(\"" + important[j] + "\")' onmouseover='highlightKeyword(\"" + important[j] + "\")'>" + important[j] + "</span>";
 				//Interpret asterisks in important word as literals and not as character with special meaning
 				if (important[j].indexOf('*') != -1) {
 					important[j] = important[j].replace(/\*/g, "&#42;");
@@ -887,7 +882,6 @@ function highlightHtml(otherTag, thisTag) {
 
 //Array containing HTML attributes. Needs to be filled with a complete list of attributes, the array contains only the most common ones for now.
 htmlAttrArray = new Array('action', 'class', 'disabled', 'href', 'id', 'rel', 'src', 'style', 'title', 'type');
-htmlEventArray = new Array('onclick', 'onmouseout', 'onmouseleave', 'onmouseover', 'onmouseenter','onload', 'onkeydown','onkeyup','onkeypress','oninput');
 
 //----------------------------------------------------------------------------------
 // 	popupDocumentation: Creates a pop-up window containing relevant documentation to a


### PR DESCRIPTION
Fixed the bug with specific important words. Events will no longer be highlighted as important within document examples in codeviewer. 

Testing may be required since there is no popup redirecting to a google search when I click on an important word in a document example but when testing on a18wilis end this works. 

How to test: add for example "onclick" and "hello" (if your example contains the word hello) to the important word list. See issue #8094 