### PR TITLE
ShowDugga: Removed "top" to fix problem with panel

### DIFF
--- a/DuggaSys/templates/bit-dugga.js
+++ b/DuggaSys/templates/bit-dugga.js
@@ -286,7 +286,7 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.top+dhei+10), left:lpos, width:bw,height:hh,display:"block"})
+	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh,display:"block"})
 	$("#pop").removeClass("arrow-topr");
 	$("#pop").removeClass("arrow-top");
 	$("#pop").addClass(popclass);

--- a/DuggaSys/templates/color-dugga.js
+++ b/DuggaSys/templates/color-dugga.js
@@ -234,7 +234,7 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.top+dhei+10), left:lpos, width:bw,height:hh,display:"block"})
+	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh,display:"block"})
 	$("#pop").removeClass("arrow-topr");
 	$("#pop").removeClass("arrow-top");
 	$("#pop").addClass(popclass);

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -283,7 +283,7 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.top+dhei+10), left:lpos, width:bw,height:hh,display:"block"})
+	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh,display:"block"})
 	$("#pop").removeClass("arrow-topr");
 	$("#pop").removeClass("arrow-top");
 	$("#pop").addClass(popclass);

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -224,7 +224,7 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.top+dhei+10), left:lpos, width:bw,height:hh,display:"block"})
+	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh,display:"block"})
 	$("#pop").removeClass("arrow-topr");
 	$("#pop").removeClass("arrow-top");
 	$("#pop").addClass(popclass);


### PR DESCRIPTION
The only thing "top" does is disconnect the hexadecimal panel from the accordion. Although it positions the panel in a good way. Now it works like it should, but the panel is placed a bit lower than before. 

![e85784c480c1546fe5f15df197521d48](https://user-images.githubusercontent.com/49142704/80489384-0a3f2e80-8960-11ea-98e8-ea2cad9b5cbe.gif)

This fixes the problems with the accordion in "Färgdugga 1" and "Färgdugga 2" as well. 