### PR TITLE
Fixes #8314 - Proper check to prevent action on wrong objects

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4458,14 +4458,13 @@ function loadAppearanceForm() {
     let type = object.symbolkind;
 
     //Get objects connected to uml-line and sets name in appearance menu(used for Line direction)
-    var connectedObjectsArray = object.getConnectedObjects();
-    if(object.symbolkind == 7){
+    if(object.symbolkind == symbolKind.umlLine){
+        let connectedObjectsArray = object.getConnectedObjects();
         document.getElementById('First').innerHTML = connectedObjectsArray[0].name;
         //Selection to check if relation is to the same entity. If so: both are named from object 0
         if(typeof connectedObjectsArray[1] == "undefined"){
             document.getElementById('Second').innerHTML =  connectedObjectsArray[0].name;
-        }
-        else{
+        } else {
             document.getElementById('Second').innerHTML = connectedObjectsArray[1].name;
         }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4686,9 +4686,11 @@ function getGroupsByType(type) {
 
 //Shoud simulate button click or enter click in appearance menu to save and close
 function submitAppearanceForm() {
-    if(typeof diagram[lastSelectedObject] !== 'undefined'){
-        diagram[lastSelectedObject].resizeUMLToMinHeight();
-    }
+    selected_objects.forEach(object => {
+        if(object.symbolkind === symbolKind.uml) {
+            object.resizeUMLToMinHeight();
+        }
+    });
     if(globalappearanceMenuOpen) {
         setGlobalProperties();
     } else {


### PR DESCRIPTION
Test if it is possible to change appearance for all types of objects without any errors. UML should resize back to minimum required height when appearance form is submitted. 
The problem before was that a function was executed on an object that the function was not intended for, which would break the object.

Link: http://group4.webug.his.se:20001/G4-2020-W17-ISSUE%238314/DuggaSys/diagram.php