### PR TITLE
Added logging when creating or editing course version - G1-2020-W18-ISSUE#8364

### DIFF
--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -130,6 +130,11 @@ if(checklogin()){
 				$debug="Error inserting entries\n".$error[2];
 			} 
 
+			// Logging for create a fresh course version
+			$description=$cid." ".$versid;
+			logUserEvent($userid, EventTypes::AddCourseVers, $description);
+
+
 		}else if(strcmp($opt,"UPDATEVRS")===0){
 				$query = $pdo->prepare("UPDATE vers SET versname=:versname WHERE cid=:cid AND coursecode=:coursecode AND vers=:vers;");
 				$query->bindParam(':cid', $courseid);
@@ -182,6 +187,10 @@ if(checklogin()){
 					$error=$query->errorInfo();
 					$debug="Error updating entries\n".$error[2];
 				}
+
+				// Logging for creating a copy of course version
+				$description=$cid." ".$versid;
+				logUserEvent($userid, EventTypes::AddCourseVers, $description);
 
 				// Duplicate duggas and dugga variants
 				$duggalist=array();

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -347,6 +347,11 @@ if($gradesys=="UNK") $gradesys=0;
 									$debug="Error updating entries".$error[2];
 								}
 						}
+
+						// Logging for editing course version
+						$description=$courseid." ".$versid;
+						logUserEvent($userid, EventTypes::EditCourseVers, $description);	
+
 				} else if(strcmp($opt,"CHGVERS")===0) {
 					$query = $pdo->prepare("UPDATE course SET activeversion=:vers WHERE cid=:cid");
 					$query->bindParam(':cid', $courseid);

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -315,12 +315,14 @@ abstract class EventTypes {
 	const ServiceClientEnd = 8;
 	const Logout = 9;
 	const pageLoad = 10;
-  const PageNotFound = 11;
-  const RequestNewPW = 12;
+  	const PageNotFound = 11;
+  	const RequestNewPW = 12;
 	const CheckSecQuestion = 13;
-  const SectionItems = 14;
+  	const SectionItems = 14;
 	const AddFile = 15;
-  const AddCourse = 18;
+	const EditCourseVers = 16;
+	const AddCourseVers = 17;
+  	const AddCourse = 18;
 	const EditCourse = 19;
 }
 


### PR DESCRIPTION
When editing a existing course version or creating a new logging of these events will take place.
![Screenshot 2020-04-22 at 14 39 53](https://user-images.githubusercontent.com/62876614/79982891-44fc1f00-84a7-11ea-8b44-cf7416d41e9b.png)
![Screenshot 2020-04-22 at 14 41 52](https://user-images.githubusercontent.com/62876614/79983025-7674ea80-84a7-11ea-8f08-68205bb5d06a.png)

The result from doing the above will result in: 
![Screenshot 2020-04-22 at 14 40 38](https://user-images.githubusercontent.com/62876614/79982904-49283c80-84a7-11ea-8af8-d9ccc9049ae7.png)

--- 
How to test: 
Download https://sqlitebrowser.org/dl/

![Screenshot 2020-04-22 at 11 55 52](https://user-images.githubusercontent.com/62876614/79968339-3d7d4b80-8490-11ea-8d10-443631279259.png)
