### PR TITLE
fix issue#8585 Remove comment-border when selected

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2110,7 +2110,7 @@ function Symbol(kindOfSymbol) {
 				ctx.strokeStyle = '#DC143C';
 			}else{
 				ctx.fillStyle = this.properties['fontColor'];
-        		ctx.strokeStyle = this.properties['strokeColor'];
+				ctx.strokeStyle = this.properties['strokeColor'];
 			}
 
 			//add permanent outline for comments

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2107,14 +2107,14 @@ function Symbol(kindOfSymbol) {
 			// Set text to redish if crossing line
 			if(!checkSamePage(x1,y1,x2,y2)){
 				ctx.fillStyle = '#DC143C';
-        ctx.strokeStyle = '#DC143C';
+				ctx.strokeStyle = '#DC143C';
 			}else{
 				ctx.fillStyle = this.properties['fontColor'];
-        ctx.strokeStyle = this.properties['strokeColor'];
+        		ctx.strokeStyle = this.properties['strokeColor'];
 			}
 
 			//add permanent outline for comments
-			if (this.properties['isComment'] == true){
+			if (this.properties['isComment'] == true && !this.isHovered && !this.targeted){
 				ctx.lineWidth = 1 * diagram.getZoomValue();
 				ctx.setLineDash([5, 4]);
 				ctx.rect(x1, y1, x2-x1, y2-y1);
@@ -2126,7 +2126,7 @@ function Symbol(kindOfSymbol) {
 			for (var i = 0; i < this.textLines.length; i++) {
 				ctx.fillText(this.textLines[i].text, this.getTextX(x1, midx, x2), y1 + (this.properties['textSize'] * 1.7) / 2 + (this.properties['textSize'] * i));
 			}
-		}//here you could add an extra statment to make comments look different the regular text
+		}
     }
 
     //--------------------------------------------------------------------


### PR DESCRIPTION
Before fix when selecting a comment the black border overlapps with the selection's orange border. The comment border should not be visible when selected. 

Link to test: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238585/DuggaSys/diagram.php

Create a textobject and select the comment-box. Now try to hover and select the textobject. If the black border is not visible it is working as intended.  

Before:

![75892dc1cc2be95f1afeb21b84c6f1da](https://user-images.githubusercontent.com/49142301/80472884-a27bea00-8945-11ea-8867-400c3ff09f25.gif)

After:

![f307edf2514e4d256eb891c43ba316b1](https://user-images.githubusercontent.com/49142301/80472907-adcf1580-8945-11ea-8f39-dd2927406483.gif)
