### PR TITLE
Updated editImpWords to better fit with the code standard.

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -355,8 +355,9 @@ var tabLine = function (text) {
 var addedWords = [];
 var removedWords = [];
 
-function editImpWords(editType) {
-	var word = $("#impword").val();
+function editImpWords(editType) 
+{
+	var word = document.getElementById("impword").value;
 	var left = 0;
 	var right = 0;
 	//Check if the word contains an uneven amount of parenthesis
@@ -383,8 +384,8 @@ function editImpWords(editType) {
 			}
 		});
 		if (exists == false) {
-			$("#impwords").append('<option>' + word + '</option>');
-			$("#impword").val("");
+			$("#impwords")[0].innerHTML += '<option>' + word + '</option>';
+			document.getElementById("impword").value = word;
 			addedWords.push(word);
 		}
 	} else if (editType == "-") {


### PR DESCRIPTION
Minimalized JQuery within the function "editImpWords" and replaced it with vanilla JavaScript where appropriate.

Test by first adding an important word to the word list and the saving it. It should work precisely as it did before the changes. Same goes for removing a word from the important word list. Both of these functions should work with no problems occuring.