### PR TITLE
solves issue#8434

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3662,6 +3662,14 @@ function toggleFullscreen(){
     }
 }
 
+//-----------------------
+// Close popup when entering fullscreen
+//-----------------------
+
+function closeFullscreenDialog(){
+    $("#fullscreenDialog").hide();
+}
+
 
 //-------------------------------------------------------------------------
 // findPos: Recursive Pos of div in document - should work in most browsers

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3642,6 +3642,8 @@ function toggleFullscreen(){
         canvas_border.style.border = 0 + "px";
         fullscreen = true;
 
+        $("#fullscreenDialog").css("display", "flex");
+
         // Refit canvas to current container
         canvasSize();
     } else if (fullscreen){

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -707,6 +707,18 @@
             </div>
         </div>
     </div>
+    <!-- Fullscreen toggle dialog -->
+    <div id="fullscreenDialog" class='loginBoxContainer importDiagram'>
+        <div class='loginBox fullscreenContainer'>
+            <div class='loginBoxheader fullscreenHeader'>
+            </div>
+            <div class='mode-wrap'>
+                <div id="modeSwitchButton1" class="importButtonWrap">
+                    <button id="fullscreenButtonAccept" type="button" class="buttonStyleDialog" onclick="closeFullscreenDialog();">Accept</button>
+                </div>
+            </div>
+        </div>
+    </div>
     <!-- content END -->
     <?php
         include '../Shared/loginbox.php';

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -711,10 +711,18 @@
     <div id="fullscreenDialog" class='loginBoxContainer importDiagram'>
         <div class='loginBox fullscreenContainer'>
             <div class='loginBoxheader fullscreenHeader'>
+                <h3 id="fullscreenHeaderText">Fullscreen mode enabled</h3>
             </div>
-            <div class='mode-wrap'>
-                <div id="modeSwitchButton1" class="importButtonWrap">
-                    <button id="fullscreenButtonAccept" type="button" class="buttonStyleDialog" onclick="closeFullscreenDialog();">Accept</button>
+            <div class='fullscreen-wrap'>
+                To exit, press 'Escape' or 'Shift + F11'.
+                <br>To show/hide toolbar, press...
+                <div class="fullscreenCheckbox">
+                    <label>
+                        <input type="checkbox"> Don't show this again!
+                    </label>
+                </div>
+                <div id="fullscreenOkButton">
+                    <button id="fullscreenButtonAccept" type="button" class="buttonStyleDialog" onclick="closeFullscreenDialog();">Ok</button>
                 </div>
             </div>
         </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -715,12 +715,13 @@
             </div>
             <div class='fullscreen-wrap'>
                 To exit, press 'Escape' or 'Shift + F11'.
-                <br>To show/hide toolbar, press...
+                <!-- <br>To show/hide toolbar, press... 
                 <div class="fullscreenCheckbox">
                     <label>
                         <input type="checkbox"> Don't show this again!
                     </label>
                 </div>
+                *This will be implemented later*-->
                 <div id="fullscreenOkButton">
                     <button id="fullscreenButtonAccept" type="button" class="buttonStyleDialog" onclick="closeFullscreenDialog();">Ok</button>
                 </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5655,6 +5655,10 @@ textarea#mrkdwntxt {
   padding-right: 10px;
 }
 
+.fullscreen-wrap {
+  text-align: center;
+}
+
 /* Shortcuts diagram */
 
 .shortcutsDiagram {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5641,6 +5641,20 @@ textarea#mrkdwntxt {
   padding-right: 10px;
 }
 
+/* Fullscreen dialog */
+.fullscreenDialog {
+  display: none;
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.fullscreenContainer {
+  min-height: 80px;
+}
+
+.fullscreenHeader h3 {
+  padding-right: 10px;
+}
+
 /* Shortcuts diagram */
 
 .shortcutsDiagram {


### PR DESCRIPTION
Added popup message when entering fullscreen with a message on how to exit. Prepared for future additions, such as how to add/hide toolbar. Enter fullscreen by going View > Fullscreen to test this. The shortcut Shift+F11 is solved with another issue and will not work here.