### PR TITLE
G1 2020 w18 issue#8453

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -629,7 +629,8 @@ function changeDirectory(kind) {
 var addedRows = new Array();
 var removedRows = new Array();
 
-function editImpRows(editType) {
+function editImpRows(editType) 
+{
 	var rowFrom = parseInt(document.getElementById("improwfrom").value);
 	var rowTo = parseInt(document.getElementById("improwto").value);
 	var row = document.getElementById("improwfrom").value + " - " + document.getElementById("improwto").value;

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -630,10 +630,10 @@ var addedRows = new Array();
 var removedRows = new Array();
 
 function editImpRows(editType) {
-	var rowFrom = parseInt($("#improwfrom").val());
-	var rowTo = parseInt($("#improwto").val());
-	var row = $("#improwfrom").val() + " - " + $("#improwto").val();
-
+	var rowFrom = parseInt(document.getElementById("improwfrom").value);
+	var rowTo = parseInt(document.getElementById("improwto").value);
+	var row = document.getElementById("improwfrom").value + " - " + document.getElementById("improwto").value;
+	
 	if (editType == "+" &&
 		rowFrom <= rowTo &&
 		rowFrom > 0 &&
@@ -646,9 +646,9 @@ function editImpRows(editType) {
 		});
 
 		if (exists == false) {
-			$("#improws").append('<option>' + row + '</option>');
-			$("#improwfrom").val("");
-			$("#improwto").val("");
+			document.getElementById("improws").innerHTML += '<option>' + row + '</option>';
+			document.getElementById("improwfrom").value ="";
+			document.getElementById("improwto").value ="";
 			addedRows.push([openBoxID, rowFrom, rowTo]);
 		}
 	} else if (editType == "-") {


### PR DESCRIPTION
Updated function "editImpRows" to better fit the code standard. This was made by replacing most JQuery functionality with native JavaScript where appropriate.

Test by editing a panel on the codeviewer-interface (any template works). Try specifying a some important rows (e.g rows 2-4) and press "Save". The page should update and highlight the important rows. Now try to unmark the rows as important (done by selecting said important rows and pressing on the "-" button in the editor) to check if it's still possible to remove important rows.