### PR TITLE
Fixes issue#8248, ability to use enter instead of click in dropdown menu

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -634,6 +634,13 @@ function keyDownHandler(e) {
         eraseSelectedObject(event);
         SaveState();
     }  
+    //Check if enter is pressed when "focused" on an item in the dropdown menu
+    if(key == keyMap.enterKey) {
+        const onclickElements = document.activeElement.querySelectorAll("[onclick]");
+        onclickElements.forEach(element => {
+        element.click();
+        });
+    }
     if(enableShortcuts){ // Only enter if keyboard shortcuts are enabled
         if (key == keyMap.spacebarKey) {
             // This if-else statement is used to make sure mouse clicks can not exit the MoveAround mode.

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -140,7 +140,7 @@
                                         <a class="drop-down-option" id="svgid" onclick='ExportSVG(this);'>Export SVG</a>
                                     </div>
                                     <div class="export-drop-down-item" tabindex="0">
-                                        <a class="drop-down-option" id="picid">Export Picture</a>
+                                        <a class="drop-down-option" id="picid" onclick='ExportPicture(this);'>Export Picture</a>
                                     </div>
                                     <div class="export-drop-down-item" tabindex="0">
                                         <a class="drop-down-option" id="svgidA4" onclick='ExportSVGA4(this);'>Export as A4 size(SVG)</a>

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -413,8 +413,13 @@ function ExportSVGA4(el) {
 //------------------------------------------------
 // used when exporting the file as a .png image.
 //------------------------------------------------
-
-$(document).ready(function() {
+function ExportPicture(el) {
+    var canvasId = 'diagramCanvas';
+    var filename = 'picture.png';
+    el.href = document.getElementById(canvasId).toDataURL();
+    el.download = filename;
+}
+/*$(document).ready(function() {
     function downloadCanvas(link, canvasId, filename) {
         link.href = document.getElementById(canvasId).toDataURL();
         link.download = filename;
@@ -423,4 +428,4 @@ $(document).ready(function() {
     document.getElementById('picid').addEventListener('click', function() {
         downloadCanvas(this, 'diagramCanvas', 'picture.png');
     }, false);
-});
+});*/

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -419,13 +419,3 @@ function ExportPicture(el) {
     el.href = document.getElementById(canvasId).toDataURL();
     el.download = filename;
 }
-/*$(document).ready(function() {
-    function downloadCanvas(link, canvasId, filename) {
-        link.href = document.getElementById(canvasId).toDataURL();
-        link.download = filename;
-    }
-
-    document.getElementById('picid').addEventListener('click', function() {
-        downloadCanvas(this, 'diagramCanvas', 'picture.png');
-    }, false);
-});*/


### PR DESCRIPTION
It is now possible to navigate the dropdown menu and press enter instead of clicking on dropdown items. [Issue#8248](https://github.com/HGustavs/LenaSYS/issues/8248)