### PR TITLE
Solution for copying ER-lines when copy-pasting. issue#6977

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -694,16 +694,31 @@ function keyDownHandler(e) {
         } else if (ctrlIsClicked && key == keyMap.vKey ) {
             //Ctrl + v
             var temp = [];
-            var lines = [];
+            var connected = [];
+            //Handles copying of lines
+            for (var y = 0; y < cloneTempArray.length; y++) {
+                for (var x = 0; x < cloneTempArray.length; x++) {
+                    if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].bottomRight)){
+                        var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].bottomRight);
+                        connected.push({from:y, to:x, loc: location, lineloc: "bottomRight", lineloc2: "topLeft"});
+                    }
+                    else if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].topLeft)){
+                        var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].topLeft);
+                        connected.push({from:y, to:x, loc: location, lineloc: "topLeft", lineloc2: "bottomRight"});
+                        
+                    }
+                }
+            }
             for (var i = 0; i < cloneTempArray.length; i++) {
                 const cloneIndex = copySymbol(cloneTempArray[i]) - 1;
                 temp.push(diagram[cloneIndex]);
-                if(diagram[cloneIndex].symbolkind == 4){
-                    lines.push(diagram[cloneIndex]);
-                }
+            }
+            for(var j = 0 ; j < connected.length ; j++){
+                var lineEnd1 =  temp[connected[j].to][connected[j].lineloc];
+                var lineEnd2 = temp[connected[j].to][connected[j].lineloc2];
+                temp[connected[j].from][connected[j].loc].push({from: lineEnd1, to: lineEnd2});
             }
             cloneTempArray = temp;
-            connectCopiedLine(cloneTempArray, lines);
             selected_objects = temp;
             updateGraphics();
             SaveState();
@@ -773,85 +788,6 @@ function keyDownHandler(e) {
         }
     }
 }
