### PR TITLE
#8203 Fix - Update dugga.js

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -330,7 +330,7 @@ function removeYearFromDate(date){
 
 function setExpireCookie(){
     if(localStorage.getItem("securityquestion") == "set") {
-				const expireDate = new Date();
+				var expireDate = new Date();
 				// A test date so you dont have to actually wait 1 hour and 45 minutes.
 				// Don't forget to change the one below (setExpireCookieLogOut()) too.
 				//expireDate.setMinutes(expireDate.getMinutes() + 1);	// For testing
@@ -345,7 +345,7 @@ function setExpireCookie(){
 
 function setExpireCookieLogOut() {
     if (localStorage.getItem("securityquestion") == "set") {
-				const expireDate = new Date();
+				var expireDate = new Date();
 				//expireDate.setMinutes(expireDate.getMinutes() + 2);	// For testing
 				expireDate.setMinutes(expireDate.getMinutes() + 120);	// For actual use
         document.cookie = "sessionEndTimeLogOut=expireC; expires=" + expireDate.toUTCString() + "; path=/";

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -330,11 +330,12 @@ function removeYearFromDate(date){
 
 function setExpireCookie(){
     if(localStorage.getItem("securityquestion") == "set") {
-				var expireDate = new Date();
-				// a test date so you dont have to actually wait 1 hour and 45 minutes
-				//expireDate.setMinutes(expireDate.getMinutes() + 1);
-				expireDate.setMinutes(expireDate.getMinutes() + 105);
-        document.cookie = "sessionEndTime=expireC; expires=" + expireDate.toGMTString() + "; path=/";
+				const expireDate = new Date();
+				// A test date so you dont have to actually wait 1 hour and 45 minutes.
+				// Don't forget to change the one below (setExpireCookieLogOut()) too.
+				//expireDate.setMinutes(expireDate.getMinutes() + 1);	// For testing
+				expireDate.setMinutes(expireDate.getMinutes() + 105);	// For actual use
+        document.cookie = "sessionEndTime=expireC; expires=" + expireDate.toUTCString() + "; path=/";
     }
 }
 
@@ -344,11 +345,10 @@ function setExpireCookie(){
 
 function setExpireCookieLogOut() {
     if (localStorage.getItem("securityquestion") == "set") {
-				var expireDate = new Date();
-				// test date
-				//expireDate.setMinutes(expireDate.getMinutes() + 2);
-				expireDate.setMinutes(expireDate.getMinutes() + 120);
-        document.cookie = "sessionEndTimeLogOut=expireC; expires=" + expireDate.toGMTString() + "; path=/";
+				const expireDate = new Date();
+				//expireDate.setMinutes(expireDate.getMinutes() + 2);	// For testing
+				expireDate.setMinutes(expireDate.getMinutes() + 120);	// For actual use
+        document.cookie = "sessionEndTimeLogOut=expireC; expires=" + expireDate.toUTCString() + "; path=/";
     }
 }
 


### PR DESCRIPTION
First and foremost it solves issue #8203 

It also changes the variable `expireDate` in both functions `setExpireCookie` and `setExpireCookieLogOut` to a constant. Plus some minor changes to the comments.

To test this one change the following lines in `dugga.js` to the following: 
<img width="709" alt="Skärmavbild 2020-04-17 kl  13 58 04" src="https://user-images.githubusercontent.com/62876260/79566874-8bbad500-80b3-11ea-9700-e92965cac9ce.png">
<img width="709" alt="Skärmavbild 2020-04-17 kl  13 58 23" src="https://user-images.githubusercontent.com/62876260/79566883-8fe6f280-80b3-11ea-9220-133125b4d4d7.png">

I had some minor issues testing this on my browser. You might have to:
- Clear the cache
- Restart the server
- Reinstall LenaSYS (after making changes to dugga.js)