### PR TITLE
Updated functions "openTemplateWindow" and "closeTemplateWindow" within codeviewer.js - G1-2020-W18-ISSUE#8554

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2228,7 +2228,7 @@ function closeEditExample() {
 //----------------------------------------------------------------------------------
 
 function openTemplateWindow() {
-	$("#chooseTemplateContainer").css("display", "flex");
+	document.getElementById("chooseTemplateContainer").style.display = "flex";
 }
 
 //----------------------------------------------------------------------------------
@@ -2237,7 +2237,7 @@ function openTemplateWindow() {
 //----------------------------------------------------------------------------------
 
 function closeTemplateWindow() {
-	$("#chooseTemplateContainer").css("display", "none");
+	document.getElementById("chooseTemplateContainer").style.display = "none";
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Updated functions "openTemplateWindow" and "closeTemplateWindow" within codeviewer.js to better fit the code standard by replacing jQuery.

Test by clicking the "Choose Template" icon (next to the play button) to bring up the template window and then by closing it.