-
-function connectCopiedLine(cloneTempArray, lines) {
-    var alreadyConnectedLines = [];
-    
-    for (var i = 0; i < cloneTempArray.length; i++) {
-        //top
-        if(cloneTempArray[i].connectorTop.length > 0){
-            for(var j = 0 ; j < cloneTempArray[i].connectorTop.length ; j++){
-                for(var k = 0; k < cloneTempArray.length; k++){
-                    if(cloneTempArray[k].hasConnectorFromPoint(cloneTempArray[i].connectorTop[j].to) && k != i  && !alreadyConnectedLines.includes(cloneTempArray[i].connectorTop[j].to)){
-                        var newline = lines.pop();
-                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorTop[j].to).to = newline.topLeft;
-                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorTop[j].to).from = newline.bottomRight;
-                        cloneTempArray[i].connectorTop[j].to = newline.bottomRight;
-                        cloneTempArray[i].connectorTop[j].from = newline.topLeft;
-                        alreadyConnectedLines.push(cloneTempArray[i].connectorTop[j].to);
-                        alreadyConnectedLines.push(cloneTempArray[i].connectorTop[j].from);
-                        console.log("top");
-                    }
-                }
-            }
-        }
-        //right    
-        if(cloneTempArray[i].connectorRight.length > 0){
-            for(var j = 0 ; j < cloneTempArray[i].connectorRight.length ; j++){
-                for(var k = 0; k < cloneTempArray.length; k++){
-                    if(cloneTempArray[k].hasConnectorFromPoint(cloneTempArray[i].connectorRight[j].to) && k != i  && !alreadyConnectedLines.includes(cloneTempArray[i].connectorRight[j].to)){
-                        console.log(cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorRight[j].to).to);
-                        var newline = lines.pop();
-                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorRight[j].to).to = newline.topLeft;
-                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorRight[j].to).from = newline.bottomRight;
-                        cloneTempArray[i].connectorRight[j].to = newline.bottomRight;
-                        cloneTempArray[i].connectorRight[j].from = newline.topLeft;
-                        alreadyConnectedLines.push(cloneTempArray[i].connectorRight[j].to);
-                        alreadyConnectedLines.push(cloneTempArray[i].connectorRight[j].from);
-                        console.log("Right" , cloneTempArray[k] , cloneTempArray[i]);
-                        console.log(newline);
-                    }
-                }
-            }
-        }
-        //Bottom    
-        if(cloneTempArray[i].connectorBottom.length > 0){
-            for(var j = 0 ; j < cloneTempArray[i].connectorBottom.length ; j++){
-                for(var k = 0; k < cloneTempArray.length; k++){
-                    if(cloneTempArray[k].hasConnectorFromPoint(cloneTempArray[i].connectorBottom[j].to) && k != i  && !alreadyConnectedLines.includes(cloneTempArray[i].connectorBottom[j].to)){
-                        var newline = lines.pop();
-                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorBottom[j].to).to = newline.topLeft;
-                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorBottom[j].to).from = newline.bottomRight;
-                        cloneTempArray[i].connectorBottom[j].to = newline.bottomRight;
-                        cloneTempArray[i].connectorBottom[j].from = newline.topLeft;
-                        alreadyConnectedLines.push(cloneTempArray[i].connectorBottom[j].to);
-                        alreadyConnectedLines.push(cloneTempArray[i].connectorBottom[j].from);
-                        console.log("Bottom");
-                    }
-                }
-            }
-        }
-        
-        //Left    
-        if(cloneTempArray[i].connectorLeft.length > 0){
-            for(var j = 0 ; j < cloneTempArray[i].connectorLeft.length ; j++){
-                for(var k = 0; k < cloneTempArray.length; k++){
-                    if(cloneTempArray[k].hasConnectorFromPoint(cloneTempArray[i].connectorLeft[j].to) && k != i  && !alreadyConnectedLines.includes(cloneTempArray[i].connectorLeft[j].to)){
-                        console.log(alreadyConnectedLines , cloneTempArray[i].connectorLeft[j].to);
-                        var newline = lines.pop();
-                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorLeft[j].to).to = newline.topLeft;
-                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorLeft[j].to).from = newline.bottomRight;
-                        cloneTempArray[i].connectorLeft[j].to = newline.bottomRight;
-                        cloneTempArray[i].connectorLeft[j].from = newline.topLeft;
-                        alreadyConnectedLines.push(cloneTempArray[i].connectorLeft[j].to);
-                        alreadyConnectedLines.push(cloneTempArray[i].connectorLeft[j].from);
-                        console.log("Left");
-                    }
-                }
-            }
-        }
-    }
-} 
 
 //----------------------------------------------------
 // Map actual coordinates to canvas offset from origo
