### PR TITLE
Change the max-width from 400px to 350px. #7276

### DIFF
--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -34,7 +34,7 @@
 </div>
 
 <div id='duggaInfoBox' class="loginBoxContainer" style="display:none">
-  <div class="loginBox"  style="max-width:400px;">
+  <div class="loginBox"  style="max-width:350px;">
     <div class='loginBoxheader'>
         <h3>Dugga - HTML/CSS</h3>
         <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>


### PR DESCRIPTION
Change the max-width from 400px to 350px. Changed in random css dugga. Because it was not given enough space for "duggaInfoBox". To test you must use mobile mode from inspect.
<img width="371" alt="Screenshot 2020-04-21 at 10 56 38" src="https://user-images.githubusercontent.com/49142649/79846504-d2177900-83be-11ea-9338-a02861eb8f71.png">
