### PR TITLE
fix issue#8265 Make it easier to see if a text are a comment

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2021,13 +2021,13 @@ function Symbol(kindOfSymbol) {
 				ctx.rect(x1, y1, x2-x1, y2-y1);
 				ctx.stroke();
 			}
-            //add permanent outline for comments
-            if (this.properties['isComment'] == true){
-                ctx.lineWidth = 1 * diagram.getZoomValue();
-                ctx.setLineDash([5, 4]);
-                ctx.rect(x1, y1, x2-x1, y2-y1);
-                ctx.stroke();
-            }
+			//add permanent outline for comments
+			if (this.properties['isComment'] == true){
+				ctx.lineWidth = 1 * diagram.getZoomValue();
+				ctx.setLineDash([5, 4]);
+				ctx.rect(x1, y1, x2-x1, y2-y1);
+				ctx.stroke();
+			}
 			ctx.fillStyle = this.properties['fontColor'];
 			ctx.textAlign = this.textAlign;
 			for (var i = 0; i < this.textLines.length; i++) {

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2021,7 +2021,13 @@ function Symbol(kindOfSymbol) {
 				ctx.rect(x1, y1, x2-x1, y2-y1);
 				ctx.stroke();
 			}
-
+            //add permanent outline for comments
+            if (this.properties['isComment'] == true){
+                ctx.lineWidth = 1 * diagram.getZoomValue();
+                ctx.setLineDash([5, 4]);
+                ctx.rect(x1, y1, x2-x1, y2-y1);
+                ctx.stroke();
+            }
 			ctx.fillStyle = this.properties['fontColor'];
 			ctx.textAlign = this.textAlign;
 			for (var i = 0; i < this.textLines.length; i++) {


### PR DESCRIPTION
When user selects the comment box of a text object the object gets a dashed border. This way the user knows if the text is a comment or not without having to check.

How it should look like:

![9d33f15bdffda7f4282afde23dc4bf86](https://user-images.githubusercontent.com/49142301/79977303-55f46280-849e-11ea-9c75-f52e502e1f93.gif)

Link to test: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238265/DuggaSys/diagram.php