@@ -1130,49 +1066,7 @@ function copySymbol(symbol) {
 
     clone.topLeft = points.push(topLeftClone) - 1;
     clone.bottomRight = points.push(bottomRightClone) - 1;
-    console.log(clone);
 
-    var copiedLines = [];
-    for(var x = 0 ; cloneTempArray.length > x ; x++ ){
-        if(cloneTempArray[x].symbolkind == 4){
-            copiedLines.push(cloneTempArray[x].bottomRight);
-            copiedLines.push(cloneTempArray[x].topLeft);
-        }
-    }
-
-    if(symbol.connectorRight != "" && copiedLines.length > 0){
-        for(var x = 0 ; x < symbol.connectorRight.length ; x++){
-            if(copiedLines.includes(symbol.connectorRight[x].to) || copiedLines.includes(symbol.connectorRight[x].from)){
-                var connectorRightClone = jQuery.extend(true, {}, symbol.connectorRight[x]);
-                clone.connectorRight[x] = connectorRightClone;
-            }
-        }  
-    }
-    if(symbol.connectorLeft != "" && copiedLines.length > 0){
-        for(var x = 0 ; x < symbol.connectorLeft.length ; x++){
-            if(copiedLines.includes(symbol.connectorLeft[x].to) || copiedLines.includes(symbol.connectorLeft[x].from)){
-                var connectorLeftClone = jQuery.extend(true, {}, symbol.connectorLeft[x]);  
-                clone.connectorLeft[x] = connectorLeftClone;
-            }
-        }
-    }
-    if(symbol.connectorTop != "" && copiedLines.length > 0){
-        for(var x = 0 ; x < symbol.connectorTop.length ; x++){
-            if(copiedLines.includes(symbol.connectorTop[x].to) || copiedLines.includes(symbol.connectorTop[x].from)){
-                var connectorTopClone = jQuery.extend(true, {}, symbol.connectorTop[x]);  
-                clone.connectorTop[x] = connectorTopClone;
-            }
-        }
-    }
-    if(symbol.connectorBottom != "" && copiedLines.length > 0){
-        for(var x = 0 ; x < symbol.connectorBottom.length ; x++){
-            if(copiedLines.includes(symbol.connectorBottom[x].to) || copiedLines.includes(symbol.connectorBottom[x].from)){
-                var connectorBottomClone = jQuery.extend(true, {}, symbol.connectorBottom[x]);  
-                clone.connectorBottom[x] = connectorBottomClone;
-            }
-        }
-    }
-    
     if(clone.symbolkind != symbolKind.uml) {
         clone.centerPoint = points.push(centerPointClone) - 1;
     }else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -694,15 +694,16 @@ function keyDownHandler(e) {
         } else if (ctrlIsClicked && key == keyMap.vKey ) {
             //Ctrl + v
             var temp = [];
+            var lines = [];
             for (var i = 0; i < cloneTempArray.length; i++) {
-                //Display cloned objects except lines
-                if (cloneTempArray[i].symbolkind != symbolKind.line
-                    && cloneTempArray[i].symbolkind != symbolKind.umlLine) {
-                    const cloneIndex = copySymbol(cloneTempArray[i]) - 1;
-                    temp.push(diagram[cloneIndex]);
+                const cloneIndex = copySymbol(cloneTempArray[i]) - 1;
+                temp.push(diagram[cloneIndex]);
+                if(diagram[cloneIndex].symbolkind == 4){
+                    lines.push(diagram[cloneIndex]);
                 }
             }
             cloneTempArray = temp;
+            connectCopiedLine(cloneTempArray, lines);
             selected_objects = temp;
             updateGraphics();
             SaveState();
@@ -772,6 +773,85 @@ function keyDownHandler(e) {
         }
     }
 }
+
+function connectCopiedLine(cloneTempArray, lines) {
+    var alreadyConnectedLines = [];
+    
+    for (var i = 0; i < cloneTempArray.length; i++) {
+        //top
+        if(cloneTempArray[i].connectorTop.length > 0){
+            for(var j = 0 ; j < cloneTempArray[i].connectorTop.length ; j++){
+                for(var k = 0; k < cloneTempArray.length; k++){
+                    if(cloneTempArray[k].hasConnectorFromPoint(cloneTempArray[i].connectorTop[j].to) && k != i  && !alreadyConnectedLines.includes(cloneTempArray[i].connectorTop[j].to)){
+                        var newline = lines.pop();
+                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorTop[j].to).to = newline.topLeft;
+                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorTop[j].to).from = newline.bottomRight;
+                        cloneTempArray[i].connectorTop[j].to = newline.bottomRight;
+                        cloneTempArray[i].connectorTop[j].from = newline.topLeft;
+                        alreadyConnectedLines.push(cloneTempArray[i].connectorTop[j].to);
+                        alreadyConnectedLines.push(cloneTempArray[i].connectorTop[j].from);
+                        console.log("top");
+                    }
+                }
+            }
+        }
+        //right    
+        if(cloneTempArray[i].connectorRight.length > 0){
+            for(var j = 0 ; j < cloneTempArray[i].connectorRight.length ; j++){
+                for(var k = 0; k < cloneTempArray.length; k++){
+                    if(cloneTempArray[k].hasConnectorFromPoint(cloneTempArray[i].connectorRight[j].to) && k != i  && !alreadyConnectedLines.includes(cloneTempArray[i].connectorRight[j].to)){
+                        console.log(cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorRight[j].to).to);
+                        var newline = lines.pop();
+                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorRight[j].to).to = newline.topLeft;
+                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorRight[j].to).from = newline.bottomRight;
+                        cloneTempArray[i].connectorRight[j].to = newline.bottomRight;
+                        cloneTempArray[i].connectorRight[j].from = newline.topLeft;
+                        alreadyConnectedLines.push(cloneTempArray[i].connectorRight[j].to);
+                        alreadyConnectedLines.push(cloneTempArray[i].connectorRight[j].from);
+                        console.log("Right" , cloneTempArray[k] , cloneTempArray[i]);
+                        console.log(newline);
+                    }
+                }
+            }
+        }
+        //Bottom    
+        if(cloneTempArray[i].connectorBottom.length > 0){
+            for(var j = 0 ; j < cloneTempArray[i].connectorBottom.length ; j++){
+                for(var k = 0; k < cloneTempArray.length; k++){
+                    if(cloneTempArray[k].hasConnectorFromPoint(cloneTempArray[i].connectorBottom[j].to) && k != i  && !alreadyConnectedLines.includes(cloneTempArray[i].connectorBottom[j].to)){
+                        var newline = lines.pop();
+                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorBottom[j].to).to = newline.topLeft;
+                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorBottom[j].to).from = newline.bottomRight;
+                        cloneTempArray[i].connectorBottom[j].to = newline.bottomRight;
+                        cloneTempArray[i].connectorBottom[j].from = newline.topLeft;
+                        alreadyConnectedLines.push(cloneTempArray[i].connectorBottom[j].to);
+                        alreadyConnectedLines.push(cloneTempArray[i].connectorBottom[j].from);
+                        console.log("Bottom");
+                    }
+                }
+            }
+        }
+        
+        //Left    
+        if(cloneTempArray[i].connectorLeft.length > 0){
+            for(var j = 0 ; j < cloneTempArray[i].connectorLeft.length ; j++){
+                for(var k = 0; k < cloneTempArray.length; k++){
+                    if(cloneTempArray[k].hasConnectorFromPoint(cloneTempArray[i].connectorLeft[j].to) && k != i  && !alreadyConnectedLines.includes(cloneTempArray[i].connectorLeft[j].to)){
+                        console.log(alreadyConnectedLines , cloneTempArray[i].connectorLeft[j].to);
+                        var newline = lines.pop();
+                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorLeft[j].to).to = newline.topLeft;
+                        cloneTempArray[k].getConnectorFromPoint(cloneTempArray[i].connectorLeft[j].to).from = newline.bottomRight;
+                        cloneTempArray[i].connectorLeft[j].to = newline.bottomRight;
+                        cloneTempArray[i].connectorLeft[j].from = newline.topLeft;
+                        alreadyConnectedLines.push(cloneTempArray[i].connectorLeft[j].to);
+                        alreadyConnectedLines.push(cloneTempArray[i].connectorLeft[j].from);
+                        console.log("Left");
+                    }
+                }
+            }
+        }
+    }
+} 
 
 //----------------------------------------------------
 // Map actual coordinates to canvas offset from origo
