### PR TITLE
Fixed permission text for Windows/Linux/OSX #8000

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -74,6 +74,11 @@
           } else {
               echo getenv(filegroup($putFileHere))['name'];
       }?>" +
+            "<br><br>" +
+      "current os: " +
+      "<?php
+      echo PHP_OS_FAMILY;
+      }?>" +
       "<br><br>" +
       "To do this run the command:<br>" +
       "sudo chgrp -R www-data " + filePath + "</h2><br>" +

--- a/install/install.php
+++ b/install/install.php
@@ -59,13 +59,15 @@
 
 <!-- Start permission-modal code -->
 <script>
-    var modalRead = false; // Have the user read info?
-    var modal = document.getElementById('warning'); // Get the modal
-    var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
-    var filePath = "<?php echo $putFileHere; ?>";
     var os = "<?php echo PHP_OS_FAMILY ?>";
 
-    document.getElementById('dialogText').innerHTML="<div><h1>" +
+    if(os != Windows){
+      var modalRead = false; // Have the user read info?
+      var modal = document.getElementById('warning'); // Get the modal
+      var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
+      var filePath = "<?php echo $putFileHere; ?>";
+
+      document.getElementById('dialogText').innerHTML="<div><h1>" +
       "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
       "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
       "<br><br>" +
@@ -84,6 +86,7 @@
       "<br>" +
       "<input title='I have completed necessary steps' onclick='if(this.checked){haveRead(true)}else{haveRead(false)}' class='startCheckbox' type='checkbox' value='1' autofocus>" +
       "<i>I promise I have done this.</i></div>";
+    }
 
     function haveRead(isTrue) {
         modalRead = isTrue;

--- a/install/install.php
+++ b/install/install.php
@@ -46,7 +46,10 @@
 
   /************* MODAL TO SHOW STEPS BEFORE AND AFTER ****************/
   $putFileHere = cdirname(getcwd(), 1); // Path to lenasys
-  echo "
+  $operatingSystem = PHP_OS_FAMILY;
+
+  if($operatingSystem == Windows){
+    echo "
     <div id='warning' class='modal'>
       <!-- Modal content -->
       <div class='modal-content'>
@@ -55,38 +58,36 @@
       </div>
     </div>
   ";
+  }
 ?>
 
 <!-- Start permission-modal code -->
 <script>
+    var modalRead = false; // Have the user read info?
+    var modal = document.getElementById('warning'); // Get the modal
+    var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
+    var filePath = "<?php echo $putFileHere; ?>";
     var os = "<?php echo PHP_OS_FAMILY ?>";
 
-    if(os != Windows){
-      var modalRead = false; // Have the user read info?
-      var modal = document.getElementById('warning'); // Get the modal
-      var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
-      var filePath = "<?php echo $putFileHere; ?>";
-
-      document.getElementById('dialogText').innerHTML="<div><h1>" +
-      "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
-      "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
-      "<br><br>" +
-      "current owner: " +
-      "<?php 
-          if(function_exists('posix_getpwuid')) {
-              echo posix_getpwuid(filegroup($putFileHere))['name'];
-          } else {
-              echo getenv(filegroup($putFileHere))['name'];
-      }?>" +
-      "<br>" +
-      "current os: " + os +
-      "<br><br>" +
-      "To do this run the command:<br>" +
-      "sudo chgrp -R www-data " + filePath + "</h2><br>" +
-      "<br>" +
-      "<input title='I have completed necessary steps' onclick='if(this.checked){haveRead(true)}else{haveRead(false)}' class='startCheckbox' type='checkbox' value='1' autofocus>" +
-      "<i>I promise I have done this.</i></div>";
-    }
+    document.getElementById('dialogText').innerHTML="<div><h1>" +
+    "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
+    "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
+    "<br><br>" +
+    "current owner: " +
+    "<?php 
+        if(function_exists('posix_getpwuid')) {
+            echo posix_getpwuid(filegroup($putFileHere))['name'];
+        } else {
+            echo getenv(filegroup($putFileHere))['name'];
+    }?>" +
+    "<br>" +
+    "current os: " + os +
+    "<br><br>" +
+    "To do this run the command:<br>" +
+    "sudo chgrp -R www-data " + filePath + "</h2><br>" +
+    "<br>" +
+    "<input title='I have completed necessary steps' onclick='if(this.checked){haveRead(true)}else{haveRead(false)}' class='startCheckbox' type='checkbox' value='1' autofocus>" +
+    "<i>I promise I have done this.</i></div>";
 
     function haveRead(isTrue) {
         modalRead = isTrue;

--- a/install/install.php
+++ b/install/install.php
@@ -69,8 +69,8 @@
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
     var filePath = "<?php echo $putFileHere; ?>";
     var os = "<?php echo PHP_OS_FAMILY ?>";
-    var firstText = setFirstText(os);
-    var secondText = setSecondText(os);
+    var firstText = setFirstText(os); // Set first text depending on O/S
+    var secondText = setSecondText(os); // Set second text depending on O/S
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
     "-!- READ THIS BEFORE YOU START -!-</h1><br>" +

--- a/install/install.php
+++ b/install/install.php
@@ -48,7 +48,8 @@
   $putFileHere = cdirname(getcwd(), 1); // Path to lenasys
   $operatingSystem = PHP_OS_FAMILY;
 
-  if($operatingSystem == 'Windows'){
+  /************* MODAL ONLY RELEVANT FOR SYSTEMS NOT WINDOWS  ****************/
+  if($operatingSystem != 'Windows'){
     echo "
     <div id='warning' class='modal'>
       <!-- Modal content -->
@@ -56,9 +57,9 @@
         <span title='Close pop-up' class='close''>&times;</span>
           <span id='dialogText'></span>
       </div>
-    </div>
+    </div> 
   ";
-  }
+  } // maybe here put script when in seperate file.
 ?>
 
 <!-- Start permission-modal code -->
@@ -67,11 +68,18 @@
     var modal = document.getElementById('warning'); // Get the modal
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
     var filePath = "<?php echo $putFileHere; ?>";
-    var os = "<?php echo PHP_OS_FAMILY ?>";
+    var operatingSystem = "<?php echo PHP_OS_FAMILY ?>";
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
     "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
-    "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
+    switch(operatingSystem){
+      case Linux:
+        "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
+      case Darwin
+        "<h2>Make sure you set ownership of LenaSYS directory to 'www'." +
+    }
+    
+
     "<br><br>" +
     "current owner: " +
     "<?php 
@@ -81,10 +89,17 @@
             echo getenv(filegroup($putFileHere))['name'];
     }?>" +
     "<br>" +
-    "current os: " + os +
+    "current os: " + operatingSystem +
     "<br><br>" +
     "To do this run the command:<br>" +
-    "sudo chgrp -R www-data " + filePath + "</h2><br>" +
+    
+    switch(operatingSystem){	
+	    case Linux:
+		    "sudo chgrp -R www-data " + filePath + "</h2><br>" +
+	    case Darwin
+		    "sudo chgrp -R www " + filePath + "</h2><br>" +
+    }
+
     "<br>" +
     "<input title='I have completed necessary steps' onclick='if(this.checked){haveRead(true)}else{haveRead(false)}' class='startCheckbox' type='checkbox' value='1' autofocus>" +
     "<i>I promise I have done this.</i></div>";

--- a/install/install.php
+++ b/install/install.php
@@ -88,7 +88,7 @@
       os +
     "<br><br>" +
     "To do this run the command:<br>" +
-    "sudo chgrp -R www-data " + filePath + "</h2><br>" +
+    secondText +
     "<br>" +
     "<input title='I have completed necessary steps' onclick='if(this.checked){haveRead(true)}else{haveRead(false)}' class='startCheckbox' type='checkbox' value='1' autofocus>" +
     "<i>I promise I have done this.</i></div>";
@@ -112,9 +112,9 @@
       var returnText;
       switch(os){
         case Linux:
-          returnText = "sudo chgrp -R www-data " + filePath + "</h2><br>";
+          returnText = "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
         case Darwin
-          returnText = "sudo chgrp -R www " + filePath + "</h2><br>";
+          returnText = "<h2>Make sure you set ownership of LenaSYS directory to 'www'";
       }
       return returnText;
     }

