### PR TITLE
Only people with write access can see trash button

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -85,7 +85,7 @@ function returnedFile(data) {
 
     if (data['studentteacher']) {
         document.getElementById('fabButton').style.display = "none";
-    } else {
+    } else if(data['waccess']) {
         tblheadPre["trashcan"] = "";
         colOrderPre.push("trashcan");
     }

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -200,12 +200,15 @@ if (checklogin() && $hasAccess) {
     $access = True;
 }
 
+$waccess = hasAccess($userid, $cid, 'w');
+
 $array = array(
     'entries' => $entries,
     'debug' => $debug,
     'gfiles' => $gfiles,
     'lfiles' => $lfiles,
     'access' => $access,
+    'waccess' => $waccess,
     'studentteacher' => $studentTeacher
 );
 


### PR DESCRIPTION
Fixed so that trash button only shows up for people with write access instead of everyone that had access to the page could see it even student teachers.

To this on the server a user with super user is needed to even access the fileed.php and then the user needs to have write access.
Currently no user has both so updating the database for teacher3 would be the best solution because teacher3 has write access on most courses but not super user and give teacher3 super user.

Then just use brom who lacks write access to not see the trash buttons and then teacher3 who does too see the trash buttons.
