### PR TITLE
Fixes #7677 - Changing appearance of different types of objects simultaneously

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4600,6 +4600,21 @@ function createCardinality() {
     }
 }
 
+function createCollapsible(formGroups, types, index) {
+    const collapsibleElement = document.createElement("div");
+    const objectTypesElement = document.createElement("div");
+    const iconContainer = document.createElement("div");
+    const icon = document.createElement("div");
+    const title = document.createElement("div");
+    const formGroupContainer = document.createElement("div");
+
+    collapsibleElement.appendChild(objectTypesElement);
+    collapsibleElement.appendChild(formGroupContainer);
+    objectTypesElement.appendChild(iconContainer);
+    objectTypesElement.appendChild(title);
+    iconContainer.appendChild(icon);
+}
+
 function loadGlobalAppearanceForm() {
     showFormGroups(-1);
     globalappearanceMenuOpen = true;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4750,7 +4750,17 @@ function showFormGroups(typesToShow) {
     formGroupsToShow.forEach(group => group.style.display = "block");
 
     const groupsByTypes = formGroupsToShow.reduce((result, group) => {
-        
+        const groupTypes = group.dataset.types.split(",");
+        const types = groupTypes.filter(type => typesToShow.includes(parseInt(type)));
+        const duplicateTypesIndex = result.findIndex(item => sameMembers(item.types, types));
+        if(duplicateTypesIndex === -1) {
+            result.push({
+                groups: [group],
+                types: types
+            });
+        } else {
+            result[duplicateTypesIndex].groups.push(group);
+        }
         return result;
     }, []);
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4738,10 +4738,27 @@ function loadAppearanceForm() {
 }
 
 function showFormGroups(typesToShow) {
+    const form = document.getElementById("appearanceForm");
+
+    //Replace appearance form with original to keep structure after collapsible addition changes it
+    form.parentNode.replaceChild(originalAppearanceForm, form);
+
     const allformGroups = document.querySelectorAll("#appearanceForm .form-group");
     const formGroupsToShow = getGroupsByTypes(typesToShow);
+
     allformGroups.forEach(group => group.style.display = "none");
     formGroupsToShow.forEach(group => group.style.display = "block");
+
+    const groupsByTypes = formGroupsToShow.reduce((result, group) => {
+        
+        return result;
+    }, []);
+
+    initAppearanceForm();
+    groupsByTypes.forEach((object, i) => createCollapsible(object.groups, object.types, i));
+
+    //Always put submit-button in the end of the form
+    document.getElementById("appearanceForm").appendChild(document.getElementById("appearanceButtonContainer"));
 }
 
 function getTextareaText(array) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4845,6 +4845,7 @@ function setSelections(object) {
 function setSelectedObjectsProperties(element) {
     const types = element.parentNode.dataset.types.split(",");
     let textareaIndex = 0;
+    let nameIndex = 0;
 
     //Using global array populated with objects when form is loaded to prevent selected objects that are locked
     appearanceObjects.forEach(object => {
@@ -4864,6 +4865,9 @@ function setSelectedObjectsProperties(element) {
                 }
             } else if(element.id == "commentCheck") {
                 object[access[0]][access[1]] = element.checked;
+            } else if(element.id === "name") {
+                object[access[0]] = element.value.split(",")[nameIndex].trim();
+                nameIndex++;
             } else if(access.length === 1) {
                 object[access[0]] = element.value;
             } else if(access.length === 2) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4622,7 +4622,6 @@ function loadAppearanceForm() {
     //Undefined would mean the symbol is actually a path not having symbolKind, 0 is used as default for paths
     if(typeof type === "undefined") type = 0;
 
-    const typeElement = document.getElementById("type");
     const nameElement = document.getElementById("name");
 
     showFormGroups(type);
@@ -4632,12 +4631,10 @@ function loadAppearanceForm() {
 
     switch(type) {
         case symbolKind.erAttribute:
-            typeElement.innerHTML = makeoptions("Normal", ["Primary key", "Partial key", "Normal", "Multivalue", "Derive"], ["Primary key", "Partial key", "Normal", "Multivalue", "Derive"]);
             nameElement.value = object.name;
             break;
         case symbolKind.erEntity:
         case symbolKind.erRelation:
-            typeElement.innerHTML = makeoptions("Normal", ["Weak", "Strong"], ["Weak", "Normal"]);
             nameElement.value = object.name;
             break;
         case symbolKind.line:
@@ -4647,14 +4644,9 @@ function loadAppearanceForm() {
             if(!hasEntity || !hasRelation) {
                 document.getElementById("cardinalityER").parentNode.style.display = "none";
             }
-            typeElement.innerHTML = makeoptions("Normal", ["Normal", "Forced", "Derived"], ["Normal", "Forced", "Derived"]);
             document.getElementById("typeLine").focus();
             break;
         case symbolKind.umlLine:
-            const lineTypes = ["Normal", "Association", "Inheritance", "Implementation", "Dependency", "Aggregation", "Composition"];
-            typeElement.innerHTML = makeoptions("Normal", lineTypes, lineTypes);
-            typeElement.focus();
-
             //Get objects connected to uml-line and sets name in appearance menu(used for Line direction)
             const connectedObjectsArray = object.getConnectedObjects();
             document.getElementById("First").innerHTML = connectedObjectsArray[0].name;
@@ -4664,6 +4656,7 @@ function loadAppearanceForm() {
             } else {
                 document.getElementById("Second").innerHTML = connectedObjectsArray[1].name;
             }
+            document.getElementById("typeLineUML").focus();
         case symbolKind.text:
             document.getElementById("freeText").value = getTextareaText(object.textLines);
             document.getElementById("freeText").focus();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4642,25 +4642,18 @@ function loadAppearanceForm() {
             break;
         case symbolKind.line:
             const connections = object.getConnectedObjects();
-            const entities = connections.filter(symbol => symbol.symbolkind === symbolKind.erEntity);
-            const relations = connections.filter(symbol => symbol.symbolkind === symbolKind.erRelation);
-            typeElement.innerHTML = makeoptions("Normal", ["Normal", "Forced", "Derived"], ["Normal", "Forced", "Derived"]);
-            typeElement.focus();
-            if(entities.length > 0 && relations.length > 0) {
-                document.getElementById("cardinality").innerHTML = makeoptions("", ["None", "1", "N", "M"], ["None", "1", "N", "M"]);
-                document.getElementById("cardinalityUML").style.display = "none";
-            } else {
-                document.getElementById("cardinality").parentNode.style.display = "none";
+            const hasEntity = connections.some(symbol => symbol.symbolkind === symbolKind.erEntity);
+            const hasRelation = connections.some(symbol => symbol.symbolkind === symbolKind.erRelation);
+            if(!hasEntity || !hasRelation) {
+                document.getElementById("cardinalityER").parentNode.style.display = "none";
             }
+            typeElement.innerHTML = makeoptions("Normal", ["Normal", "Forced", "Derived"], ["Normal", "Forced", "Derived"]);
+            document.getElementById("typeLine").focus();
             break;
         case symbolKind.umlLine:
             const lineTypes = ["Normal", "Association", "Inheritance", "Implementation", "Dependency", "Aggregation", "Composition"];
-            const cardinalities = ["None", "0..1", "1..1", "0..*", "1..*"];
             typeElement.innerHTML = makeoptions("Normal", lineTypes, lineTypes);
             typeElement.focus();
-            document.getElementById("cardinalityUML").style.display = "block";
-            document.getElementById("cardinality").innerHTML = makeoptions("None", cardinalities, cardinalities);
-            document.getElementById("cardinalityUML").innerHTML = makeoptions("None", cardinalities, cardinalities);
 
             //Get objects connected to uml-line and sets name in appearance menu(used for Line direction)
             const connectedObjectsArray = object.getConnectedObjects();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4847,16 +4847,15 @@ function initAppearanceForm() {
                     element.addEventListener("input", setGlobalProperties);
                 }
             } else if(element.tagName === "INPUT" || element.tagName === "TEXTAREA") {
-                if(element.type === "submit") {
-                    element.addEventListener("click", submitAppearanceForm);
-                } else {
-                    element.addEventListener("input", setObjectProperties);
-                }
+                element.addEventListener("input", setObjectProperties);
             } else if(element.tagName === "SELECT") {
                 element.addEventListener("change", setObjectProperties);
             }
         });
     });
+
+    const submitButton = document.querySelector("#appearanceButtonContainer .submit-button");
+    submitButton.addEventListener("click", submitAppearanceForm);
 
     const appearanceContainer = document.getElementById("appearance");
     appearanceContainer.addEventListener("mousedown", e => appearanceMouseDownElement = e.target);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4657,26 +4657,39 @@ function loadGlobalAppearanceForm() {
     setGlobalSelections();
 }
 
+let appearanceObjects = [];
+
 function loadAppearanceForm() {
-    //Should not load a form if no symbol was selected or any selected symbol is locked
-    if(selected_objects.length < 1) return;
-    for(let i = 0; i < selected_objects.length; i++){
-        if(selected_objects[i].isLocked) return;
+    appearanceObjects = [];
+
+    //Should not load form if there are no unlocked objects.
+    //Do not care about locked objects in appearance form.
+    for(const object of selected_objects) {
+        if(!object.isLocked) {
+            appearanceObjects.push(object);
+        }
+    }
+    if(appearanceObjects.length < 1) {
+        return;
     }
 
-    //Get type of previously selected symbol according to symbolKind object
-    const object = selected_objects[selected_objects.length - 1];
-    let type = object.symbolkind;
-
-    //Undefined would mean the symbol is actually a path not having symbolKind, 0 is used as default for paths
-    if(typeof type === "undefined") type = 0;
-
-    const nameElement = document.getElementById("name");
-
-    showFormGroups([type]);
+    const types = appearanceObjects.reduce((result, object) => {
+        const type = object.symbolkind || 0;
+        if(!result.includes(type)) {
+            result.push(type);
+        }
+        return result;
+    }, []);
+    
+    showFormGroups(types);
     toggleApperanceElement(true);
-
+    
+    const nameElement = document.getElementById("name");
     nameElement.focus();
+
+    //Temporary until solution for multiple
+    const type = types[0];
+    const object = appearanceObjects[0];
 
     switch(type) {
         case symbolKind.erAttribute:

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4781,10 +4781,11 @@ function getTextareaText(array) {
     return text;
 }
 
-function setTextareaText(element, array) {
-    const textLines = element.value.split('\n');
-    array = [];
-    textLines.forEach(text => array.push({"text": text}));
+function getTextareaArray(element, index) {
+    const objectText = element.value.split(",\n");
+    const indexTextLines = objectText[index].split("\n");
+    const array = [];
+    indexTextLines.forEach(text => array.push({"text": text}));
     return array;
 }
 
@@ -4843,13 +4844,15 @@ function setSelections(object) {
 
 function setSelectedObjectsProperties(element) {
     const types = element.parentNode.dataset.types.split(",");
+    let textareaIndex = 0;
 
     //Using global array populated with objects when form is loaded to prevent selected objects that are locked
     appearanceObjects.forEach(object => {
         if((types.includes((object.symbolkind || 0).toString()))) {
             const access = element.dataset.access.split(".");
             if(element.nodeName === "TEXTAREA") {
-                object[access[0]] = setTextareaText(element, object[access[0]]);
+                object[access[0]] = getTextareaArray(element, textareaIndex);
+                textareaIndex++;
             } else if(element.type === "range") {
                 object[access[0]] = element.value / 100;
             } else if(access[0] === "cardinality") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4600,6 +4600,18 @@ function createCardinality() {
     }
 }
 
+const symbolTypeMap = {
+    "-1": "Global",
+    "0": "Path",
+    "1": "UML",
+    "2": "Attribute",
+    "3": "Entity",
+    "4": "ER line",
+    "5": "Relation",
+    "6": "Text",
+    "7": "UML line"
+}
+
 function createCollapsible(formGroups, types, index) {
     const collapsibleElement = document.createElement("div");
     const objectTypesElement = document.createElement("div");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4625,6 +4625,16 @@ function createCollapsible(formGroups, types, index) {
     }
 
     iconContainer.addEventListener("click", () => collapsibleElement.classList.toggle("closed"));
+
+    //Set collapsible title to the object names the collapsible should represent. Seperate by comma (no comma for last)
+    types.forEach((type, i) => {
+        title.innerText += symbolTypeMap[type];
+        if(i !== types.length - 1) title.innerText += ", ";
+    });
+
+    formGroups.forEach(group => formGroupContainer.appendChild(group));
+
+    document.getElementById("appearanceForm").appendChild(collapsibleElement);
 }
 
 function loadGlobalAppearanceForm() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4672,14 +4672,9 @@ function loadAppearanceForm() {
     if(appearanceObjects.length < 1) {
         return;
     }
-
-    const types = appearanceObjects.reduce((result, object) => {
-        const type = object.symbolkind || 0;
-        if(!result.includes(type)) {
-            result.push(type);
-        }
-        return result;
-    }, []);
+    
+    //Get all unique types from the selected objects
+    const types = [...new Set(appearanceObjects.map(object => object.symbolkind || 0))];
     
     showFormGroups(types);
     toggleApperanceElement(true);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4672,7 +4672,7 @@ function loadAppearanceForm() {
     if(appearanceObjects.length < 1) {
         return;
     }
-    
+
     //Get all unique types from the selected objects
     const types = [...new Set(appearanceObjects.map(object => object.symbolkind || 0))];
     
@@ -4681,6 +4681,10 @@ function loadAppearanceForm() {
     
     const nameElement = document.getElementById("name");
     nameElement.focus();
+
+    appearanceObjects.forEach((object, i) => {
+
+    });
 
     //Temporary until solution for multiple
     const type = types[0];
@@ -4843,6 +4847,9 @@ function setObjectProperties() {
 //Stores which element the mouse was pressed down on while in the appearance menu.
 let appearanceMouseDownElement = null;
 
+//Stores a copy of the appearance form HTML-element with its childnodes
+let originalAppearanceForm = null;
+
 function initAppearanceForm() {
     const formGroups = document.querySelectorAll("#appearanceForm .form-group");
     formGroups.forEach(group => {
@@ -4872,6 +4879,8 @@ function initAppearanceForm() {
             toggleApperanceElement();
         }
     });
+
+    originalAppearanceForm = document.getElementById("appearanceForm").cloneNode(true);
 }
 
 function getGroupsByTypes(typesToShow) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4841,32 +4841,27 @@ function setSelections(object) {
 }
 
 
-function setObjectProperties() {
-    for(const object of selected_objects) {
-        const groups = getGroupsByTypes([object.symbolkind || 0]);
-        groups.forEach(group => {
-            const elements = group.querySelectorAll("input:not([type='submit']), select, textarea");
-            elements.forEach(element => {
-                let access = element.dataset.access.split(".");
-                if(element.nodeName === "TEXTAREA") {
-                    object[access[0]] = setTextareaText(element, object[access[0]]);
-                } else if(element.type === "range") {
-                    object[access[0]] = element.value / 100;
-                } else if(access[0] === "cardinality") {
-                    if(element.style.display !== "none") {
-                        if(element.value === "None") element.value = "";
-                        object[access[0]][access[1]] = element.value;
-                    }
-                } else if(element.id == "commentCheck") {
-                    object[access[0]][access[1]] = element.checked;
-                } else if(access.length === 1) {
-                    object[access[0]] = element.value;
-                } else if(access.length === 2) {
-                    object[access[0]][access[1]] = element.value;
-                }
-            });
-        });        
-    }
+function setSelectedObjectsProperties(element) {
+    //Using global array populated with objects when form is loaded to prevent selected objects that are locked
+    appearanceObjects.forEach(object => {
+        const access = element.dataset.access.split(".");
+        if(element.nodeName === "TEXTAREA") {
+            object[access[0]] = setTextareaText(element, object[access[0]]);
+        } else if(element.type === "range") {
+            object[access[0]] = element.value / 100;
+        } else if(access[0] === "cardinality") {
+            if(element.style.display !== "none") {
+                if(element.value === "None") element.value = "";
+                object[access[0]][access[1]] = element.value;
+            }
+        } else if(element.id == "commentCheck") {
+            object[access[0]][access[1]] = element.checked;
+        } else if(access.length === 1) {
+            object[access[0]] = element.value;
+        } else if(access.length === 2) {
+            object[access[0]][access[1]] = element.value;
+        }
+    });
     updateGraphics();
 }
 
@@ -4888,9 +4883,9 @@ function initAppearanceForm() {
                     element.addEventListener("input", setGlobalProperties);
                 }
             } else if(element.tagName === "INPUT" || element.tagName === "TEXTAREA") {
-                element.addEventListener("input", setObjectProperties);
+                element.addEventListener("input", () => setSelectedObjectsProperties(element));
             } else if(element.tagName === "SELECT") {
-                element.addEventListener("change", setObjectProperties);
+                element.addEventListener("change", () => setSelectedObjectsProperties(element));
             }
         });
     });
@@ -4927,8 +4922,6 @@ function submitAppearanceForm() {
     });
     if(globalappearanceMenuOpen) {
         setGlobalProperties();
-    } else {
-        setObjectProperties();
     }
     SaveState();
     toggleApperanceElement();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4761,6 +4761,14 @@ function showFormGroups(typesToShow) {
     document.getElementById("appearanceForm").appendChild(document.getElementById("appearanceButtonContainer"));
 }
 
+function containsAll(array1, array2) {
+    return array1.every(item => array2.includes(item));
+}
+
+function sameMembers(array1, array2) {
+    return containsAll(array1, array2) && containsAll(array2, array1);
+}
+
 function getTextareaText(array) {
     let text = "";
     for (let i = 0; i < array.length; i++) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4613,6 +4613,18 @@ function createCollapsible(formGroups, types, index) {
     objectTypesElement.appendChild(iconContainer);
     objectTypesElement.appendChild(title);
     iconContainer.appendChild(icon);
+
+    collapsibleElement.classList.add("collapsible");
+    objectTypesElement.classList.add("object-types");
+    iconContainer.classList.add("square");
+    formGroupContainer.classList.add("form-groups");
+
+    //The first collapsible should be opened by default, possible others should be closed
+    if(index !== 0) {
+        collapsibleElement.classList.add("closed");
+    }
+
+    iconContainer.addEventListener("click", () => collapsibleElement.classList.toggle("closed"));
 }
 
 function loadGlobalAppearanceForm() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4679,62 +4679,53 @@ function loadAppearanceForm() {
     showFormGroups(types);
     toggleApperanceElement(true);
     
-    const nameElement = document.getElementById("name");
-    nameElement.focus();
+    let erCardinalityVisible = false;
 
-    appearanceObjects.forEach((object, i) => {
+    //A comma at the end to seperate objects right now. Should be fixed in seperate issue to only appear on last object in the type
+    appearanceObjects.forEach(object => {
+        if(object.symbolkind === symbolKind.uml || object.symbolkind === symbolKind.erAttribute || object.symbolkind === symbolKind.erEntity || object.symbolkind === symbolKind.erRelation) {
+            document.getElementById("name").value += object.name + ", ";
+            document.getElementById("name").focus();
+        }
 
-    });
-
-    //Temporary until solution for multiple
-    const type = types[0];
-    const object = appearanceObjects[0];
-
-    switch(type) {
-        case symbolKind.erAttribute:
-            nameElement.value = object.name;
-            break;
-        case symbolKind.erEntity:
-        case symbolKind.erRelation:
-            nameElement.value = object.name;
-            break;
-        case symbolKind.line:
+        if(object.symbolkind === symbolKind.line) {
             const connections = object.getConnectedObjects();
             const hasEntity = connections.some(symbol => symbol.symbolkind === symbolKind.erEntity);
             const hasRelation = connections.some(symbol => symbol.symbolkind === symbolKind.erRelation);
-            if(!hasEntity || !hasRelation) {
-                document.getElementById("cardinalityER").parentNode.style.display = "none";
+            if(!erCardinalityVisible) {
+                if(hasEntity && hasRelation) {
+                    document.getElementById("cardinalityER").parentNode.style.display = "block";
+                    erCardinalityVisible = true;
+                } else {
+                    document.getElementById("cardinalityER").parentNode.style.display = "none";
+                }
             }
             document.getElementById("typeLine").focus();
-            break;
-        case symbolKind.umlLine:
+        } else if(object.symbolkind === symbolKind.umlLine) {
             //Get objects connected to uml-line and sets name in appearance menu(used for Line direction)
             const connectedObjectsArray = object.getConnectedObjects();
-            document.getElementById("First").innerHTML = connectedObjectsArray[0].name;
+            document.getElementById("First").innerHTML += connectedObjectsArray[0].name + ", ";
             //Selection to check if relation is to the same entity. If so: both are named from object 0
             if(typeof connectedObjectsArray[1] == "undefined"){
-                document.getElementById("Second").innerHTML =  connectedObjectsArray[0].name;
+                document.getElementById("Second").innerHTML +=  connectedObjectsArray[0].name + ", ";
             } else {
-                document.getElementById("Second").innerHTML = connectedObjectsArray[1].name;
+                document.getElementById("Second").innerHTML += connectedObjectsArray[1].name + ", ";
             }
             document.getElementById("typeLineUML").focus();
-        case symbolKind.text:
-            document.getElementById("freeText").value = getTextareaText(object.textLines);
+        } else if(object.symbolkind === symbolKind.text) {
+            document.getElementById("freeText").value += getTextareaText(object.textLines) + ",\n";
             document.getElementById("freeText").focus();
             textAppearanceOpen = true;
-            break;
-        case symbolKind.uml:
-            nameElement.value = object.name;
-            document.getElementById("umlAttributes").value = getTextareaText(object.attributes);
-            document.getElementById("umlOperations").value = getTextareaText(object.operations);
+        } else if(object.symbolkind === symbolKind.uml) {
+            document.getElementById("umlOperations").value += getTextareaText(object.operations) + ",\n";
+            document.getElementById("umlAttributes").value += getTextareaText(object.attributes) + ",\n";
             classAppearanceOpen = true;
-            break;
-        case 0:
+        } else if(object.kind === kind.path) {
             document.getElementById("figureOpacity").value = object.opacity * 100;
             document.getElementById("fillColor").focus();
-            break;
-    }
-    setSelections(object);
+        }
+        setSelections(object);
+    });
 }
 
 function showFormGroups(typesToShow) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4650,7 +4650,7 @@ function createCollapsible(formGroups, types, index) {
 }
 
 function loadGlobalAppearanceForm() {
-    showFormGroups(-1);
+    showFormGroups([-1]);
     globalappearanceMenuOpen = true;
     toggleApperanceElement(true);
     document.getElementById("lineThicknessGlobal").value = settings.properties.lineWidth;
@@ -4673,7 +4673,7 @@ function loadAppearanceForm() {
 
     const nameElement = document.getElementById("name");
 
-    showFormGroups(type);
+    showFormGroups([type]);
     toggleApperanceElement(true);
 
     nameElement.focus();
@@ -4725,9 +4725,9 @@ function loadAppearanceForm() {
     setSelections(object);
 }
 
-function showFormGroups(type) {
+function showFormGroups(typesToShow) {
     const allformGroups = document.querySelectorAll("#appearanceForm .form-group");
-    const formGroupsToShow = getGroupsByType(type);
+    const formGroupsToShow = getGroupsByTypes(typesToShow);
     allformGroups.forEach(group => group.style.display = "none");
     formGroupsToShow.forEach(group => group.style.display = "block");
 }
@@ -4751,7 +4751,7 @@ function setTextareaText(element, array) {
 }
 
 function setGlobalSelections() {
-    const groups = getGroupsByType(-1);
+    const groups = getGroupsByTypes([-1]);
     groups.forEach(group => {
         const select = group.querySelector("select");
         if(select !== null) {
@@ -4762,7 +4762,7 @@ function setGlobalSelections() {
 }
 
 function setGlobalProperties() {
-    const groups = getGroupsByType(-1);
+    const groups = getGroupsByTypes([-1]);
     groups.forEach(group => {
         const element = group.querySelector("select, input:not([type='submit'])");
         if(element !== null) {
@@ -4775,12 +4775,7 @@ function setGlobalProperties() {
 }
 
 function setSelections(object) {
-    let groups = [];
-    if(object.kind === kind.symbol) {
-        groups = getGroupsByType(object.symbolkind);
-    } else if(object.kind === kind.path) {
-        groups = getGroupsByType(0);
-    }
+    const groups = getGroupsByTypes([object.symbolkind || 0]);
 
     groups.forEach(group => {
         const elements = group.querySelectorAll("select, input[type='checkbox']");
@@ -4810,12 +4805,7 @@ function setSelections(object) {
 
 function setObjectProperties() {
     for(const object of selected_objects) {
-        let groups = [];
-        if(object.kind === kind.symbol) {
-            groups = getGroupsByType(object.symbolkind);
-        } else if(object.kind === kind.path) {
-            groups = getGroupsByType(0);
-        }
+        const groups = getGroupsByTypes([object.symbolkind || 0]);
         groups.forEach(group => {
             const elements = group.querySelectorAll("input:not([type='submit']), select, textarea");
             elements.forEach(element => {
@@ -4877,11 +4867,11 @@ function initAppearanceForm() {
     });
 }
 
-function getGroupsByType(type) {
+function getGroupsByTypes(typesToShow) {
     const formGroups = document.querySelectorAll("#appearanceForm .form-group");
     return [...formGroups].filter(group => {
         const types = group.dataset.types.split(",");
-        return types.includes(type.toString());
+        return typesToShow.some(type => types.includes(type.toString()));
     });
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4842,24 +4842,30 @@ function setSelections(object) {
 
 
 function setSelectedObjectsProperties(element) {
+    const types = element.parentNode.dataset.types.split(",");
+
     //Using global array populated with objects when form is loaded to prevent selected objects that are locked
     appearanceObjects.forEach(object => {
-        const access = element.dataset.access.split(".");
-        if(element.nodeName === "TEXTAREA") {
-            object[access[0]] = setTextareaText(element, object[access[0]]);
-        } else if(element.type === "range") {
-            object[access[0]] = element.value / 100;
-        } else if(access[0] === "cardinality") {
-            if(element.style.display !== "none") {
-                if(element.value === "None") element.value = "";
+        if((types.includes((object.symbolkind || 0).toString()))) {
+            const access = element.dataset.access.split(".");
+            if(element.nodeName === "TEXTAREA") {
+                object[access[0]] = setTextareaText(element, object[access[0]]);
+            } else if(element.type === "range") {
+                object[access[0]] = element.value / 100;
+            } else if(access[0] === "cardinality") {
+                if(element.style.display !== "none") {
+                    if(element.value === "None") {
+                        element.value = "";
+                    }
+                    object[access[0]][access[1]] = element.value;
+                }
+            } else if(element.id == "commentCheck") {
+                object[access[0]][access[1]] = element.checked;
+            } else if(access.length === 1) {
+                object[access[0]] = element.value;
+            } else if(access.length === 2) {
                 object[access[0]][access[1]] = element.value;
             }
-        } else if(element.id == "commentCheck") {
-            object[access[0]][access[1]] = element.checked;
-        } else if(access.length === 1) {
-            object[access[0]] = element.value;
-        } else if(access.length === 2) {
-            object[access[0]][access[1]] = element.value;
         }
     });
     updateGraphics();

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -479,7 +479,7 @@
     </div>
     <!-- The Appearance menu. Default state is display: none; -->
     <div id="appearance" class='loginBoxContainer'>
-        <div class='loginBox'>
+        <div id="appearanceFormContainer" class='loginBox'>
             <div class='loginBoxheader'>
                 <h3 id='loginBoxTitle'>Appearance</h3>
                 <div class='cursorPointer' onclick='toggleApperanceElement();'>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -67,6 +67,14 @@
             <option value=\'Impact\'>Impact</option>
             <option value=\'Calibri\'>Calibri</option>
         ';
+
+        $cardinalitiesUML = '
+            <option value=\'None\' selected>None</option>
+            <option value=\'0..1\'>0..1</option>
+            <option value=\'1..1\'>1..1</option>
+            <option value=\'0..*\'>0..*</option>
+            <option value=\'1..*\'>1..*</option>
+        ';
     ?>
     <!-- content START -->
     <div id="contentDiagram">
@@ -532,10 +540,20 @@
                             <option value="Second" id = "Second">Second object</option>
                         </select>
                     </div>
-                    <div class="form-group" data-types="4,7">
-                        <label for="cardinality">Cardinality:</label>
-                        <select id="cardinality" data-access="cardinality.value"></select></br>
-                        <select id="cardinalityUML" data-access="cardinality.valueUML"></select>
+                    <div class="form-group" data-types="4">
+                        <label for="cardinalityER">ER cardinality:</label>
+                        <select id="cardinalityER" data-access="cardinality.value">
+                            <option value="None" selected>None</option>
+                            <option value="1">1</option>
+                            <option value="N">N</option>
+                            <option value="M">M</option>
+                        </select>
+                    </div>
+                    <div class="form-group" data-types="7">
+                        <label for="cardinalityUMLFirst">UML cardinality:</label>
+                        <select id="cardinalityUMLFirst" data-access="cardinality.value"><?=$cardinalitiesUML;?></select>
+                        </br>
+                        <select id="cardinalityUMLSecond" data-access="cardinality.valueUML"><?=$cardinalitiesUML;?></select>
                     </div>
                     <div class="form-group" data-types="1">
                         <label for="umlAttributes">Attributes:</label>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -493,9 +493,42 @@
                         <label for="name">Name:</label>
                         <input type="text" id="name" data-access="name">
                     </div>
-                    <div class="form-group" data-types="2,3,4,5,7">
-                        <label for="type">Type:</label>
-                        <select id="type" data-access="properties.key_type"></select>
+                    <div class="form-group" data-types="2">
+                        <label for="typeAttribute">Attribute type:</label>
+                        <select id="typeAttribute" data-access="properties.key_type">
+                            <option value="Normal" selected>Normal</option>
+                            <option value="Primary key">Primary key</option>
+                            <option value="Partial key">Partial key</option>
+                            <option value="Multivalue">Multivalue</option>
+                            <option value="Derive">Derive</option>
+                        </select>
+                    </div>
+                    <div class="form-group" data-types="3,5">
+                        <label for="typeEntityRelation">Entity/relation type:</label>
+                        <select id="typeEntityRelation" data-access="properties.key_type">
+                            <option value="Normal" selected>Strong</option>
+                            <option value="Weak">Weak</option>
+                        </select>
+                    </div>
+                    <div class="form-group" data-types="4">
+                        <label for="typeLine">ER line type:</label>
+                        <select id="typeLine" data-access="properties.key_type">
+                            <option value="Normal" selected>Normal</option>
+                            <option value="Forced">Forced</option>
+                            <option value="Derived">Derived</option>
+                        </select>
+                    </div>
+                    <div class="form-group" data-types="7">
+                        <label for="typeLineUML">UML line type:</label>
+                        <select id="typeLineUML" data-access="properties.key_type">
+                            <option value="Normal" selected>Normal</option>
+                            <option value="Association">Association</option>
+                            <option value="Inheritance">Inheritance</option>
+                            <option value="Implementation">Implementation</option>
+                            <option value="Dependency">Dependency</option>
+                            <option value="Aggregation">Aggregation</option>
+                            <option value="Composition">Composition</option>
+                        </select>
                     </div>
                     <div class="form-group" data-types="2,3,5">
                         <label for="backgroundColor">Background color:</label>
@@ -534,10 +567,10 @@
                         </select>
                     </div>
                     <div class="form-group" data-types="7">
-                        <label for="lineDirection">Line direction:</label>
+                        <label for="lineDirection">UML line direction:</label>
                         <select id="lineDirection" data-access="lineDirection">
                             <option value="First" id="First">First object</option>
-                            <option value="Second" id = "Second">Second object</option>
+                            <option value="Second" id="Second">Second object</option>
                         </select>
                     </div>
                     <div class="form-group" data-types="4">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -569,8 +569,8 @@
                     <div class="form-group" data-types="7">
                         <label for="lineDirection">UML line direction:</label>
                         <select id="lineDirection" data-access="lineDirection">
-                            <option value="First" id="First">First object</option>
-                            <option value="Second" id="Second">Second object</option>
+                            <option value="First" id="First"></option>
+                            <option value="Second" id="Second"></option>
                         </select>
                     </div>
                     <div class="form-group" data-types="4">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -628,8 +628,8 @@
 						<label for="commentCheck">Comment</label>
 						<input type="checkbox" id="commentCheck" data-access="properties.isComment" />
 					</div>
-                    <div class="form-group" style="text-align:center;" data-types="-1,0,1,2,3,4,5,6,7">
-                        <input type="submit" class="submit-button" value="Ok" style="margin:0;float:none;">
+                    <div id="appearanceButtonContainer">
+                        <input type="submit" class="submit-button" value="Ok">
                     </div>				
                 </div>
             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -60,6 +60,13 @@
             <option value=\'Medium\'>Medium</option>
             <option value=\'Large\'>Large</option>
         ';
+
+        $fonts = '
+            <option value=\'Arial\'>Arial</option>
+            <option value=\'Courier New\'>Courier New</option>
+            <option value=\'Impact\'>Impact</option>
+            <option value=\'Calibri\'>Calibri</option>
+        ';
     ?>
     <!-- content START -->
     <div id="contentDiagram">
@@ -496,12 +503,7 @@
                     </div>
                     <div class="form-group" data-types="2,3,5,6">
                         <label for="fontFamily">Font family:</label>
-                        <select id="fontFamily" data-access="properties.font">
-                            <option value="Arial">Arial</option>
-                            <option value="Courier New">Courier New</option>
-                            <option value="Impact">Impact</option>
-                            <option value="Calibri">Calibri</option>
-                        </select>
+                        <select id="fontFamily" data-access="properties.font"><?=$fonts?></select>
                     </div>
                     <div class="form-group" data-types="2,3,5,6">
                         <label for="fontColor">Font color:</label>
@@ -553,12 +555,7 @@
                     </div>
                     <div class="form-group" data-types="-1">
                         <label for="fontFamilyGlobal">Font family:</label>
-                        <select id="fontFamilyGlobal" data-access="properties.font">
-                            <option value="Arial">Arial</option>
-                            <option value="Courier New">Courier New</option>
-                            <option value="Impact">Impact</option>
-                            <option value="Calibri">Calibri</option>
-                        </select>
+                        <select id="fontFamilyGlobal" data-access="properties.font"><?=$fonts?></select>
                     </div>
                     <div class="form-group" data-types="-1">
                         <label for="fontColorGlobal">Font color:</label>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -53,6 +53,13 @@
             <option value=\'#ffffff\'>White</option>
             <option value=\'#000000\'>Black</option>
         ';
+
+        $textSizes = '
+            <option value=\'Tiny\'>Tiny</option>
+            <option value=\'Small\'>Small</option>
+            <option value=\'Medium\'>Medium</option>
+            <option value=\'Large\'>Large</option>
+        ';
     ?>
     <!-- content START -->
     <div id="contentDiagram">
@@ -466,6 +473,7 @@
             </div>
             <div class='table-wrap'>
                 <div id="appearanceForm">
+                    <!-- -1->Global, 0->Free draw, 1->UML, 2->Attribute, 3->Entity, 4->Line, 5->Relation, 6->Text, 7-UML-line -->
                     <div class="form-group" data-types="1,2,3,5">
                         <label for="name">Name:</label>
                         <input type="text" id="name" data-access="name">
@@ -501,12 +509,7 @@
                     </div>
                     <div class="form-group" data-types="2,3,5,6">
                         <label for="textSize">Text size:</label>
-                        <select id="textSize" data-access="properties.sizeOftext">
-                            <option value="Tiny">Tiny</option>
-                            <option value="Small">Small</option>
-                            <option value="Medium">Medium</option>
-                            <option value="Large">Large</option>
-                        </select>
+                        <select id="textSize" data-access="properties.sizeOftext"><?=$textSizes;?></select>
                     </div>
                     <div class="form-group" data-types="2,3,5,0">
                         <label for="lineColor">Line color:</label>
@@ -563,12 +566,7 @@
                     </div>
                     <div class="form-group" data-types="-1">
                     <label for="textSizeGlobal">Text size:</label>
-                    <select id="textSizeGlobal" data-access="properties.sizeOftext">
-                        <option value="Tiny">Tiny</option>
-                        <option value="Small">Small</option>
-                        <option value="Medium">Medium</option>
-                        <option value="Large">Large</option>
-                    </select>
+                    <select id="textSizeGlobal" data-access="properties.sizeOftext"><?=$textSizes;?></select>
                     </div>
                     <div class="form-group" data-types="-1">
                         <label for="lineColorGlobal">Line color:</label>
@@ -584,8 +582,7 @@
 					</div>
                     <div class="form-group" style="text-align:center;" data-types="-1,0,1,2,3,4,5,6,7">
                         <input type="submit" class="submit-button" value="Ok" style="margin:0;float:none;">
-                    </div>
-									
+                    </div>				
                 </div>
             </div>
         </div>

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -26,7 +26,7 @@ function Symbol(kindOfSymbol) {
     this.centerPoint;               // centerPoint
     this.cardinality = 
       {"value": null, "isCorrectSide": null, "symbolKind": null, "axis": null, "parentBox": null};
-    this.lineDirection;
+    this.lineDirection = "First";
     this.recursiveLineExtent = 40;  // Distance out from the entity that recursive lines go
     this.minWidth;
     this.minHeight;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4934,7 +4934,7 @@ only screen and (max-device-width: 320px) {
 }
 
 #appearanceFormContainer {
-  min-width: 280px;
+  width: 280px;
 }
 
 #appearanceButtonContainer {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4997,6 +4997,47 @@ only screen and (max-device-width: 320px) {
   border-radius: 0;
 }
 
+/* Collapsible */
+.collapsible {
+
+}
+
+.collapsible .object-types {
+  padding-top: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.collapsible .object-types .square {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+  background-color: var(--color-primary-light);
+  border: 1px solid var(--color-border-primary);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+}
+
+.collapsible .object-types .square div {
+  width: 80%;
+  height: 80%;
+  content:url("../icons/Minus.svg");
+}
+
+.collapsible.closed .object-types .square div {
+  content:url("../icons/Plus.svg");
+}
+
+.collapsible .form-groups {
+  display: block;
+}
+
+.collapsible.closed .form-groups {
+  display: none;
+}
+
 /* Diagram canvas */
 #diagramCanvasContainer {
   margin-left: 52px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4933,6 +4933,10 @@ only screen and (max-device-width: 320px) {
   box-sizing: border-box;
 }
 
+#appearanceFormContainer {
+  min-width: 280px;
+}
+
 #appearanceButtonContainer {
   margin: 16px 0;
   text-align: center;
@@ -4946,6 +4950,11 @@ only screen and (max-device-width: 320px) {
 .form-group {
   margin: 16px 0;
 }
+
+.form-group select {
+  width: 100%;
+}
+
 .form-group input[type=range]::-moz-range-thumb{
   box-shadow: 1px 1px 1px #000000, 0px 0px 1px #0d0d0d;
   border: 1px solid #000000;
@@ -4970,13 +4979,22 @@ only screen and (max-device-width: 320px) {
 }
 
 #appearanceForm textarea {
-  height: 100px;
+  height: 124px;
+  width: 100%;
   resize: none;
 }
 
 
 #name {
-  padding: 2px 0px 2px 10px;
+  width: 100%;
+  color: #6f6f6f;
+  background-color: #ffffff;
+  border: 1px solid var(--color-border-2);
+  padding: 5px;
+  font-size: 14px;
+  line-height: 18px;
+  box-sizing: border-box;
+  border-radius: 0;
 }
 
 /* Diagram canvas */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4933,6 +4933,16 @@ only screen and (max-device-width: 320px) {
   box-sizing: border-box;
 }
 
+#appearanceButtonContainer {
+  margin: 16px 0;
+  text-align: center;
+}
+
+#appearanceButtonContainer .submit-button {
+  margin: 0;
+  float: none;
+}
+
 .form-group {
   margin: 16px 0;
 }


### PR DESCRIPTION
This is a big rework for issue #7677 so it should be tested thoroughly.

Before, it was difficult changing appearance of different types of objects simultaneously. It only worked decently when the selected objects all had the exact same properties that should be affected. It was impossible to change the names of objects to different things at the same time, they would all get the same name. The same goes for textareas, all would get the exact same text. I imagine these as being properties that should be different. The appearance form would before only show the inputs that should be shown for the previously selected object and ignore all the other selected objects needs. This was not a good way to handle it.

In this rework all types that have the exact same properties in common are grouped under one collapsible menu. If only one type of object is selected only one collapsible will be shown for that object. If other type of objects are selected at the same time, all common properties will be under one collapsible while all the dissimilar properties gets into separate collapsible for the type. This makes it possible to always make changes to everything in one appearance menu, without limitation. It is possible to add many objects of every possible type, select them all, and open the appearance menu and still be able to make correct changes to everything. On top of that it is also possible to give different selected objects different names in the same appearance menu, the names are split up by a comma. Editing on one side of the comma will affect one object, while the other side will affect another. The same works for textareas where a comma plus new line works as a separator. 

- Open the appearance menu with a few different types selected of objects selected and see so styling works for everything. Try a few times with different types of objects.
- Test to create every type of object (entities, attributes, relations, UML classes, paths, text, UML lines, er lines between entity-relation, er lines between attributes and entities/relations) and open the appearance menu with everything selected at the same time. Try to change all types of styling.
- Try to edit name and textareas that are separated by a character to see if it the text applies to the right objects.

Link: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%237677/DuggaSys/diagram.php
