### PR TITLE
Fixing shadows over 'home' and 'back' icons | Fix for issue #8703

### DIFF
--- a/Shared/icons/HomeShadow.svg
+++ b/Shared/icons/HomeShadow.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32.6 32" style="enable-background:new 0 0 32.6 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.22;}
+	.st1{filter:url(#Adobe_OpacityMaskFilter);}
+	.st2{mask:url(#SVGID_1_);}
+	.st3{fill:#FFFFFF;}
+</style>
+<g id="home-icon_1_" class="st0">
+	<defs>
+		<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="7.1" y="8.7" width="25.5" height="22.2">
+			<feFlood  style="flood-color:white;flood-opacity:1" result="back"/>
+			<feBlend  in="SourceGraphic" in2="back" mode="normal"/>
+		</filter>
+	</defs>
+	<mask maskUnits="userSpaceOnUse" x="7.1" y="8.7" width="25.5" height="22.2" id="SVGID_1_">
+		<g class="st1">
+			<image style="overflow:visible;" width="30" height="27" xlink:href="9BA695FE.jpg"  transform="matrix(1 0 0 1 5 5.975)">
+			</image>
+		</g>
+	</mask>
+	<g class="st2">
+		<path d="M19.9,14.5l9.7,8v8.4h-7.1V26h-5.3v4.9h-7.1v-8.4L19.9,14.5z M19.9,12.3l10.8,9l1.9-1.8L19.9,8.7L7.1,19.6L9,21.4
+			L19.9,12.3z"/>
+	</g>
+</g>
+<path id="home-icon" class="st3" d="M16.5,11.1l9.7,8v8.4h-7.1v-4.9h-5.3v4.9H6.8v-8.4L16.5,11.1z M16.5,8.9l10.8,9l1.9-1.8
+	L16.5,5.3L3.7,16.2L5.6,18L16.5,8.9z"/>
+</svg>

--- a/Shared/icons/UpShadow.svg
+++ b/Shared/icons/UpShadow.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.22;}
+	.st1{filter:url(#Adobe_OpacityMaskFilter);}
+	.st2{mask:url(#SVGID_1_);}
+	.st3{fill:#FFFFFF;}
+</style>
+<g class="st0">
+	<defs>
+		<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="3.3" y="5.9" width="20.3" height="18.1">
+			<feFlood  style="flood-color:white;flood-opacity:1" result="back"/>
+			<feBlend  in="SourceGraphic" in2="back" mode="normal"/>
+		</filter>
+	</defs>
+	<mask maskUnits="userSpaceOnUse" x="3.3" y="5.9" width="20.3" height="18.1" id="SVGID_1_">
+		<g class="st1">
+			<image style="overflow:visible;" width="25" height="23" xlink:href="9F71F152.jpg"  transform="matrix(1 0 0 1 1 3)">
+			</image>
+		</g>
+	</mask>
+	<g class="st2">
+		<g>
+			<path id="Play_10_" d="M14.9,22.8c0,1.1-0.8,1.5-1.7,1L4,18.4c-0.9-0.5-0.9-1.4,0-1.9l9.2-5.3c0.9-0.5,1.7-0.1,1.7,1V22.8z"/>
+			<path d="M23.6,16.3L23.6,16.3c0-0.1,0-0.5,0-1.1V7.6c0-0.9-0.8-1.7-1.7-1.7h-0.1c-0.9,0-1.7,0.8-1.7,1.7v7.6
+				c0,0.3-0.3,0.6-0.6,0.6h-7.6c-0.9,0-1.7,0.8-1.7,1.7v0.1c0,0.9,0.8,1.7,1.7,1.7h10c0.9,0,1.7-0.8,1.7-1.7v-0.1
+				C23.6,16.9,23.6,16.5,23.6,16.3z"/>
+		</g>
+	</g>
+</g>
+<g>
+	<path id="Play" class="st3" d="M13.5,19.6c0,1.1-0.8,1.5-1.7,1l-9.2-5.3c-0.9-0.5-0.9-1.4,0-1.9L11.8,8c0.9-0.5,1.7-0.1,1.7,1V19.6
+		z"/>
+	<path class="st3" d="M22.1,13.1L22.1,13.1c0-0.1,0-0.5,0-1.1V4.4c0-0.9-0.8-1.7-1.7-1.7h-0.1c-0.9,0-1.7,0.8-1.7,1.7V12
+		c0,0.3-0.3,0.6-0.6,0.6h-7.6c-0.9,0-1.7,0.8-1.7,1.7v0.1c0,0.9,0.8,1.7,1.7,1.7h10c0.9,0,1.7-0.8,1.7-1.7v-0.1
+		C22.2,13.7,22.2,13.4,22.1,13.1z"/>
+</g>
+</svg>

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -33,11 +33,11 @@
 				  echo "<td class='navButt' id='back' title='Back'>";
 			}
 			if($noup=='COURSE'){
-					echo "<a class='navButt' href='../DuggaSys/courseed.php'>";
+					echo "<a id='upIcon' class='navButt' href='../DuggaSys/courseed.php'>";
 					echo "<img src='../Shared/icons/Up.svg'></a></td>";
 					// echo "<td>GREGER!</td>";	
 			}else if($noup=='SECTION'){
-					echo "<a href='";
+					echo "<a  id='upIcon' href='";
 					echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
 					echo "'>";
 					echo "<img src='../Shared/icons/Up.svg'></a></td>";
@@ -277,6 +277,26 @@ function mouseOutHome() {
    }
 }
 
+document.getElementById("upIcon").addEventListener("mouseover", mouseOverUp);
+document.getElementById("upIcon").addEventListener("mouseout", mouseOutUp);
+
+function mouseOverUp() {
+	var obj = document.getElementById("upIcon");
+   if(obj != null)
+   {
+      var images = obj.getElementsByTagName('img');
+      images[0].src = '../Shared/icons/UpShadow.svg';
+   }
+}
+
+function mouseOutUp() {
+	var obj = document.getElementById("upIcon");
+   if(obj != null)
+   {
+      var images = obj.getElementsByTagName('img');
+      images[0].src = '../Shared/icons/Up.svg';
+   }
+}
 
 
 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -22,7 +22,7 @@
 				$_SESSION['coursevers'] = "UNK";
 	
 			// Always show home button which links to course homepage
-			echo "<td class='navButt' id='home' title='Home'><a class='navButt' href='../DuggaSys/courseed.php'><img src='../Shared/icons/Home.svg'></a></td>";
+			echo "<td class='navButt' id='home' title='Home'><a id='homeIcon' class='navButt' href='../DuggaSys/courseed.php'><img src='../Shared/icons/Home.svg'></a></td>";
 			// Generate different back buttons depending on which page is including
 			// this file navheader file. The switch case uses ternary operators to
 			// determine the href attribute value. (if(this) ? dothis : elsethis)
@@ -255,6 +255,31 @@
 	function hoverBack(){
 		$(".dropdown-list-container").css("display", "none");
 	}
+
+document.getElementById("homeIcon").addEventListener("mouseover", mouseOverHome);
+document.getElementById("homeIcon").addEventListener("mouseout", mouseOutHome);
+
+function mouseOverHome() {
+	var obj = document.getElementById("homeIcon");
+   if(obj != null)
+   {
+      var images = obj.getElementsByTagName('img');
+      images[0].src = '../Shared/icons/HomeShadow.svg';
+   }
+}
+
+function mouseOutHome() {
+	var obj = document.getElementById("homeIcon");
+   if(obj != null)
+   {
+      var images = obj.getElementsByTagName('img');
+      images[0].src = '../Shared/icons/Home.svg';
+   }
+}
+
+
+
+
 </script>
 <script type="text/javascript">
 	(function(proxied) {


### PR DESCRIPTION
Fixed so there is now a box-shadow effect on the 'home' and 'back' icons (see image for reference)

![image](https://user-images.githubusercontent.com/49142028/80710595-4bb21400-8aef-11ea-9b43-9579c8a7791b.png)
