### PR TITLE
Fixes #8508 - Duplicate objects in selected_objects array

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -114,7 +114,7 @@ var canvasTouchClick = false;       // Canvas touch state
 var lastZoomValue = localStorage.getItem("zoomValue") || 1.00;      //Records last zoomvalue, 1.00 if none has been recorded
 var zoomValue = lastZoomValue;
 var md = mouseState.empty;          // Mouse state, Mode to determine action on canvas
-var hoveredObject = false;
+var hoveredObject;
 var markedObject = false;
 var lineStartObj = -1;
 var fullscreen = false;             // Used to toggle fullscreen 
@@ -2943,7 +2943,7 @@ function reWrite() {
 
     if (developerModeActive) {
         let coordinatesText = `<p><b>Mouse:</b> (${decimalPrecision(currentMouseCoordinateX, 0).toFixed(0)}, ${decimalPrecision(currentMouseCoordinateY, 0).toFixed(0)})</p>`;
-        if (hoveredObject && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free") {
+        if (typeof hoveredObject !== "undefined" && hoveredObject.symbolkind != symbolKind.umlLine && hoveredObject.symbolkind != symbolKind.line && hoveredObject.figureType != "Free") {
             coordinatesText += `<p><b>Object center:</b> (${Math.round(points[hoveredObject.centerPoint].x)}, ${Math.round(points[hoveredObject.centerPoint].y)})</p>`;
         }
         coordinatesElement.innerHTML = `${coordinatesText}</p>`;
@@ -3399,6 +3399,7 @@ function undoDiagram(event) {
 
     selected_objects = diagram.filter(object => object.targeted);
     cloneTempArray = selected_objects;
+    hoveredObject = undefined;
 }
 
 //----------------------------------------------------------------------
@@ -3418,6 +3419,7 @@ function redoDiagram(event) {
 
     selected_objects = diagram.filter(object => object.targeted);
     cloneTempArray = selected_objects;
+    hoveredObject = undefined;
 }
 
 //----------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -718,6 +718,7 @@ function keyDownHandler(e) {
         } else if (ctrlIsClicked && key == keyMap.vKey ) {
             //Ctrl + v
             let temp = [];
+            SaveState();
             for(const object of cloneTempArray) {
                 if(object.kind === kind.path) {
                     temp.push(copyPath(object));

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -735,6 +735,7 @@ function keyDownHandler(e) {
         else if (key == keyMap.yKey && ctrlIsClicked) redoDiagram(event);
         else if (key == keyMap.aKey && ctrlIsClicked) {
             e.preventDefault();
+            selected_objects = [];
             for (var i = 0; i < diagram.length; i++) {
                 selected_objects.push(diagram[i]);
                 diagram[i].targeted = true;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3398,7 +3398,7 @@ function undoDiagram(event) {
     if (tmpDiagram != null) LoadImport(tmpDiagram);
 
     selected_objects = diagram.filter(object => object.targeted);
-    cloneTempArray = selected_objects;
+    cloneTempArray = [];
     hoveredObject = undefined;
 }
 
@@ -3418,7 +3418,7 @@ function redoDiagram(event) {
     if (tmpDiagram != null) LoadImport(tmpDiagram);
 
     selected_objects = diagram.filter(object => object.targeted);
-    cloneTempArray = selected_objects;
+    cloneTempArray = [];
     hoveredObject = undefined;
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3398,6 +3398,7 @@ function undoDiagram(event) {
     if (tmpDiagram != null) LoadImport(tmpDiagram);
 
     selected_objects = diagram.filter(object => object.targeted);
+    cloneTempArray = selected_objects;
 }
 
 //----------------------------------------------------------------------
@@ -3416,6 +3417,7 @@ function redoDiagram(event) {
     if (tmpDiagram != null) LoadImport(tmpDiagram);
 
     selected_objects = diagram.filter(object => object.targeted);
+    cloneTempArray = selected_objects;
 }
 
 //----------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -717,21 +717,23 @@ function keyDownHandler(e) {
             fillCloneArray();
         } else if (ctrlIsClicked && key == keyMap.vKey ) {
             //Ctrl + v
-            let temp = [];
-            SaveState();
-            for(const object of cloneTempArray) {
-                if(object.kind === kind.path) {
-                    temp.push(copyPath(object));
-                } else {
-                    temp.push(copySymbol(object));
-                }
-            }
-            setConnectedLines(temp);
-            cloneTempArray = temp;
-            if(temp.length !== 0) {
-                selected_objects = temp;
-                updateGraphics();
+            if(cloneTempArray.length !== 0) {
                 SaveState();
+                let temp = [];
+                for(const object of cloneTempArray) {
+                    if(object.kind === kind.path) {
+                        temp.push(copyPath(object));
+                    } else {
+                        temp.push(copySymbol(object));
+                    }
+                }
+                setConnectedLines(temp);
+                cloneTempArray = temp;
+                if(temp.length !== 0) {
+                    selected_objects = temp;
+                    updateGraphics();
+                    SaveState();
+                }
             }
         }
         else if (key == keyMap.zKey && ctrlIsClicked) undoDiagram(event);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -727,9 +727,11 @@ function keyDownHandler(e) {
             }
             setConnectedLines(temp);
             cloneTempArray = temp;
-            selected_objects = temp;
-            updateGraphics();
-            SaveState();
+            if(temp.length !== 0) {
+                selected_objects = temp;
+                updateGraphics();
+                SaveState();
+            }
         }
         else if (key == keyMap.zKey && ctrlIsClicked) undoDiagram(event);
         else if (key == keyMap.yKey && ctrlIsClicked) redoDiagram(event);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3396,6 +3396,8 @@ function undoDiagram(event) {
     var tmpDiagram = localStorage.getItem("diagram" + diagramNumber);
     localStorage.setItem("diagramNumber", diagramNumber);
     if (tmpDiagram != null) LoadImport(tmpDiagram);
+
+    selected_objects = diagram.filter(object => object.targeted);
 }
 
 //----------------------------------------------------------------------
@@ -3412,6 +3414,8 @@ function redoDiagram(event) {
     var tmpDiagram = localStorage.getItem("diagram" + diagramNumber);
     localStorage.setItem("diagramNumber", diagramNumber);
     if (tmpDiagram != null) LoadImport(tmpDiagram);
+
+    selected_objects = diagram.filter(object => object.targeted);
 }
 
 //----------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -729,11 +729,9 @@ function keyDownHandler(e) {
                 }
                 setConnectedLines(temp);
                 cloneTempArray = temp;
-                if(temp.length !== 0) {
-                    selected_objects = temp;
-                    updateGraphics();
-                    SaveState();
-                }
+                selected_objects = temp;
+                updateGraphics();
+                SaveState();
             }
         }
         else if (key == keyMap.zKey && ctrlIsClicked) undoDiagram(event);


### PR DESCRIPTION
Before it worked fine to manually select each object by CTRL clicking on them one by one. It also worked fine to use the keyboard shortcut CTRL+A to select all objects when no objects are already selected. However, when some objects were already manually selected and the CTRL+A shortcut was used to select all objects, all objects will be added to selected_objects on top of the ones that were already manually selected. This caused problems for multiple things. This is now fixed.

Copying and pasting after redo and undo was a problem before. It was not be possible to copy the selected object after undoing directly and all the objects that were selected when copying would not be selected again after paste and undo. It would be good to fix this since it would make it easier to just copy and paste the selected ones again. This was fixed as well.

Also fixed an error that could appear after undoing and trying to paste. This is related to the hovering of objects in developer mode. A object that does not exist would be in the hoveredObject variable so this variable was set to undefined when undoing or redoing.

- Test to manually select a few objects. Then click CTRL + A, the shortcut command for selecting all objects in the diagram. Go to your browser console and write selected_objects to see how many objects it contains. The correct number of objects should appear.
- Experiment with redo and undo together with copy and paste. Try to copy and paste objects, undo the action and see so the objects that were selected before paste is selected after undo. Try to use the CTRL + A command to select all directly after undoing and paste to see so this works without the copy paste being locked after undo. Experiment more with some different objects to see if you can find some problem.

Link: http://group4.webug.his.se:20001/G4-2020-W19-ISSUE%238508/DuggaSys/diagram.php