### PR TITLE
fix issue#8257 Changed arity to length 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4193,6 +4193,7 @@ function mouseupevt(ev) {
         erEnityA.bottomRight = p2;
         erEnityA.centerPoint = p3;
         erEnityA.arity = [];
+      //TEST
         erEnityA.object_type = "";
         diagram.push(erEnityA);
         //selecting the newly created enitity and open the dialogmenu.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4192,8 +4192,7 @@ function mouseupevt(ev) {
         erEnityA.topLeft = p1;
         erEnityA.bottomRight = p2;
         erEnityA.centerPoint = p3;
-        erEnityA.arity = [];
-      //TEST
+        erEnityA.length = [];
         erEnityA.object_type = "";
         diagram.push(erEnityA);
         //selecting the newly created enitity and open the dialogmenu.


### PR DESCRIPTION
According to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arity) the arity function is no longer compatible with most browsers. The arity function has therefore been changed to length. 

![Screenshot_28](https://user-images.githubusercontent.com/49142301/79958620-6fd47c00-8483-11ea-9514-866910115637.png)

![Screenshot_29](https://user-images.githubusercontent.com/49142301/79958629-73680300-8483-11ea-88a7-83891ca54a2f.png)

This will be hard to test since the functionality should be unchanged. Test to make sure creating an entity still works as intended. 

Link to test: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238257/DuggaSys/diagram.php
