### PR TITLE
The extra course version dropdown is now removed

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -42,14 +42,7 @@
 					echo "'>";
 					echo "<img src='../Shared/icons/Up.svg'></a></td>";
 			}
-			// if the user only have access type W(write) course-dropdown should be shown
-			if(checklogin() && (hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'w'))) {				
-				echo "<td style='display: inline-block;' title='Choose course version'>";
-				echo "    <div class='course-dropdown-div'>";
-				echo "      <select id='courseDropdownTop' class='course-dropdown' onchange='goToVersion(this)' ></select>";
-				echo "    </div>";
-				echo "</td>";
-			}
+
 	
 			// Adding buttons for courses
 			if($noup=='COURSE'){


### PR DESCRIPTION
Removed the extra course version dropdown that did not work and only showed for people with write access. The error that this was supposed fix in issue #7802 no longer remains but should be tested by the reviewer just to make sure.