### PR TITLE
Added logging when adding new files in fileed - G1-2020-W17-#8264

### DIFF
--- a/DuggaSys/filereceive.php
+++ b/DuggaSys/filereceive.php
@@ -38,6 +38,16 @@ if (isset($_SESSION['uid'])) {
     $userid = "UNK";
 }
 
+// Gets username based on uid
+$query = $pdo->prepare( "SELECT username FROM user WHERE uid = :uid");
+    $query->bindParam(':uid', $userid);
+    $query-> execute();
+
+    // This while is only performed if userid was set through _SESSION['uid'] check above, a guest will not have it's username set
+    while ($row = $query->fetch(PDO::FETCH_ASSOC)){
+        $username = $row['username'];
+}
+
 $log_uuid = getOP('log_uuid');
 
 $filo = print_r($_FILES, true);
@@ -175,10 +185,13 @@ if ($storefile) {
 
                 if ($kind == "LFILE") {
                     $movname = $currcvd . "/courses/" . $cid . "/" . $vers . "/" . $fname;
+                    logUserEvent($username, EventTypes::AddFile, "VersionLocal"." , ".$fname);
                 } else if ($kind == "MFILE") {
                     $movname = $currcvd . "/courses/" . $cid . "/" . $fname;
+                    logUserEvent($username, EventTypes::AddFile, "CourseLocal"." , ".$fname);
                 } else {
                     $movname = $currcvd . "/courses/global/" . $fname;
+                    logUserEvent($username, EventTypes::AddFile, "Global"." , ".$fname);
                 }
 
                 // check if upload is successful

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -315,9 +315,11 @@ abstract class EventTypes {
 	const ServiceClientEnd = 8;
 	const Logout = 9;
 	const pageLoad = 10;
-  const PageNotFound = 11;
-  const RequestNewPW = 12;
-  const CheckSecQuestion = 13;
+  	const PageNotFound = 11;
+  	const RequestNewPW = 12;
+	const CheckSecQuestion = 13;
+	  
+	const AddFile = 15;
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When adding course local, version local, and global files logging is now in place.

![Screenshot 2020-04-20 at 16 17 32](https://user-images.githubusercontent.com/62876614/79762159-aba40000-8322-11ea-9ee0-d6dcd193f0f0.png)

The result from using either of these will show up like this in the sqlite db:

![Screenshot 2020-04-20 at 16 12 33](https://user-images.githubusercontent.com/62876614/79761933-61228380-8322-11ea-9136-e85f2480ad14.png)

How to test:
Download https://sqlitebrowser.org/dl/

Choose open database
![Screenshot 2020-04-17 at 12 08 08](https://user-images.githubusercontent.com/62876614/79558244-23182c00-80a4-11ea-87f3-2cd1147def6c.png)

Open the db file located in the log dir
![Screenshot 2020-04-17 at 12 07 14](https://user-images.githubusercontent.com/62876614/79558338-417e2780-80a4-11ea-9a02-7524b8e0ad53.png)
![Screenshot 2020-04-17 at 12 07 25](https://user-images.githubusercontent.com/62876614/79558345-4511ae80-80a4-11ea-9746-817755b62e7e.png)


co authored with @a18jakme 