### PR TITLE
The text is no longer cut off.

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3128,7 +3128,8 @@ span.arrow {
 }
 
 .checknarrow {
-  max-width: 140px !important;
+  width: 280px;
+  max-width: 280px !important;
   min-width: 140px !important;
 }
 


### PR DESCRIPTION
![bild](https://user-images.githubusercontent.com/46450106/79559470-17c60000-80a6-11ea-9c0e-73c8b0fe9cb3.png)

