### PR TITLE
Removed warning regarding åäö

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -393,8 +393,11 @@ function updateItem() {
   $("#editSection").css("display", "none");
 }
 
-function updateDeadline(){
-  AJAXService("UPDATEDEADLINE", prepareItem(), "SECTION");
+function updateDeadline() {
+    var kind = $("#type").val();
+    if (kind == 3) {
+        AJAXService("UPDATEDEADLINE", prepareItem(), "SECTION");
+    }
 }
 
 //----------------------------------------------------------------------------------
@@ -1768,27 +1771,6 @@ function validateDate(startDate, endDate, dialogID) {
     if (startDate === 'estartdate' && endDate === 'eenddate') {
       window.bool6 = false;
     }
-  }
-}
-
-// Validates sectionname
-function validateSectionName(nameid, dialogid) {
-  //Regex for space and uppercase+lowercase letters
-  var Name = /^[a-zA-Z_ ]+$/;
-  var name = document.getElementById(nameid);
-  var x = document.getElementById(dialogid);
-
-  //If sectionname is only letters
-  if (name.value.match(Name)) {
-    name.style.borderColor = "#383";
-    name.style.borderWidth = "2px";
-    x.style.display = "none";
-    window.bool7 = true;
-  } else {
-    name.style.borderColor = "#E54";
-    x.style.display = "block";
-    name.style.borderWidth = "2px";
-    window.bool7 = false;
   }
 }
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -188,7 +188,7 @@
 	?>
 
 		<!-- Edit Section Dialog START -->
-		<div id='editSection' onmouseover="validateSectionName('sectionname','dialog7');"  class='loginBoxContainer' style='display:none;'>
+		<div id='editSection' class='loginBoxContainer' style='display:none;'>
 		<div class='loginBox' style='width:460px;'>
 			<div class='loginBoxheader'>
 				<h3 id='editSectionDialogTitle'>Edit Item</h3>
@@ -198,9 +198,8 @@
 				<input type='hidden' id='lid' value='Toddler' />
 				<div id='inputwrapper-name' class='inputwrapper'>
 					<span>Name:</span>
-					<input oninput="validateSectionName('sectionname','dialog7')" type='text' class='textinput' id='sectionname' value='sectionname' maxlength="64"/>
+					<input type='text' class='textinput' id='sectionname' value='sectionname' maxlength="64"/>
 				</div>
-				<p id="dialog7" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Only letters (not åäö)</p>
 				<div id='inputwrapper-type' class='inputwrapper'>
 					<span>Type:</span>
 					 <!-- If you want to change the names of the spans, make sure that they fit with the dropdown box.


### PR DESCRIPTION
Removed the warning that course names may not include åäö, when clearly they can include them.