### PR TITLE
ShowDugga: Added inline styling to position the panel

### DIFF
--- a/DuggaSys/templates/dugga1.html
+++ b/DuggaSys/templates/dugga1.html
@@ -61,7 +61,7 @@
 		</tr>
 </table>
 
-<div id="pop" class="popover arrow-topr" style='display:none;'>
+<div id="pop" class="popover arrow-topr" style='top:-35px;display:none;'>
 		<table width="100%" height="100%" style='border-collapse: separate;'>
 				<tr>
 						<td class='hexbutt' onclick="setval('0');">0</td>

--- a/DuggaSys/templates/dugga2.html
+++ b/DuggaSys/templates/dugga2.html
@@ -45,7 +45,7 @@
 		</tr>
 </table>
 
-<div id="pop" class="popover arrow-topr" style='display:none;'>
+<div id="pop" class="popover arrow-topr" style='top:-35px;display:none;'>
 		<table width="100%" height="100%" style='border-collapse: separate;'>
 				<tr>
 						<td class='hexbutt' onclick="setval('0');">0</td>


### PR DESCRIPTION
The first idea was to adjust the code for the top positioning in dugga1.js and dugga2.js, but with javascript I couldn't get the top position to always be -35px. By just adding "top:-35px" to the div containing the hexadecimal values the problem was solved. 

Now it looks like it should and everything feels more connected. 

![image](https://user-images.githubusercontent.com/49142704/80708865-a85fff80-8aec-11ea-9393-b1e3e6d094cb.png)

This fixes the issues in both the "biträkningsduggor" and the "färgduggor". 