### PR TITLE
Close the "new course version" and "edit course version" windows with ESC button, fix for issue #7385

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -237,6 +237,12 @@ function showEditVersion() {
   $("#editCourseVersion").css("display", "flex");
 }
 
+document.addEventListener('keydown', function (event) {
+  if (event.key === 'Escape') {
+    $("#editCourseVersion").css("display", "none");
+  }
+})
+
 function displaymessage() {
   $(".messagebox").css("display", "block");
 }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -237,9 +237,11 @@ function showEditVersion() {
   $("#editCourseVersion").css("display", "flex");
 }
 
+// Close the "edit course version" and "new course version" windows by pressing the ESC button
 document.addEventListener('keydown', function (event) {
   if (event.key === 'Escape') {
     $("#editCourseVersion").css("display", "none");
+    $("#newCourseVersion").css("display", "none");
   }
 })
 


### PR DESCRIPTION
It is now possible to close the "new course version" and "edit course version" windows with the **ESC** button.

These buttons:
![image](https://user-images.githubusercontent.com/49142028/79456190-5d26f680-7fee-11ea-8081-0f14de10eeec.png)

And these windows:
![image](https://user-images.githubusercontent.com/49142028/79456218-66b05e80-7fee-11ea-9448-326564c790ae.png)

![image](https://user-images.githubusercontent.com/49142028/79456297-88a9e100-7fee-11ea-8e16-36abf8fb5369.png)


