### PR TITLE
Changed csv-delimiter to "," instead of ";"

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1317,7 +1317,7 @@ function exportCell(format, cell, colname) {
 	str = "";
 	if (format === "csv") {
 		if (colname == "FnameLname") {
-			str = cell.ssn + ";";
+			str = cell.ssn + ",";
 
 			str += cell.firstname + " " + cell.lastname;
 			str = str.replace(/\&aring\;/g, "å");
@@ -1359,7 +1359,7 @@ function exportColumnHeading(format, heading, colname) {
 	str = "";
 	if (format === "csv") {
 		if (colname == "FnameLname") {
-			str = "Personnummer;Namn";
+			str = "Personnummer,Namn";
 		} else {
 			heading = heading.replace(/\&aring\;/g, "å");
 			heading = heading.replace(/\&Aring\;/g, "Å");


### PR DESCRIPTION
In this pull request, it is easier to see which attributes belongs to which ssn. Before, only the header (Personnummer, namn) had been separated from each other correctly. With @a17pioja. See example below:

Before:
![image](https://user-images.githubusercontent.com/62876523/79747910-c4092000-830c-11ea-802f-ef6378984af8.png)

After:
![image](https://user-images.githubusercontent.com/62876523/79747055-514b7500-830b-11ea-8306-956c62eace96.png)
