### PR TITLE
ShowDugga: Removed "position: absolute" to fix the buttons

### DIFF
--- a/DuggaSys/templates/dugga1.html
+++ b/DuggaSys/templates/dugga1.html
@@ -61,7 +61,7 @@
 		</tr>
 </table>
 
-<div id="pop" class="popover arrow-topr" style='position:absolute;display:none;'>
+<div id="pop" class="popover arrow-topr" style='display:none;'>
 		<table width="100%" height="100%" style='border-collapse: separate;'>
 				<tr>
 						<td class='hexbutt' onclick="setval('0');">0</td>

--- a/DuggaSys/templates/dugga2.html
+++ b/DuggaSys/templates/dugga2.html
@@ -45,7 +45,7 @@
 		</tr>
 </table>
 
-<div id="pop" class="popover arrow-topr" style='position:absolute;display:none;'>
+<div id="pop" class="popover arrow-topr" style='display:none;'>
 		<table width="100%" height="100%" style='border-collapse: separate;'>
 				<tr>
 						<td class='hexbutt' onclick="setval('0');">0</td>


### PR DESCRIPTION
By removing the absolute position the buttons behave like they should. Now they automatically move if the upper box is bigger. 
Henrik wrote this comment on the issue: "if the upper box is bigger it should automatically displace buttons unless something is awry". By removing the absolute position the buttons moves if something pushes them down. Like the hexadecimal panel does. 

**Note:** To test this correctly you must go to dugga1.js or dugga2.js and remove "top+" from line 286 (line 227 in dugga2.js). If you don't it will look really weird. This is not a problem because that issue has already been fixed. Check pull request #8609. 