@@ -1003,12 +1083,25 @@ function copySymbol(symbol) {
     }
 
     var topLeftClone = jQuery.extend(true, {}, points[symbol.topLeft]);
-    topLeftClone.x += 10;
-    topLeftClone.y += 10;
+    if(symbol.symbolkind!=4){
+        topLeftClone.x += 10;
+        topLeftClone.y += 10;
+    }
+    else{
+        topLeftClone.x -= 10;
+        topLeftClone.y -= 10;
+    }
 
     var bottomRightClone = jQuery.extend(true, {}, points[symbol.bottomRight]);
-    bottomRightClone.x += 10;
-    bottomRightClone.y += 10;
+    if(symbol.symbolkind!=4){
+        bottomRightClone.x += 10;
+        bottomRightClone.y += 10;
+    }
+    else{
+        bottomRightClone.x -= 10;
+        bottomRightClone.y -= 10;
+    }
+
 
     var centerPointClone = jQuery.extend(true, {}, points[symbol.centerPoint]);
     centerPointClone.x += 10;
@@ -1021,23 +1114,65 @@ function copySymbol(symbol) {
     }
 
     if(symbol.symbolkind == symbolKind.uml) {
-        clone.name = symbol.name;
+        clone.name = symbol.name + " copy";
     }else if(symbol.symbolkind == symbolKind.erAttribute) {
-        clone.name = symbol.name;
+        clone.name = symbol.name + " copy";
     }else if(symbol.symbolkind == symbolKind.erEntity) {
-        clone.name = symbol.name;
+        clone.name = symbol.name + " copy";
     }else if(symbol.symbolkind == symbolKind.line) {
-        clone.name = symbol.name;
+        clone.name = symbol.name + " copy";
     }else if(symbol.symbolkind == symbolKind.text) {
-        clone.name = symbol.name;
+        clone.name = symbol.name + " copy";
         clone.textLines.push({text:clone.name});
     } else{
-        clone.name = symbol.name;
+        clone.name = symbol.name + " copy";
     }
 
     clone.topLeft = points.push(topLeftClone) - 1;
     clone.bottomRight = points.push(bottomRightClone) - 1;
