### PR TITLE
Deleted the draggable interaction on dugga stats. #8206

### DIFF
--- a/DuggaSys/templates/3d-dugga.js
+++ b/DuggaSys/templates/3d-dugga.js
@@ -134,7 +134,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	createTextures();
 

--- a/DuggaSys/templates/XMLAPI_report1_file_receive.js
+++ b/DuggaSys/templates/XMLAPI_report1_file_receive.js
@@ -92,7 +92,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 
 	$("#content").css({"position":"relative","top":"50px"});

--- a/DuggaSys/templates/bit-dugga.js
+++ b/DuggaSys/templates/bit-dugga.js
@@ -162,7 +162,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	var p = jQuery.parseJSON(param);
 	var daJSON = jQuery.parseJSON(danswer);

--- a/DuggaSys/templates/boxmodell.js
+++ b/DuggaSys/templates/boxmodell.js
@@ -203,7 +203,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	canvas = document.getElementById("myCanvas");
 	ctx = canvas.getContext('2d');

--- a/DuggaSys/templates/color-dugga.js
+++ b/DuggaSys/templates/color-dugga.js
@@ -159,7 +159,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	$("#feedbackBox").css("display","none");
 	var p = jQuery.parseJSON(param.replace(/\*/g, '"'));

--- a/DuggaSys/templates/curve-dugga.js
+++ b/DuggaSys/templates/curve-dugga.js
@@ -158,7 +158,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	running = true;
 	canvas = document.getElementById('a');

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -160,7 +160,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	var p = jQuery.parseJSON(param);
 	var daJSON = jQuery.parseJSON(danswer);

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -155,7 +155,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	$("#feedbackBox").css("display","none");
 	var p = jQuery.parseJSON(param.replace(/\*/g, '"'));

--- a/DuggaSys/templates/dugga3.js
+++ b/DuggaSys/templates/dugga3.js
@@ -157,7 +157,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	running = true;
 	canvas = document.getElementById('a');

--- a/DuggaSys/templates/dugga4.js
+++ b/DuggaSys/templates/dugga4.js
@@ -173,7 +173,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	/* reset */
 	sf = 2.0;

--- a/DuggaSys/templates/dugga5.js
+++ b/DuggaSys/templates/dugga5.js
@@ -135,7 +135,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	createTextures();
 

--- a/DuggaSys/templates/feedback_dugga.js
+++ b/DuggaSys/templates/feedback_dugga.js
@@ -201,8 +201,7 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
       		document.getElementById('duggaTotalTime').innerHTML=userStats[1];
       		document.getElementById('duggaClicks').innerHTML=userStats[2];
       		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];	
-      		$("#duggaStats").css("display","block");
-      		$("#duggaStats").draggable({ handle:'.loginBoxheader'});	      
+      		$("#duggaStats").css("display","block");	      
       }
 	}
 

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -168,7 +168,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 
 	inParams = parseGet();

--- a/DuggaSys/templates/group-assignment.js
+++ b/DuggaSys/templates/group-assignment.js
@@ -166,7 +166,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 
 	inParams = parseGet();

--- a/DuggaSys/templates/html_css_dugga.js
+++ b/DuggaSys/templates/html_css_dugga.js
@@ -179,7 +179,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	document.getElementById('feedbackBox').style.display = "none";
 	/* reset */

--- a/DuggaSys/templates/html_css_dugga_light.js
+++ b/DuggaSys/templates/html_css_dugga_light.js
@@ -200,7 +200,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 
 	/* reset */

--- a/DuggaSys/templates/shapes-dugga.js
+++ b/DuggaSys/templates/shapes-dugga.js
@@ -145,7 +145,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
 		$("#duggaStats").css("display","block");
-		$("#duggaStats").draggable({ handle:'.loginBoxheader'});
 	}
 	var canvas = document.getElementById("myCanvas");
 	ctx = canvas.getContext("2d");


### PR DESCRIPTION
Deleted the row $("#duggaStats").draggable({ handle:'.loginBoxheader'}); from all dugga stats. So it is not possible to drag or move the box anymore. According to @HGustavs, the possibility of iterating with draggable would be completely removed.