### PR TITLE
Fixes #8388 - Appearance menu closes on mousedown inside then mouseup outside

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4765,7 +4765,12 @@ function initAppearanceForm() {
     });
 
     const appearanceContainer = document.getElementById("appearance");
-    appearanceContainer.addEventListener("click", clickOutsideAppearanceForm);
+    appearanceContainer.addEventListener("mousedown", e => {
+
+    });
+    appearanceContainer.addEventListener("mouseup", e => {
+
+    });
 }
 
 function getGroupsByType(type) {
@@ -4792,13 +4797,3 @@ function submitAppearanceForm() {
     SaveState();
     toggleApperanceElement();
 }
-
-function clickOutsideAppearanceForm(e) {
-    const formContainer = document.querySelector(".loginBox");
-
-    //Close appearance if the clicked element is not a child/grand-child of formContanier
-    if(!formContainer.contains(e.target)) {
-        toggleApperanceElement();
-    }
-}
-

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4741,6 +4741,12 @@ function setObjectProperties() {
     updateGraphics();
 }
 
+//Stores which element the mouse was pressed down on which element the mouse was released on while in the appearance menu.
+const appearanceMouseElements = {
+    down: null,
+    up: null
+};
+
 function initAppearanceForm() {
     const formGroups = document.querySelectorAll("#appearanceForm .form-group");
     formGroups.forEach(group => {
@@ -4765,12 +4771,8 @@ function initAppearanceForm() {
     });
 
     const appearanceContainer = document.getElementById("appearance");
-    appearanceContainer.addEventListener("mousedown", e => {
-
-    });
-    appearanceContainer.addEventListener("mouseup", e => {
-
-    });
+    appearanceContainer.addEventListener("mousedown", e => appearanceMouseElements.down = e.target);
+    appearanceContainer.addEventListener("mouseup", e => appearanceMouseElements.up = e.target);
 }
 
 function getGroupsByType(type) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4741,11 +4741,8 @@ function setObjectProperties() {
     updateGraphics();
 }
 
-//Stores which element the mouse was pressed down on which element the mouse was released on while in the appearance menu.
-const appearanceMouseElements = {
-    down: null,
-    up: null
-};
+//Stores which element the mouse was pressed down on while in the appearance menu.
+let appearanceMouseDownElement = null;
 
 function initAppearanceForm() {
     const formGroups = document.querySelectorAll("#appearanceForm .form-group");
@@ -4771,8 +4768,12 @@ function initAppearanceForm() {
     });
 
     const appearanceContainer = document.getElementById("appearance");
-    appearanceContainer.addEventListener("mousedown", e => appearanceMouseElements.down = e.target);
-    appearanceContainer.addEventListener("mouseup", e => appearanceMouseElements.up = e.target);
+    appearanceContainer.addEventListener("mousedown", e => appearanceMouseDownElement = e.target);
+    appearanceContainer.addEventListener("mouseup", e => {
+        if(appearanceMouseDownElement === appearanceContainer && e.target === appearanceContainer) {
+            toggleApperanceElement();
+        }
+    });
 }
 
 function getGroupsByType(type) {


### PR DESCRIPTION
The appearance menu was always closed before when the user clicked outside the appearance menu. It could be mouseup inside of the appearance menu while mouseup happened outside of the appearance menu. This resulted in it getting closed when the user didn't want it closed. For example this could happen when highlighting text in an input and accidentally moving the mouse outside of the appearance menu releasing it there.

This pull request fixes the problem. 
- Test to do mousedown and mouseup outside the appearance menu. This should close it.
- Test to do mousedown over a select or an input and then do not release the mouse button until you are outside the appearance menu. This should not close it.
- Test to do mousedown outside of the appearance menu and do mouseup inside the appearance menu. This should not close it.

Link: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238388/DuggaSys/diagram.php