### PR TITLE
Removed error related to enter-keylistener in accessEd 

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -664,8 +664,7 @@ function mouseDown(e) {
 function mouseUp(e) {
 	// if the target of the click isn't the container nor a descendant of the container
 	if (typeof(activeElement) !== "undefined" && typeof(e.target) !== "undefined") {
-		var checkboxes = $(activeElement).find(".checkboxes");
-		checkboxes = activeElement.parentElement.lastChild;
+		var checkboxes = activeElement.parentElement.lastChild;
 		if (!checkboxes.contains(e.target) && e.target.parentElement != activeElement) {
 			updateAndCloseGroupDropdown(checkboxes);
 		}

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -694,6 +694,10 @@ document.addEventListener("keyup", function(event)
   if (event.keyCode === 13)
   {
     // If user presses key: Enter (13)
+    // if group dropdown is open, update and close it
+    if (typeof(activeElement) !== "undefined")
+    	updateAndCloseGroupDropdown(activeElement.parentElement.lastChild);
+    // update current cell
     updateCellInternal();
   } else if (event.keyCode === 27) {
     // If user presses key: Escape (27)

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -647,7 +647,10 @@ function SortableTable(param) {
 	}
 
 	this.updateCell = function () {
-		tbl.tblbody[sortableTable.edit_rowno][sortableTable.edit_columnname] = updateCellCallback(sortableTable.edit_rowno, null, sortableTable.edit_columnname, sortableTable.edit_tableid, null, sortableTable.edit_rowid);
+		var celldata = updateCellCallback(sortableTable.edit_rowno, null, sortableTable.edit_columnname, sortableTable.edit_tableid, null, sortableTable.edit_rowid);
+		if (typeof(celldata) !== "undefined") {
+			tbl.tblbody[sortableTable.edit_rowno][sortableTable.edit_columnname] = celldata;
+		}
 		this.renderTable();
 	}
 


### PR DESCRIPTION
- Removes error (fixes #8216 )
- Enter now updates group dropdown if pressed with dropdown checkboxes open
- Removed unnecessary code row in MouseUp function (should not change functionality)