### PR TITLE
FIxes #8427 - Auto focus in appearance menu

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4595,6 +4595,7 @@ function loadAppearanceForm() {
             const entities = connections.filter(symbol => symbol.symbolkind === symbolKind.erEntity);
             const relations = connections.filter(symbol => symbol.symbolkind === symbolKind.erRelation);
             typeElement.innerHTML = makeoptions("Normal", ["Normal", "Forced", "Derived"], ["Normal", "Forced", "Derived"]);
+            typeElement.focus();
             if(entities.length > 0 && relations.length > 0) {
                 document.getElementById("cardinality").innerHTML = makeoptions("", ["None", "1", "N", "M"], ["None", "1", "N", "M"]);
                 document.getElementById("cardinalityUML").style.display = "none";
@@ -4606,6 +4607,7 @@ function loadAppearanceForm() {
             const lineTypes = ["Normal", "Association", "Inheritance", "Implementation", "Dependency", "Aggregation", "Composition"];
             const cardinalities = ["None", "0..1", "1..1", "0..*", "1..*"];
             typeElement.innerHTML = makeoptions("Normal", lineTypes, lineTypes);
+            typeElement.focus();
             document.getElementById("cardinalityUML").style.display = "block";
             document.getElementById("cardinality").innerHTML = makeoptions("None", cardinalities, cardinalities);
             document.getElementById("cardinalityUML").innerHTML = makeoptions("None", cardinalities, cardinalities);
@@ -4622,6 +4624,7 @@ function loadAppearanceForm() {
             break;
         case 0:
             document.getElementById("figureOpacity").value = object.opacity * 100;
+            document.getElementById("fillColor").focus();
             break;
     }
     setSelections(object);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4572,10 +4572,13 @@ function loadAppearanceForm() {
     //Undefined would mean the symbol is actually a path not having symbolKind, 0 is used as default for paths
     if(typeof type === "undefined") type = 0;
 
-    showFormGroups(type);
-
     const typeElement = document.getElementById("type");
     const nameElement = document.getElementById("name");
+
+    showFormGroups(type);
+    toggleApperanceElement(true);
+
+    nameElement.focus();
 
     switch(type) {
         case symbolKind.erAttribute:
@@ -4608,6 +4611,7 @@ function loadAppearanceForm() {
             document.getElementById("cardinalityUML").innerHTML = makeoptions("None", cardinalities, cardinalities);
         case symbolKind.text:
             document.getElementById("freeText").value = getTextareaText(object.textLines);
+            document.getElementById("freeText").focus();
             textAppearanceOpen = true;
             break;
         case symbolKind.uml:
@@ -4621,7 +4625,6 @@ function loadAppearanceForm() {
             break;
     }
     setSelections(object);
-    toggleApperanceElement(true);
 }
 
 function showFormGroups(type) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4557,18 +4557,6 @@ function loadAppearanceForm() {
     const object = selected_objects[selected_objects.length - 1];
     let type = object.symbolkind;
 
-    //Get objects connected to uml-line and sets name in appearance menu(used for Line direction)
-    if(object.symbolkind == symbolKind.umlLine){
-        let connectedObjectsArray = object.getConnectedObjects();
-        document.getElementById('First').innerHTML = connectedObjectsArray[0].name;
-        //Selection to check if relation is to the same entity. If so: both are named from object 0
-        if(typeof connectedObjectsArray[1] == "undefined"){
-            document.getElementById('Second').innerHTML =  connectedObjectsArray[0].name;
-        } else {
-            document.getElementById('Second').innerHTML = connectedObjectsArray[1].name;
-        }
-    }
-
     //Undefined would mean the symbol is actually a path not having symbolKind, 0 is used as default for paths
     if(typeof type === "undefined") type = 0;
 
@@ -4611,6 +4599,16 @@ function loadAppearanceForm() {
             document.getElementById("cardinalityUML").style.display = "block";
             document.getElementById("cardinality").innerHTML = makeoptions("None", cardinalities, cardinalities);
             document.getElementById("cardinalityUML").innerHTML = makeoptions("None", cardinalities, cardinalities);
+
+            //Get objects connected to uml-line and sets name in appearance menu(used for Line direction)
+            const connectedObjectsArray = object.getConnectedObjects();
+            document.getElementById("First").innerHTML = connectedObjectsArray[0].name;
+            //Selection to check if relation is to the same entity. If so: both are named from object 0
+            if(typeof connectedObjectsArray[1] == "undefined"){
+                document.getElementById("Second").innerHTML =  connectedObjectsArray[0].name;
+            } else {
+                document.getElementById("Second").innerHTML = connectedObjectsArray[1].name;
+            }
         case symbolKind.text:
             document.getElementById("freeText").value = getTextareaText(object.textLines);
             document.getElementById("freeText").focus();


### PR DESCRIPTION
This adds auto focus functionality to the appearance menu when it opens. This makes it easy to start typing or selecting directly with the keyboard instead of having to manually select the input with the mouse first. It is also easy to tab through the inputs in the form as the first option in the loaded form will always be auto focused.

The name input will be automatically selected for entities, relations, attributes, and UML classes (where they exist).
The type attribute will be automatically selected for all types of lines since that is the first and most important option for lines.
The textarea will be selected for text objects.
The fill color option will be selected for free drawn objects.

Test so all of the conditions above works as intended.

Link: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238427/DuggaSys/diagram.php