+    console.log(clone);
 
+    var copiedLines = [];
+    for(var x = 0 ; cloneTempArray.length > x ; x++ ){
+        if(cloneTempArray[x].symbolkind == 4){
+            copiedLines.push(cloneTempArray[x].bottomRight);
+            copiedLines.push(cloneTempArray[x].topLeft);
+        }
+    }
+
+    if(symbol.connectorRight != "" && copiedLines.length > 0){
+        for(var x = 0 ; x < symbol.connectorRight.length ; x++){
+            if(copiedLines.includes(symbol.connectorRight[x].to) || copiedLines.includes(symbol.connectorRight[x].from)){
+                var connectorRightClone = jQuery.extend(true, {}, symbol.connectorRight[x]);
+                clone.connectorRight[x] = connectorRightClone;
+            }
+        }  
+    }
+    if(symbol.connectorLeft != "" && copiedLines.length > 0){
+        for(var x = 0 ; x < symbol.connectorLeft.length ; x++){
+            if(copiedLines.includes(symbol.connectorLeft[x].to) || copiedLines.includes(symbol.connectorLeft[x].from)){
+                var connectorLeftClone = jQuery.extend(true, {}, symbol.connectorLeft[x]);  
+                clone.connectorLeft[x] = connectorLeftClone;
+            }
+        }
+    }
+    if(symbol.connectorTop != "" && copiedLines.length > 0){
+        for(var x = 0 ; x < symbol.connectorTop.length ; x++){
+            if(copiedLines.includes(symbol.connectorTop[x].to) || copiedLines.includes(symbol.connectorTop[x].from)){
+                var connectorTopClone = jQuery.extend(true, {}, symbol.connectorTop[x]);  
+                clone.connectorTop[x] = connectorTopClone;
+            }
+        }
+    }
+    if(symbol.connectorBottom != "" && copiedLines.length > 0){
+        for(var x = 0 ; x < symbol.connectorBottom.length ; x++){
+            if(copiedLines.includes(symbol.connectorBottom[x].to) || copiedLines.includes(symbol.connectorBottom[x].from)){
+                var connectorBottomClone = jQuery.extend(true, {}, symbol.connectorBottom[x]);  
+                clone.connectorBottom[x] = connectorBottomClone;
+            }
+        }
+    }
+    
     if(clone.symbolkind != symbolKind.uml) {
         clone.centerPoint = points.push(centerPointClone) - 1;
     }else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -696,28 +696,7 @@ function keyDownHandler(e) {
             var temp = [];
             var connected = [];
             //Handles copying of lines
-            for (var y = 0; y < cloneTempArray.length; y++) {
-                for (var x = 0; x < cloneTempArray.length; x++) {
-                    if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].bottomRight)){
-                        var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].bottomRight);
-                        connected.push({from:y, to:x, loc: location, lineloc: "bottomRight", lineloc2: "topLeft"});
-                    }
-                    else if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].topLeft)){
-                        var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].topLeft);
-                        connected.push({from:y, to:x, loc: location, lineloc: "topLeft", lineloc2: "bottomRight"});
-                        
-                    }
-                }
-            }
-            for (var i = 0; i < cloneTempArray.length; i++) {
-                const cloneIndex = copySymbol(cloneTempArray[i]) - 1;
-                temp.push(diagram[cloneIndex]);
-            }
-            for(var j = 0 ; j < connected.length ; j++){
-                var lineEnd1 =  temp[connected[j].to][connected[j].lineloc];
-                var lineEnd2 = temp[connected[j].to][connected[j].lineloc2];
-                temp[connected[j].from][connected[j].loc].push({from: lineEnd1, to: lineEnd2});
-            }
+            drawCopyERLines(connected , temp);
             cloneTempArray = temp;
             selected_objects = temp;
             updateGraphics();
