### PR TITLE
Changed all current logUserEvent to log userid instead of username - G1-2020-W18-ISSUE#8337

### DIFF
--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -190,10 +190,12 @@ Testing Link:
 
 			// Logs users who view example, along with the example they have viewed
 			if ($userid == "00") {
-				logUserEvent($username, EventTypes::DuggaRead, $exampleid." ".$courseID." ".$cvers);
+				$description=$exampleid." ".$courseID." ".$cvers;
+				logUserEvent($_COOKIE["cookie_guest"], EventTypes::DuggaRead, $description);
 			}
 			else{
-				logUserEvent($_COOKIE["cookie_guest"], EventTypes::DuggaRead, $exampleid." ".$courseID." ".$cvers);
+				$description=$exampleid." ".$courseID." ".$cvers;
+				logUserEvent($userid, EventTypes::DuggaRead, $description);
 			}
 
 			// This checks if courseID and exampleid is not UNK and if it is UNK then it will appliances codeviewer "false" and a error message will be presented

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -44,16 +44,6 @@ if(isset($_SESSION['uid'])){
 $ha=null;
 $debug="NONE!";
 
-// Gets username based on uid
-$query = $pdo->prepare( "SELECT username FROM user WHERE uid = :uid");
-$query->bindParam(':uid', $userid);
-$query-> execute();
-
-// This while is only performed if userid was set through _SESSION['uid'] check above, a guest will not have it's username set
-while ($row = $query->fetch(PDO::FETCH_ASSOC)){
-	$username = $row['username'];
-}
-
 $log_uuid = getOP('log_uuid');
 $info=$opt." ".$cid." ".$coursename." ".$versid." ".$visibility;
 logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "courseedservice.php",$userid,$info);
@@ -84,8 +74,9 @@ if(checklogin()){
 				$debug="Error updating entries\n".$error[2];
 			} 
 
