### PR TITLE
fileedservice AVG duration is now shown. Remove diagramservice log.

### DIFF
--- a/DuggaSys/diagramservice.php
+++ b/DuggaSys/diagramservice.php
@@ -32,7 +32,7 @@
 
     $log_uuid = getOP('log_uuid');
     $info=$opt." ".$courseid." ".$coursename;
-    logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "diagramservice.php",$userid,$info);
+    //logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "diagramservice.php",$userid,$info);
 
     $log_db = new PDO('sqlite:../../GHdataD.db');
     $gituser = $loginname;
@@ -108,5 +108,5 @@
     $array = array('debug' => $debug, 'weeks' => $weeks);
     echo json_encode($array);
 
-    logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "diagramservice.php",$userid,$info);
+    //logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "diagramservice.php",$userid,$info);
 ?>

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -24,7 +24,7 @@ $studentTeacher = false;
 
 $log_uuid = getOP('log_uuid');
 $info = $opt . " " . $cid . " " . $coursevers . " " . $fid . " " . $filename . " " . $kind;
-logServiceEvent($userid, EventTypes::ServiceServerStart, "fileedservice.php", $userid, $info);
+logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "fileedservice.php", $userid, $info);
 
 if (hasAccess($userid, $cid, 'w') || hasAccess($userid, $cid, 'st') || isSuperUser($userid) || hasAccess($userid,$cid, 'sv')) {
     $hasAccess = true;
@@ -256,3 +256,4 @@ $array = array(
 
 echo json_encode($array);
 logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "fileedservice.php", $userid, $info);
+?>


### PR DESCRIPTION
diagramservice reads GitHub activity data. In this situation we cant take out that data which means the log becomes null.

Test this by upload a file in fileed.php:
![image](https://user-images.githubusercontent.com/49142935/80574413-124faa80-8a02-11ea-8dbf-3106d46998bc.png)

Navigate to the analytic.php/Service speed. 
![image](https://user-images.githubusercontent.com/49142935/80574433-1a0f4f00-8a02-11ea-8c4e-f2268afc8c8d.png)
