### PR TITLE
Fixes #8254 - Set loaded value on zoom range on initialization

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1226,6 +1226,7 @@ function initializeCanvas() {
     const diagramContainer = document.getElementById("diagramCanvasContainer");
     const moveButton = document.getElementById("moveButton");
     const zoomTextElement = document.getElementById("zoomV");
+    const zoomRange = document.getElementById("ZoomSelect");
     const coordinatesElement = document.getElementById("valuesCanvas");
 
     canvas = document.getElementById("diagramCanvas");
@@ -1234,6 +1235,7 @@ function initializeCanvas() {
     }
 
     zoomTextElement.innerHTML = `<p><b>Zoom:</b> ${Math.round(zoomValue * 100)}%</p>`;
+    zoomRange.value = zoomValue;
 
     coordinatesElement.style.display = 'none';
     moveButton.style.visibility = 'hidden';
@@ -3046,7 +3048,7 @@ function zoomInMode(event) {
 
     let oldZoom = zoomValue;
     zoomValue = document.getElementById("ZoomSelect").value;
-    localStorage.setItem("zoomValue", document.getElementById("ZoomSelect").value);
+    localStorage.setItem("zoomValue", zoomValue);
     localStorage.setItem("cameraPosX", origoOffsetX);
     localStorage.setItem("cameraPosY", origoOffsetY);
     let zoomDifference = 1 + (zoomValue - oldZoom);


### PR DESCRIPTION
Fixed the problem of zoom value going back to 100% +- 10% on zoom in or out after the page has been refreshed. Zoom value and camera position is after a recent implementation stored in local storage and loaded on page refresh. The range slider for zoom did however not get the zoom value loaded from local storage which makes it be 100% as default while the zoom being shown on page refresh is loaded from local storage.

-Test if the zoom after page refresh works as expected. If the zoom was 50% when refreshing it should after page refresh be 50% and go to 40% on zoom out and 60%.

Link: http://group4.webug.his.se:20001/G4-2020-W17-ISSUE%238254/DuggaSys/diagram.php