### PR TITLE
Fixes #8591- No longer creating useless points when copying lines

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1087,8 +1087,10 @@ function copySymbol(symbol) {
                     }
                 }
 
-                const point = points[pointIndexes[key].old];
-                newPointIndex = points.addPoint(point.x + 50, point.y + 50, point.isSelected);
+                if(newPointIndex !== null) {
+                    const point = points[pointIndexes[key].old];
+                    newPointIndex = points.addPoint(point.x + 50, point.y + 50, point.isSelected);
+                }
             } else {
                 newPointIndex = pointIndexes[keyContainsDuplicateOldPoint].new;
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1076,6 +1076,11 @@ function copySymbol(symbol) {
 
             let newPointIndex = 0;
             if(typeof keyContainsDuplicateOldPoint === "undefined") {
+
+                if(symbol.symbolkind === symbolKind.line && key === "bottomRight") {
+                    
+                }
+
                 const point = points[pointIndexes[key].old];
                 newPointIndex = points.addPoint(point.x + 50, point.y + 50, point.isSelected);
             } else {
@@ -1096,7 +1101,7 @@ function copySymbol(symbol) {
 }
 
 //----------------------------------------------------------------------
-// copySymbol: Clone a path object
+// copyPath: Clone a path object
 //----------------------------------------------------------------------
 function copyPath(path) {
     const clone = Object.assign(new Path, JSON.parse(JSON.stringify(path)));

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4490,7 +4490,6 @@ function mouseupevt(ev) {
             erLineA.topLeft = p1;
             erLineA.object_type = "";
             erLineA.bottomRight = p2;
-            erLineA.centerPoint = p3;
             //always put lines at the bottom since they always render at the bottom, that seems to be the most logical thing to do
             diagram.unshift(erLineA);
             //selecting the newly created enitity and open the dialogmenu.
@@ -4567,7 +4566,6 @@ function mouseupevt(ev) {
             umlLineA.topLeft = p1;
             umlLineA.object_type = "";
             umlLineA.bottomRight = p2;
-            umlLineA.centerPoint = p3;
             umlLineA.isRecursiveLine = lineStartObj == markedObject;
             if (umlLineA.isRecursiveLine) {
                 points[umlLineA.topLeft].x = points[umlLineA.bottomRight].x;
@@ -4928,7 +4926,6 @@ function createSymbol(p1BeforeResize, p2BeforeResize){
                 erLineA.topLeft = p1;
                 erLineA.object_type = "";
                 erLineA.bottomRight = p2;
-                erLineA.centerPoint = p3;
                 diagram.unshift(erLineA);
                 lastSelectedObject = diagram.length -1;
                 diagram[lastSelectedObject].targeted = true;
@@ -4942,7 +4939,6 @@ function createSymbol(p1BeforeResize, p2BeforeResize){
             umlLineA.topLeft = p1;
             umlLineA.object_type = "";
             umlLineA.bottomRight = p2;
-            umlLineA.centerPoint = p3;
             umlLineA.isRecursiveLine = lineStartObj == markedObject;
             if (umlLineA.isRecursiveLine) {
                 points[umlLineA.topLeft].x = points[umlLineA.bottomRight].x;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1077,6 +1077,10 @@ function copySymbol(symbol) {
             let newPointIndex = 0;
             if(typeof keyContainsDuplicateOldPoint === "undefined") {
 
+                //Special case for ER lines connected to attributes
+                //The second point of an er line connected to an attribute is the attribute's centerPoint
+                //This code finds connected attributes that will be copied and prevents the second point from being duplicated if the attribute will also be copied
+                //If the attribute will not be copied the point should be created
                 if(symbol.symbolkind === symbolKind.line && key === "bottomRight") {
                     const connectedAttribute = symbol.getConnectedObjects().find(object => object.symbolkind === symbolKind.erAttribute);
                     if(typeof connectedAttribute !== "undefined") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1079,6 +1079,9 @@ function copySymbol(symbol) {
 
                 if(symbol.symbolkind === symbolKind.line && key === "bottomRight") {
                     const connectedAttribute = symbol.getConnectedObjects().find(object => object.symbolkind === symbolKind.erAttribute);
+                    if(typeof connectedAttribute !== "undefined") {
+                        const isAttributeSelected = cloneTempArray.some(object => Object.is(connectedAttribute, object));
+                    }
                 }
 
                 const point = points[pointIndexes[key].old];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1081,6 +1081,9 @@ function copySymbol(symbol) {
                     const connectedAttribute = symbol.getConnectedObjects().find(object => object.symbolkind === symbolKind.erAttribute);
                     if(typeof connectedAttribute !== "undefined") {
                         const isAttributeSelected = cloneTempArray.some(object => Object.is(connectedAttribute, object));
+                        if(isAttributeSelected) {
+                            newPointIndex = null;
+                        }
                     }
                 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1078,7 +1078,7 @@ function copySymbol(symbol) {
             if(typeof keyContainsDuplicateOldPoint === "undefined") {
 
                 if(symbol.symbolkind === symbolKind.line && key === "bottomRight") {
-                    
+                    const connectedAttribute = symbol.getConnectedObjects().find(object => object.symbolkind === symbolKind.erAttribute);
                 }
 
                 const point = points[pointIndexes[key].old];


### PR DESCRIPTION
A useless point was created every time a line was copied before. This is now fixed. The centerPoint of all lines were removed since it is redundant and causing problems with the copySymbol function. A special case was also developed for ER lines connecting to attributes. ER lines are connecting to the attribute's centerPoint and is therefore reusing the centerPoint of the attribute instead of having a unique point reference for its bottomRight key. A special case was needed to prevent a useless point from being created when an er line is copied together with a connected attribute. If a ER line is copied on its own or together with a relation or entity this point should still be created.

- Test to create lines of all types. This includes UML lines (do not test recursive UML line as this was fixed on another branch but not included in this branch), ER line -> Entity, ER line -> Relation, ER line -> Attribute. Copy and paste them all. You need to be in developer mode to see the any points being useless. Move the objects away or delete them so you can easily see if useless points remain.
- Test to move around the objects after copying and pasting.

Link: http://group4.webug.his.se:20001/G4-2020-W19-ISSUE%238591/DuggaSys/diagram.php