### PR TITLE
Added file selection option to file information tab in analytic - G1-2020-W19-ISSUE#8673

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -291,32 +291,80 @@ function loadServiceCrashes() {
 
 
 function loadFileInformation() {
-	loadAnalytics("fileInformation", function(data) {
-		$('#analytic-info').append("<p>File information for created and edited files.</p>");
-
-		var tableData = [["Username", "Action", "Version", "File", "Timestamp"]];
-		for (var i = 0; i < data.length; i++) {
-			var description = data[i].description.split(" ");
-			var version = description[0];
-			var file =  description[1];
-
-			if(data[i].eventType == 15){
-				var action = "Created"
-			}
-			else{
-				var action = "Edited"
-			}
-
-			tableData.push([
-				data[i].userName,
-				action,
-				version,
-				file,
-				data[i].timestamp
-			]);
-		}
-		$('#analytic-info').append(renderTable(tableData));
-	});
+    $('#analytic-info').empty();
+	$('#analytic-info').append("<p>File information for created and edited files.</p>");
+	
+	/* SAVE FOR LATER: DATE PICKING
+    var inputDateFrom = $('<input type="text"></input>')
+        .datepicker({
+            dateFormat: "yy-mm-dd"
+        })
+        .datepicker("setDate", "-1m")
+        .appendTo($('#analytic-info'));
+ 
+    var inputDateTo = $('<input type="text"></input>')
+        .datepicker({
+            dateFormat: "yy-mm-dd"
+        })
+        .datepicker("setDate", "+1d")
+        .appendTo($('#analytic-info'));
+	*/
+ 
+    function updateFileInformation() {
+        $.ajax({
+            url: "analyticService.php",
+            type: "POST",
+            dataType: "json",
+            data: {
+				query: "fileInformation",
+            },
+            success: function(data) {
+                var files = {};
+                $.each(data, function(i, row) {
+                    var description = row.description.split(" ");
+                    var version = description[0];
+                    var file =  description[1];
+ 
+                    if(row.eventType == 15){
+                        var action = "Created"
+                    }
+                    else{
+                        var action = "Edited"
+                    }
+ 
+                    if (!files.hasOwnProperty(file)) {
+                        files[file] = [["Username", "Action", "Version", "File", "Timestamp"]];
+                    }
+                    files[file].push([
+                        row.userName,
+                        action,
+                        version,
+                        file,
+                        row.timestamp
+                    ]);
+                });
+ 
+                $('#analytic-info > select.file-select').remove();
+                var fileSelect = $('<select class="file-select"></select>');
+                for (var file in files) {
+                    if (files.hasOwnProperty(file)) {
+                        fileSelect.append('<option value="' + file + '">' + file + '</option>')
+                    }
+                }
+                fileSelect.change(function() {
+                    $('#analytic-info').append(renderTable(files[$(this).val()]));
+                });
+                $('#analytic-info').append(fileSelect);
+                fileSelect.change();
+            }
+        });
+    }
+   
+	// SAVE FOR LATER: DATE PICKING
+    //inputDateFrom.change(updateFileInformation);
+    //inputDateTo.change(updateFileInformation);
+ 
+    updateFileInformation();
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Added file selection option through a dropdown menu. Did not managed to get date picking to work correctly like the issue request. Will create seperate issue for that specifically.

![Screenshot 2020-04-30 at 13 21 58](https://user-images.githubusercontent.com/62876614/80705032-f45b7600-8ae5-11ea-92d0-a76c4397f137.png)

Additonally removal function of  previously requested tables will be added in a separate issue. In the picture below you can see an example of this issue. The table for the previous request remains. 

![Screenshot 2020-04-30 at 13 22 07](https://user-images.githubusercontent.com/62876614/80705026-f02f5880-8ae5-11ea-9bec-5a82eae5fb6f.png)

How to test:
Edit or create files in fileed, the navigate to analytic.php where the logging result will be presented under the file information tab. 
