### PR TITLE
Fixes #8344 - Tab enter now works only when focusing on defined classes

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -638,7 +638,12 @@ function keyDownHandler(e) {
     }  
     //Check if enter is pressed when "focused" on an item in the dropdown menu
     if(key == keyMap.enterKey) {
-
+        const allowedClasses = ["drop-down-item", "export-drop-down-item", "papersize-drop-down-item"];
+        const isAllowed = allowedClasses.some(className => document.activeElement.classList.contains(className));
+        if(isAllowed) {
+            const onclickElement = document.activeElement.querySelector("[onclick]");
+            onclickElement.click();
+        }
     }
     if(enableShortcuts){ // Only enter if keyboard shortcuts are enabled
         if (key == keyMap.spacebarKey) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -638,10 +638,7 @@ function keyDownHandler(e) {
     }  
     //Check if enter is pressed when "focused" on an item in the dropdown menu
     if(key == keyMap.enterKey) {
-        const onclickElements = document.activeElement.querySelectorAll("[onclick]");
-        onclickElements.forEach(element => {
-        element.click();
-        });
+
     }
     if(enableShortcuts){ // Only enter if keyboard shortcuts are enabled
         if (key == keyMap.spacebarKey) {


### PR DESCRIPTION
All functions executed when enter was pressed from anywhere, without focus on the correct dropdown item. This fixes this so the correct onclick function executes when focus is on a dropdown item. 

-Test to tab through the dropdown items and execute the functionality by enter on the focused one.