### PR TITLE
solves issue#8481

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -228,7 +228,9 @@ const defaultXKey = 88;
 const defaultWindowsKey = 91;
 const defaultNum1 = 97;
 const defaultNum2 = 98;
+const defaultF11Key = 122;
 const defaultLessThanKey = 226;
+
 //Keybinding variables                       
 isBindingKey = false;                        // Is used when binding keys
 keyBeingBound = null;
@@ -270,6 +272,7 @@ var keyMap = { //rebindable keys format is (keyName, default-value)
     num1 : defaultNum1,
     num2 : defaultNum2,
     lessThanKey : defaultLessThanKey,
+    f11Key :  defaultF11Key,
 }
 
 // Map keycodes to key names
@@ -754,14 +757,17 @@ function keyDownHandler(e) {
         } else if (shiftIsClicked && key == keyMap.dKey) {
         developerMode(event);
         } else if (shiftIsClicked && key == keyMap.mKey  && !modeSwitchDialogActive) {
-                toggleMode();
+            toggleMode();
         } else if (shiftIsClicked && key == keyMap.xKey) {
             lockSelected(event);
         } else if (shiftIsClicked && key == keyMap.oKey) {
             resetViewToOrigin(event);
         } else if (shiftIsClicked && key == keyMap.key4) {
             toggleVirtualPaper(event);
-        } else if (shiftIsClicked && key == keyMap.upArrow) {
+        } else if (shiftIsClicked && key == keyMap.f11Key) {
+            toggleFullscreen();
+        }
+        else if (shiftIsClicked && key == keyMap.upArrow) {
             align(event, 'top');
         } else if (shiftIsClicked && key == keyMap.rightArrow) {
             align(event, 'right');

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -321,10 +321,8 @@
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item" tabindex="0">
-                                <div id="full-screen" class="drop-down-item">
-                                    <span class="drop-down-option" onclick='toggleFullscreen()'>Fullscreen</span>
-                                    <i id="hotkey-fullscreen" class="hotKeys">Shift + F11</i>
-                                </div>
+                                <span class="drop-down-option" onclick="toggleFullscreen();">Fullscren</span>
+                                <i id="hotkey-fullscreen" class="hotKeys">Shift + F11</i>           
                             </div>
                         </div>
                     </div>
@@ -332,7 +330,7 @@
                         <span class="drop-down-label">Align</span>
                         <div class="drop-down">
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="toggleGrid(event)">Snap to grid</span>
+                                <span class="drop-down-option" onclick="toggleGrid(event);">Snap to grid</span>
                             </div>
                             <div class="drop-down-divider">
                             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -321,7 +321,7 @@
                             <div class="drop-down-divider">
                             </div>
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="toggleFullscreen();">Fullscren</span>
+                                <span class="drop-down-option" onclick="toggleFullscreen();">Fullscreen</span>
                                 <i id="hotkey-fullscreen" class="hotKeys">Shift + F11</i>           
                             </div>
                         </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1694,6 +1694,11 @@ input {
   top: 10px;
 }
 
+#hotkey-fullscreen {
+  right: 35px;
+  top: 445px;
+}
+
 #hotkey-displayTools {
   right: 36px;
   top: 45px;


### PR DESCRIPTION
Adjusted text to appear inside drop-down menu and added keyboard command for fullscreen. To test, simply open View in menus to confirm text is alligned (see screenshot in issue for reference), and hit Shift+f11 to verify the shortcut is working. 

http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238481/