### PR TITLE
fix issue#8488 localStorage for virtual paper display and virtual paper size

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2775,7 +2775,7 @@ function setModeOnRefresh() {
 function setPaperSizeOnRefresh() {
 	const tempPaperSize = localStorage.getItem("paperSize");
 	if(tempPaperSize != null){
-		paperSize = tempPaperSize;
+        paperSize = tempPaperSize;
 	}
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -482,8 +482,9 @@ function init() {
     canvasSize(); 
     loadDiagram(); 
     setModeOnRefresh(); 
+    setPaperSizeOnRefresh();
     initAppearanceForm();
-    setPaperSize(event, 4);
+    setPaperSize(event, paperSize);
     updateGraphics(); 
 }
 
@@ -2213,6 +2214,7 @@ function setPaperSize(event, size){
 		setCheckbox($(`.drop-down-option:contains(${name})`), selectedPaper[i]);
 	}
 	paperSize = size; 
+	localStorage.setItem("paperSize", paperSize);
 	updateGraphics();
 }
 
@@ -2753,6 +2755,13 @@ function setModeOnRefresh() {
         switchToolbarER();
         hideCrosses();
     }
+}
+
+function setPaperSizeOnRefresh() {
+	const tempPaperSize = localStorage.getItem("paperSize");
+	if(tempPaperSize != null){
+		paperSize = tempPaperSize;
+	}
 }
 
 //--------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -482,6 +482,7 @@ function init() {
     canvasSize(); 
     loadDiagram(); 
     setModeOnRefresh(); 
+    refreshVirtualPaper();
     setPaperSizeOnRefresh();
     initAppearanceForm();
     setPaperSize(event, paperSize);
@@ -1675,8 +1676,22 @@ function toggleVirtualPaper(event) {
         showPaperState();
         updateGraphics();
     }
-
+    localStorage.setItem("virtualPaper", togglePaper);
     setCheckbox($(".drop-down-option:contains('Display Virtual Paper')"), togglePaper);
+}
+
+function refreshVirtualPaper() {
+    var tempPaperState = localStorage.getItem("virtualPaper");
+    if (tempPaperState != null) {
+        togglePaper = tempPaperState;
+        if (togglePaper == 'true') {
+            togglePaper = false;
+            toggleVirtualPaper(event);
+        } else {
+            togglePaper = true;
+            toggleVirtualPaper(event);
+        }
+    }
 }
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
The visibility and size of virtual paper is now stored in localStorage. If the user displays virtual paper it should still be visible when the page is updated. The same thing applies for paper size. 

**Test this**: Select Display Virtual Paper and change paper size to something else than the default A4. Update the page and check if the paper is still visible and has the same size you selected. 

Another way to check if the values have been stored in localStorage is to enter the browsers inspect mode: Inspect -> Application -> Local Storage. Make sure the virtualPaper and paperSize are stored.

![73a6ca72f8405d2060b958f6fd0a2630](https://user-images.githubusercontent.com/49142301/80948900-4b698f80-8df3-11ea-9cb9-4ff6415c09de.png)

Link to test: http://group4.webug.his.se:20001/G4-2020-W19-ISSUE%238488/DuggaSys/diagram.php


