### PR TITLE
Resulted: Fixed minor styling issues and made functions for dropdowns.

### DIFF
--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -348,9 +348,9 @@ function SortableTable(param) {
 		
 		// Add Column for counter if the sortabletable should have a counter column.
 		if (this.hasCounter) {
-			str += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='counter" + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "'></th>";
-			mhstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='counter" + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'></th>";
-			mhfstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='counter" + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'></th>";
+			str += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='counter" + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "'></th>";
+			mhstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='counter" + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'></th>";
+			mhfstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='counter" + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'></th>";
 		}
 		for (var columnOrderIdx = 0; columnOrderIdx < columnOrder.length; columnOrderIdx++) {
 			var colname = columnOrder[columnOrderIdx];
@@ -360,31 +360,31 @@ function SortableTable(param) {
 				if (renderSortOptions !== null) {
 					if (columnOrderIdx < freezePaneIndex) {
 						if (colname == sortcolumn) {
-							mhfstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'>" + renderSortOptions(colname, sortkind, col) + "</th>";
+							mhfstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'>" + renderSortOptions(colname, sortkind, col) + "</th>";
 						} else {
-							mhfstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'>" + renderSortOptions(colname, -1, col) + "</th>";
+							mhfstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'>" + renderSortOptions(colname, -1, col) + "</th>";
 						}
 					}
 					if (colname == sortcolumn) {
-						str += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "'>" + renderSortOptions(colname, sortkind, col) + "</th>";
-						mhstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'>" + renderSortOptions(colname, sortkind, col) + "</th>";
+						str += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "'>" + renderSortOptions(colname, sortkind, col) + "</th>";
+						mhstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'>" + renderSortOptions(colname, sortkind, col) + "</th>";
 					} else {
-						str += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "' onmouseover='showFullHeaderDrop(this);' onmouseleave='removeFullHeaderDrop(this)'>" + renderSortOptions(colname, -1, col) + "</th>";
+						str += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "' onmouseover='showFullHeaderDrop(this);' onmouseleave='removeFullHeaderDrop(this)'>" + renderSortOptions(colname, -1, col) + "</th>";
 						str += "<div id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl_dropdown' style='display: none; background-color: white; padding: 10px;'>" + col + "</div>"; // Dropdown that shows the name of the column.
-						mhstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'>" + renderSortOptions(colname, -1, col) + "</th>";
+						mhstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'>" + renderSortOptions(colname, -1, col) + "</th>";
 					}
 				} else {
 					if (columnOrderIdx < freezePaneIndex) {
 						if (colname == sortcolumn) {
-							mhfstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'>" + col + "</th>";
+							mhfstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'>" + col + "</th>";
 						} else {
-							mhfstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'>" + col + "</th>";
-							mhvstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhv' class='" + this.tableid + "'>" + col + "</th>";
+							mhfstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhf' class='" + this.tableid + "'>" + col + "</th>";
+							mhvstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mhv' class='" + this.tableid + "'>" + col + "</th>";
 						}
 					}
 					if (col != "move") {
-						str += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "'>" + col + "</th>";
-						mhstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'>" + col + "</th>";
+						str += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "'>" + col + "</th>";
+						mhstr += "<th style='max-width:200px;min-width:150px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'>" + col + "</th>";
 					}
 				}
 			}

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -369,7 +369,8 @@ function SortableTable(param) {
 						str += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "'>" + renderSortOptions(colname, sortkind, col) + "</th>";
 						mhstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'>" + renderSortOptions(colname, sortkind, col) + "</th>";
 					} else {
-						str += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "'>" + renderSortOptions(colname, -1, col) + "</th>";
+						str += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl' class='" + this.tableid + "' onmouseover='showFullHeaderDrop(this);' onmouseleave='removeFullHeaderDrop(this)'>" + renderSortOptions(colname, -1, col) + "</th>";
+						str += "<div id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl_dropdown' style='display: none; background-color: white; padding: 10px;'>" + col + "</div>"; // Dropdown that shows the name of the column.
 						mhstr += "<th style='max-width:200px;text-overflow: ellipsis;overflow: hidden;' id='" + colname + DELIMITER + this.tableid + DELIMITER + "tbl" + DELIMITER + "mh' class='" + this.tableid + "'>" + renderSortOptions(colname, -1, col) + "</th>";
 					}
 				} else {
@@ -776,6 +777,21 @@ function SortableTable(param) {
 	}
 }
 
+// Shows the tableheads full column name dropdown and positions it below the selected column.
+function showFullHeaderDrop(element) {
+	var dropdown = document.getElementById(element.id + "_dropdown");
+	var header = document.getElementById(element.id);
+	var headerPos = header.getBoundingClientRect();
+	dropdown.style.display = 'block';
+	dropdown.style.position = 'absolute';
+	dropdown.style.top = (headerPos.top + header.offsetHeight) + "px";
+	dropdown.style.left = headerPos.left + "px";
+}
+
+// Removes the tableheads full column name dropdown.
+function removeFullHeaderDrop(element) {
+	document.getElementById(element.id + "_dropdown").style.display = 'none';
+}
 
 // This is not generic should be local function for each module.
 /*

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2243,7 +2243,7 @@ div.submit-button:disabled {
 .list th {
   background: var(--color-primary);
   color: var(--color-text-header);
-  line-height: 28px;
+  line-height: 20px;
   font-weight: bold;
   padding: 5px;
 }
@@ -2328,10 +2328,6 @@ div.submit-button:disabled {
 .sortableHeading {
   display: inline !important;
   cursor: pointer;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  padding-left: 16px;
-  padding-right: 16px;
 }
 
 #editpopover {


### PR DESCRIPTION
Fixed the problem that the overflow-text could cause by adding a onmouseover-function that displays a dropdown containing the full text that the ellipsis cuts off. 

![image](https://user-images.githubusercontent.com/49142704/79586693-c3d11080-80d1-11ea-8bc2-f62f4eea1645.png)

Also added a min-width to the th-elements to avoid narrow table heads and also removed some styling that disturbed the th-texts formatting. 

![image](https://user-images.githubusercontent.com/49142704/79586991-2a562e80-80d2-11ea-8cf9-b7900c1d421e.png)

Co-authored-by: b18fella <b18fella@users.noreply.github.com>