### PR TITLE
fix issue#5679 Selection of entities while line tool is chosen

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4025,6 +4025,10 @@ function mousedownevt(ev) {
 
             //Get which kind of symbol mousedownevt execute on
             symbolStartKind = diagram[lineStartObj].symbolkind;
+            //Select when in CreateLine mode
+            if (uimode == "CreateLine"){
+              handleSelect();
+            }
         }
     } else if (sel.distance < tolerance / zoomValue) {
         md = mouseState.insidePoint;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4205,7 +4205,8 @@ function mouseupevt(ev) {
             }
         }
     }
-    if (symbolStartKind == symbolKind.uml && uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode) {
+  
+    if (symbolStartKind == symbolKind.uml && uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode && startMouseCoordinateX != currentMouseCoordinateX && startMouseCoordinateY != currentMouseCoordinateY) {
         saveState = false;
         uimode = "CreateUMLLine";
         //Check if you release on canvas or try to draw a line from entity to entity
@@ -4227,9 +4228,6 @@ function mouseupevt(ev) {
                 var createNewPoint = false;
                 if (diagram[lineStartObj].symbolkind == symbolKind.erAttribute) {
                     p1 = diagram[lineStartObj].centerPoint;
-                }else if ((startMouseCoordinateX == currentMouseCoordinateX) && (startMouseCoordinateY == currentMouseCoordinateY)){
-                    createNewPoint = false;
-                    okToMakeLine = false;
                 }else {
                     createNewPoint = true;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4319,11 +4319,11 @@ function mouseupevt(ev) {
         {
             diagramObject.pointsAtSamePosition = true;
         }
-    } else if (uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode) {
+    } else if (uimode == "CreateLine") {
         //Code for making a line, if start and end object are different, except attributes and if no object is text
         if((symbolStartKind != symbolEndKind || (symbolStartKind == symbolKind.erAttribute && symbolEndKind == symbolKind.erAttribute)
         || symbolStartKind == symbolKind.uml && symbolEndKind == symbolKind.uml) && (symbolStartKind != symbolKind.line && symbolEndKind != symbolKind.line)
-        && (symbolStartKind != symbolKind.text && symbolEndKind != symbolKind.text) && okToMakeLine) {
+        && (symbolStartKind != symbolKind.text && symbolEndKind != symbolKind.text) && okToMakeLine  && md == mouseState.boxSelectOrCreateMode) {
             erLineA = new Symbol(symbolKind.line); // Lines
             erLineA.name = "Line" + diagram.length;
             erLineA.topLeft = p1;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4227,6 +4227,9 @@ function mouseupevt(ev) {
                 var createNewPoint = false;
                 if (diagram[lineStartObj].symbolkind == symbolKind.erAttribute) {
                     p1 = diagram[lineStartObj].centerPoint;
+                }else if ((startMouseCoordinateX == currentMouseCoordinateX) && (startMouseCoordinateY == currentMouseCoordinateY)){
+                    createNewPoint = false;
+                    okToMakeLine = false;
                 }else {
                     createNewPoint = true;
                 }


### PR DESCRIPTION
Before fix it was impossible to select attributes, entities, relations, classes and lines while Create Line tool was selected. Now you should be able to select all of the options above while the Create Line tool is active. 

Before fix you could create a recursive line to classes by clicking on them. Now you have to drag the mouse on the class to create a recursive line instead.

Link to test: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%235679/DuggaSys/diagram.php

First test:

Connect Attributes, relations and entities with lines and while the line tool is still active try to select all of them, including the lines themselves. 

Before:

![5ae1821ae421b5b03da843be31cbb300](https://user-images.githubusercontent.com/49142301/80210244-b9fc5f80-8633-11ea-830b-5eeb3ddb125f.gif)

After: 

![8c24a12058bf343a4592ad1773ea3361](https://user-images.githubusercontent.com/49142301/80210389-fcbe3780-8633-11ea-8eb4-44e3e700f316.gif)

Second test:

In UML-mode create two classes and connect them with a line. While the line tool is still active try to select the classes and the line. Also try to create a recursive line by holding down the mouse on a class, drag the mouse a bit, and then release the mouse. 

Before:

![fb0b7e117913a52586777716a3d09f08](https://user-images.githubusercontent.com/49142301/80210888-d9e05300-8634-11ea-86ef-48660562ec39.gif)

After: 

![281de6bf6dd36a394d7e2b381f8acf0f](https://user-images.githubusercontent.com/49142301/80210986-0dbb7880-8635-11ea-8216-c84731b39147.gif)




