### PR TITLE
Saved the correct version name when there are several with the same vers

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -583,7 +583,7 @@ function returnedSection(data) {
           var vversz = itemz['vers'];
           var vnamez = itemz['versname'];
           if (retdata['coursevers'] == vversz) {
-            versionname = vnamez;
+              versionname = vnamez;
           }
         }
       }
@@ -609,7 +609,7 @@ function returnedSection(data) {
           bstr += ">" + item['versname'] + " - " + item['vers'] + "</option>";
         }
         // save vers, versname and motd from table vers as global variables.
-        if (querystring['coursevers'] == item['vers']) versnme = item['versname'];
+        versnme = versionname;
         if (querystring['coursevers'] == item['vers']) motd = item['motd'];
         if (querystring['coursevers'] == item['vers']) versnr = item['vers'];
       }


### PR DESCRIPTION
Now the correct versionname is shown in edit course version if there are several versions with the same version ID.