### PR TITLE
Added underline and hover effect on back to login - G1-2020-W18-ISSUE#7395

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1299,6 +1299,18 @@ input {
   text-decoration: underline;
 }
 
+.newpassword .forgotPw {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.newpassword .forgotPw:hover {
+  cursor: pointer;
+  text-decoration: underline;
+  background:yellow;
+}
+
+
 .loginBox .form-control {
   margin: 3px 0px 3px 0px;
 }


### PR DESCRIPTION
Before:

![Screenshot 2020-04-24 at 11 04 12](https://user-images.githubusercontent.com/62876614/80195000-8b728a80-861b-11ea-9274-9a4599e0dc63.png)

After:
![Screenshot 2020-04-24 at 11 04 37](https://user-images.githubusercontent.com/62876614/80195028-93322f00-861b-11ea-9cfb-e4879800da26.png)

![Screenshot 2020-04-24 at 11 04 28](https://user-images.githubusercontent.com/62876614/80195055-9af1d380-861b-11ea-97d4-3144e230c439.png)
