### PR TITLE
Solved browser percent not showing up in analytic - G1-2020-W19-ISSEU#8583

### DIFF
--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -167,9 +167,9 @@ function browserPercentage(){
 	$result = $GLOBALS['log_db']->query('
 		SELECT
 			browser,
-			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceClientStart.') AS percentage
+			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceServerStart.') AS percentage
 		FROM serviceLogEntries
-		WHERE eventType = '.EventTypes::ServiceClientStart.'
+		WHERE eventType = '.EventTypes::ServiceServerStart.'
 		GROUP BY browser
 		ORDER BY percentage DESC
 	')->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
Replaced EventType::ServiceClientStart with EventTypes::ServiceServerStart. No logging in place for ServiceClientStart. 

![Screenshot 2020-04-29 at 09 44 00](https://user-images.githubusercontent.com/62876614/80572270-42954a00-89fe-11ea-9194-be2245cb86f4.png)
