### PR TITLE
G1 2020 w17 issue#8128

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -3062,6 +3062,8 @@ function resizeBoxes(parent, templateId) {
 //----------------------------------------------------------------------------------
 
 function alignBoxesWidth(boxValArray, boxNumBase, boxNumAlign) {
+   var box1 = document.querySelector('#box1');
+   var box2 = document.querySelector('#box2');
 	var remainWidth = boxValArray['parent']['width'] - $(boxValArray['box' + boxNumBase]['id']).width();
 
 	//Corrects bug that sets left property on boxNumAlign. Forces it to have left property turned off. Also forced a top property on boxNumBase.
@@ -3078,13 +3080,17 @@ function alignBoxesWidth(boxValArray, boxNumBase, boxNumAlign) {
 	boxValArray['box' + boxNumAlign]['width'] = remainWidthPer;
 		
 	// makes the element dissapear when certain treshold is met
-	if(basePer < 15) {
+	if(basePer < 15 && box1.className=='box codebox') {
 		document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
-	}else if (basePer > 85) {
+	}else if (basePer > 85 && box2.className=='box codebox') {
 		document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
 	} else {
+      if(box1.className=='box codebox') {
 		document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+	 }
+     if(box2.className=='box codebox') {
 		document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
+	 }
 	}
 }
 
@@ -3094,6 +3100,9 @@ function alignBoxesWidth(boxValArray, boxNumBase, boxNumAlign) {
 //----------------------------------------------------------------------------------
 
 function alignBoxesWidth3Boxes(boxValArray, boxNumBase, boxNumAlign, boxNumAlignSecond) {
+    var box1 = document.querySelector('#box1');
+    var box2 = document.querySelector('#box2');
+    var box3 = document.querySelector('#box3');
 	var remainWidth = boxValArray['parent']['width'] - $(boxValArray['box' + boxNumBase]['id']).width();
 	var remainWidthPer = (remainWidth / boxValArray['parent']['width']) * 100;
 	var basePer = 100 - remainWidthPer;
@@ -3110,15 +3119,22 @@ function alignBoxesWidth3Boxes(boxValArray, boxNumBase, boxNumAlign, boxNumAlign
 	boxValArray['box' + boxNumAlignSecond]['width'] = $(boxValArray['box' + boxNumAlignSecond]['id']).width();
 
 	// makes the element dissapear when certain treshold is met
-	if(basePer < 15) {
+	if(basePer < 15 && box1.className=='box codebox') {
 		document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
-	}else if (basePer > 85) {
+	}else if (basePer > 85 && box2.className=='box codebox') {
 		document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
-	} else {
+	}else if (basePer > 85 && box3.className=='box codebox') {
+        document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
+	}else {
+      if(box1.className=='box codebox') {
 		document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+	 }
+     if(box2.className=='box codebox') {
 		document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
+	 }
+     if(box3.className=='box codebox') {
+        document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
+	 }
 	}
 }
 

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -816,6 +816,7 @@ function createboxmenu(contentid, boxid, type) {
 		if (type == "CODE") {
 			str += "<td class='butto2 copybutton' id='copyClipboard' title='Copy to clipboard' onclick='copyCodeToClipboard(" + boxid + ");' ><img id='copyIcon' src='../Shared/icons/Copy.svg' /></td>";
 		}
+		
 
 		str += '</tr></table>';
 		boxmenu.innerHTML = str;
@@ -2238,24 +2239,23 @@ function minimizeBoxes(boxid) {
 	var parentDiv = document.getElementById("div2");
 	var boxValArray = initResizableBoxValues(parentDiv);
 	var templateid = retData['templateid'];
-	document.querySelector('#box'+boxid+'wrapper #copyClipboard').style.display = 'none';
 
 	getLocalStorageProperties(boxValArray);
 
 	//For template 1
 	if (templateid == 1) {
 		if (boxid == 1) {
-			$(boxValArray['box' + 2]['id']).width("0%");
+			$(boxValArray['box' + 2]['id']).width("100%");
 
 			$(boxValArray['box' + boxid]['id']).width("0%");
 			alignBoxesWidth(boxValArray, 1, 2);
 		}
 
 		if (boxid == 2) {
-			$(boxValArray['box' + 1]['id']).width("0%");
+			$(boxValArray['box' + 1]['id']).width("100%");
 
 			$(boxValArray['box' + boxid]['id']).width("0%");
-			alignBoxesWidth(boxValArray, 2, 1);
+			alignBoxesWidth(boxValArray, 1, 2);
 		}
 	}
 	//for template 2
@@ -2356,7 +2356,7 @@ function maximizeBoxes(boxid) {
 			$(boxValArray['box' + 1]['id']).width("0%");
 
 			$(boxValArray['box' + boxid]['id']).width("100%");
-			alignBoxesWidth(boxValArray, 2, 1);
+			alignBoxesWidth(boxValArray, 1, 2);
 		}
 	}
 
@@ -2657,7 +2657,7 @@ function hideMaximizeAndResetButton() {
 	}
 }
 
-//hide maximizeButton
+//hide minimizeButton
 function hideMinimizeButton() {
 	var templateid = retData['templateid'];
 	if (templateid > 2) {
@@ -3062,35 +3062,43 @@ function resizeBoxes(parent, templateId) {
 //----------------------------------------------------------------------------------
 
 function alignBoxesWidth(boxValArray, boxNumBase, boxNumAlign) {
-   var box1 = document.querySelector('#box1');
-   var box2 = document.querySelector('#box2');
 	var remainWidth = boxValArray['parent']['width'] - $(boxValArray['box' + boxNumBase]['id']).width();
-
 	//Corrects bug that sets left property on boxNumAlign. Forces it to have left property turned off. Also forced a top property on boxNumBase.
 	$(boxValArray['box' + boxNumAlign]['id']).css("left", "");
 	$(boxValArray['box' + boxNumBase]['id']).css("top", " ");
 
 	var remainWidthPer = (remainWidth / boxValArray['parent']['width']) * 100;
 	var basePer = 100 - remainWidthPer;
-
 	$(boxValArray['box' + boxNumBase]['id']).width(basePer + "%");
 	$(boxValArray['box' + boxNumAlign]['id']).width(remainWidthPer + "%");
 
 	boxValArray['box' + boxNumBase]['width'] = basePer;
 	boxValArray['box' + boxNumAlign]['width'] = remainWidthPer;
-		
 	// makes the element dissapear when certain treshold is met
-	if(basePer < 15 && box1.className=='box codebox') {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
-	}else if (basePer > 85 && box2.className=='box codebox') {
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
-	} else {
-      if(box1.className=='box codebox') {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
-	 }
-     if(box2.className=='box codebox') {
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
-	 }
+	if (basePer < 15) {
+		
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
+		}
+		
+	}else if (basePer > 85) {
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+		}
+		
+	}else {
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
+		}
 	}
 }
 
@@ -3100,9 +3108,6 @@ function alignBoxesWidth(boxValArray, boxNumBase, boxNumAlign) {
 //----------------------------------------------------------------------------------
 
 function alignBoxesWidth3Boxes(boxValArray, boxNumBase, boxNumAlign, boxNumAlignSecond) {
-    var box1 = document.querySelector('#box1');
-    var box2 = document.querySelector('#box2');
-    var box3 = document.querySelector('#box3');
 	var remainWidth = boxValArray['parent']['width'] - $(boxValArray['box' + boxNumBase]['id']).width();
 	var remainWidthPer = (remainWidth / boxValArray['parent']['width']) * 100;
 	var basePer = 100 - remainWidthPer;
@@ -3119,22 +3124,27 @@ function alignBoxesWidth3Boxes(boxValArray, boxNumBase, boxNumAlign, boxNumAlign
 	boxValArray['box' + boxNumAlignSecond]['width'] = $(boxValArray['box' + boxNumAlignSecond]['id']).width();
 
 	// makes the element dissapear when certain treshold is met
-	if(basePer < 15 && box1.className=='box codebox') {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
-	}else if (basePer > 85 && box2.className=='box codebox') {
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
-	}else if (basePer > 85 && box3.className=='box codebox') {
-        document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
-	}else {
-      if(box1.className=='box codebox') {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
-	 }
-     if(box2.className=='box codebox') {
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
-	 }
-     if(box3.className=='box codebox') {
-        document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
-	 }
+	if(basePer < 15) {
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		}
+	}else if (basePer > 85) {
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
+		}
+	} else {
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
+		}
 	}
 }
 
@@ -3155,14 +3165,26 @@ function alignBoxesWidthTemplate8(boxValArray, boxNumBase, boxNumAlign, boxNumAl
 
 	// makes the element dissapear when certain treshold is met
 	if(basePer < 15) {
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
+		}
 	}else if (basePer > 85) {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		}
 	} else {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
+		}
 	}
 }
 
@@ -3253,16 +3275,32 @@ function alignWidth4boxes(boxValArray, boxNumBase, boxNumAlign, boxNumAlignSecon
 
 	// makes the element dissapear when certain treshold is met
 	if(basePer < 15) {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		}
 	}else if (basePer > 85) {
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box4wrapper #copyClipboard').style.display = 'none';
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box4').className == 'box codebox'){
+			document.querySelector('#box4wrapper #copyClipboard').style.display = 'none';
+		}
 	} else {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box4wrapper #copyClipboard').style.display = 'block';
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box4').className == 'box codebox'){
+			document.querySelector('#box4wrapper #copyClipboard').style.display = 'block';
+		}
 	}
 }
 
@@ -3293,16 +3331,32 @@ function alignWidthTemplate7(boxValArray, boxNumBase, boxNumAlign, boxNumAlignSe
 
 	// makes the element dissapear when certain treshold is met
 	if(basePer > 85) {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		}
 	}else if (basePer < 15) {
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box4wrapper #copyClipboard').style.display = 'none';
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box4').className == 'box codebox'){
+			document.querySelector('#box4wrapper #copyClipboard').style.display = 'none';
+		}
 	} else {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box4wrapper #copyClipboard').style.display = 'block';
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box4').className == 'box codebox'){
+			document.querySelector('#box4wrapper #copyClipboard').style.display = 'block';
+		}
 	}
 }
 
