### PR TITLE
Double scrollbars solved

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -110,6 +110,7 @@ body {
   width: 100%;
   height: 100%;
   background-color: var(--color-background);
+  overflow: hidden;
 }
 
 table {

--- a/Shared/css/template6.css
+++ b/Shared/css/template6.css
@@ -24,9 +24,6 @@
     width: -webkit-calc(66.0%);
     width: -moz-calc(66.0%);
     width: calc(66.0%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;
@@ -44,9 +41,6 @@
     width: -webkit-calc(66.0%);
     width: -moz-calc(66.0%); 
     width: calc(66.0%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;
@@ -64,9 +58,6 @@
     width: -webkit-calc(66.0%);
     width: -moz-calc(66.0%);
     width: calc(66.0%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;

--- a/Shared/css/template7.css
+++ b/Shared/css/template7.css
@@ -28,9 +28,6 @@
     width: -webkit-calc(66.0%);
     width: -moz-calc(66.0%);
     width: calc(66.0%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;
@@ -48,9 +45,6 @@
     width: -webkit-calc(66.0%);
     width: -moz-calc(66.0%); 
     width: calc(66.0%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;
@@ -68,9 +62,6 @@
     width: -webkit-calc(66.0%);
     width: -moz-calc(66.0%);
     width: calc(66.0%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;

--- a/Shared/css/template9.css
+++ b/Shared/css/template9.css
@@ -23,9 +23,6 @@
     width: -webkit-calc(66.7%);
     width: -moz-calc(66.7%);
     width: calc(66.7%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 70%;
     min-height: 10%;
@@ -43,9 +40,6 @@
     width: -webkit-calc(66.7%);
     width: -moz-calc(66.7%); 
     width: calc(66.7%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;
@@ -64,9 +58,6 @@
     width: -webkit-calc(66.7%);
     width: -moz-calc(66.7%);
     width: calc(66.7%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;
@@ -84,9 +75,6 @@
     width: -webkit-calc(66.7%);
     width: -moz-calc(66.7%);
     width: calc(66.7%);
-    overflow: scroll;
-    overflow-y: auto;
-    overflow-x: auto;
     z-index: 2;
     max-height: 80%;
     min-height: 10%;


### PR DESCRIPTION
The templates that had double scrollbars on some boxes have now been fixed.

Template 6:
![bild](https://user-images.githubusercontent.com/62876715/79742554-45f44b80-8303-11ea-9bce-0964b011d998.png)

Template 7:
![bild](https://user-images.githubusercontent.com/62876715/79742688-82c04280-8303-11ea-937f-76981ecaed56.png)

Template 8:
![bild](https://user-images.githubusercontent.com/62876715/79742791-ac796980-8303-11ea-9566-b2a7c660cbb5.png)

Template 9:
![bild](https://user-images.githubusercontent.com/62876715/79742827-b7cc9500-8303-11ea-8b2b-51e8e249336d.png)