--- a/install/install.php
+++ b/install/install.php
@@ -69,8 +69,8 @@
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
     var filePath = "<?php echo $putFileHere; ?>";
     var os = "<?php echo PHP_OS_FAMILY ?>";
-    var firstText = setFirstText();
-    var secondText = setSecondText();
+    var firstText = setFirstText(os);
+    var secondText = setSecondText(os);
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
     "-!- READ THIS BEFORE YOU START -!-</h1><br>" +
@@ -97,11 +97,17 @@
         modalRead = isTrue;
     }
 
-    function setFirstText(){
-      return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
+    function setFirstText(os){
+      var test;
+      switch(os){
+        case "Linux":
+          test = "test";
+          break;
+      }
+      return test;
     }
 
-    function setSecondText(){
+    function setSecondText(os){
       return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
     }
 </script>

--- a/install/install.php
+++ b/install/install.php
@@ -78,7 +78,7 @@
       "current os: " +
       "<?php
       echo PHP_OS_FAMILY;
-      }?>" +
+      ?>" +
       "<br><br>" +
       "To do this run the command:<br>" +
       "sudo chgrp -R www-data " + filePath + "</h2><br>" +

--- a/install/install.php
+++ b/install/install.php
@@ -72,14 +72,6 @@
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
     "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
-    switch(operatingSystem){
-      case Linux:
-        "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
-      case Darwin
-        "<h2>Make sure you set ownership of LenaSYS directory to 'www'." +
-    }
-    
-
     "<br><br>" +
     "current owner: " +
     "<?php 
@@ -92,14 +84,7 @@
     "current os: " + operatingSystem +
     "<br><br>" +
     "To do this run the command:<br>" +
-    
-    switch(operatingSystem){	
-	    case Linux:
-		    "sudo chgrp -R www-data " + filePath + "</h2><br>" +
-	    case Darwin
-		    "sudo chgrp -R www " + filePath + "</h2><br>" +
-    }
-
+    "sudo chgrp -R www-data " + filePath + "</h2><br>" +
     "<br>" +
     "<input title='I have completed necessary steps' onclick='if(this.checked){haveRead(true)}else{haveRead(false)}' class='startCheckbox' type='checkbox' value='1' autofocus>" +
     "<i>I promise I have done this.</i></div>";

--- a/install/install.php
+++ b/install/install.php
@@ -59,7 +59,6 @@
 
 <!-- Start permission-modal code -->
 <script>
-  if(<?php echo PHP_OS_FAMILY ?> != Windows){
     var modalRead = false; // Have the user read info?
     var modal = document.getElementById('warning'); // Get the modal
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
@@ -86,7 +85,6 @@
     function haveRead(isTrue) {
         modalRead = isTrue;
     }
-  }
 </script>
 
 <div id="header">

--- a/install/install.php
+++ b/install/install.php
@@ -98,17 +98,29 @@
     }
 
     function setFirstText(os){
-      var test;
+      var firstText;
       switch(os){
         case "Linux":
-          test = "test";
+          firstText = "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'.";
+          break;
+        case "Darwin":
+          firstText = "<h2>Make sure you set ownership of LenaSYS directory to 'www'";
           break;
       }
-      return test;
+      return firstText;
     }
 
     function setSecondText(os){
-      return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
+      var secondText;
+      switch(os){
+        case "Linux":
+          secondText = "sudo chgrp -R www-data " + filePath + "</h2><br>";
+          break;
+        case "Darwin":
+          secondText = "sudo chgrp -R www " + filePath + "</h2><br>";
+          break;
+      }
+      return secondText;
     }
 </script>
 