@@ -3406,18 +3460,38 @@ function alignTemplate9Width(boxValArray, boxOne, boxTwo, boxThree, boxFour, box
 
 	// makes the element dissapear when certain treshold is met
 	if(basePer < 15) {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'none';
+		}
 	}else if (basePer > 85) {
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box4wrapper #copyClipboard').style.display = 'none';
-		document.querySelector('#box5wrapper #copyClipboard').style.display = 'none';
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box4').className == 'box codebox'){
+			document.querySelector('#box4wrapper #copyClipboard').style.display = 'none';
+		}
+		if(document.querySelector('#box5').className == 'box codebox'){
+			document.querySelector('#box5wrapper #copyClipboard').style.display = 'none';
+		}
 	} else {
-		document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box4wrapper #copyClipboard').style.display = 'block';
-		document.querySelector('#box5wrapper #copyClipboard').style.display = 'block';
+		if(document.querySelector('#box1').className == 'box codebox'){
+			document.querySelector('#box1wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box2').className == 'box codebox'){
+			document.querySelector('#box2wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box3').className == 'box codebox'){
+			document.querySelector('#box3wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box4').className == 'box codebox'){
+			document.querySelector('#box4wrapper #copyClipboard').style.display = 'block';
+		}
+		if(document.querySelector('#box5').className == 'box codebox'){
+			document.querySelector('#box5wrapper #copyClipboard').style.display = 'block';
+		}
 	}
 }
 


### PR DESCRIPTION
Windows can now be resized at all times(I expect) and no errors are thrown either. Error was caused by the AlignBoxesWidth function that tried to hide/show a Clipboard button even when the box didn't have one, which then caused the error and probihited the windows from resizing.

Now the code checks if the box is a codebox(has a Clipboard), before trying to hide/show the Clipboard.