### PR TITLE
Service crashes data now shown

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -261,7 +261,7 @@ function loadServiceCrashes() {
 			return n.length >= width ? n : new Array(width - n.length + 1).join('0') + n;
 		}
 
-		function formatDate(date) {
+		/*function formatDate(date) {
 			var year = date.getFullYear();
 			var month = date.getMonth();
 			var day = date.getDate();
@@ -270,7 +270,7 @@ function loadServiceCrashes() {
 			var seconds = date.getSeconds();
 			var millis = date.getMilliseconds();
 			return year + "-" + pad(month, 2) + "-" + pad(day, 2) + " " + pad(hour, 2) + ":" + pad(minute, 2) + ":" + pad(seconds, 2) + "." + pad(millis, 3);
-		}
+		}*/
 
 		$.each(crashes, function(i, crash) {
 			var str = "<div>";
@@ -278,10 +278,10 @@ function loadServiceCrashes() {
 			str += "<br>User agent: " + crash.userAgent;
 			str += "<br>OS: " + crash.operatingSystem;
 			str += "<br>Browser: " + crash.browser;
-			str += "<br><br>Client start: " + formatDate(crash.steps[5]);
+			/*str += "<br><br>Client start: " + formatDate(crash.steps[5]);
 			str += "<br>Server start: " + (crash.steps[6] === undefined ? 'missing' : formatDate(crash.steps[6]));
 			str += "<br>Server end: " + (crash.steps[7] === undefined ? 'missing' : formatDate(crash.steps[7]));
-			str += "<br>Client end (fourth round trip): " + (crash.steps[8] === undefined ? 'missing' : formatDate(crash.steps[8]));
+			str += "<br>Client end (fourth round trip): " + (crash.steps[8] === undefined ? 'missing' : formatDate(crash.steps[8]));*/
 			str += "<br><hr></div>";
 			$('#analytic-info').append(str);
 		});

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -184,7 +184,7 @@ function serviceCrashes(){
 	$result = $GLOBALS['log_db']->query('
 		SELECT * 
 		FROM serviceLogEntries
-		WHERE uuid NOT IN (SELECT DISTINCT uuid FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceClientEnd.');
+		WHERE uuid NOT IN (SELECT DISTINCT uuid FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceServerEnd.');
 	')->fetchAll(PDO::FETCH_ASSOC);
 	echo json_encode($result);
 }


### PR DESCRIPTION
When a service is called with a serviceStart but no serviceEnd its shown in service crashes on analytic.php. 
![image](https://user-images.githubusercontent.com/49142935/80594309-0c1df600-8a23-11ea-9717-16f78551c1a1.png)

Show a Date it's still a problem, this need to be solved in another issue. 

How to test:
comment out a ServiceServerEnd event. 
![image](https://user-images.githubusercontent.com/49142935/80594531-72a31400-8a23-11ea-8f38-1dc011a7a34f.png)