@@ -786,6 +765,38 @@ function keyDownHandler(e) {
         } else if (shiftIsClicked && key == keyMap.leftArrow) {
             align(event, 'left');
         }
+    }
+}
+
+function drawCopyERLines(connected , temp){
+    for (var y = 0; y < cloneTempArray.length; y++) {
+        for (var x = 0; x < cloneTempArray.length; x++) {
+            if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].bottomRight)){
+                var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].bottomRight);
+                connected.push({from:y, to:x, loc: location, lineloc: "bottomRight", lineloc2: "topLeft"});
+            }
+            else if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].topLeft)){
+                var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].topLeft);
+                connected.push({from:y, to:x, loc: location, lineloc: "topLeft", lineloc2: "bottomRight"});
+                
+            }
+        }
+    }
+    for (var i = 0; i < cloneTempArray.length; i++) {
+        const cloneIndex = copySymbol(cloneTempArray[i]) - 1;
+        temp.push(diagram[cloneIndex]);
+    }
+
+    for(var j = 0 ; j < connected.length ; j++){
+        if(temp[connected[j].from].symbolkind == symbolKind.erAttribute){
+            temp[connected[j].to][connected[j].lineloc] = temp[connected[j].from].centerPoint;
+        }
+    }
+
+    for(var j = 0 ; j < connected.length ; j++){
+        var lineEnd1 =  temp[connected[j].to][connected[j].lineloc];
+        var lineEnd2 = temp[connected[j].to][connected[j].lineloc2];
+        temp[connected[j].from][connected[j].loc].push({from: lineEnd1, to: lineEnd2});
     }
 }
 
@@ -1050,18 +1061,18 @@ function copySymbol(symbol) {
     }
 
     if(symbol.symbolkind == symbolKind.uml) {
-        clone.name = symbol.name + " copy";
+        clone.name = symbol.name;
     }else if(symbol.symbolkind == symbolKind.erAttribute) {
-        clone.name = symbol.name + " copy";
+        clone.name = symbol.name;
     }else if(symbol.symbolkind == symbolKind.erEntity) {
-        clone.name = symbol.name + " copy";
+        clone.name = symbol.name;
     }else if(symbol.symbolkind == symbolKind.line) {
-        clone.name = symbol.name + " copy";
+        clone.name = symbol.name;
     }else if(symbol.symbolkind == symbolKind.text) {
-        clone.name = symbol.name + " copy";
+        clone.name = symbol.name;
         clone.textLines.push({text:clone.name});
     } else{
-        clone.name = symbol.name + " copy";
+        clone.name = symbol.name;
     }
 
     clone.topLeft = points.push(topLeftClone) - 1;

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -611,6 +611,29 @@ function Symbol(kindOfSymbol) {
         }
     }
 
