### PR TITLE
G2 2020 w18 #8425

### DIFF
--- a/DuggaSys/templates/bit-dugga.js
+++ b/DuggaSys/templates/bit-dugga.js
@@ -271,8 +271,8 @@ function hexClick(divid)
 	dpos=$("#"+divid).position();
 	dwid=$("#"+divid).width();
 	dhei=$("#"+divid).height();
-	bw=Math.round(dwid)*2.0;
-	if(bw<128) bw=128;
+	bw=Math.round(dwid)*1.10;
+	if(bw<180) bw=180;	// Ensure minimum width of the HEX-box
 	
 	lpos=dpos.left;
 	

--- a/DuggaSys/templates/color-dugga.js
+++ b/DuggaSys/templates/color-dugga.js
@@ -219,8 +219,8 @@ function hexClick(divid)
 	dpos=$("#"+divid).position();
 	dwid=$("#"+divid).width();
 	dhei=$("#"+divid).height();
-	bw=Math.round(dwid)*2.0;
-	if(bw<128) bw=128;
+	bw=Math.round(dwid)*1.50;
+	if(bw<180) bw=180;	// Ensure minimum width of the HEX-box
 	
 	lpos=dpos.left;
 	

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -268,8 +268,8 @@ function hexClick(divid)
 	dpos=$("#"+divid).position();
 	dwid=$("#"+divid).width();
 	dhei=$("#"+divid).height();
-	bw=Math.round(dwid)*2.0;
-	if(bw<128) bw=128;
+	bw=Math.round(dwid)*1.1;
+	if(bw<180) bw=180;	// Ensure minimum width of the HEX-box
 	
 	lpos=dpos.left;
 	

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -209,8 +209,8 @@ function hexClick(divid)
 	dpos=$("#"+divid).position();
 	dwid=$("#"+divid).width();
 	dhei=$("#"+divid).height();
-	bw=Math.round(dwid)*2.0;
-	if(bw<128) bw=128;
+	bw=Math.round(dwid)*1.50;
+	if(bw<180) bw=180;	// Ensure minimum width of the HEX-box
 	
 	lpos=dpos.left;
 	


### PR DESCRIPTION
Changed the width of the hexadecimal input box on color dugga and bit dugga.
- Usually the width is much lower now which make it look more nimble
- Minimum width was set higher though since it looks really stupid when the width is too small

To the this login as `Toddler`, use password `Kong` and go to the webbutveckling course and take a look on the relevant duggor.