### PR TITLE
g1-2020-w17-issue#7955

### DIFF
--- a/DuggaSys/showdoc.php
+++ b/DuggaSys/showdoc.php
@@ -124,9 +124,8 @@
 
 		// Check if its a table
 		function isTable($item) {
-  			// return 1 if space followed by a pipe-character and have closing pipe-character
-        //return preg_match('/^\s*\|\s*(.*)\|/', $item);
-        return false; // disabled for now
+  		// return 1 if space followed by a pipe-character and have closing pipe-character
+        return preg_match('/^\s*\|\s*(.*)\|/', $item);
 		}
 
     // The creation and destruction of lists

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -200,8 +200,7 @@ function isOrderdList(item) {
 // CHeck if its a table
 function isTable(item) {
     // return true if space followed by a pipe-character and have closing pipe-character
-    //return /^\s*\|\s*(.*)\|/gm.test(item);
-    return false;
+    return /^\s*\|\s*(.*)\|/gm.test(item);
 }
 // The creation and destruction of lists
 function handleLists(currentLine, prevLine, nextLine) {


### PR DESCRIPTION
Removed commented out code so that markdown would recognize that a table is created.
![bild](https://user-images.githubusercontent.com/49142342/79443553-42e31d80-7fda-11ea-94cc-31843b27bc42.png)

Alignment now works and it works together with lists (both unordered and ordered). It follows standard markdown syntax for tables.