### PR TITLE
Fix for lines turning invisible after free-draw

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2499,6 +2499,7 @@ function eraseSelectedObject(event) {
 function setMode(mode) {
     cancelFreeDraw();
     uimode = mode;
+    figureType = null;
     if(mode == 'Free' || mode == 'Text') {
       uimode = "CreateFigure";
       figureType = mode;


### PR DESCRIPTION
Fixes #8615

Figuretype was not changed back after free-draw function was used. Now UML-lines should not be affected by this.

Test by drawing a free-draw object, then drawing a UML-line. Before the line would create points but be invisible. Now it should display correctly.