### PR TITLE
Fix so that active labels are also cleared, #8340

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1508,7 +1508,8 @@ function initializeCanvas() {
 
 function clearActiveDropdownElement(){
     if (document.activeElement.className.match("menu-drop-down") || 
-    document.activeElement.className.match("drop-down-item")) {
+    document.activeElement.className.match("drop-down-item") ||
+    document.activeElement.className.match("drop-down-label")) {
         document.activeElement.blur();
     }
 


### PR DESCRIPTION
Distribute and help dropdowns in the diagram still overlapped after the fix, this should make the deselect work properly for them too. Original issue #8099.