### PR TITLE
Fixing the X button | Fix for issue #8626

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1241,7 +1241,7 @@ input {
   font-weight: bold;
 }
 
-.loginBoxheader div:hover {
+.loginBoxheader div:hover, .logoutBoxheader div:hover {
   background-color: #ce3d3d;
 }
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1057,9 +1057,9 @@ function setupLoginLogoutButton(isLoggedIn){
 		$("#loginbutton").off("click");
 		$("#loginbutton").click(function(){
 			$("#logoutBox").show();
+			$("#logoutBox").css('display', 'block');
 			$(".buttonLogoutCancelBox").click(function(){
 				$("#logoutBox").hide();
-
 			});
 
 

--- a/Shared/logoutbox.php
+++ b/Shared/logoutbox.php
@@ -1,6 +1,6 @@
 <!-- Overlay -->
 <div id="overlay" style="display: none;"></div>
-<div id='logoutBox' class="logoutBoxContainer" style="display: none;">
+<div id='logoutBox' class="logoutBoxContainer" style="display: none">
 	<div id='logout' class="logoutBox">
 		<div class='logoutBoxheader'>
 			<h3>Sign out</h3>


### PR DESCRIPTION
Fix so that you can now close the logout popup window by pressing 'x' without having to press 'cancel' first.

Before this fix, you couldn't press the red 'X' button to close the window the FIRST time you opened the log out box. You had to press the 'cancel' button first, then open the logout box AGAIN and press 'X'. The second time you press 'X', it works. 

I've fixed it so that you can press 'X' the first time you open the logout box and it closes like it's supposed to do.

Press here:
![image](https://user-images.githubusercontent.com/49142028/80612165-e0f3d080-8a3b-11ea-80d8-6af920ea9477.png)

This box:
![image](https://user-images.githubusercontent.com/49142028/80612205-efda8300-8a3b-11ea-9790-8c66c9a6c5fd.png)

