### PR TITLE
Fixes #8513 - Copy path objects

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1122,6 +1122,12 @@ function copySymbol(symbol) {
 function copyPath(path) {
     const clone = Object.assign(new Path, path);
 
+    const oldPointIndexes = clone.segments.reduce((result, segment) => {
+        result.push(segment.pa);
+        result.push(segment.pb);
+        return [...new Set(result)];
+    }, []);
+
     diagram.push(clone);
 
     return clone;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -799,7 +799,7 @@ function drawCopyERLines(temp) {
 
     for (var y = 0; y < cloneTempArray.length; y++) {
         for (var x = 0; x < cloneTempArray.length; x++) {
-            if(cloneTempArray[x].kind !== kind.path) {
+            if(cloneTempArray[x].kind !== kind.path && cloneTempArray[y].kind !== kind.path) {
                 if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].bottomRight)) {
                     var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].bottomRight);
                     connected.push({from:y, to:x, loc: location, lineloc: "bottomRight", lineloc2: "topLeft"});

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1151,6 +1151,9 @@ function copyPath(path) {
         }
     }
 
+    clone.targeted = true;
+    path.targeted = false;
+
     diagram.push(clone);
 
     return clone;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -799,14 +799,14 @@ function drawCopyERLines(temp) {
 
     for (var y = 0; y < cloneTempArray.length; y++) {
         for (var x = 0; x < cloneTempArray.length; x++) {
-            if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].bottomRight)){
-                var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].bottomRight);
-                connected.push({from:y, to:x, loc: location, lineloc: "bottomRight", lineloc2: "topLeft"});
-            }
-            else if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].topLeft)){
-                var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].topLeft);
-                connected.push({from:y, to:x, loc: location, lineloc: "topLeft", lineloc2: "bottomRight"});
-                
+            if(cloneTempArray[x].kind !== kind.path) {
+                if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].bottomRight)) {
+                    var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].bottomRight);
+                    connected.push({from:y, to:x, loc: location, lineloc: "bottomRight", lineloc2: "topLeft"});
+                } else if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].topLeft)) {
+                    var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].topLeft);
+                    connected.push({from:y, to:x, loc: location, lineloc: "topLeft", lineloc2: "bottomRight"});   
+                }
             }
         }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1140,6 +1140,17 @@ function copyPath(path) {
         return result
     }, []);
 
+    for(const segment of clone.segments) {
+        for(const pointIndex of pointIndexes) {
+            if(segment.pa === pointIndex.old) {
+                segment.pa = pointIndex.new;
+            }
+            if(segment.pb === pointIndex.old) {
+                segment.pb = pointIndex.new;
+            }
+        }
+    }
+
     diagram.push(clone);
 
     return clone;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1154,6 +1154,8 @@ function copyPath(path) {
     clone.targeted = true;
     path.targeted = false;
 
+    clone.calculateBoundingBox();
+
     diagram.push(clone);
 
     return clone;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1120,7 +1120,7 @@ function copySymbol(symbol) {
 // copySymbol: Clone a path object
 //----------------------------------------------------------------------
 function copyPath(path) {
-    const clone = Object.assign(new Path, path);
+    const clone = Object.assign(new Path, JSON.parse(JSON.stringify(path)));
 
     const oldPointIndexes = clone.segments.reduce((result, segment) => {
         result.push(segment.pa);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -714,10 +714,15 @@ function keyDownHandler(e) {
             fillCloneArray();
         } else if (ctrlIsClicked && key == keyMap.vKey ) {
             //Ctrl + v
-            var temp = [];
-            var connected = [];
-            //Handles copying of lines
-            drawCopyERLines(connected , temp);
+            let temp = [];
+            for(const object of cloneTempArray) {
+                if(object.kind === kind.path) {
+                    copyPath(object);
+                } else {
+                    temp.push(copySymbol(object));
+                }
+            }
+            drawCopyERLines(temp);
             cloneTempArray = temp;
             selected_objects = temp;
             updateGraphics();
@@ -789,7 +794,9 @@ function keyDownHandler(e) {
     }
 }
 
-function drawCopyERLines(connected , temp){
+function drawCopyERLines(temp) {
+    var connected = [];
+
     for (var y = 0; y < cloneTempArray.length; y++) {
         for (var x = 0; x < cloneTempArray.length; x++) {
             if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].bottomRight)){
@@ -802,10 +809,6 @@ function drawCopyERLines(connected , temp){
                 
             }
         }
-    }
-    for (var i = 0; i < cloneTempArray.length; i++) {
-        const cloneIndex = copySymbol(cloneTempArray[i]) - 1;
-        temp.push(diagram[cloneIndex]);
     }
 
     for(var j = 0 ; j < connected.length ; j++){
@@ -1028,7 +1031,7 @@ points.addPoint = function(xCoordinate, yCoordinate, isSelected) {
 }
 
 //----------------------------------------------------------------------
-// copySymbol: Clone an object
+// copySymbol: Clone a symbol object
 //----------------------------------------------------------------------
 function copySymbol(symbol) {
     var clone = new Symbol(symbol.symbolkind);
@@ -1110,7 +1113,14 @@ function copySymbol(symbol) {
     symbol.targeted = false;
     diagram.push(clone);
 
-    return diagram.length;
+    return clone;
+}
+
+//----------------------------------------------------------------------
+// copySymbol: Clone a path object
+//----------------------------------------------------------------------
+function copyPath(path) {
+
 }
 
 //--------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1128,6 +1128,18 @@ function copyPath(path) {
         return [...new Set(result)];
     }, []);
 
+    const pointIndexes = oldPointIndexes.reduce((result, pointIndex) => {
+        const point = points[pointIndex];
+        const newPointIndex = points.addPoint(point.x + 100, point.y + 100, point.isSelected);
+
+        result.push({
+            old: pointIndex,
+            new: newPointIndex
+        });
+
+        return result
+    }, []);
+
     diagram.push(clone);
 
     return clone;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -717,7 +717,7 @@ function keyDownHandler(e) {
             let temp = [];
             for(const object of cloneTempArray) {
                 if(object.kind === kind.path) {
-                    copyPath(object);
+                    temp.push(copyPath(object));
                 } else {
                     temp.push(copySymbol(object));
                 }
@@ -1120,7 +1120,11 @@ function copySymbol(symbol) {
 // copySymbol: Clone a path object
 //----------------------------------------------------------------------
 function copyPath(path) {
+    const clone = Object.assign(new Path, path);
 
+    diagram.push(clone);
+
+    return clone;
 }
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
This pull request will make it possible to correctly copy and paste path symbols. Before paths were treated like symbols which would create a dummy symbol wasting memory.

- Test to create several paths, select them, copy them and paste them.
- Create other type of objects, select them at the same time as paths and copy and paste everything.

Link: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238513/DuggaSys/diagram.php