### PR TITLE
Exporting as SVG now handles UMl lines

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3192,6 +3192,11 @@ function redoDiagram(event) {
 // diagramToSVG: Used when exporting the diagram to svg
 //----------------------------------------------------------------------
 function diagramToSVG() {
+    origoOffsetX = 0;
+    origoOffsetY = 0;
+    zoomValue = 1.00;
+    updateGraphics();
+    SaveState();
     var str = "";
     // Convert figures to SVG first so they appear behind other objects
     for (var i = 0; i < diagram.length; i++) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3208,23 +3208,6 @@ function diagramToSVG() {
     return str;
 }
 
-function diagramToSVG() {
-    var str = "";
-    // Convert figures to SVG first so they appear behind other objects
-    for (var i = 0; i < diagram.length; i++) {
-        if (diagram[i].kind == kind.path) str += diagram[i].figureToSVG();
-    }
-    // Convert lines to SVG second so they appear behind other symbols but above figures
-    for (var i = 0; i < diagram.length; i++) {
-        if (diagram[i].kind == kind.symbol && diagram[i].symbolkind == symbolKind.line) str += diagram[i].symbolToSVG(i);
-    }
-    // Convert other objects to SVG
-    for (var i = 0; i < diagram.length; i++) {
-        if (diagram[i].kind == kind.symbol && diagram[i].symbolkind != symbolKind.line) str += diagram[i].symbolToSVG(i);
-    }
-    return str;
-}
-
 //----------------------------------------------------------------------
 // setCheckbox: Check or uncheck the checkbox contained in 'element'
 //              This function adds a checkbox element if there is none


### PR DESCRIPTION
Solves #7543
When exporting diagram to SVG the UML lines should now be displayed, and in hopefully all cases be displayed exactly how they appear in the diagram.

When testing, please be sure to clear localstorage first!