### PR TITLE
Fixes #8169 - Move coordinates element on small screens

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4636,9 +4636,11 @@ only screen and (max-device-width: 320px) {
   display: none;
 }
 
-@media only screen and (max-width: 600){
+@media only screen and (max-width: 600px) {
   #valuesCanvas {
-    display: none !important;
+    right: unset;
+    left: 4px;
+    bottom: 42px;
   }
 }
 


### PR DESCRIPTION
The coordinates element does now move to a more appropriate position on smaller screens to not be behind zoom element.

Link: http://group4.webug.his.se:20001/G4-2020-W17-ISSUE%238169/DuggaSys/diagram.php

![image](https://user-images.githubusercontent.com/49121839/79754587-13a11900-8318-11ea-84d1-3342f5bf338b.png)
