### PR TITLE
Added basic service logging for diagramservice and highscoreservice.php - G1-2020-W17-ISSUE#8213

### DIFF
--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -21,13 +21,8 @@ $debug="NONE!";
 $log_db = new PDO('sqlite:../../GHData/GHdata_2019_10.db');
 
 $opt = getOP('opt');
+$courseid=getOP('courseid');
 $coursename=getOP('coursename');
-$visibility=getOP('visib');
-$versid=getOP('versid');
-
-$log_uuid = getOP('log_uuid');
-$info=$opt." ".$cid." ".$coursename." ".$versid." ".$visibility;
-logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "contributionservice.php",$userid,$info);
 
 $allusers=array();
 $allrowranks=array();
@@ -73,6 +68,10 @@ if(strcmp($opt,"get")==0) {
 		$lastname="UNK";
 		$firstname="UNK";
 	}
+
+	$log_uuid = getOP('log_uuid');
+	$info=$opt." ".$courseid." ".$coursename;
+	logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "contributionservice.php",$userid,$info);
 
 	//$debug=print_r($_SESSION,true);
 

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -15,11 +15,19 @@ session_start();
 $cid=$_SESSION['courseid'];
 $vers=$_SESSION['coursevers'];
 
+
 $debug="NONE!";
 
 $log_db = new PDO('sqlite:../../GHData/GHdata_2019_10.db');
 
 $opt = getOP('opt');
+$coursename=getOP('coursename');
+$visibility=getOP('visib');
+$versid=getOP('versid');
+
+$log_uuid = getOP('log_uuid');
+$info=$opt." ".$cid." ".$coursename." ".$versid." ".$visibility;
+logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "courseedservice.php",$userid,$info);
 
 $allusers=array();
 $allrowranks=array();
@@ -631,4 +639,7 @@ if(strcmp($opt,"get")==0) {
 	);
 	echo json_encode($array);
 }
+
+logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "courseedservice.php",$userid,$info);
+
 ?>

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -27,7 +27,7 @@ $versid=getOP('versid');
 
 $log_uuid = getOP('log_uuid');
 $info=$opt." ".$cid." ".$coursename." ".$versid." ".$visibility;
-logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "courseedservice.php",$userid,$info);
+logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "contributionservice.php",$userid,$info);
 
 $allusers=array();
 $allrowranks=array();
@@ -640,6 +640,6 @@ if(strcmp($opt,"get")==0) {
 	echo json_encode($array);
 }
 
-logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "courseedservice.php",$userid,$info);
+logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "contributionservice.php",$userid,$info);
 
 ?>

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -69,9 +69,9 @@ if(strcmp($opt,"get")==0) {
 		$firstname="UNK";
 	}
 
-	$log_uuid = getOP('log_uuid');
-	$info=$opt." ".$courseid." ".$coursename;
-	logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "contributionservice.php",$userid,$info);
+	// $log_uuid = getOP('log_uuid');
+	// $info=$opt." ".$courseid." ".$coursename;
+	// logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "contributionservice.php",$userid,$info);
 
 	//$debug=print_r($_SESSION,true);
 

--- a/DuggaSys/diagramservice.php
+++ b/DuggaSys/diagramservice.php
@@ -25,15 +25,13 @@
         $firstname = "UNK";
     }
 
-    $cid=$_SESSION['courseid'];
-    
     $opt = getOP('opt');
+    $courseid=getOP('courseid');
     $coursename=getOP('coursename');
-    $visibility=getOP('visib');
-    $versid=getOP('versid');
+   
 
     $log_uuid = getOP('log_uuid');
-    $info=$opt." ".$cid." ".$coursename." ".$versid." ".$visibility;
+    $info=$opt." ".$courseid." ".$coursename;
     logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "diagramservice.php",$userid,$info);
 
     $log_db = new PDO('sqlite:../../GHdataD.db');

