### PR TITLE
fix issue#6429 prevent a mutation of a free-drawn object

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1908,12 +1908,10 @@ function eraseSelectedObject(event) {
 //------------------------------------------------------
 
 function setMode(mode) {
+  cancelFreeDraw();
     uimode = mode;
     if(mode == 'Free' || mode == 'Text') {
       uimode = "CreateFigure";
-      if(figureType == "Free") {
-          cancelFreeDraw();
-      }
       figureType = mode;
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1908,7 +1908,7 @@ function eraseSelectedObject(event) {
 //------------------------------------------------------
 
 function setMode(mode) {
-  cancelFreeDraw();
+    cancelFreeDraw();
     uimode = mode;
     if(mode == 'Free' || mode == 'Text') {
       uimode = "CreateFigure";


### PR DESCRIPTION
Simple fix to prevent a mutation of a free-drawn object to occur. When the user is in mid-drawing and changes modes (for example create attribute) the drawing should be cancelled instead of creating a mutation. 

Before: 

![6dcb3442fe21c9702396bbc665bc5bd1](https://user-images.githubusercontent.com/49142301/79734903-bdbc7900-82f7-11ea-9092-f607eed6240a.gif)

After:

![5fc06b6330ff658ba64a992a761093cd](https://user-images.githubusercontent.com/49142301/79734932-c6ad4a80-82f7-11ea-88bc-b1653caca984.gif)



