### PR TITLE
minWidth safeguard added, ISSUE#8594

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3916,6 +3916,11 @@ function mousemoveevt(ev) {
                 } else {
                     // normal resize
                     //console.log(sel.point.x);
+                    for (var i = 0; i < diagram.length; i++) {
+                        if (points[diagram[i].bottomRight] == sel.point || points[diagram[i].topLeft] == sel.point || points[diagram[i].topRight] == sel.point || points[diagram[i].bottomLeft] == sel.point) {
+                            object = diagram[i];
+                        }
+                    }
                     var yDiff = points[sel.attachedSymbol.bottomRight].y - points[sel.attachedSymbol.topLeft].y;
                     var xDiff = points[sel.attachedSymbol.bottomRight].x - points[sel.attachedSymbol.topLeft].x;
                     var change = ((currentMouseCoordinateX - sel.point.x) + (currentMouseCoordinateY - sel.point.y)) / 2;

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -28,6 +28,7 @@ function Symbol(kindOfSymbol) {
     this.lineDirection = "First";
     this.recursiveLineExtent = 40;  // Distance out from the entity that recursive lines go
     this.minWidth;
+    this.UMLabsoluteMinWidth = 112.685546875; // The absolute smallest width a UML object can have
     this.minHeight;
     this.group = 0;                 // What group this symbol belongs to
     this.isLocked = false;          // If the symbol is locked
@@ -362,8 +363,11 @@ function Symbol(kindOfSymbol) {
                 }
             }
             ctx.font = "14px Arial";
-            this.minWidth = ctx.measureText(longestStr).width + 15;
-
+            //Check if the new min width is smaller than the absolute min, if it isn't, change min
+            newWidth = ctx.measureText(longestStr).width + 15;
+            if(newWidth >= this.UMLabsoluteMinWidth){
+                this.minWidth = newWidth;
+            }
             if(points[this.bottomRight].y-points[this.topLeft].y < this.minHeight) {
                 // If the height is less than the minimum, push out the
                 // point that the user is dragging


### PR DESCRIPTION
Added if statement and a absolute minimum value that minWidth can have to prevent it from shrinking too small to contain the text in the UML class.

![Untitled](https://user-images.githubusercontent.com/62876844/80699366-2071f980-8adc-11ea-9861-a16057d066b3.png)
