### PR TITLE
Fixes #8557 - Comma separation should not be after last object

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5259,13 +5259,18 @@ function loadAppearanceForm() {
         indexes[key].max += value;
     });
 
-    indexes.name = {
-        current: 0,
-        max: 0
-    };
-
     //Get all unique types from the selected objects
     const types = [...new Set(appearanceObjects.map(object => object.symbolkind || 0))];
+
+    indexes.name = {
+        current: 0,
+        max: types.reduce((result, type) => {
+            if(type === symbolKind.uml || type === symbolKind.erAttribute || type === symbolKind.erEntity || type === symbolKind.erRelation) {
+                result += indexes[type].max;
+            }
+            return result;
+        }, 0)
+    };
     
     showFormGroups(types);
     toggleApperanceElement(true);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5256,6 +5256,7 @@ function loadAppearanceForm() {
                 max: 0
             };
         }
+        indexes[key].max += value;
     });
 
     //Get all unique types from the selected objects

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5246,6 +5246,11 @@ function loadAppearanceForm() {
 
     const indexes = {};
 
+    const typeToAmountMap = appearanceObjects.reduce((result, object) => {
+        result.set(object.symbolkind || 0, (result.get(object.symbolkind || 0) || 0) + 1);
+        return result;
+    }, new Map());
+    
     //Get all unique types from the selected objects
     const types = [...new Set(appearanceObjects.map(object => object.symbolkind || 0))];
     

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5259,8 +5259,8 @@ function loadAppearanceForm() {
         indexes[key].max += value;
     });
 
-    //Get all unique types from the selected objects
-    const types = [...new Set(appearanceObjects.map(object => object.symbolkind || 0))];
+    //Get all unique types of selected objects
+    const types = Object.keys(indexes).map(Number);
 
     indexes.name = {
         current: 0,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5259,6 +5259,11 @@ function loadAppearanceForm() {
         indexes[key].max += value;
     });
 
+    indexes.name = {
+        current: 0,
+        max: 0
+    };
+
     //Get all unique types from the selected objects
     const types = [...new Set(appearanceObjects.map(object => object.symbolkind || 0))];
     

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5246,11 +5246,18 @@ function loadAppearanceForm() {
 
     const indexes = {};
 
-    const typeToAmountMap = appearanceObjects.reduce((result, object) => {
+    appearanceObjects.reduce((result, object) => {
         result.set(object.symbolkind || 0, (result.get(object.symbolkind || 0) || 0) + 1);
         return result;
-    }, new Map());
-    
+    }, new Map()).forEach((value, key) => {
+        if(typeof indexes[key] === "undefined") {
+            indexes[key] = {
+                current: 0,
+                max: 0
+            };
+        }
+    });
+
     //Get all unique types from the selected objects
     const types = [...new Set(appearanceObjects.map(object => object.symbolkind || 0))];
     

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5318,8 +5318,13 @@ function loadAppearanceForm() {
             }
             document.getElementById("typeLineUML").focus();
         } else if(object.symbolkind === symbolKind.text) {
-            document.getElementById("freeText").value += getTextareaText(object.textLines) + ",\n";
-            document.getElementById("freeText").focus();
+            const textarea = document.getElementById("freeText");
+            indexes[symbolKind.text].current++;
+            textarea.value += getTextareaText(object.textLines);
+            if(indexes[symbolKind.text].max > indexes[symbolKind.text].current) {
+                textarea.value += ",\n";
+            }
+            textarea.focus();
         } else if(object.symbolkind === symbolKind.uml) {
             document.getElementById("umlOperations").value += getTextareaText(object.operations) + ",\n";
             document.getElementById("umlAttributes").value += getTextareaText(object.attributes) + ",\n";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5244,8 +5244,12 @@ function loadAppearanceForm() {
     }
     if(appearanceObjects.length < 1) return;
 
+    //Stores current index and maximum index for each type of selected object
+    //Current index will be used for comma separation, to only create comma when max is more than current
     const indexes = {};
 
+    //Reduce the selected objects array to a Map with key symbolKind and value the number of times that symbolKind occurs
+    //Iterate through the map and put the correct values in the indexes object
     appearanceObjects.reduce((result, object) => {
         result.set(object.symbolkind || 0, (result.get(object.symbolkind || 0) || 0) + 1);
         return result;
@@ -5262,6 +5266,7 @@ function loadAppearanceForm() {
     //Get all unique types of selected objects
     const types = Object.keys(indexes).map(Number);
 
+    //The max index for the name input should be based on all object types that have the name input
     indexes.name = {
         current: 0,
         max: types.reduce((result, type) => {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5326,8 +5326,13 @@ function loadAppearanceForm() {
             }
             textarea.focus();
         } else if(object.symbolkind === symbolKind.uml) {
-            document.getElementById("umlOperations").value += getTextareaText(object.operations) + ",\n";
-            document.getElementById("umlAttributes").value += getTextareaText(object.attributes) + ",\n";
+            indexes[symbolKind.uml].current++;
+            document.getElementById("umlOperations").value += getTextareaText(object.operations);
+            document.getElementById("umlAttributes").value += getTextareaText(object.attributes);
+            if(indexes[symbolKind.uml].max > indexes[symbolKind.uml].current) {
+                document.getElementById("umlOperations").value += ",\n";
+                document.getElementById("umlAttributes").value += ",\n";
+            }
         } else if(object.kind === kind.path) {
             document.getElementById("figureOpacity").value = object.opacity * 100;
             document.getElementById("fillColor").focus();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5282,11 +5282,15 @@ function loadAppearanceForm() {
     
     let erCardinalityVisible = false;
 
-    //A comma at the end to seperate objects right now. Should be fixed in seperate issue to only appear on last object in the type
     appearanceObjects.forEach(object => {
         if(object.symbolkind === symbolKind.uml || object.symbolkind === symbolKind.erAttribute || object.symbolkind === symbolKind.erEntity || object.symbolkind === symbolKind.erRelation) {
-            document.getElementById("name").value += object.name + ", ";
-            document.getElementById("name").focus();
+            const nameElement = document.getElementById("name");
+            indexes.name.current++;
+            nameElement.value += object.name;
+            if(indexes.name.max > indexes.name.current) {
+                nameElement.value += ", ";
+            }
+            nameElement.focus();
         }
 
         if(object.symbolkind === symbolKind.line) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5242,9 +5242,9 @@ function loadAppearanceForm() {
             appearanceObjects.push(object);
         }
     }
-    if(appearanceObjects.length < 1) {
-        return;
-    }
+    if(appearanceObjects.length < 1) return;
+
+    const indexes = {};
 
     //Get all unique types from the selected objects
     const types = [...new Set(appearanceObjects.map(object => object.symbolkind || 0))];


### PR DESCRIPTION
The comma always appeared after the last object, so even when having only one object there was a comma at the end, and typing after the comma would result in nothing changing. Now the comma will never appear after the last object. This affects name input, UML operations textarea, UML attributes textarea, free text textarea.

- Test to select a few objects at the same time making multiple names appear in the name input separated by commas. Make sure no comma appears after the last object name. Test to edit the different names separated by commas.
- Test to select several UML classes and edit the attributes and operations separated by comma followed by new line. Make sure it affects the correct object.
- Test the same as for UML for text objects.
- Test to select many different types of objects at the same and change the different inputs.

I am aware of problems occurring when multiple objects are selected and the value of one of them are emptied completely making one index disappear. This will be fixed in a new issue so do not test to empty values when multiple objects are selected.

Link: http://group4.webug.his.se:20001/G4-2020-W18-ISSUE%238557/DuggaSys/diagram.php