--- a/install/install.php
+++ b/install/install.php
@@ -48,7 +48,7 @@
   $putFileHere = cdirname(getcwd(), 1); // Path to lenasys
   $operatingSystem = PHP_OS_FAMILY;
 
-  if($operatingSystem == Windows){
+  if($operatingSystem == 'Windows'){
     echo "
     <div id='warning' class='modal'>
       <!-- Modal content -->

--- a/install/install.php
+++ b/install/install.php
@@ -73,11 +73,7 @@
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
     "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
-    switch(os){
-      case Linux:
-        "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'.";
-        break;
-    }
+    "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
     "<br><br>" +
     "current owner: " +
     "<?php 

--- a/install/install.php
+++ b/install/install.php
@@ -69,13 +69,12 @@
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
     var filePath = "<?php echo $putFileHere; ?>";
     var os = "<?php echo PHP_OS_FAMILY ?>";
-    var ownerText = setOwnerText();
-    var settingText = setSettingsText();
-
+    var firstText = setFirstText();
+    var secondText = setSecondText();
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
-    "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
-    ownerText +
+    "-!- READ THIS BEFORE YOU START -!-</h1><br>" +
+    firstText +
     "<br><br>" +
     "current owner: " +
       "<?php 
@@ -98,12 +97,26 @@
         modalRead = isTrue;
     }
 
-    function setOwnerText(){
-      return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
+    function setFirstText(){
+      var returnText;
+      switch(os){
+        case Linux:
+          returnText = "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
+        case Darwin
+          returnText = "<h2>Make sure you set ownership of LenaSYS directory to 'www'";
+      }
+      return returnText;
     }
 
-    function setSettingsText(){
-      
+    function setSecondText(){
+      var returnText;
+      switch(os){
+        case Linux:
+          returnText = "sudo chgrp -R www-data " + filePath + "</h2><br>";
+        case Darwin
+          returnText = "sudo chgrp -R www " + filePath + "</h2><br>";
+      }
+      return returnText;
     }
 </script>
 

--- a/install/install.php
+++ b/install/install.php
@@ -69,21 +69,24 @@
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
     var filePath = "<?php echo $putFileHere; ?>";
     var os = "<?php echo PHP_OS_FAMILY ?>";
+    var ownerText = setOwnerText();
+    var settingText = setSettingsText();
 
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
     "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
-    "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
+    ownerText +
     "<br><br>" +
     "current owner: " +
-    "<?php 
-        if(function_exists('posix_getpwuid')) {
-            echo posix_getpwuid(filegroup($putFileHere))['name'];
-        } else {
-            echo getenv(filegroup($putFileHere))['name'];
-    }?>" +
+      "<?php 
+          if(function_exists('posix_getpwuid')) {
+              echo posix_getpwuid(filegroup($putFileHere))['name'];
+          } else {
+              echo getenv(filegroup($putFileHere))['name'];
+      }?>" +
     "<br>" +
-    "current os: " + os +
+    "current os: " + 
+      os +
     "<br><br>" +
     "To do this run the command:<br>" +
     "sudo chgrp -R www-data " + filePath + "</h2><br>" +
@@ -93,6 +96,14 @@
 
     function haveRead(isTrue) {
         modalRead = isTrue;
+    }
+
+    function setOwnerText(){
+      return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'.";
+    }
+
+    function setSettingsText(){
+      
     }
 </script>
 

--- a/install/install.php
+++ b/install/install.php
@@ -59,12 +59,13 @@
 
 <!-- Start permission-modal code -->
 <script>
-  var modalRead = false; // Have the user read info?
-  var modal = document.getElementById('warning'); // Get the modal
-  var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
-  var filePath = "<?php echo $putFileHere; ?>";
+  if(<?php echo PHP_OS_FAMILY ?> != Windows){
+    var modalRead = false; // Have the user read info?
+    var modal = document.getElementById('warning'); // Get the modal
+    var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
+    var filePath = "<?php echo $putFileHere; ?>";
 
-  document.getElementById('dialogText').innerHTML="<div><h1>" +
+    document.getElementById('dialogText').innerHTML="<div><h1>" +
       "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
       "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'.<br>" +
       "current owner: " +
@@ -74,22 +75,20 @@
           } else {
               echo getenv(filegroup($putFileHere))['name'];
       }?>" +
-            "<br><br>" +
-      "current os: " +
-      "<?php
-      echo PHP_OS_FAMILY;
-      ?>" +
       "<br><br>" +
+      "current os: " + "<?php echo PHP_OS_FAMILY ?>" + 
       "To do this run the command:<br>" +
       "sudo chgrp -R www-data " + filePath + "</h2><br>" +
       "<br>" +
       "<input title='I have completed necessary steps' onclick='if(this.checked){haveRead(true)}else{haveRead(false)}' class='startCheckbox' type='checkbox' value='1' autofocus>" +
       "<i>I promise i have done this and will not complain that it's not working</i></div>";
 
-  function haveRead(isTrue) {
-      modalRead = isTrue;
+    function haveRead(isTrue) {
+        modalRead = isTrue;
+    }
   }
 </script>
+
 <div id="header">
   <h1>LenaSYS Installer</h1>
   <span title="Open start-dialog" id="showModalBtn"><b>Open start-dialog again.</b><br> (To see what permissions to set)</span>

--- a/install/install.php
+++ b/install/install.php
@@ -99,7 +99,7 @@
     }
 
     function setOwnerText(){
-      return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'.";
+      return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
     }
 
     function setSettingsText(){

--- a/install/install.php
+++ b/install/install.php
@@ -63,10 +63,12 @@
     var modal = document.getElementById('warning'); // Get the modal
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
     var filePath = "<?php echo $putFileHere; ?>";
+    var os = "<?php echo PHP_OS_FAMILY ?>";
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
       "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
-      "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'.<br>" +
+      "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'." +
+      "<br><br>" +
       "current owner: " +
       "<?php 
           if(function_exists('posix_getpwuid')) {
@@ -74,13 +76,14 @@
           } else {
               echo getenv(filegroup($putFileHere))['name'];
       }?>" +
+      "<br>" +
+      "current os: " + os +
       "<br><br>" +
-      "current os: " + "<?php echo PHP_OS_FAMILY ?>" + 
       "To do this run the command:<br>" +
       "sudo chgrp -R www-data " + filePath + "</h2><br>" +
       "<br>" +
       "<input title='I have completed necessary steps' onclick='if(this.checked){haveRead(true)}else{haveRead(false)}' class='startCheckbox' type='checkbox' value='1' autofocus>" +
-      "<i>I promise i have done this and will not complain that it's not working</i></div>";
+      "<i>I promise I have done this.</i></div>";
 
     function haveRead(isTrue) {
         modalRead = isTrue;
@@ -489,7 +492,7 @@
 
             document.getElementById('dialogText').innerHTML = '<div><h1>!!!WARNING!!!</h1><br>' +
                 '<h2>READ INSTRUCTIONS UNDER INSTALL PROGRESS.</h2>' +
-                '<p>If you don\'t follow these instructions nothing will work. Group 3 will not take any ' +
+                '<p>If you don\'t follow these instructions nothing will work. G4-2020 will not take any ' +
                 'responsibility for your failing system.</p>';
 
             // When the user clicks on <span> (x), close the modal

--- a/install/install.php
+++ b/install/install.php
@@ -98,25 +98,11 @@
     }
 
     function setFirstText(){
-      var returnText;
-      switch(os){
-        case Linux:
-          returnText = "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
-        case Darwin
-          returnText = "<h2>Make sure you set ownership of LenaSYS directory to 'www'";
-      }
-      return returnText;
+      return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
     }
 
     function setSecondText(){
-      var returnText;
-      switch(os){
-        case Linux:
-          returnText = "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
-        case Darwin
-          returnText = "<h2>Make sure you set ownership of LenaSYS directory to 'www'";
-      }
-      return returnText;
+      return "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'. WON";
     }
 </script>
 

--- a/install/install.php
+++ b/install/install.php
@@ -49,6 +49,7 @@
   $operatingSystem = PHP_OS_FAMILY;
 
   /************* MODAL ONLY RELEVANT FOR SYSTEMS NOT WINDOWS  ****************/
+  /************* SO WE ONLY SHOW IT FOR NON-WINDOWS SYSTEMS   ****************/
   if($operatingSystem != 'Windows'){
     echo "
     <div id='warning' class='modal'>
@@ -59,7 +60,7 @@
       </div>
     </div> 
   ";
-  } // maybe here put script when in seperate file.
+  } 
 ?>
 
 <!-- Start permission-modal code -->
@@ -68,7 +69,7 @@
     var modal = document.getElementById('warning'); // Get the modal
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
     var filePath = "<?php echo $putFileHere; ?>";
-    var os = "<?php echo PHP_OS_FAMILY ?>";
+    var os = "<?php echo PHP_OS_FAMILY ?>"; // Get O/S of the system running the installer
     var firstText = setFirstText(os); // Set first text depending on O/S
     var secondText = setSecondText(os); // Set second text depending on O/S
 
@@ -96,7 +97,10 @@
     function haveRead(isTrue) {
         modalRead = isTrue;
     }
-
+    
+    /*************           Function to set the first text           ****************/
+    /*************      Takes O/S of installing system as input       ****************/
+    /************* Easy to extend to new supported operating systems. ****************/
     function setFirstText(os){
       var firstText;
       switch(os){

--- a/install/install.php
+++ b/install/install.php
@@ -68,10 +68,16 @@
     var modal = document.getElementById('warning'); // Get the modal
     var span = document.getElementsByClassName("close")[0]; // Get the button that opens the modal
     var filePath = "<?php echo $putFileHere; ?>";
-    var operatingSystem = "<?php echo PHP_OS_FAMILY ?>";
+    var os = "<?php echo PHP_OS_FAMILY ?>";
+
 
     document.getElementById('dialogText').innerHTML="<div><h1>" +
     "!!!!!!READ THIS BEFORE YOU START!!!!!!</h1><br>" +
+    switch(os){
+      case Linux:
+        "<h2>Make sure you set ownership of LenaSYS directory to 'www-data'.";
+        break;
+    }
     "<br><br>" +
     "current owner: " +
     "<?php 
@@ -81,7 +87,7 @@
             echo getenv(filegroup($putFileHere))['name'];
     }?>" +
     "<br>" +
-    "current os: " + operatingSystem +
+    "current os: " + os +
     "<br><br>" +
     "To do this run the command:<br>" +
     "sudo chgrp -R www-data " + filePath + "</h2><br>" +


### PR DESCRIPTION
The installer now show the right permission settings depending on o/s of system running the installer. I checked my permissions on Windows and couldnt find any special. So for Windows-systems the permission text are now disabled.

![linux](https://user-images.githubusercontent.com/62878146/80866748-b8184900-8c90-11ea-9f07-61663e654d21.png)

![mac](https://user-images.githubusercontent.com/62878146/80866753-bcdcfd00-8c90-11ea-8850-ba99e38616f1.png)
