### PR TITLE
G2 2020 w19 #7769 updated accessed dropdowns to a div-based solution

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -251,29 +251,21 @@ function getColname(e){
 function changeOptDiv(e) {
 	var paramlist = e.target.parentElement.parentElement.id.split("_");
 	key = getColname(e);
-
 	keyvalue = e.target.getAttribute('data-value');
-	console.log(e.target.parentElement.parentElement.id);
-	console.log(keyvalue);
 	
 	obj = {
 		uid: paramlist[1],
 		[key]: keyvalue
 	}
-	console.log(obj);
-	console.log(paramlist[1], paramlist[0], keyvalue);
 	updateDropdownInTable(e.target.parentElement.parentElement.firstChild, obj);
 	changeProperty(paramlist[1], paramlist[0], keyvalue);
 	e.target.parentElement.parentElement.firstChild.innerHTML = e.target.innerHTML;
 }
+
 function changeOptDivStudent(e,value){
 	var paramlist = e.target.parentElement.parentElement.id.split("_");
 	key = getColname(e);
-
 	keyvalue = e.target.getAttribute('data-value');
-	
-	console.log(e.target.parentElement.parentElement.id);
-	console.log(keyvalue);
 	
 	obj = {
 		[key]: keyvalue

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -257,6 +257,7 @@ function changeOptDiv(e) {
 	console.log(keyvalue);
 	
 	obj = {
+		uid: paramlist[1],
 		[key]: keyvalue
 	}
 	console.log(obj);
@@ -342,7 +343,14 @@ function renderCell(col, celldata, cellid) {
 		}
 		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div '>"+examinerName+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItemWithValue(obj.examiner, filez['teachers'], "name", "uid") + "</div>";
 	} else if (col == "vers") {
-		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div >"+filez['courses'][0].versname+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItem(obj.vers, filez['courses'], "versname", "vers") + "</select>";
+		var versname = "null"
+		for (var i = 0; i < filez['courses'].length; i++) {
+			if (obj.vers == filez['courses'][i]['vers']) {
+				versname = filez['courses'][i]['versname'];
+			}
+		}
+
+		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div >"+versname+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItem(obj.vers, filez['courses'], "versname", "vers") + "</select>";
         for (var submission of filez['submissions']) {
             if (obj.uid === submission.uid) {
                 str += "<img class='oldSubmissionIcon' title='View old version' src='../Shared/icons/DocumentDark.svg' onclick='showVersion(" + submission.vers + ")'>";

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -393,7 +393,7 @@ function renderCell(col, celldata, cellid) {
             optstr = "";
         }
 		str = "<div class='multiselect-group'><div class='group-select-box' onclick='showCheckboxes(this)'>";
-		str += "<div><div class='access-dropdown'>" + optstr + "<img class='sortingArrow' src='../Shared/icons/desc_black.svg'/></div></div><div class='overSelect'></div></div><div class='checkboxes' id='grp" + obj.uid + "' >";
+		str += "<div><div class='access-dropdown'><span>" + optstr + "</span><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/></div></div><div class='overSelect'></div></div><div class='checkboxes' id='grp" + obj.uid + "' >";
 		for (var i = 0; i < filez['groups'].length; i++) {
 			var group = filez['groups'][i];
 			if (tgroups.indexOf((group.groupkind + "_" + group.groupval)) > -1) {
@@ -642,7 +642,7 @@ function showCheckboxes(element) {
 //----------------------------------------------------------------------------------
 
 function updateAndCloseGroupDropdown(checkboxes){
-	var str = "", readStr = "";
+	var str = "", readStr = "<span>";
 	for (i = 0; i < checkboxes.childNodes.length; i++) {
 		if (checkboxes.childNodes[i].childNodes[0].checked) {
 			str += checkboxes.childNodes[i].childNodes[0].value + " ";
@@ -653,6 +653,7 @@ function updateAndCloseGroupDropdown(checkboxes){
 	// if user unpresses all checkboxes it the student will now belong to no group
 	else changeProperty(checkboxes.id.substr(3), "group", "None");
 
+	readStr += "</span><img class='sortingArrow' src='../Shared/icons/desc_black.svg'>";
 	activeElement.children[0].children[0].innerHTML = readStr;
 
 	obj = {

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -239,16 +239,45 @@ function resetPw(uid, username) {
 	}, "ACCESS");
 }
 
+function getColname(e){
+	var element = e.target.parentElement.parentElement;
+	var cellelement = element.closest("td");
+	let regex = new RegExp("^r([0-9]+)" + myTable.getDelimiter() + "([a-zA-Z0-9]+)" + myTable.getDelimiter() + "(.*)")
+	let match = cellelement.id.match(regex);
+	var colname = match[3];
+	return colname.toString();
+}
+
 function changeOptDiv(e) {
-	console.log(e.target.parentElement.parentElement.id);
 	var paramlist = e.target.parentElement.parentElement.id.split("_");
-	changeProperty(paramlist[1], paramlist[0], e.target.innerHTML);
+	key = getColname(e);
+
+	keyvalue = e.target.getAttribute('data-value');
+	console.log(e.target.parentElement.parentElement.id);
+	console.log(keyvalue);
+	
+	obj = {
+		[key]: keyvalue
+	}
+	console.log(obj);
+	console.log(paramlist[1], paramlist[0], keyvalue);
+	updateDropdownInTable(e.target.parentElement.parentElement.firstChild, obj);
+	changeProperty(paramlist[1], paramlist[0], keyvalue);
 	e.target.parentElement.parentElement.firstChild.innerHTML = e.target.innerHTML;
 }
 function changeOptDivStudent(e,value){
-	console.log(e.target.parentElement.parentElement.id);
-	console.log(value);
 	var paramlist = e.target.parentElement.parentElement.id.split("_");
+	key = getColname(e);
+
+	keyvalue = e.target.getAttribute('data-value');
+	
+	console.log(e.target.parentElement.parentElement.id);
+	console.log(keyvalue);
+	
+	obj = {
+		[key]: keyvalue
+	}
+	updateDropdownInTable(e.target.parentElement.parentElement.firstChild, obj);
 	changeProperty(paramlist[1], paramlist[0], value);
 	e.target.parentElement.parentElement.firstChild.innerHTML = e.target.innerHTML;
 }

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -8,6 +8,8 @@ var tableName = "accessTable";
 var tableCellName = "accessTableCell";
 var myTable;
 var accessFilter = "WRST";
+var trueTeacher;
+var examinerName;
 
 //----------------------------------------------------------------------------
 //----------==========########## User Interface ##########==========----------
@@ -237,6 +239,18 @@ function resetPw(uid, username) {
 	}, "ACCESS");
 }
 
+function changeOptDiv(e) {
+	console.log(e.target.parentElement.parentElement.id);
+	var paramlist = e.target.parentElement.parentElement.id.split("_");
+	changeProperty(paramlist[1], paramlist[0], e.target.innerHTML);
+}
+function changeOptDivStudent(e,value){
+	console.log(e.target.parentElement.parentElement.id);
+	console.log(value);
+	var paramlist = e.target.parentElement.parentElement.id.split("_");
+	changeProperty(paramlist[1], paramlist[0], value);
+}
+
 function changeOpt(e) {
 	var paramlist = e.target.id.split("_");
 	obj = {
@@ -285,11 +299,19 @@ function renderCell(col, celldata, cellid) {
 			str = "<div style='display:flex;'><span id='" + col + "_" + obj.uid + "' style='margin:0 4px;flex-grow:1;'>" + obj[col] + "</span></div>";
 		}
 	} else if (col == "class") {
-		str = "<select onchange='changeOpt(event)' id='" + col + "_" + obj.uid + "'><option value='None'>None</option>" + makeoptionsItem(obj.class, filez['classes'], "class", "class") + "</select>";
+		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div >"+obj.class+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItem(obj.class, filez['classes'], "class", "class") + "</div>";
 	} else if (col == "examiner") {
-		str = "<select onchange='changeOpt(event)' id='" + col + "_" + obj.uid + "'><option value='None'>None</option>" + makeoptionsItem(obj.examiner, filez['teachers'], "name", "uid") + "</select>";
+		for(i = 0; i < filez['teachers'].length; i++){
+			if(obj.examiner == filez['teachers'][i].uid){
+				examinerName = filez['teachers'][i].name;
+			}
+		}
+		if(examinerName == null){
+			examinerName = "None";
+		}
+		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div >"+examinerName+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItemWithValue(obj.examiner, filez['teachers'], "name", "uid") + "</div>";
 	} else if (col == "vers") {
-        str = "<select onchange='changeOpt(event)' id='" + col + "_" + obj.uid + "'>" + makeoptionsItem(obj.vers, filez['courses'], "versname", "vers") + "</select>";
+		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div >"+filez['courses'][0].versname+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItem(obj.vers, filez['courses'], "versname", "vers") + "</select>";
         for (var submission of filez['submissions']) {
             if (obj.uid === submission.uid) {
                 str += "<img class='oldSubmissionIcon' title='View old version' src='../Shared/icons/DocumentDark.svg' onclick='showVersion(" + submission.vers + ")'>";
@@ -297,16 +319,26 @@ function renderCell(col, celldata, cellid) {
             }
         };
 	} else if (col == "access") {
-		str = "<select onchange='changeOpt(event)' id='" + col + "_" + obj.uid + "'>" + makeoptions(obj.access, ["Teacher", "Student", "Student teacher"], ["W", "R", "ST"]) + "</select>";
+		if(obj.access == "W"){
+			trueTeacher = "Teacher";
+		}
+		else if (obj.access == "R"){
+			trueTeacher = "Student";
+		}
+		else {
+			trueTeacher = "Student teacher";
+		}
+		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div >"+trueTeacher+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makeDivItemStudent(obj.access, ["Teacher", "Student", "Student teacher"], ["W", "R", "ST"]) + "</select>";
 	} else if (col == "requestedpasswordchange") {
 		
 		if (parseFloat(obj.recent) < 1440) {
-			str = "<input class='submit-button new-user' type='button' value='Reset PW' style='display:block;margin:auto;float:none;'";
+			str = "<div class='submit-button' style='display:block;margin:auto;float:none;'";
 		} else {
-			str = "<input class='submit-button resetpw-button' type='button' value='Reset PW'";
+			str = "<div class='submit-button' id='reset-pw' style='display:block;margin:auto;float:none;'";
 		}
 		str += " onclick='if(confirm(\"Reset password for " + obj.username + "?\")) ";
 		str += "resetPw(\"" + obj.uid + "\",\"" + obj.username + "\"); return false;'>";
+		str += "Reset PW";
 	} else if (col == "groups") {
 		if (obj.groups == null) {
 			tgroups = [];
@@ -322,7 +354,7 @@ function renderCell(col, celldata, cellid) {
             optstr = "";
         }
 		str = "<div class='multiselect-group'><div class='group-select-box' onclick='showCheckboxes(this)'>";
-		str += "<select><option>" + optstr + "</option></select><div class='overSelect'></div></div><div class='checkboxes' id='grp" + obj.uid + "' >";
+		str += "<div><div class='access-dropdown'>" + optstr + "<img class='sortingArrow' src='../Shared/icons/desc_black.svg'/></div></div><div class='overSelect'></div></div><div class='checkboxes' id='grp" + obj.uid + "' >";
 		for (var i = 0; i < filez['groups'].length; i++) {
 			var group = filez['groups'][i];
 			if (tgroups.indexOf((group.groupkind + "_" + group.groupval)) > -1) {

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -243,12 +243,14 @@ function changeOptDiv(e) {
 	console.log(e.target.parentElement.parentElement.id);
 	var paramlist = e.target.parentElement.parentElement.id.split("_");
 	changeProperty(paramlist[1], paramlist[0], e.target.innerHTML);
+	e.target.parentElement.parentElement.firstChild.innerHTML = e.target.innerHTML;
 }
 function changeOptDivStudent(e,value){
 	console.log(e.target.parentElement.parentElement.id);
 	console.log(value);
 	var paramlist = e.target.parentElement.parentElement.id.split("_");
 	changeProperty(paramlist[1], paramlist[0], value);
+	e.target.parentElement.parentElement.firstChild.innerHTML = e.target.innerHTML;
 }
 
 function changeOpt(e) {
@@ -309,7 +311,7 @@ function renderCell(col, celldata, cellid) {
 		if(examinerName == null){
 			examinerName = "None";
 		}
-		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div >"+examinerName+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItemWithValue(obj.examiner, filez['teachers'], "name", "uid") + "</div>";
+		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div '>"+examinerName+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItemWithValue(obj.examiner, filez['teachers'], "name", "uid") + "</div>";
 	} else if (col == "vers") {
 		str = "<div class='access-dropdown' id='" + col + "_" + obj.uid + "'><Div >"+filez['courses'][0].versname+"</Div><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/>" + makedivItem(obj.vers, filez['courses'], "versname", "vers") + "</select>";
         for (var submission of filez['submissions']) {
@@ -541,26 +543,27 @@ function returnedAccess(data) {
 		tblbody: data['entries'],
 		tblfoot: {}
 	}
+	//myTable = undefined;
 	var colOrder = ["username",/* "ssn",*/ "firstname", "lastname", "class", "modified", "examiner", "vers", "access", "groups", "requestedpasswordchange"]
 	if (typeof myTable === "undefined") { // only create a table if none exists
-	myTable = new SortableTable({
-		data: tabledata,
-		tableElementId: "accessTable",
-		filterElementId: "filterOptions",
-		renderCellCallback: renderCell,
-		renderSortOptionsCallback: renderSortOptions,
-		renderColumnFilterCallback: renderColumnFilter,
-		rowFilterCallback: rowFilter,
-		displayCellEditCallback: displayCellEdit,
-		updateCellCallback: updateCellCallback,
-		columnOrder: colOrder,
-		freezePaneIndex: 4,
-		hasRowHighlight: true,
-		hasMagicHeadings: false,
-		hasCounterColumn: true
-	});
+		myTable = new SortableTable({
+			data: tabledata,
+			tableElementId: "accessTable",
+			filterElementId: "filterOptions",
+			renderCellCallback: renderCell,
+			renderSortOptionsCallback: renderSortOptions,
+			renderColumnFilterCallback: renderColumnFilter,
+			rowFilterCallback: rowFilter,
+			displayCellEditCallback: displayCellEdit,
+			updateCellCallback: updateCellCallback,
+			columnOrder: colOrder,
+			freezePaneIndex: 4,
+			hasRowHighlight: true,
+			hasMagicHeadings: false,
+			hasCounterColumn: true
+		});
 
-	myTable.renderTable();
+		myTable.renderTable();
 	}
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2869,6 +2869,47 @@ span.arrow {
   margin-left: 5px;
 }
 
+.access-dropdown-content{
+  display: none;
+  position: absolute;
+  background-color: #f1f1f1;
+  min-width: 160px;
+  overflow: auto;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+}
+.access-dropdown-content div {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+  cursor: pointer;
+}
+.access-dropdown-content div:hover {
+  background-color: rgb(228, 227, 226);
+}
+.access-dropdown{
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+
+padding: 10px;
+}
+.access-dropdown:hover .access-dropdown-content {
+  display: block;
+}
+
+#reset-pw{
+  width:70%; 
+  margin-left:20px;
+  background-color: rgb(254, 204, 86); color: #614875;
+
+}
+
+.show{
+  display:block;
+}
+
 .oldSubmissionIcon {
   height: 20px;
   margin-left: 10px;
@@ -5493,7 +5534,8 @@ only screen and (max-device-width: 320px) {
   height: 30px;
   color: #fff;
   cursor: pointer;
-  margin-top: auto;
+  margin-top: 20px;
+  margin-bottom: 2px;
   margin-right: 3%;
   font-size: 14px;
   transition: 1s background-color;

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -208,14 +208,59 @@ function makeoptions(option,optionlist,valuelist)
 
 function makeoptionsItem(option,optionlist,optionstring,valuestring)
 {
-		var str="";
-		for(var i=0;i<optionlist.length;i++){
-				str+="<option ";
-				if(optionlist[i][valuestring]==option){
-						str+="selected='selected' ";
-				}
-				str+="value='"+optionlist[i][valuestring]+"'>"+optionlist[i][optionstring]+"</option>";
+	var str="";
+	for(var i=0;i<optionlist.length;i++){
+		str+="<option ";
+		if(optionlist[i][valuestring]==option){
+			str+="selected='selected' ";
 		}
+		str+="value='"+optionlist[i][valuestring]+"'>"+optionlist[i][optionstring]+"</option>";
+	}
+	return str;
+}
+
+//----------------------------------------------------------------------------------
+// makedivItem: Prepares a dropdown list specifically for items such as code examples / dugga etc
+//----------------------------------------------------------------------------------
+
+function makedivItem(option,optionlist,optionstring,valuestring)
+{
+		var str="";
+		str +="<div class='access-dropdown-content'>"
+			for(var i=0;i<optionlist.length;i++){
+				str+="<div onclick='changeOptDiv(event)'> ";
+				str+=""+optionlist[i][optionstring]+"</div>";
+			}
+		str +="</div>"
+		return str;
+}
+
+function makedivItemWithValue(option,optionlist,optionstring,valuestring)
+{
+		var str="";
+		str +="<div class='access-dropdown-content'>"
+			for(var i=0;i<optionlist.length;i++){
+				str+="<div onclick='changeOptDivStudent(event,\""+optionlist[i][valuestring]+"\")'> ";
+				str+=""+optionlist[i][optionstring]+"</div>";
+			}
+		str +="</div>"
+		return str;
+}
+
+function makeDivItemStudent(option,optionlist,valuelist)
+{
+		var str="";
+		var stringArray = ["W","R","ST"];
+		str +="<div class='access-dropdown-content'>"
+		for(var i=0;i<optionlist.length;i++){
+			str+="<div onclick='changeOptDivStudent(event,\""+stringArray[i]+"\")'";
+			if(valuelist==null){
+				str+=">"+optionlist[i]+"</div>";
+			}else{
+				str+=">"+optionlist[i]+"</div>";
+			}
+		}
+		str +="</div>"
 		return str;
 }
 
@@ -1632,8 +1677,7 @@ function hideServerMessage() {
 		opacity: 0, 
 		top: -$containerHeight.outerHeight() 
 	}, 200, "easeInOutSine", () => {
-		//After animation is done.
-		$containerHeight.css("opacity", "1");
+		$containerHeight.css(opacity, 1);
 	});
 }
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -228,7 +228,7 @@ function makedivItem(option,optionlist,optionstring,valuestring)
 		var str="";
 		str +="<div class='access-dropdown-content'>"
 			for(var i=0;i<optionlist.length;i++){
-				str+="<div onclick='changeOptDiv(event)'> ";
+				str+="<div data-value='"+optionlist[i][valuestring]+"' onclick='changeOptDiv(event)'> ";
 				str+=""+optionlist[i][optionstring]+"</div>";
 			}
 		str +="</div>"
@@ -240,7 +240,7 @@ function makedivItemWithValue(option,optionlist,optionstring,valuestring)
 		var str="";
 		str +="<div class='access-dropdown-content'>"
 			for(var i=0;i<optionlist.length;i++){
-				str+="<div onclick='changeOptDivStudent(event,\""+optionlist[i][valuestring]+"\")'> ";
+				str+="<div data-value='"+optionlist[i][valuestring]+"' onclick='changeOptDivStudent(event,\""+optionlist[i][valuestring]+"\")'> ";
 				str+=""+optionlist[i][optionstring]+"</div>";
 			}
 		str +="</div>"
@@ -253,7 +253,7 @@ function makeDivItemStudent(option,optionlist,valuelist)
 		var stringArray = ["W","R","ST"];
 		str +="<div class='access-dropdown-content'>"
 		for(var i=0;i<optionlist.length;i++){
-			str+="<div onclick='changeOptDivStudent(event,\""+stringArray[i]+"\")'";
+			str+="<div data-value='"+stringArray[i]+"' onclick='changeOptDivStudent(event,\""+stringArray[i]+"\")'";
 			if(valuelist==null){
 				str+=">"+optionlist[i]+"</div>";
 			}else{

--- a/Shared/icons/desc_black.svg
+++ b/Shared/icons/desc_black.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<path fill="#000000" d="M12.359,5.083c0.551,0,0.709,0.343,0.352,0.761l-4.062,4.76c-0.356,0.418-0.94,0.418-1.297,0L3.29,5.844
+	C2.933,5.425,3.091,5.083,3.641,5.083H12.359z"/>
+</svg>


### PR DESCRIPTION
Solves #7769.

Most of this was made by @a18petha and @g18marma. 

The rest are modifications to their code (for the most part) to make it compatible with our changes to accessed.js (the bulk of their code was written almost a month ago).

The dropdowns in the Access Editor no longer uses select-elements (using these can result in bad performance since they are operator system specific).

For now all the dropdowns except the group dropdowns are opened by hovering them. This should/will most likely be changed. There are also some styling "issues", like some dropdowns not being wide enough (in my opinion). That should be a separate issue. This issue is only concerned with updating dropdowns to a more efficient solution and to get those working properly.

![image](https://user-images.githubusercontent.com/49141758/80717155-cfbcc980-8af8-11ea-8094-a3d29d7d21d1.png)
