### PR TITLE
Redesign of sub-heading on fileed page, fixes issue #8172

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -57,7 +57,7 @@ $codeLinkQuery->execute();
             </button>
         </div>
         <div class='titles' style='padding-top:10px;'>
-			<h1 style='flex:1;text-align:center;'>Files</h1>
+			<h1 style='flex:1;text-align:left;margin-left:15px;'>Files</h1>
         </div>
         <div style='display:flex;justify-content:space-between;align-items:flex-end;'>
             <div style='display:flex;flex-wrap:wrap;'>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -57,7 +57,7 @@ $codeLinkQuery->execute();
             </button>
         </div>
         <div class='titles' style='padding-top:10px;'>
-			<h1 style='flex:1;text-align:left;margin-left:15px;'>Files</h1>
+			<h1 style='flex:1;text-align:left;margin-left:15px;'>Edit files</h1>
         </div>
         <div style='display:flex;justify-content:space-between;align-items:flex-end;'>
             <div style='display:flex;flex-wrap:wrap;'>


### PR DESCRIPTION

The sub-heading on fileed has been changed from "Files" to "Edit files". Its position has been changed from center-align to left-align, with some margin to the left.

![image](https://user-images.githubusercontent.com/49142028/79549246-06292c00-8097-11ea-95e1-5d85eb225e40.png)