### PR TITLE
Change name to Add phrase and added a clearbutton. #6919

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -560,6 +560,12 @@ function saveResponse() {
 	document.getElementById("responseArea").innerHTML = "";
 	$("#previewpopover").css("display", "none");
 }
+//----------------------------------------
+// Clear response textbox on Preview Popover.
+//----------------------------------------
+function clearResponseArea(){
+	document.getElementById("responseArea").innerHTML = "";
+}
 
 //----------------------------------------
 // Renderer

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -138,7 +138,7 @@ pdoConnect();
 										<table width="100%" height="100%">
 											<tr height="24px">
 													<td>
-															<button onclick='addCanned();'>Add</button>
+															<button onclick='addCanned();'>Add phrase</button>
 															<select id="cannedResponse">
 																	<option>&laquo; NONE &raquo;</option>
 																	<option>(Y) </option>
@@ -155,6 +155,8 @@ pdoConnect();
 											<tr height="24px">
 													<td>
 															<button onclick='saveResponse();'>Save</button>
+															<!-- Clear text in textarea id="responseArea" -->
+															<button onclick='clearResponseArea()'>Clear</button>
 													</td>
 											</tr>
 										</table>


### PR DESCRIPTION
- Change name on Add button to Add phrase. To clarify what it adds.
- Added a clearbutton.
- Added a function that set the text to "" in the textarea with id="responseArea".