### PR TITLE
G1 2020 w17 issue#8202

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -780,13 +780,13 @@ function createboxmenu(contentid, boxid, type) {
 		if (retData['writeaccess'] == "w") {
 			if (type == "DOCUMENT") {
 				str += "<td class='butto2 editcontentbtn showdesktop codedropbutton' id='settings' title='Edit box settings' onclick='displayEditContent(" + boxid + ");' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
-				str += '<td class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
+				str += '<td id = "boxtitlewrapper" class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
 			} else if (type == "CODE") {
 				str += "<td class='butto2 editcontentbtn showdesktop codedropbutton' id='settings' title='Edit box settings' onclick='displayEditContent(" + boxid + ");' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
-				str += '<td class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
+				str += '<td id = "boxtitlewrapper" class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
 			} else if (type == "IFRAME") {
 				str += "<td class='butto2 editcontentbtn showdesktop codedropbutton' id='settings' title='Edit box settings' onclick='displayEditContent(" + boxid + ");' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
-				str += '<td class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
+				str += '<td id = "boxtitlewrapper" class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
 			} else {
 				str += "<td class='butto2 showdesktop'>";
 				str += "<select class='chooseContentSelect' onchange='changeboxcontent(this.value,\"" + boxid + "\",\"" + contentid + "\");removeboxmenu(\"" + contentid + "menu\");'>";
@@ -798,7 +798,7 @@ function createboxmenu(contentid, boxid, type) {
 			}
 			// If reader doesn't have write access, only the boxtitle is shown
 		} else {
-			str += '<td class="boxtitlewrap"><span class="boxtitle">' + retData['box'][boxid - 1][4] + '</span></td>';
+			str += '<td id = "boxtitlewrapper" class="boxtitlewrap"><span class="boxtitle">' + retData['box'][boxid - 1][4] + '</span></td>';
 		}
 
 		if(retData['box'][boxid - 1][1] == "DOCUMENT"){
@@ -816,10 +816,10 @@ function createboxmenu(contentid, boxid, type) {
 		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' onclick='maximizeBoxes(" + boxid + ");'><p>MAX</p></div>";
 		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' onclick='minimizeBoxes(" + boxid + ");'><p>MIN</p></div>";
 		str += "<div id='resetBoxes'><td class='butto2 resetbtn' onclick='resetBoxes();'><p>RES</p></div>";
-		str += "<div id='testBoxes'><td class='butto2 resetbtn' onclick='newUpdateFile(\"../courses/1/"+retData['box'][boxid - 1][5]+"\",\""+ retData['box'][boxid - 1][5]+"\",\""+kind+"\")'><p> <img id='dorf'  title='Edit file'  class='markdownIcon' src='../Shared/icons/markdownPen.svg'> </p></div>";
+		// str += "<div id='testBoxes'><td class='butto2 resetbtn' onclick='newUpdateFile(\"../courses/1/"+retData['box'][boxid - 1][5]+"\",\""+ retData['box'][boxid - 1][5]+"\",\""+kind+"\")'><p> <img id='dorf'  title='Edit file'  class='markdownIcon' src='../Shared/icons/markdownPen.svg'> </p></div>";
 		// Show the copy to clipboard button for code views only
 		if (type == "CODE") {
-			str += "<td class='butto2 copybutton' id='copyClipboard' title='Copy to clipboard' onclick='copyCodeToClipboard(" + boxid + ");' ><img id='copyIcon' src='../Shared/icons/Copy.svg' /></td>";
+			str += "<div id='copyClipboard'><td class='butto2 copybutton' id='copyClipboard' title='Copy to clipboard' onclick='copyCodeToClipboard(" + boxid + ");' ><img id='copyIcon' src='../Shared/icons/Copy.svg' /></td>";
 		}
 		
 
@@ -2706,6 +2706,7 @@ function resizeBoxes(parent, templateId) {
 			},
 			resize: function (e, ui) {
 				alignBoxesWidth(boxValArray, 1, 2);
+				hideDescription();
 			},
 			stop: function (e, ui) {
 				setLocalStorageProperties(templateId, boxValArray);
@@ -3091,28 +3092,34 @@ function alignBoxesWidth(boxValArray, boxNumBase, boxNumAlign) {
 	boxValArray['box' + boxNumBase]['width'] = basePer;
 	boxValArray['box' + boxNumAlign]['width'] = remainWidthPer;
 	// makes the element dissapear when certain treshold is met
-	if (basePer < 15) {
-    
+	if (basePer < 20) {
 		if(document.querySelector('#box' + boxNumBase).className == 'box codebox'){
 			document.querySelector('#box' + boxNumBase + 'wrapper #copyClipboard').style.display = 'none';
+			//document.querySelector('#box' + boxNumBase + 'wrapper #copyIcon').style.display = 'none';
+			document.querySelector('#box' + boxNumBase + 'wrapper #boxtitlewrapper').style.display = 'none';
 		}
 		if(document.querySelector('#box' + boxNumAlign).className == 'box codebox'){
 			document.querySelector('#box' + boxNumAlign + 'wrapper #copyClipboard').style.display = 'block';
+			document.querySelector('#box' + boxNumAlign + 'wrapper #boxtitlewrapper').style.display = 'table-cell';
 		}
 		
-	}else if (basePer > 85) {
+	}else if (basePer > 80) {
 		if(document.querySelector('#box' + boxNumAlign).className == 'box codebox'){
 			document.querySelector('#box' + boxNumAlign + 'wrapper #copyClipboard').style.display = 'none';
+			document.querySelector('#box' + boxNumAlign + 'wrapper #boxtitlewrapper').style.display = 'none';
 		}
 		if(document.querySelector('#box' + boxNumBase).className == 'box codebox'){
 			document.querySelector('#box' + boxNumBase + 'wrapper #copyClipboard').style.display = 'block';
+			document.querySelector('#box' + boxNumBase + 'wrapper #boxtitlewrapper').style.display = 'table-cell';
 		}
 		
 	}else {
 		if(document.querySelector('#box' + boxNumBase).className == 'box codebox'){
 			document.querySelector('#box' + boxNumBase + 'wrapper #copyClipboard').style.display = 'block';
+			document.querySelector('#box' + boxNumBase + 'wrapper #boxtitlewrapper').style.display = 'table-cell';
 		}
 		if(document.querySelector('#box' + boxNumAlign).className == 'box codebox'){
+			document.querySelector('#box' + boxNumAlign + 'wrapper #boxtitlewrapper').style.display = 'table-cell';
 			document.querySelector('#box' + boxNumAlign + 'wrapper #copyClipboard').style.display = 'block';
 		}
 	}
@@ -3978,4 +3985,8 @@ function showBox(id) {
 			box.style.display = 'none';
 		}
 	});
+}
+
+function hideDescription() {
+	var descText = document.getElementById
 }

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -813,9 +813,9 @@ function createboxmenu(contentid, boxid, type) {
 
 		// Add resize, reset and edit buttons
 		
-		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' onclick='maximizeBoxes(" + boxid + ");'><p>Maximize</p></div>";
-		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' onclick='minimizeBoxes(" + boxid + ");'><p>Minimize</p></div>";
-		str += "<div id='resetBoxes'><td class='butto2 resetbtn' onclick='resetBoxes();'><p> Reset </p></div>";
+		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' onclick='maximizeBoxes(" + boxid + ");'><p>MAX</p></div>";
+		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' onclick='minimizeBoxes(" + boxid + ");'><p>MIN</p></div>";
+		str += "<div id='resetBoxes'><td class='butto2 resetbtn' onclick='resetBoxes();'><p>RES</p></div>";
 		str += "<div id='testBoxes'><td class='butto2 resetbtn' onclick='newUpdateFile(\"../courses/1/"+retData['box'][boxid - 1][5]+"\",\""+ retData['box'][boxid - 1][5]+"\",\""+kind+"\")'><p> <img id='dorf'  title='Edit file'  class='markdownIcon' src='../Shared/icons/markdownPen.svg'> </p></div>";
 		// Show the copy to clipboard button for code views only
 		if (type == "CODE") {

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -74,6 +74,7 @@
 
 /* BOXMENU STYLING START */
 .buttomenu2 {
+    background-color: #5A5757;
     position: absolute;
     top: 0px;
     width: calc(100%);
@@ -598,6 +599,7 @@
 }
 
 /* BOXMENU STYLING START */
+/*
 .buttomenu2Style{
 	background-color: #5A5757;
 }
@@ -627,6 +629,7 @@
   background-color: #938C8C;
     cursor: pointer;
 }
+*/
 .butto2:hover{
     background-color: #938C8C;
     cursor: pointer;
@@ -902,15 +905,15 @@
 }
 
 /* style for the maximize and reset button*/
-.maximizebtn {
+.maximizebtn, .minimizebtn, .resetbtn {
     color: #DFF0D8;
-    width: 75px;
+    width: 50px;
     padding-right: 3px;
     text-align: center;
     font-size: 13px;
     display: table-cell !important;
 }
-
+/*
 .minimizebtn {
     color: #DFF0D8;
     width: 75px;
@@ -927,13 +930,7 @@
     font-size: 13px;
     display: table-cell !important;
 }
-
-
-
-
-
-
-
+*/
 
 /* style for the copy button and copy notification*/
 .copybutton {

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -599,37 +599,7 @@
 }
 
 /* BOXMENU STYLING START */
-/*
-.buttomenu2Style{
-	background-color: #5A5757;
-}
 
-.buttomenu2Style .wordlistselect{
-   color: white;
-   background: url("../new icons/expand_button.svg") no-repeat 50px #5C5A5A;
-   background-size:15px 15px;
-   border: 1px solid #ccc;
-}
-
-.buttomenu2Style .boxcontentselect{
-    color: white;
-   background: url("../new icons/expand_button.svg") no-repeat 120px #5C5A5A;
-   background-size:15px 15px;
-   border: 1px solid #ccc;
-}
-
-.buttomenu2Style .chooseContentSelect{
-    color: white;
-   background: url("../new icons/expand_button.svg") no-repeat 120px #5C5A5A;
-   background-size:15px 15px;
-   border: 1px solid #ccc;
-}
-
-.buttomenu2Style select:hover{
-  background-color: #938C8C;
-    cursor: pointer;
-}
-*/
 .butto2:hover{
     background-color: #938C8C;
     cursor: pointer;
@@ -649,7 +619,7 @@
 
 .editcontentbtn {
     vertical-align: middle;
-    width: 32px;
+    min-width: 32px;
     height: 32px;
     text-align: center;
 }
@@ -905,37 +875,22 @@
 }
 
 /* style for the maximize and reset button*/
-.maximizebtn, .minimizebtn, .resetbtn {
+.maximizebtn, .minimizebtn, .resetbtn, .copybutton {
     color: #DFF0D8;
     width: 50px;
     padding-right: 3px;
     text-align: center;
     font-size: 13px;
-    display: table-cell !important;
+    display: table-cell;
 }
-/*
-.minimizebtn {
-    color: #DFF0D8;
-    width: 75px;
-    padding-right: 3px;
-    text-align: center;
-    font-size: 13px;
-    display: table-cell !important;
-}
-
-.resetbtn {
-    color: #DFF0D8;
-    width: 50px;
-    text-align: center;
-    font-size: 13px;
-    display: table-cell !important;
-}
-*/
 
 /* style for the copy button and copy notification*/
 .copybutton {
-    position: absolute;
     right: 10px;
+}
+
+#copyBtn {
+    float:right;
 }
 
 .copybutton img {


### PR DESCRIPTION
This fix only removes the description when screens are resized to make sure min max and reset are still possible to be clicked.
To make the best possible solution a bigger rework of the menu should to be done by not using a table. This however looke better than overlapping and doesn't "destroy" the graphic in the same way as before.
Also removed some redundant css. 