### PR TITLE
Filled empty slots in the table of resultEd - Issue #8406

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -928,12 +928,11 @@ function renderCell(col, celldata, cellid) {
 		if (celldata.kind == 4) {
 			str += "dugga-moment ";
 		}
-		else if (celldata.uid ==218) {
-			// do nothing
-			str += "dugga-empty ";
+		else if (celldata.grade != null) {
+			// do nothing for the purpose of being able to generate styling for empty cells
 		}
 		else {
-			//str += "dugga-empty ";
+			str += "dugga-empty ";
 		}
 		if (celldata.grade > 1) {
 			str += "dugga-pass";

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -928,8 +928,12 @@ function renderCell(col, celldata, cellid) {
 		if (celldata.kind == 4) {
 			str += "dugga-moment ";
 		}
-		else if (celldata.kind != 4 || celldata.kind != 3 || celldata.kind != 2 || celldata.kind != 1 || celldata.kind != 0 || celldata.kind != 5 || celldata.kind != 6) {
+		else if (celldata.uid ==218) {
+			// do nothing
 			str += "dugga-empty ";
+		}
+		else {
+			//str += "dugga-empty ";
 		}
 		if (celldata.grade > 1) {
 			str += "dugga-pass";

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -928,6 +928,9 @@ function renderCell(col, celldata, cellid) {
 		if (celldata.kind == 4) {
 			str += "dugga-moment ";
 		}
+		else if (celldata.kind != 4 || celldata.kind != 3 || celldata.kind != 2 || celldata.kind != 1 || celldata.kind != 0 || celldata.kind != 5 || celldata.kind != 6) {
+			str += "dugga-empty ";
+		}
 		if (celldata.grade > 1) {
 			str += "dugga-pass";
 		} else if (celldata.needMarking == true && celldata.submitted <= celldata.deadline) {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3223,6 +3223,10 @@ span.arrow {
   background-image: url('../icons/Stripes2.png');
 }
 
+.dugga-empty {
+  background-color: black;
+}
+
 .dugga-result-subheader {
   border-top: 2px solid white;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3224,8 +3224,13 @@ span.arrow {
 }
 
 .dugga-empty {
-  background-color: #ddd;
   height: 50px;
+  background-color: #aaa;
+  background-image: url('../icons/not_announced_icon.svg');
+  opacity: 0.2;
+  background-repeat: no-repeat;
+  background-size: 20%;
+  background-position: center center;
 }
 
 .dugga-result-subheader {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3224,7 +3224,8 @@ span.arrow {
 }
 
 .dugga-empty {
-  background-color: black;
+  background-color: #ddd;
+  height: 50px;
 }
 
 .dugga-result-subheader {

--- a/Shared/icons/not_announced_icon.svg
+++ b/Shared/icons/not_announced_icon.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="17.797363mm"
+   height="8.1700439mm"
+   viewBox="0 0 17.797363 8.1700439"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="not_announced_icon.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2"
+     inkscape:cx="-5.5858555"
+     inkscape:cy="132.1166"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-31.867305,-46.248339)">
+    <g
+       id="g24">
+      <g
+         aria-label="N/A"
+         transform="scale(0.26458333)"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:roboto;-inkscape-font-specification:roboto;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         id="flowRoot10">
+        <path
+           id="path3737"
+           style=""
+           d="m 181.14648,195.8125 h -11.91406 l -2.67578,7.42187 h -3.86719 l 10.85938,-28.4375 h 3.28125 l 10.8789,28.4375 h -3.84765 z m -10.78125,-3.08594 h 9.66797 l -4.84375,-13.30078 z m -21.25,12.94922 h -3.10546 l 11.875,-30.87891 h 3.08593 z m -6.8164,-2.44141 h -3.76953 l -14.31641,-21.91406 v 21.91406 h -3.76953 v -28.4375 h 3.76953 l 14.35547,22.01172 v -22.01172 h 3.73047 z" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
In this pull request, we have changed the background color of the empty slots so that each empty spot has the same color. Then, we added the text "N/A", indicating that there is no data available in the spot, or that the same user is not assigned to the dugga concerned. 

![image](https://user-images.githubusercontent.com/62876523/80107561-83630e00-857b-11ea-8995-f808b6573341.png)

This fixes #8406 
With @a17pioja.