### PR TITLE
Reduced jQuery within highlightKeyword

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1095,10 +1095,10 @@ function highlightKeyword(kw) {
 
 	$(".impword").each(function () {
 		if(this.classList.contains("imphi")){
-			$(this).removeClass("imphi");
+			this.classList.remove("imphi");
 		}
 		else if(this.innerHTML == kw || this.innerHTML == kwDoubleQuotes || this.innerHTML == kwSingleQuote) {
-			$(this).addClass("imphi");
+			this.classList.add("imphi");
 		}
 	});
 }


### PR DESCRIPTION
Reduced jQuery functionality within highlightKeyword. 

Test by navigating to codeviewer.php and either moving the mouse cursor over one of the default added keywords or by clicking the "EditExample" button (the big cogwheel in the top section) and adding an important word and doing the same.