### PR TITLE
fix issue#8629 Popup only appears in Draw Free mode

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4192,7 +4192,7 @@ function mousedownevt(ev) {
         handleSelect();
     } else {
         md = mouseState.boxSelectOrCreateMode; // Box select or Create mode.
-        if(ev.button == rightMouseClick && uimode == "CreateFigure"){
+        if(ev.button == rightMouseClick && figureType == "Free"){
             endFreeDraw();
         }
         if (uimode != "MoveAround" && !ctrlIsClicked) {


### PR DESCRIPTION
The "Please draw more lines!" popup should not appear when the user rightclicks in Draw Text mode. 

Test this: Enter Draw Text mode and rightclick on the canvas. If the popup does not appear the issue is fixed. 

Link to test: http://group4.webug.his.se:20001/G4-2020-W19-ISSUE%238629/DuggaSys/diagram.php

Before: 

![d09c7c796eea6385702413520a8f0570](https://user-images.githubusercontent.com/49142301/80945760-d09d7600-8dec-11ea-84e5-a37f5945c5b8.gif)

After:

![ef620e88641e17c751d30b538a0e729d](https://user-images.githubusercontent.com/49142301/80945817-fa569d00-8dec-11ea-867b-b1b13f8abd03.gif)

