### PR TITLE
Implemented freedraw for mobile, issue#8674

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4783,10 +4783,10 @@ function resizeElement(selected) {
         var xDiff = points[selected.attachedSymbol.bottomRight].x - points[selected.attachedSymbol.topLeft].x;
         var change = ((currentMouseCoordinateX - selected.point.x) + (currentMouseCoordinateY - selected.point.y)) / 2;
         // Can't resize below minimum threshold
-        if(minSizeCheck(xDiff, selected.attachedSymbol, "x") == false || 5 > change < 5){
+        if(minSizeCheck(xDiff, selected.attachedSymbol, "x") == false || 5 > change > -5){
             selected.point.x = currentMouseCoordinateX;
         }
-        if(minSizeCheck(yDiff, selected.attachedSymbol, "y") == false || 5 > change < 5){
+        if(minSizeCheck(yDiff, selected.attachedSymbol, "y") == false || 5 > change > -5){
             selected.point.y = currentMouseCoordinateY;
         }
     }
@@ -4796,10 +4796,10 @@ function resizeElement(selected) {
         var xDiff = points[selected.attachedSymbol.bottomRight].x - points[selected.attachedSymbol.topLeft].x;
         var change = ((currentMouseCoordinateX - selected.point.x.x) - (currentMouseCoordinateY - selected.point.y.y)) / 2;
         // Can't resize below minimum threshold
-        if(minSizeCheck(xDiff, selected.attachedSymbol, "x") == false || 5 > change < 5){
+        if(minSizeCheck(xDiff, selected.attachedSymbol, "x") == false || 5 > change > -5){
             selected.point.x.x = currentMouseCoordinateX;
         }
-        if(minSizeCheck(yDiff, selected.attachedSymbol, "y") == false || 5 > change < 5){
+        if(minSizeCheck(yDiff, selected.attachedSymbol, "y") == false || 5 > change > -5){
             selected.point.y.y = currentMouseCoordinateY;
         }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4820,6 +4820,13 @@ function touchEndEvent(event) {
         deactivateMovearound();
         updateGraphics();
     }
+    if (uimode == "CreateFigure" && md == mouseState.boxSelectOrCreateMode) {
+        if (figureType == "Free") {
+            figureFreeDraw();
+            updateGraphics();
+            return;
+        }
+    }
 
     var p1BeforeResize;
     var p2BeforeResize;


### PR DESCRIPTION
Should now be possible to freedraw on mobile. It works in the same way as for non-mobiles. Click to add points to the figure and click the first point to finish the figure.