### PR TITLE
G2 2020 w17 #8323 cookie message can now be closed in Random CSS Dugga

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2073,6 +2073,10 @@ div.submit-button:disabled {
   text-align: right;
 }
 
+#submitButtonTable{
+  z-index:500;
+}
+
 #submitButtonTable input.large-button {
   width: 160px !important;
   height: 48px !important;


### PR DESCRIPTION
Solves #8323. 

Set z-index for #submitButtonTable to 500, meaning the cookie message (z-index 1000) will be displayed on top of it. This should not break anything else but please look through the different duggas during testing.

![image](https://user-images.githubusercontent.com/49141758/79845380-3f2a0f00-83bd-11ea-9db1-8a349d139ad6.png)

