### PR TITLE
Replaced the link corresponding with the ---===######===--- dropdown choice - G1-2020-W18-ISSUE#1796

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1055,6 +1055,9 @@ function returnedSection(data) {
   // Change the scroll position to where the user was last time.
   $(window).scrollTop(localStorage.getItem("sectionEdScrollPosition" + retdata.coursecode));
 
+  // Replaces the link corresponding with dropdown choice ---===######===--- with dummylink, in this case error page 403
+  replaceDefualtLink();
+
   addClasses();
 }
 
@@ -1528,6 +1531,18 @@ $(window).load(function () {
 function link_is_external(link_element) {
     return (link_element.host !== window.location.host);
 }
+
+// Replaces the link corresponding wtih the dropdown choices ---===######===--- with a link to errorpage instead
+function replaceDefualtLink(){
+  var links = document.getElementsByTagName('a');
+
+  for(var i = 0; i < links.length; i++){
+    if((links[i].getAttribute('href')) == "showdoc.php?exampleid=---===######===---&courseid=1&coursevers=45656&fname=---===######===---"){
+      links[i].href = "../errorpages/403.php";
+    }
+  }
+}
+
 
 // Adds classes to <a> element depending on if they are external / internal
 function addClasses() {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1537,7 +1537,8 @@ function replaceDefualtLink(){
   var links = document.getElementsByTagName('a');
 
   for(var i = 0; i < links.length; i++){
-    if((links[i].getAttribute('href')) == "showdoc.php?exampleid=---===######===---&courseid=1&coursevers=45656&fname=---===######===---"){
+    if((links[i].getAttribute('href')) == ("showdoc.php?exampleid=---===######===---&courseid=" + querystring['courseid'] + "&coursevers=" + 
+    querystring['coursevers'] + "&fname=---===######===---")){
       links[i].href = "../errorpages/403.php";
     }
   }

--- a/errorpages/403.php
+++ b/errorpages/403.php
@@ -9,8 +9,8 @@ $noup="NONE";
 */
 
 // Get the sites current URL
-$actual_link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/";
-$startURL = $actual_link . "DuggaSys/courseed.php";
+$actual_link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+$startURL = str_replace("errorpages/403.php","", $actual_link) . "DuggaSys/courseed.php";
 ?>
 <!DOCTYPE html>
 <html>

--- a/errorpages/403.php
+++ b/errorpages/403.php
@@ -7,6 +7,10 @@ include_once "../Shared/basic.php";
 /*
 $noup="NONE";
 */
+
+// Get the sites current URL
+$actual_link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/";
+$startURL = $actual_link . "DuggaSys/courseed.php";
 ?>
 <!DOCTYPE html>
 <html>
@@ -27,6 +31,6 @@ $noup="NONE";
 <body>
     You may not view this page
     <br>
-    <a href="/LenaSYS/DuggaSys/courseed.php">Go to start</a>
+    <a href="<?php echo $startURL; ?>">Go to start</a>
 </body>
 </html>

--- a/errorpages/403.php
+++ b/errorpages/403.php
@@ -27,6 +27,6 @@ $noup="NONE";
 <body>
     You may not view this page
     <br>
-    <a href="/DuggaSys/courseed.php">Go to start</a>
+    <a href="/LenaSYS/DuggaSys/courseed.php">Go to start</a>
 </body>
 </html>

--- a/errorpages/404.php
+++ b/errorpages/404.php
@@ -45,6 +45,6 @@ logServiceEvent($log_uuid, EventTypes::PageNotFound ,$service ,$userid,$info);
 </head>
 <body>
 <h1>404 - File not found</h1>
-	<a href="/DuggaSys/courseed.php">Go to start</a>
+	<a href="/LenaSYS/DuggaSys/courseed.php">Go to start</a>
 </body>
 </html>


### PR DESCRIPTION
When creating a new item of type link in sectioned, all choices corresponding with the choice 
---===######===--- in the dropdown menu will now redirect to error page 403. 

How to test:

Create a link, the default link choice in the dropdown should be: 

![Screenshot 2020-04-27 at 09 54 45](https://user-images.githubusercontent.com/62876614/80347900-3c239880-886d-11ea-95a9-ceec7aad34f3.png)

Now when clicking the link. 

![Screenshot 2020-04-27 at 09 55 13](https://user-images.githubusercontent.com/62876614/80348224-c409a280-886d-11ea-8e95-dd623de50928.png)

You should be redirected to 403 error page:

![Screenshot 2020-04-27 at 09 55 23](https://user-images.githubusercontent.com/62876614/80348230-c7049300-886d-11ea-9ada-b46b7de50e6b.png)
