### PR TITLE
Added logging when downloading all contents from course vers - G1-2020-W18-ISSUE#8433

### DIFF
--- a/DuggaSys/downloadzip.php
+++ b/DuggaSys/downloadzip.php
@@ -26,6 +26,10 @@ if(isset($_SESSION['uid'])){
 	$userid="UNK";
 }
 
+// Logging who request to download all content from what course version 
+$description=$cid." ".$vers;
+logUserEvent($userid, EventTypes::DownloadAllCourseVers, $description);
+
 // Create new zip class 
 $zip	=	new	ZipArchive; 
 
@@ -103,10 +107,6 @@ if($zip	->	open($zipcreated,	ZipArchive::CREATE	)	===	TRUE){
 	}
 }
 
-// Logging who request to download all content from what course version 
-$description=$cid." ".$vers;
-logUserEvent($userid, EventTypes::DownloadAllCourseVers,$description);
-	
 
 ?>
 <html>

--- a/DuggaSys/downloadzip.php
+++ b/DuggaSys/downloadzip.php
@@ -20,6 +20,11 @@ $pathToActiveVersionOfCourse	=	'/courses/' . $cid .	'/'	.	$vers	.	'/';
 $zipcreated	=	"./downloads/courseID-"	.	$cid	.	"_version-"	.	$vers	.	"_All_files.zip";
 $error = false;
 
+if(isset($_SESSION['uid'])){
+	$userid=$_SESSION['uid'];
+}else{
+	$userid="UNK";
+}
 
 // Create new zip class 
 $zip	=	new	ZipArchive; 
@@ -97,6 +102,10 @@ if($zip	->	open($zipcreated,	ZipArchive::CREATE	)	===	TRUE){
 		$error = true;
 	}
 }
+
+// Logging who request to download all content from what course version 
+$description=$cid." ".$vers;
+logUserEvent($userid, EventTypes::DownloadAllCourseVers,$description);
 	
 
 ?>

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -324,6 +324,8 @@ abstract class EventTypes {
 	const AddCourseVers = 17;
   	const AddCourse = 18;
 	const EditCourse = 19;
+	const ResetPW = 20;
+	const DownloadAllCourseVers = 21;
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When downloading all contents from a course verse:
![Screenshot 2020-04-23 at 09 12 29](https://user-images.githubusercontent.com/62876614/80081685-906c0700-8553-11ea-9c40-d42e2dd2b473.png)

The result in the sqlite db will be:
![Screenshot 2020-04-23 at 11 13 52](https://user-images.githubusercontent.com/62876614/80081672-8cd88000-8553-11ea-82fe-f8e17951cb91.png)

---
How to test: 
Download https://sqlitebrowser.org/dl/

![Screenshot 2020-04-22 at 11 55 52](https://user-images.githubusercontent.com/62876614/79968339-3d7d4b80-8490-11ea-8d10-443631279259.png)
