### PR TITLE
Added event-documentation to PopupDocumentation

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -885,7 +885,7 @@ function highlightHtml(otherTag, thisTag) {
 	document.getElementById(thisTag).classList.toggle("html");
 }	
 
-//Array containing HTML attributes. Needs to be filled with a complete list of attributes, the array contains only the most common ones for now.
+//Arrays containing HTML attributes and event-attributes. Needs to be filled with a complete list of attributes, the array contains only the most common ones for now.
 htmlAttrArray = new Array('action', 'class', 'disabled', 'href', 'id', 'rel', 'src', 'style', 'title', 'type');
 htmlEventArray = new Array('onclick', 'onmouseout', 'onmouseleave', 'onmouseover', 'onmouseenter','onload', 'onkeydown','onkeyup','onkeypress','oninput');
 
@@ -917,6 +917,8 @@ function popupDocumentation(id, lang) {
 	}else if(lang == "multi"){
 		if(htmlAttrArray.includes(id)){
 			url = "https://www.w3schools.com/tags/att_"+id+".asp";
+		}else if(htmlEventArray.includes(id)){
+			url = "https://www.w3schools.com/tags/ev_"+id+".asp";
 		}else{
 			url = "https://www.php.net/results.php?q="+id+"&l=en&p=all";
 		}


### PR DESCRIPTION
Added relevant documentation to popup-windows for when users click on
highlighted HTML-events.

Test by uploading/editing a .html-file to contain a HTML-event (e.g. <div onclick="test">). Add a HTML-event to the important word list (Must be an event that exists within "HtmlEventArray" in codeviewer.js in order to work) and then click on the event. A popup should appear which displays a page containing information about the event.

Co-Authored-By: a18geoge <a18geoge@users.noreply.github.com>