-			$description=$coursename." ".$coursecode;
-			logUserEvent($username, EventTypes::AddCourse, $description);
+			// Logging for creating new course
+			$description=$coursename." ".$coursecode." "."Hidden";
+			logUserEvent($userid, EventTypes::AddCourse, $description);
 
 		}else if(strcmp($opt,"NEWVRS")===0){
 			$query = $pdo->prepare("INSERT INTO vers(cid,coursecode,vers,versname,coursename,coursenamealt) values(:cid,:coursecode,:vers,:versname,:coursename,:coursenamealt);");
@@ -440,6 +431,7 @@ if(checklogin()){
 				$debug="Error updating entries\n".$error[2];
 			}
 
+			// Belongs to Logging 
 			if($visibility==0){
 				$visibilityName = "Hidden";
 			}
@@ -453,8 +445,9 @@ if(checklogin()){
 				$visibilityName = "Deleted";
 			}
 			
+			// Logging for editing of course
 			$description=$coursename." ".$coursecode." ".$visibilityName;
-			logUserEvent($username, EventTypes::EditCourse, $description);
+			logUserEvent($userid, EventTypes::EditCourse, $description);
 
 		}else if(strcmp($opt,"SETTINGS")===0){
 		$query = $pdo->prepare("INSERT INTO settings (motd,readonly) VALUES (:motd, :readonly);");

--- a/DuggaSys/filereceive.php
+++ b/DuggaSys/filereceive.php
@@ -38,16 +38,6 @@ if (isset($_SESSION['uid'])) {
     $userid = "UNK";
 }
 
-// Gets username based on uid
-$query = $pdo->prepare( "SELECT username FROM user WHERE uid = :uid");
-    $query->bindParam(':uid', $userid);
-    $query-> execute();
-
-    // This while is only performed if userid was set through _SESSION['uid'] check above, a guest will not have it's username set
-    while ($row = $query->fetch(PDO::FETCH_ASSOC)){
-        $username = $row['username'];
-}
-
 $log_uuid = getOP('log_uuid');
 
 $filo = print_r($_FILES, true);
@@ -189,13 +179,22 @@ if ($storefile) {
 
                 if ($kind == "LFILE") {
                     $movname = $currcvd . "/courses/" . $cid . "/" . $vers . "/" . $fname;
-                    logUserEvent($username, EventTypes::AddFile, "VersionLocal"." , ".$fname);
+
+                    // Logging for version local files
+                    $description="VersionLocal"." ".$fname;
+                    logUserEvent($userid, EventTypes::AddFile, $description);
                 } else if ($kind == "MFILE") {
                     $movname = $currcvd . "/courses/" . $cid . "/versionIndependence/" . $fname;
-                    logUserEvent($username, EventTypes::AddFile, "CourseLocal"." , ".$fname);
+
+                    // Logging for course local files
+                    $description="CourseLocal"." ".$fname;
+                    logUserEvent($userid, EventTypes::AddFile, $description);
                 } else {
                     $movname = $currcvd . "/courses/global/" . $fname;
-                    logUserEvent($username, EventTypes::AddFile, "Global"." , ".$fname);
+
+                    // Logging for global files
+                    $description="Global"." ".$fname;
+                    logUserEvent($userid, EventTypes::AddFile, $description);
                 }
 
                 // check if upload is successful

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -52,16 +52,6 @@ $unmarked = 0;
 $groups=array();
 $grplst=array();
 
-// Gets username based on uid
-$query = $pdo->prepare( "SELECT username FROM user WHERE uid = :uid");
-$query->bindParam(':uid', $userid);
-$query-> execute();
-
-// This while is only performed if userid was set through _SESSION['uid'] check above, a guest will not have it's username set
-while ($row = $query->fetch(PDO::FETCH_ASSOC)){
-        $username = $row['username'];
-}
-
 if($gradesys=="UNK") $gradesys=0;
 
 		$today = date("Y-m-d H:i:s");
@@ -213,7 +203,10 @@ if($gradesys=="UNK") $gradesys=0;
 						$query->bindParam(':groupkind', $grptype);
 					} else {
 						$query->bindValue(':groupkind', null, PDO::PARAM_STR);
-                        logUserEvent($username,EventTypes::SectionItems,$sectname);
+
+						// Logging for newly added items
+						$description=$sectname;
+                        logUserEvent($userid,EventTypes::SectionItems,$sectname);
 
 					}
 

--- a/Shared/loginlogout.php
+++ b/Shared/loginlogout.php
@@ -60,14 +60,26 @@ if($opt=="REFRESH"){
 				$res["securityquestion"] = "set";
 			}
 
+			//LOGGING STARTS HERE ->
+			// Gets uid based on username
+			$query = $pdo->prepare( "SELECT uid FROM user WHERE username = :username");
+			$query->bindParam(':username', $username);
+			$query-> execute();
+
+			// This while is only performed if userid was set through _SESSION['uid'] check above, a guest will not have it's username set
+			while ($row = $query->fetch(PDO::FETCH_ASSOC)){
+				$userid = $row['uid'];
+			}
+
 			// Log USERID for Dugga Access
-			logUserEvent($username,EventTypes::LoginSuccess,"");
+			logUserEvent($userid,EventTypes::LoginSuccess,"");
 
 		  }else{
 			addlogintry(); // If to many attempts has been commited, it will jump to this
 			// As login has failed we log the attempt
 
-			logUserEvent($username,EventTypes::LoginFail,"");
+			// Logging for failed login
+			logUserEvent($userid,EventTypes::LoginFail,"");
 		}
     }else{
 		$res = array("login" => "limit");
@@ -77,7 +89,7 @@ if($opt=="REFRESH"){
 	echo json_encode($res);
 }else{
 	//Adds a row to the logging table for the userlogout.
-	logUserEvent($_SESSION['loginname'],EventTypes::Logout,"");
+	logUserEvent($_SESSION['uid'],EventTypes::Logout,"");
 
 	// Parts of Logout copied from http://stackoverflow.com/a/3948312 and slightly modified, licensed under cc by-sa
 	// unset all of the session variables.

--- a/Shared/resetpw.php
+++ b/Shared/resetpw.php
@@ -9,7 +9,7 @@ $opt=getOP('opt');
 
 if($opt=="GETQUESTION"){
 	$username=getOP('username');
-	$securityquestion=getOP('securityquestion');
+  $securityquestion=getOP('securityquestion');
   
   // Request barrier
   $maxRequestTries = 5;
@@ -32,7 +32,18 @@ if($opt=="GETQUESTION"){
     $queryResult = $result['COUNT(*)'];
   }
 
-	pdoConnect(); // Makes sure it actually connects to a database
+  pdoConnect(); // Makes sure it actually connects to a database
+  
+  // Retriving uid from database is used for logging 
+			// Gets uid based on username
+			$query = $pdo->prepare( "SELECT uid FROM user WHERE username = :username");
+			$query->bindParam(':username', $username);
+			$query-> execute();
+
+			// This while is only performed if userid was set through _SESSION['uid'] check above, a guest will not have it's username set
+			while ($row = $query->fetch(PDO::FETCH_ASSOC)){
+				$userid = $row['uid'];
+  }
 
 	// Default values
 	$res = array("getname" => "failed");
@@ -44,7 +55,7 @@ if($opt=="GETQUESTION"){
 		$res["securityquestion"] = $_SESSION["securityquestion"];
     }else{
       $res["getname"] = $_SESSION["getname"];
-      logUserEvent($username,EventTypes::RequestNewPW,"");
+      logUserEvent($userid,EventTypes::RequestNewPW,"");
     }
   }else{
     $res["getname"] = "limit";
@@ -94,7 +105,7 @@ if($opt=="GETQUESTION"){
       }
     }else{
       $res["requestchange"] = "wrong";
-      logUserEvent($username,EventTypes::CheckSecQuestion,"");
+      logUserEvent($userid,EventTypes::CheckSecQuestion,"");
     }
   }else{
     $res["requestchange"] = "limit";


### PR DESCRIPTION
All logging using logUserEvent now instead use userid. These change can be seen in the userLogEntries table.

Previously:

![Screenshot 2020-04-22 at 10 39 34](https://user-images.githubusercontent.com/62876614/79967246-df039d80-848e-11ea-8103-dffee6f887e2.png)

After:

![Screenshot 2020-04-22 at 11 45 54](https://user-images.githubusercontent.com/62876614/79967278-e75bd880-848e-11ea-94f2-2299ba9ba659.png)

These changes encompasses:

* Editing/creating courses in courseed:
* Adding items in sectioned 
* Adding files in fileed 
* Login/Logout/LoginFail
* Reseting passowrd
* Viewing examples in codeviewer 

---
How to test: 
Download https://sqlitebrowser.org/dl/

![Screenshot 2020-04-22 at 11 55 52](https://user-images.githubusercontent.com/62876614/79968339-3d7d4b80-8490-11ea-8d10-443631279259.png)

