### PR TITLE
Added functionality to press CTRL to toggle fab button clickable

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -718,3 +718,20 @@ document.addEventListener('DOMContentLoaded', function (){
  function updateAce(data){
     editor.getSession().setValue(data);
 }
+
+// ---------------------------------------------------
+// Toggle to hide fab-button to click through it with CTRL
+//----------------------------------------------------
+
+document.addEventListener('keydown', function(e) {
+	var element = document.getElementById('fabButton');
+	if(e.keyCode === 17){
+		if(window.getComputedStyle(element, null).getPropertyValue("opacity") != "1"){
+			element.style.opacity = "1";
+			element.style.pointerEvents = "auto";
+		}else{
+            element.style.opacity = "0.3";
+			element.style.pointerEvents = "none";
+		}	
+	}
+});


### PR DESCRIPTION
In fileed, you should be able to press "ctrl" to make the FAB-button transparent and be able to click through it, this was you can click the buttons in the table behind it.