### PR TITLE
Fixes #8313 - Change derived linecap to prevent covering dashes

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1529,7 +1529,8 @@ function Symbol(kindOfSymbol) {
             ctx.strokeStyle = "#fff";
         }
         else if (this.properties['key_type'] == "Derived") {
-            ctx.lineWidth = this.properties['lineWidth'] * 2 * diagram.getZoomValue();
+            ctx.lineCap = "butt";
+            ctx.lineWidth = this.properties['lineWidth'] * 1.5 * diagram.getZoomValue();
             ctx.setLineDash([5, 4]);
         }
         checkLineIntersection(x1,y1,x2,y2);


### PR DESCRIPTION
A recent fix changed the linecap to square with the intention of connecting er entities to relations in a better looking way. This broke the derived lines (dashed line) making it impossible to see it was a derived line when the line thickness is over the smallest size. This is now fixed by changing the linecap for derived lines to "butt" which is the standard linecap, and still keeping the previously chosen linecap for other types of lines.

Test to draw derived lines and change the global line thickness to see so the dashes line is always visible.

Link: http://group4.webug.his.se:20001/G4-2020-W17-ISSUE%238313/DuggaSys/diagram.php