### PR TITLE
Added min-width to resultTable th element to minimise the shrinking

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2792,6 +2792,14 @@ span.arrow {
   border: 0px;
 }
 
+#resultTable th:first-of-type {
+  min-width: 30px;
+}
+
+#resultTable th {
+  min-width: 150px;
+}
+
 .resultTable_counter {
   text-align: center;
 }


### PR DESCRIPTION
The header still shrinks a little when not in "mini mode", this is to allow "mini mode" to be less wide than "normal mode". 
I can alter the css min-width to make the tables of "mini mode" and "normal mode" the same width (meaning it will never shrink) if that is preferable.