### PR TITLE
Better explanations in options for UML line

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4133,6 +4133,19 @@ function loadAppearanceForm() {
     const object = selected_objects[selected_objects.length - 1];
     let type = object.symbolkind;
 
+    //Get objects connected to uml-line and sets name in appearance menu(used for Line direction)
+    var connectedObjectsArray = object.getConnectedObjects();
+    if(object.symbolkind == 7){
+        document.getElementById('First').innerHTML = connectedObjectsArray[0].name;
+        //Selection to check if relation is to the same entity. If so: both are named from object 0
+        if(typeof connectedObjectsArray[1] == "undefined"){
+            document.getElementById('Second').innerHTML =  connectedObjectsArray[0].name;
+        }
+        else{
+            document.getElementById('Second').innerHTML = connectedObjectsArray[1].name;
+        }
+    }
+
     //Undefined would mean the symbol is actually a path not having symbolKind, 0 is used as default for paths
     if(typeof type === "undefined") type = 0;
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -485,8 +485,8 @@
                     <div class="form-group" data-types="7">
                         <label for="lineDirection">Line direction:</label>
                         <select id="lineDirection" data-access="lineDirection">
-                            <option value="First">First object</option>
-                            <option value="Second">Second object</option>
+                            <option value="First" id="First">First object</option>
+                            <option value="Second" id = "Second">Second object</option>
                         </select>
                     </div>
                     <div class="form-group" data-types="4,7">


### PR DESCRIPTION
Fixes #7560 

First and second object in appearance menu for UML-lines/relations now shows the connected objects names instead of "First object, Second object".