### PR TITLE
G2 2020 w19 #8572

### DIFF
--- a/DuggaSys/templates/bit-dugga.js
+++ b/DuggaSys/templates/bit-dugga.js
@@ -20,6 +20,7 @@ Example seed
 var retdata=null;
 var hc=null;
 var score = -1;
+var activehex;
 //----------------------------------------------------------------------------------
 // Setup
 //----------------------------------------------------------------------------------
@@ -286,7 +287,7 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh,display:"block"})
+	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh})
 	$("#pop").removeClass("arrow-topr");
 	$("#pop").removeClass("arrow-top");
 	$("#pop").addClass(popclass);
@@ -301,6 +302,22 @@ function setval(sval)
 		}
 		$("#pop").css({display:"none"})
 }
+
+//functionality for opening and closing hexcode input boxes
+document.addEventListener('click', function(e){
+	var pop = document.getElementById('pop');
+	if(e.target.classList.contains("hexo")){ 
+		if(pop.style.display === "block" && e.target === activehex){
+			pop.style.display = "none";
+		}else{
+			pop.style.display = "block";
+		}
+		activehex = e.target;
+	}else{
+		activehex = undefined;
+		pop.style.display = "none";
+	}
+});
 
 function resetBitstring(){
 	for (var i=0;i<8;i++){

--- a/DuggaSys/templates/color-dugga.js
+++ b/DuggaSys/templates/color-dugga.js
@@ -20,6 +20,7 @@ Example seed
 var dw,dpos,dwid,dhei,bw,lpos,popclass;
 var hc=null;
 var score = -1;
+var activehex;
 
 //----------------------------------------------------------------------------------
 // Setup
@@ -234,7 +235,7 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh,display:"block"})
+	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh})
 	$("#pop").removeClass("arrow-topr");
 	$("#pop").removeClass("arrow-top");
 	$("#pop").addClass(popclass);
@@ -253,6 +254,25 @@ function setval(sval)
 	}
 	$("#pop").css({display:"none"})
 }
+
+//----------------------------------------------------------------------------------
+// //functionality for opening and closing hexcode input boxes
+//----------------------------------------------------------------------------------
+
+document.addEventListener('click', function(e){
+	var pop = document.getElementById('pop');
+	if(e.target.classList.contains("hexo")){ 
+		if(pop.style.display === "block" && e.target === activehex){
+			pop.style.display = "none";
+		}else{
+			pop.style.display = "block";
+		}
+		activehex = e.target;
+	}else{
+		activehex = undefined;
+		pop.style.display = "none";
+	}
+});
 
 //----------------------------------------------------------------------------------
 // show/hide dugga instructions

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -20,6 +20,7 @@ Example seed
 var retdata=null;
 var hc=null;
 var score = -1;
+var activehex;
 //----------------------------------------------------------------------------------
 // Setup
 //----------------------------------------------------------------------------------
@@ -283,7 +284,7 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh,display:"block"})
+	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh})
 	$("#pop").removeClass("arrow-topr");
 	$("#pop").removeClass("arrow-top");
 	$("#pop").addClass(popclass);
@@ -298,6 +299,22 @@ function setval(sval)
 		}
 		$("#pop").css({display:"none"})
 }
+
+//functionality for opening and closing hexcode input boxes
+document.addEventListener('click', function(e){
+	var pop = document.getElementById('pop');
+	if(e.target.classList.contains("hexo")){ 
+		if(pop.style.display === "block" && e.target === activehex){
+			pop.style.display = "none";
+		}else{
+			pop.style.display = "block";
+		}
+		activehex = e.target;
+	}else{
+		activehex = undefined;
+		pop.style.display = "none";
+	}
+});
 
 function resetBitstring(){
 	for (var i=0;i<8;i++){

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -245,7 +245,11 @@ function setval(sval)
 	$("#pop").css({display:"none"})
 }
 
-//functionality for opening and closing hexcode input boxes
+
+//----------------------------------------------------------------------------------
+// //functionality for opening and closing hexcode input boxes
+//----------------------------------------------------------------------------------
+
 document.addEventListener('click', function(e){
 	var pop = document.getElementById('pop');
 	if(e.target.classList.contains("hexo")){ 

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -20,6 +20,7 @@ Example seed
 var dw,dpos,dwid,dhei,bw,lpos,popclass;
 var hc=null;
 var score = -1;
+var activehex;
 
 //----------------------------------------------------------------------------------
 // Setup
@@ -224,7 +225,7 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh,display:"block"})
+	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh})
 	$("#pop").removeClass("arrow-topr");
 	$("#pop").removeClass("arrow-top");
 	$("#pop").addClass(popclass);
@@ -243,6 +244,22 @@ function setval(sval)
 	}
 	$("#pop").css({display:"none"})
 }
+
+//functionality for opening and closing hexcode input boxes
+document.addEventListener('click', function(e){
+	var pop = document.getElementById('pop');
+	if(e.target.classList.contains("hexo")){ 
+		if(pop.style.display === "block" && e.target === activehex){
+			pop.style.display = "none";
+		}else{
+			pop.style.display = "block";
+		}
+		activehex = e.target;
+	}else{
+		activehex = undefined;
+		pop.style.display = "none";
+	}
+});
 
 //----------------------------------------------------------------------------------
 // show/hide dugga instructions


### PR DESCRIPTION
Solves #8572.

User can now close the hexadecimal input box by:
1. clicking the "parent" element (the div/button for opening the hexadecimal input box that was used to open the input box)
2. clicking somewhere on the screen that is not one of the "parent" elements
3. selecting a value in the hexadecimal input box (this was default behaviour before my changes)

If the user opens the hexadecimal input box with one div/button and clicks another, the input box will be moved accordingly (this was also default behaviour before my changes).

These changes apply to the Biträkningsduggas and Färgduggas.

I would argue these changes make the duggas feel much more responsive.