### PR TITLE
G1 2020 w18 issue#8408

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -526,7 +526,8 @@ function removeExample() {
 
 var openBoxID;
 
-function displayEditContent(boxid) {
+function displayEditContent(boxid) 
+{
 	document.getElementById("boxtitle2").removeAttribute("contenteditable");
 	// The information stored about the box is fetched
 	var box = retData['box'][boxid - 1];

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -527,26 +527,26 @@ function removeExample() {
 var openBoxID;
 
 function displayEditContent(boxid) {
-	$("#boxtitle2").removeAttr("contenteditable");
+	document.getElementById("boxtitle2").removeAttribute("contenteditable");
 	// The information stored about the box is fetched
 	var box = retData['box'][boxid - 1];
 
 	// Keeps track of the currently open box. Used when saving the box content.
 	openBoxID = boxid;
 
-	$("#boxtitle").val(box[4]);
-	$("#boxcontent").val(box[1]);
+	document.getElementById("boxtitle").value = box[4];
+	document.getElementById("boxcontent").value = box[1];
 
 	changeDirectory($("#boxcontent"));
 
 	if (box[5] != null) {
 		box[5] = box[5].replace(/&#47;/g, "/");
-		$("#filename").val(box[5]);
+		document.getElementById("filename").value = box[5]; 
 	} else {
-		$("#filename").val("");
+		document.getElementById("filename").value = "";
 	}
 
-	$("#fontsize").val(box[6]);
+	document.getElementById("fontsize").value = box[6];
 
 	var wordl = retData['wordlists'];
 	var str = "";
@@ -562,8 +562,9 @@ function displayEditContent(boxid) {
 			str += "<option>" + retData['improws'][i][1] + " - " + retData['improws'][i][2] + "</option>";
 		}
 	};
-	$("#improws").html(str);
-	$("#editContentContainer").css("display", "flex");
+	document.getElementById("improws").innerHTML = str;
+
+	document.getElementById("editContentContainer").style.display = "flex";
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Updated the function "displayEditContent" to better fit the code standard by replacing JQuery functions with native JavaScript equivalent where appropriate. Also fixed the indentation of the function to fit the code standard by moving the opening bracket one line further down.

Test by going to codeviewer.php and pressing any "Edit box settings"-button that exists (The small cogwheels on the different panels). Check if all functionality of these boxes works as intended (e.g. changing of file, kind of document, title). I recommend to check multiple panels within multiple templates in order to ensure that full functionality still exists after these changes.