### PR TITLE
Changed writeaccess to access in fileed-authorizer

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -72,9 +72,9 @@ $(function () {
 //----------------------------------------------------------------------------
 
 function returnedFile(data) {
-    //Redirects users without write-access to courseed.php
-    if (!data.writeaccess) {
-		window.location.href = 'courseed.php';
+    //Redirects users without access to courseed.php
+    if (!data.access) {
+        window.location.href = 'courseed.php';S
     }
     filez = data;
     var tblheadPre = {


### PR DESCRIPTION
Changed incorrect variable "writeaccess" to "access" within fileed.js

Test by navigating to fileed.php as a non-logged in user and as a logged in user with access (Toddler/brom). The following results are to be expected:

Non-logged in user: Redirected to courseed.php.
Logged in user with access: Ability to view and use fileed.php.