### PR TITLE
Now possible to see logs in "Service Usage" G1-2020-W19-ISSUE#8573

### DIFF
--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -133,7 +133,7 @@ function serviceUsage($start, $end, $interval){
 			COUNT(*) AS hits
 		FROM serviceLogEntries
 		WHERE
-			eventType = '.EventTypes::ServiceClientStart.'
+			eventType = '.EventTypes::ServiceServerStart.'
 			AND datetime(timeStamp/1000, \'unixepoch\') BETWEEN ? AND ?
 		GROUP BY service, dateTime;
 	');


### PR DESCRIPTION
Now possible to see diagram which showcases usage in different places, see screenshots below!
![image](https://user-images.githubusercontent.com/62876625/80582908-cc014800-8a0f-11ea-93ef-d5ba50ea4dcf.png)
![image](https://user-images.githubusercontent.com/62876625/80582913-cdcb0b80-8a0f-11ea-9fa9-d7f638b9a719.png)
![image](https://user-images.githubusercontent.com/62876625/80582918-cf94cf00-8a0f-11ea-8b0e-fec2fe427fa1.png)