+    this.getConnectorFromPoint = function(point) {
+        for (var i = 0; i < this.connectorTop.length; i++) {
+            if(this.connectorTop[i].from == point) {
+                return this.connectorTop[i];
+            }
+        }
+        for(var i = 0; i < this.connectorRight.length; i++) {
+            if(this.connectorRight[i].from == point) {
+                return this.connectorRight[i];
+            }
+        }
+        for (var i = 0; i < this.connectorBottom.length; i++) {
+            if(this.connectorBottom[i].from == point) {
+                return this.connectorBottom[i];
+            }
+        }
+        for (var i = 0; i < this.connectorLeft.length; i++) {
+            if(this.connectorLeft[i].from == point) {
+                return this.connectorLeft[i];
+            }
+        }
+    }
+
 
     //--------------------------------------------------------------------
     // isClicked: Returns true if xk,yk is inside the bounding box of the symbol

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -611,29 +611,63 @@ function Symbol(kindOfSymbol) {
         }
     }
 
-    this.getConnectorFromPoint = function(point) {
+    //--------------------------------------------------------------------
+    // Gets the connectors name from given point
+    //--------------------------------------------------------------------
+    this.getConnectorNameFromPoint = function(point) {
         for (var i = 0; i < this.connectorTop.length; i++) {
             if(this.connectorTop[i].from == point) {
-                return this.connectorTop[i];
+                return "connectorTop";
             }
         }
         for(var i = 0; i < this.connectorRight.length; i++) {
             if(this.connectorRight[i].from == point) {
-                return this.connectorRight[i];
+                return "connectorRight";
             }
         }
         for (var i = 0; i < this.connectorBottom.length; i++) {
             if(this.connectorBottom[i].from == point) {
-                return this.connectorBottom[i];
+                return "connectorBottom";
             }
         }
         for (var i = 0; i < this.connectorLeft.length; i++) {
             if(this.connectorLeft[i].from == point) {
-                return this.connectorLeft[i];
+                return "connectorLeft";
             }
         }
     }
 
+    //--------------------------------------------------------------------
+    // Gets connected lines
+    //--------------------------------------------------------------------
+    this.getConnectedTo = function(){
+        var connected = [];
+        //top
+        if(this.connectorTop.length > 0){
+            for(var j = 0 ; j < this.connectorTop.length ; j++){
+                connected.push(this.connectorTop[j].from);
+            }
+        }
+        //right
+        if(this.connectorRight.length > 0){
+            for(var j = 0 ; j < this.connectorRight.length ; j++){
+                connected.push(this.connectorRight[j].from);
+            }
+        }
+        //bottom
+        if(this.connectorBottom.length > 0){
+            for(var j = 0 ; j < this.connectorBottom.length ; j++){
+                connected.push(this.connectorBottom[j].from);
+            }
+        }
+        //left
+        if(this.connectorLeft.length > 0){
+            for(var j = 0 ; j < this.connectorLeft.length ; j++){
+                connected.push(this.connectorLeft[j].from);
+            }
+        }
+        return connected;
+    }
 
     //--------------------------------------------------------------------
     // isClicked: Returns true if xk,yk is inside the bounding box of the symbol


### PR DESCRIPTION
Fixes #6977

A solution which makes it possible for ER-lines to be copied and pasted, while keeping correct connections to it's copied objects.

Note: UML-lines ar more difficult to deal with due to breakpoints, and currently UML-classes can't even be copied. So this should be made to a separate issue.