### PR TITLE
New dummy icon for "dummy empty files", fixes issue #7856

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -260,7 +260,7 @@ $codeLinkQuery->execute();
     <ol class="fab-btn-list" style="margin: 0; padding: 0; display: none;" reversed id='fab-btn-list'>
         <li onclick="showFilePopUp('EFILE');">
             <a id="emptyFabBtn" class="btn-floating fab-btn-sm scale-transition scale-out" data-tooltip='Add Dummy Empty File'>
-                <img id="emptyFabBtnImg" class="fab-icon" src="../Shared/icons/.....">
+                <img id="emptyFabBtnImg" class="fab-icon" src="../Shared/icons/dummy_icon.svg">
             </a>
         </li>   
         <li onclick="showFilePopUp('GFILE');" >

--- a/Shared/icons/dummy_icon.svg
+++ b/Shared/icons/dummy_icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 400 400" style="enable-background:new 0 0 400 400;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:35;stroke-miterlimit:10;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M327,137.4v73.9"/>
+<path class="st0" d="M327,211.2v122.3c0.1,13.3-10,24.1-22.4,24.1H112.2c-12.5,0-22.4-10.8-22.4-24v-248c0-13.1,10.2-24,22.4-24
+	l157.2-1.9"/>
+<path class="st1" d="M244.9,64l24-21.9c0.1-0.1,0.4-0.1,0.5,0l74.9,94.5c0.2,0.3,0.2,0.8,0.1,1.2l-6.3,35.5c0,0.3-0.4,0.4-0.6,0.2
+	l-92.8-109C244.8,64.3,244.8,64.1,244.9,64z"/>
+<rect x="238" y="61.5" class="st1" width="19" height="17.2"/>
+<path class="st0" d="M324.2,177.7h-91.4c-4.2,0-7.5-3.3-7.5-7.5V74.5"/>
+</svg>


### PR DESCRIPTION
There is now a new icon for add "dummy empty files" fab button in fileed.

![image](https://user-images.githubusercontent.com/49142028/79564073-421bbb80-80ae-11ea-967f-09e59ced6c2c.png)
