### PR TITLE
#8632 Added text for no deadline

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -835,6 +835,9 @@ function renderCell(col, celldata, cellid) {
 				if (celldata.timesGraded !== 0) {
 					str += '(' + celldata.timesGraded + ')';
 				}
+				else {
+					str += 'No deadline given';
+				}
 				str += "</div>";
 				str += "</div>";
 


### PR DESCRIPTION
Added "No deadline given" to cells in the result editor when there simply is no deadline. Makes the cells in the grid at the same height and more pleasing to the eye.