### PR TITLE
Updated function "closeEditExample" within codeviewer.js - G1-2020-W19-ISSUE#8738

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2206,7 +2206,8 @@ function closeEditContent() {
 //----------------------------------------------------------------------------------
 
 function closeEditExample() {
-	$("#editExampleContainer").css("display", "none");
+	var closeEditExample = document.getElementById("editExampleContainer");
+	closeEditExample.style.display = "none";
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Updated function "closeEditExample" within codeviewer.js to better fit the code standard by replacing jQuery. 

Test by going to codeviewer.php and navigating to the "Edit Example" window by pressing the big cogwheel in the top menu ("Example Settings") and by closing the window. There should be no changes in the example window and the window should simply close.
