### PR TITLE
Solved issue where start and end date does not get set when creating course version - G1-2020-W18-ISSUE#8400

### DIFF
--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -88,7 +88,7 @@ if(checklogin()){
 			logUserEvent($username, EventTypes::AddCourse, $description);
 
 		}else if(strcmp($opt,"NEWVRS")===0){
-			$query = $pdo->prepare("INSERT INTO vers(cid,coursecode,vers,versname,coursename,coursenamealt) values(:cid,:coursecode,:vers,:versname,:coursename,:coursenamealt);");
+			$query = $pdo->prepare("INSERT INTO vers(cid,coursecode,vers,versname,coursename,coursenamealt,startdate,enddate) values(:cid,:coursecode,:vers,:versname,:coursename,:coursenamealt,:startdate,:enddate);");
 
 			$query->bindParam(':cid', $cid);
 			$query->bindParam(':coursecode', $coursecode);
@@ -96,6 +96,11 @@ if(checklogin()){
 			$query->bindParam(':versname', $versname);
 			$query->bindParam(':coursename', $coursename);
 			$query->bindParam(':coursenamealt', $coursenamealt);
+			// if start and end dates are null, insert mysql null value into database
+			if($startdate=="null") $query->bindValue(':startdate', null,PDO::PARAM_INT);
+			else $query->bindParam(':startdate', $startdate);
+			if($enddate=="null") $query->bindValue(':enddate', null,PDO::PARAM_INT);
+			else $query->bindParam(':enddate', $enddate);
 
 			/*
 			if(!$query->execute()) {


### PR DESCRIPTION
Previously when creating a new course version without using copy content the start end end date does not get added to the db. This issue is now solved and the result can be seen below:
![Screenshot 2020-04-22 at 15 15 04](https://user-images.githubusercontent.com/62876614/79987844-3107eb80-84ae-11ea-8907-39a8c4e6697f.png)
![Screenshot 2020-04-22 at 15 15 27](https://user-images.githubusercontent.com/62876614/79987875-3b29ea00-84ae-11ea-9914-495a78e1da3a.png)

How to test: 
Navigate to sectioned(any course), click plus sign button.