### PR TITLE
#8341 Removed preview window for Zip/Rar files.

### DIFF
--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -356,6 +356,9 @@ svg text {
 .previewTable tr:nth-child(even){
   background-color: #dad8db;
 }
+.previewTable a{
+	color: var(--color-text-label);
+}
 @media only screen and (max-width: 500px) {
 	.previewTable {
 		width: auto;

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1362,6 +1362,16 @@ function findfilevers(filez,cfield,ctype,displaystate,group)
 								} else {
 									tab+=filez[i].content+"</span>";
 								}
+							}else if(ctype == "zip" || ctype == "rar"){
+								tab+="<span style='cursor: pointer;text-decoration:underline;'>";
+								tab += "<a href="+filez[i].filepath+filez[i].filename+filez[i].seq+'.'+filez[i].extension+">";
+								if (mediumMediaQuery.matches) {
+									tab+=filez[i].filename.substring(0,32)+"&#8230;"+filez[i].extension+"</a></span>";
+								} else if (mobileMediaQuery.matches) {
+									tab+=filez[i].filename.substring(0,8)+"&#8230;"+filez[i].extension+"</a></span>";
+								} else {
+									tab+=filez[i].filename+"."+filez[i].extension+"</a></span>";
+								}
 							} else {
 								tab+="<span onclick='displayPreview(\""+filez[i].filepath+"\",\""+filez[i].filename+"\",\""+filez[i].seq+"\",\""+ctype+"\",\""+filez[i].extension+"\","+i+",0);' style='cursor: pointer;text-decoration:underline;'>";
 								if (mediumMediaQuery.matches) {


### PR DESCRIPTION
Changed so when you click the link for Zip/Rar files you download it immediately instead of opening a preview with a download link.

Changed the CSS to make the link look more in place.

Co-Authored-By: a18matna <a18matna@users.noreply.github.com>
Co-Authored-By: a18oscte <a18oscte@users.noreply.github.com>