--- a/DuggaSys/diagramservice.php
+++ b/DuggaSys/diagramservice.php
@@ -24,6 +24,9 @@
         $lastname = "UNK";
         $firstname = "UNK";
     }
+
+    
+
     $log_db = new PDO('sqlite:../../GHdataD.db');
     $gituser = $loginname;
     $startweek = strtotime('2015-03-29');                                   // First monday in january

--- a/DuggaSys/diagramservice.php
+++ b/DuggaSys/diagramservice.php
@@ -25,7 +25,16 @@
         $firstname = "UNK";
     }
 
+    $cid=$_SESSION['courseid'];
     
+    $opt = getOP('opt');
+    $coursename=getOP('coursename');
+    $visibility=getOP('visib');
+    $versid=getOP('versid');
+
+    $log_uuid = getOP('log_uuid');
+    $info=$opt." ".$cid." ".$coursename." ".$versid." ".$visibility;
+    logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "diagramservice.php",$userid,$info);
 
     $log_db = new PDO('sqlite:../../GHdataD.db');
     $gituser = $loginname;
@@ -100,4 +109,6 @@
     } while ($weekno < 11);
     $array = array('debug' => $debug, 'weeks' => $weeks);
     echo json_encode($array);
+
+    logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "diagramservice.php",$userid,$info);
 ?>

--- a/DuggaSys/highscoreservice.php
+++ b/DuggaSys/highscoreservice.php
@@ -20,14 +20,20 @@ if(isset($_SESSION['uid'])){
 	$userid="1";		
 } 
 
+
 $opt=getOP('opt');
 $courseid=getOP('courseid');
+$coursename=getOP('coursename');
 $coursevers=getOP('coursevers');
 $duggaid=getOP('did');
 $variant=getOP('lid');
 $moment=getOP('moment');
 
 $debug="NONE!";	
+
+$log_uuid = getOP('log_uuid');
+$info=$opt." ".$courseid." ".$coursename;
+logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "highscoreservice.php",$userid,$info);
 
 //------------------------------------------------------------------------------------------------
 // Services
@@ -98,5 +104,7 @@ $array = array(
 );
 
 echo json_encode($array);
+
+logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "highscoreservice.php",$userid,$info);
 ?>
  


### PR DESCRIPTION
Result from using the service: 

![Screenshot 2020-04-17 at 12 04 45](https://user-images.githubusercontent.com/62876614/79557940-b4d36980-80a3-11ea-8124-e4a2228f2cb6.png)
![Screenshot 2020-04-17 at 12 04 54](https://user-images.githubusercontent.com/62876614/79557954-ba30b400-80a3-11ea-9cb3-d0c5e45b51e8.png)

How to test:
Download https://sqlitebrowser.org/dl/

Choose open database
![Screenshot 2020-04-17 at 12 08 08](https://user-images.githubusercontent.com/62876614/79558244-23182c00-80a4-11ea-87f3-2cd1147def6c.png)

Open the db file located in the log dir
![Screenshot 2020-04-17 at 12 07 14](https://user-images.githubusercontent.com/62876614/79558338-417e2780-80a4-11ea-9a02-7524b8e0ad53.png)
![Screenshot 2020-04-17 at 12 07 25](https://user-images.githubusercontent.com/62876614/79558345-4511ae80-80a4-11ea-9746-817755b62e7e.png)

Run services mentioned in the pull request:
![Screenshot 2020-04-17 at 12 10 37](https://user-images.githubusercontent.com/62876614/79558456-77bba700-80a4-11ea-91fc-854d6f2354f0.png)
![Screenshot 2020-04-21 at 10 58 27](https://user-images.githubusercontent.com/62876614/79846771-1efb4f80-83bf-11ea-9d70-9b9b0e258a4d.png)


then look up the result in table:
![Screenshot 2020-04-17 at 12 12 38](https://user-images.githubusercontent.com/62876614/79558634-bfdac980-80a4-11ea-9395-a1213c8c7eb6.png)

co authored with @a18jakme 

