### PR TITLE
added function for toggling visibility of FAB-button in Dugga Editor

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -924,6 +924,19 @@ $(document).mouseout(function (e) {
 	FABMouseOut(e);
 });
 
+document.addEventListener('keydown', function(e) {
+	var element = document.getElementById('fabButtonAcc');
+	if(e.keyCode === 17){
+		if(window.getComputedStyle(element, null).getPropertyValue("opacity") != "1"){
+			element.style.opacity = "1";
+			element.style.pointerEvents = "auto";
+		}else{
+			element.style.opacity = "0.3";
+			element.style.pointerEvents = "none";
+		}	
+	}
+});
+
 $(document).mousedown(function (e) {
 	mouseDown(e);
 


### PR DESCRIPTION
Adds functionality for toggling visibility and actions of FAB-button which means the user can now click "through" the FAB-button when it is in low visibility-mode (see screenshot). This currently only affects the Dugga Editor. 

**Note:** to test this you will need to add "&cid=2" (the 2 should be whichever course you're currently viewing). Otherwise the table content will not be loaded (this is being fixed with another pull request).

This is currently toggled using the Ctrl-button. Since Ctrl is used for many global actions (Copying, Pasting etc) it's possible the keyCode used should be changed to decrease confusion (currently the visibility is toggled when copying or pasting something on the page).

Tested in Chrome and Firefox during development. There is no info to the user that this is a possible action, maybe a separate issue should be opened regarding this.

If similar functionality is wanted for other pages using a FAB-button a separate issue should be opened and a more general solution should be implemented (discarding this code).

![image](https://user-images.githubusercontent.com/49141758/79547105-bb59e500-8093-11ea-9888-9bea51763bf9.png)
