### PR TITLE
fix issue#8552 Center textobject vertically

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2124,7 +2124,7 @@ function Symbol(kindOfSymbol) {
 
 			ctx.textAlign = this.textAlign;
 			for (var i = 0; i < this.textLines.length; i++) {
-				ctx.fillText(this.textLines[i].text, this.getTextX(x1, midx, x2), y1 + (this.properties['textSize'] * 1.7) / 2 + (this.properties['textSize'] * i));
+				ctx.fillText(this.textLines[i].text, this.getTextX(x1, midx, x2), y1 + (this.properties['textSize'] * 1.99) / 2 + (this.properties['textSize'] * i));
 			}
 		}//here you could add an extra statment to make comments look different the regular text
     }


### PR DESCRIPTION
Qucik fix to center textobject vertically

Test to see if it is centered with all fontsizes and fontfamilies

Link to test: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238552/DuggaSys/diagram.php

Before:

![Screenshot_35](https://user-images.githubusercontent.com/49142301/80466771-457c3600-893d-11ea-8122-ade0a9abd3ff.png)

After:

![Screenshot_34](https://user-images.githubusercontent.com/49142301/80466791-49a85380-893d-11ea-9af6-e183cc39bb62.png)
