### PR TITLE
Fixed console errors that occur when filtering files and hovering the search bar

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -202,6 +202,16 @@ function closeConfirmation() {
     window.location.replace('fileed.php?courseid=' + querystring['courseid'] + '&coursevers=' + querystring['coursevers']);
 }
 
+//displays dropdown when hovering search bar
+function hoverSearch() {
+    $('#dropdownSearch').css({ display: 'block' });
+}
+
+//stops displaying the dropdown when removing cursor from search bar
+function leaveSearch() {
+    $('#dropdownSearch').css({ display: 'none' });
+}
+
 //------------------------------------------------------------------
 // validateForm <- Validates the file that is going to be uploaded
 //------------------------------------------------------------------

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -62,27 +62,27 @@ $codeLinkQuery->execute();
         <div style='display:flex;justify-content:space-between;align-items:flex-end;'>
             <div style='display:flex;flex-wrap:wrap;'>
                 <div style='white-space:nowrap'>
-                    <input type="radio" id="all-files-sort" name="sortKind" value="All" checked onclick="sortFilesByKind('AllFiles');count=0;searchterm='';searchKeyUp(event);fileLink.renderTable();"/>
+                    <input type="radio" id="all-files-sort" name="sortKind" value="All" checked onclick="sortFilesByKind('AllFiles');count=0;searchterm='';searchKeyUp(event);"/>
                     <label for="all-files-sort" name="sortAll" style='white-space:nowrap'>All files</label>
                 </div>
                 <div style='white-space:nowrap'>
-                    <input type="radio" id="global-files-sort" name="sortKind" value="Global" onclick="sortFilesByKind('Global');count=0;searchterm='kind::global';searchKeyUp(event);fileLink.renderTable();"/>
+                    <input type="radio" id="global-files-sort" name="sortKind" value="Global" onclick="sortFilesByKind('Global');count=0;searchterm='kind::global';searchKeyUp(event);"/>
                     <label for="global-files-sort" name="sortGlobal" style='white-space:nowrap'>Global</label>
                 </div>
                 <div style='white-space:nowrap'>
-                    <input type="radio" id="course-local-sort" name="sortKind" value="CourseLocal" onclick="sortFilesByKind('CourseLocal');count=0;searchterm='kind::course';searchKeyUp(event);fileLink.renderTable();"/>
+                    <input type="radio" id="course-local-sort" name="sortKind" value="CourseLocal" onclick="sortFilesByKind('CourseLocal');count=0;searchterm='kind::course';searchKeyUp(event);"/>
                     <label for="course-local-sort" name="sortCLocal" style='white-space:nowrap'>Course local</label>
                 </div>
                 <div style='white-space:nowrap'>
-                    <input type="radio" id="version-local-sort" name="sortKind" value="VersionLocal" onclick="sortFilesByKind('Local');count=0;searchterm='kind::version';searchKeyUp(event);fileLink.renderTable();"/>
+                    <input type="radio" id="version-local-sort" name="sortKind" value="VersionLocal" onclick="sortFilesByKind('Local');count=0;searchterm='kind::version';searchKeyUp(event);"/>
                     <label for="version-local-sort" name="sortVLocal" style='white-space:nowrap'>Version local</label>
                 </div>
                 <div style='white-space:nowrap'>
-                    <input type="radio" id="links-sort" name="sortKind" value="Links" onclick="sortFilesByKind('Link');count=0;searchterm='kind::link';searchKeyUp(event);fileLink.renderTable();"/>
+                    <input type="radio" id="links-sort" name="sortKind" value="Links" onclick="sortFilesByKind('Link');count=0;searchterm='kind::link';searchKeyUp(event);"/>
                     <label for="links-sort" name="sortLinks" style='white-space:nowrap'>Links</label>
                 </div>
                  <div style='white-space:nowrap'>
-                    <input type="radio" id="dummyEmptyFile-sort" name="sortKind" value="Dummy File" onclick="sortFilesByKind('DummyFiles');count=0;searchterm='kind::dummyfile';searchKeyUp(event);fileLink.renderTable();"/>
+                    <input type="radio" id="dummyEmptyFile-sort" name="sortKind" value="Dummy File" onclick="sortFilesByKind('DummyFiles');count=0;searchterm='kind::dummyfile';searchKeyUp(event);"/>
                     <label for="dummyEmptyFile-sort" name="sortDummyFile" style='white-space:nowrap'>Dummy files</label>
                 </div>
             </div>


### PR DESCRIPTION
Solved two issues in one PR.

1. ISSUE: https://github.com/HGustavs/LenaSYS/issues/8110
When filtering files using global, local etc, no console error is created.

2. ISSUE: Hovering over the search bar causes errors. For example:
Uncaught ReferenceError: hoverSearch is not defined...
This has now been solved and a little example div is shown:

![untitled](https://user-images.githubusercontent.com/62876507/79739607-b3ea4400-82fe-11ea-9ceb-85138b8fcbe8.PNG)
