### PR TITLE
#5617 Added a way to see the date and time an export last was executed.

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -37,6 +37,10 @@ function setup() {
     window.onscroll = function () {
 
 	};
+	
+	if (typeof localStorage.getItem("lastExpDate") != undefined) {
+		document.getElementById('lastExportedDate').innerHTML = localStorage.getItem("lastExpDate");
+	}
 
     AJAXService("GET", { cid: querystring['courseid'], vers: querystring['coursevers'] }, "RESULT");
 }
@@ -1440,6 +1444,8 @@ function ladexport() {
 	 var gradeLastExported = today + " " + time;
 	 lastExpDate.innerHTML =  gradeLastExported;
 	 document.getElementById('lastExportedDate').innerHTML = gradeLastExported;
+
+	 localStorage.setItem('lastExpDate', gradeLastExported);
 
 	AJAXService("getunexported", {}, "GEXPORT");
 }

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -36,7 +36,7 @@ function setup() {
     //benchmarkData = performance.timing;
     window.onscroll = function () {
 
-    };
+	};
 
     AJAXService("GET", { cid: querystring['courseid'], vers: querystring['coursevers'] }, "RESULT");
 }
@@ -1428,6 +1428,18 @@ function ladexport() {
 	document.getElementById("resultlistheader").innerHTML = "Results for: " + document.getElementById("ladselect").value;
 	document.getElementById("resultlistarea").value = expo;
 	document.getElementById("resultlistpopover").style.display = "flex";
+
+	var today = new Date();
+	var dd = addZero(today.getDate());
+	var mm = addZero(today.getMonth() + 1); //January is 0!
+	var yyyy = today.getFullYear();
+	var time = addZero(today.getHours()) + ":" + addZero(today.getMinutes()) + ":" + addZero(today.getSeconds());
+
+	today = yyyy + '-' + mm + '-' + dd;
+
+	 var gradeLastExported = today + " " + time;
+	 lastExpDate.innerHTML =  gradeLastExported;
+	 document.getElementById('lastExportedDate').innerHTML = gradeLastExported;
 
 	AJAXService("getunexported", {}, "GEXPORT");
 }

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -70,7 +70,10 @@ pdoConnect();
         <label>Betygsdatum</label>
         <input id="laddate" type="date" style="font-size:12px;">
         </div>
+		<div class="resultedFormsFlex">
       <button class="resultedbuttons" onclick="ladexport();">LadExport</button>
+	  <span id="lastExportedDate"></span>
+	  </div>
 			</div>
 			<div style="display: flex;">
 			<!-- Email button will be disabled if user is not logged in as admin, or not logged in at all -->

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2912,7 +2912,7 @@ span.arrow {
 .resultedFormsFlex {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
   margin: 5px;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2916,6 +2916,12 @@ span.arrow {
   margin: 5px;
 }
 
+#lastExportedDate {
+  font-size: 10px;
+  color: gray;
+  text-align: center;
+}
+
 #laddate {
   border: 1px solid var(--color-border);
 }


### PR DESCRIPTION
The last export date is stored in localStorage and the date in the localStorage is then shown under the LadExport button as shown below. Also added so that the last export date is shown in the footer of the popup.

![expDate](https://user-images.githubusercontent.com/49142651/80946662-d431fc80-8dee-11ea-870c-76fb7ad844b9.PNG)

The way to test this is to click on the "LadExport" button and then close the popup. Then you can see the date under the button and in the localStorage.

Co-Authored-By: b18veran <b18veran@users.noreply.github.com>