### PR TITLE
Fixes #8200 - Move button active when not in move mode

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -381,7 +381,10 @@ function resetToolButtonsPressed() {
     // deselect draw text button
     document.getElementById("drawtextbutton").classList.remove("pressed");
     document.getElementById("drawtextbutton").classList.add("unpressed");
-    uimode = 'normal';
+
+    if(uimode !== "MoveAround") {
+        uimode = 'normal';
+    }
 }
 
 //--------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -360,27 +360,11 @@ function resetButtonsPressed() {
 //--------------------------------------------------------------------
 
 function resetToolButtonsPressed() {
-    // deselect attribute button
-    document.getElementById("attributebutton").classList.remove("pressed");
-    document.getElementById("attributebutton").classList.add("unpressed");
-    // deselect entity button
-    document.getElementById("entitybutton").classList.remove("pressed");
-    document.getElementById("entitybutton").classList.add("unpressed");
-    // deselect relation button
-    document.getElementById("relationbutton").classList.remove("pressed");
-    document.getElementById("relationbutton").classList.add("unpressed");
-    // deselect class button
-    document.getElementById("classbutton").classList.remove("pressed");
-    document.getElementById("classbutton").classList.add("unpressed");
-    // deselect line button
-    document.getElementById("linebutton").classList.remove("pressed");
-    document.getElementById("linebutton").classList.add("unpressed");
-    // deselect draw free button
-    document.getElementById("drawfreebutton").classList.remove("pressed");
-    document.getElementById("drawfreebutton").classList.add("unpressed");
-    // deselect draw text button
-    document.getElementById("drawtextbutton").classList.remove("pressed");
-    document.getElementById("drawtextbutton").classList.add("unpressed");
+    const elementsToReset = document.querySelectorAll(".pressed:not(#moveButton)");
+    elementsToReset.forEach(element => {
+        element.classList.remove("pressed");
+        element.classList.add("unpressed");
+    });
 
     if(uimode !== "MoveAround") {
         uimode = 'normal';


### PR DESCRIPTION
Test if move button can be visible when not being in move mode by activating move mode, switching to a different diagram mode (UML, ER or DEV) and see if you will still be in move mode with the button visible (success) or if you will be in normal mode with the button visible (fail).

Also minimized related code that was repetetive to look much cleaner.

Link: http://group4.webug.his.se:20001/G4-2020-W17-ISSUE%238200/DuggaSys/diagram.php