### PR TITLE
G3 2020#8580 now you can view statisticscontent in mobile-view

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1599,6 +1599,14 @@ $(window).load(function () {
   $(".messagebox").mouseout(function () {
     $("#testbutton").css("background-color", "#614875");
   });
+  $("#sectionList_arrowStatisticsOpen").click(function () {
+    $("#sectionList_arrowStatisticsOpen").hide();
+    $("#sectionList_arrowStatisticsClosed").show();
+  });
+  $("#sectionList_arrowStatisticsClosed").click(function () {
+    $("#sectionList_arrowStatisticsOpen").show();
+    $("#sectionList_arrowStatisticsClosed").hide();
+  });
 });
 
 // Checks if <a> link is external

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1608,6 +1608,7 @@ $(window).load(function () {
       'display':'flex',
       'flex-direction': 'column'
     });
+    $(".statisticsContentBottom").show();
     
   });
   $("#sectionList_arrowStatisticsClosed").click(function () {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1604,6 +1604,7 @@ $(window).load(function () {
     $("#sectionList_arrowStatisticsClosed").show();
     $("#statisticsList").show();
     $("#statistics").hide();
+    $(".statisticsContent").show();
     $("#courseList").css({
       'display':'flex',
       'flex-direction': 'column'

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1602,10 +1602,18 @@ $(window).load(function () {
   $("#sectionList_arrowStatisticsOpen").click(function () {
     $("#sectionList_arrowStatisticsOpen").hide();
     $("#sectionList_arrowStatisticsClosed").show();
+    $("#statisticsList").show();
+    $("#statistics").hide();
+    $("#courseList").css({
+      'display':'flex',
+      'flex-direction': 'column'
+    });
+    
   });
   $("#sectionList_arrowStatisticsClosed").click(function () {
     $("#sectionList_arrowStatisticsOpen").show();
     $("#sectionList_arrowStatisticsClosed").hide();
+     $("#statisticsList").hide();
   });
 });
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -121,6 +121,10 @@
 		<div id='Sectionlist'>
 
 		<div class='course' style='display:flex; align-items:center; justify-content:flex-end;'>
+				<div style="margin:10px;">
+						<img src="../Shared/icons/right_complement.svg" id="sectionList_arrowStatisticsOpen">
+						<img src="../Shared/icons/desc_complement.svg" id="sectionList_arrowStatisticsClosed">
+				</div>
 				<div style='flex-grow:1'>
 						<span id='course-coursename' class='nowrap ellipsis' style='margin-left: 90px;margin-right:10px;'>UNK</span>
 						<span id='course-coursecode' style='margin-right:10px;'>UNK</span>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -169,6 +169,8 @@
 						<div id='statisticsSwimlanes' class='statisticsInnerBox' style=''>
 								<svg id="swimlaneSVG" width='300px' style='margin: 10px;' viewBox="0 0 300 255" xmlns="http://www.w3.org/2000/svg"></svg>
 						</div>
+						<div class="statisticsContentBottom"></div>
+
 						<!--<div style='display:flex;'>
 							<canvas id='swimlanesMoments' style='padding:10px;'></canvas>
 						</div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -473,6 +473,11 @@ p {
   background-color: var(--color-primary);
 }
 
+#sectionList_arrowStatisticsOpen,
+#sectionList_arrowStatisticsClosed{
+  display: none;
+  cursor: pointer;
+}
 .item a {
   text-decoration: none;
   color: var(--color-text-primary);
@@ -4403,6 +4408,9 @@ only screen and (max-device-width: 860px) {
 
   #statisticsList {
     display: none;
+  }
+  #sectionList_arrowStatisticsOpen{
+    display: inline;
   }
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -481,6 +481,7 @@ p {
 .statisticsContentBottom{
   min-height: 30px;
   background-color: var(--color-text-primary);
+  display: none;
 
 }
 .item a {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -478,6 +478,11 @@ p {
   display: none;
   cursor: pointer;
 }
+.statisticsContentBottom{
+  min-height: 30px;
+  background-color: var(--color-text-primary);
+
+}
 .item a {
   text-decoration: none;
   color: var(--color-text-primary);


### PR DESCRIPTION
To test this:

Go to mobile mode and then a arrow should appear on the course header. 

![Anteckning 2020-04-29 131320](https://user-images.githubusercontent.com/49142349/80589758-1805ba00-8a1b-11ea-8dde-ab574058c72e.png)

Click on that arrow and the statistics content should slide down.
