### PR TITLE
Replaced JQuery with native JavaScript where appropriate and fixed indentation in functions "showIframe" and "hideIframe".

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -4280,17 +4280,16 @@ function showBox(id) {
 	});
 }
 
-
-function showIframe(boxid,kind){
-	
-		$(".previewWindow").show();
-		$(".previewWindowContainer").css("display", "block");
+function showIframe(boxid,kind)
+{
+		document.querySelector(".previewWindow").style.display = "block";
+		document.querySelector(".previewWindowContainer").style.display = "block";
 		$("#iframeFileed").attr('src', 'fileed.php?courseid='+courseid+'&coursevers='+cvers+'&kind='+kind+'&filename='+retData['box'][boxid - 1][5]+'');
-
 }
-function hideIframe(){
-	$(".previewWindow").hide();
-	$(".previewWindowContainer").css("display", "none");
+function hideIframe()
+{
+	document.querySelector(".previewWindow").style.display = "none";
+	document.querySelector(".previewWindowContainer").style.display = "none";
 	location.reload();
 }
 


### PR DESCRIPTION
Test by going to codeviewer.php and clicking the "Edit File" button on any of the content boxes. An iFrame element should appear when clicking on the button. The iFrame element should also close by clicking the cross in the upper right corner. This should work for all boxes within all templates so be sure to test multiple boxes across several templates in order to ensure that the functionality remains. 