### PR TITLE
Fixes #8464 - Submit appearance form with enter when textarea is part of the form

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -660,8 +660,10 @@ function keyDownHandler(e) {
     }
     if(key == keyMap.escapeKey && appearanceMenuOpen) {
         toggleApperanceElement();
-    } else if(key == keyMap.enterKey && appearanceMenuOpen && !classAppearanceOpen && !textAppearanceOpen) {
-        submitAppearanceForm();
+    } else if(key == keyMap.enterKey && appearanceMenuOpen) {
+        if(document.activeElement.nodeName !== "TEXTAREA") {
+            submitAppearanceForm();
+        }
     } else if(key == keyMap.escapeKey && fullscreen) {
         toggleFullscreen();
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -184,8 +184,6 @@ var globalappearanceMenuOpen = false;   // True if global appearance menu is ope
 var diagramNumber = 0;                  // Is used for localStorage so that undo and redo works.
 var diagramCode = "";                   // Is used to stringfy the diagram-array
 var appearanceMenuOpen = false;         // True if appearance menu is open
-var classAppearanceOpen = false;        // True if appearance menu is open for type class
-var textAppearanceOpen = false;         // True if appearance menu is open for type text
 var symbolStartKind;                    // Is used to store which kind of object you start on
 var symbolEndKind;                      // Is used to store which kind of object you end on
 var cloneTempArray = [];                // Is used to store all selected objects when ctrl+c is pressed
@@ -4704,8 +4702,6 @@ function toggleApperanceElement(show = false) {
         }
 
         appearanceMenuOpen = false;
-        classAppearanceOpen = false;
-        textAppearanceOpen = false;
         globalappearanceMenuOpen = false;
         if($(".loginBox").data("ui-draggable")) {
             $(".loginBox").draggable("destroy");
@@ -4899,11 +4895,9 @@ function loadAppearanceForm() {
         } else if(object.symbolkind === symbolKind.text) {
             document.getElementById("freeText").value += getTextareaText(object.textLines) + ",\n";
             document.getElementById("freeText").focus();
-            textAppearanceOpen = true;
         } else if(object.symbolkind === symbolKind.uml) {
             document.getElementById("umlOperations").value += getTextareaText(object.operations) + ",\n";
             document.getElementById("umlAttributes").value += getTextareaText(object.attributes) + ",\n";
-            classAppearanceOpen = true;
         } else if(object.kind === kind.path) {
             document.getElementById("figureOpacity").value = object.opacity * 100;
             document.getElementById("fillColor").focus();


### PR DESCRIPTION
The appearance form can be submitted with enter. This did intentionally not work when a textarea was part of the form before. The reason for this is that it should be possible to use enter in a textarea. It would still be good to be able to submit the form with enter when the active element is not the textarea. This pull request fixes this for issue #8464.

- Test to submit the appearance form with enter when not having a textarea as the active element.
- Test to use enter in all different types of textarea to see so the appearance form does not submit.
- Test to select many different types of objects and open the appearance menu to get the new grouped collapsible structure to see if it also works here.

Link: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238464/DuggaSys/diagram.php 