### PR TITLE
No longer opens two dropdowns #8099

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1219,6 +1219,23 @@ function initializeCanvas() {
     canvas.addEventListener('touchstart', mousedownevt, false);
     canvas.addEventListener('touchend', mouseupevt, false);
     canvas.addEventListener('wheel', scrollZoom, false);
+
+    var dropDowns = document.getElementsByClassName("drop-down-label");
+    var i;
+    for (i = 0; i < dropDowns.length; i++) {
+        dropDowns[i].addEventListener("mouseover", clearActiveDropdownElement);
+    }
+}
+
+//--------------------------------------------------------------------
+// Clears the active element when hovering dropdown menus
+//--------------------------------------------------------------------
+
+function clearActiveDropdownElement(){
+    if (document.activeElement.className.match("menu-drop-down") || 
+    document.activeElement.className.match("drop-down-item")) {
+        document.activeElement.blur();
+    }
 }
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
Deselects the active element when hovering another dropdown so it doesn't stay open, meaning you can't click one and hover another to have two open at the same time.
See issue for picture of overlap.