### PR TITLE
Updated function "closeEditContent" within codeviewer.js - G1-2020-W18-ISSUE#8601

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2208,8 +2208,9 @@ function updateTemplate() {
 //----------------------------------------------------------------------------------
 
 function closeEditContent() {
-	$("#boxtitle2").attr("contenteditable", true);
-	$("#editContentContainer").css("display", "none");
+	var editBox = document.getElementById("boxtitle2");
+	editBox.setAttribute("contenteditable", true);
+	document.getElementById("editContentContainer").style.display = "none";
 	openBoxID = null;
 }
 


### PR DESCRIPTION
Updated functions "closeEditContent" within codeviewer.js to better fit the code standard by replacing jQuery.

Test by going to codeviewer.php and navigating to the "Edit Content" window by pressing the small cogwheels and by closing the window, there should be no changes in the example window and the window should simply close. Next test by checking if it is possible to edit the example by going to "Edit File" (the pencil icons on top of the examples) and saving the changes.

![closeEditContent](https://user-images.githubusercontent.com/62876595/80486285-32785e80-895b-11ea-98fd-24b15ffb05dc.png)