### PR TITLE
Added function to delete tables in analytic.js - G1-2020-W19-ISSUE#8732

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -352,6 +352,7 @@ function loadFileInformation() {
                     }
                 }
                 fileSelect.change(function() {
+					deleteTable();
                     $('#analytic-info').append(renderTable(files[$(this).val()]));
                 });
                 $('#analytic-info').append(fileSelect);
@@ -389,6 +390,16 @@ function clearCanvas(canvas) {
 	var ctx = canvas.getContext("2d");
 	ctx.setTransform(1, 0, 0, 1, 0, 0);
 	ctx.clearRect(0, 0, canvas.width, canvas.height);
+}
+
+//------------------------------------------------------------------------------------------------
+// Deletes tables with the class name "rows" 
+//------------------------------------------------------------------------------------------------
+function deleteTable() {
+	var table = document.getElementsByClassName("rows");
+    while(table.length > 0){
+        table[0].parentNode.removeChild(table[0]);
+    }
 }
 
 //------------------------------------------------------------------------------------------------
@@ -505,7 +516,7 @@ function drawPieChart(data) {
 function renderTable(data) {
 	if (!$.isArray(data)) return;
 
-	var str = '<table class="list">';
+	var str = '<table class="list rows">';
 	if (data.length > 0) {
 		// Render headings
 		str += "<thead><tr>";


### PR DESCRIPTION
Added function that delete tables in analytic.js and used the function to remove tables that remained from previous request in the file information tab. 

Before:

![Screenshot 2020-04-30 at 13 22 07](https://user-images.githubusercontent.com/62876614/80955041-d3a16200-8dfe-11ea-85e4-5a5f7c21546a.png)

Only the selected table is suppose to be displayed.

After: 

![Screenshot 2020-05-04 at 11 53 09](https://user-images.githubusercontent.com/62876614/80955122-f59ae480-8dfe-11ea-967e-992e79f3212e.png)

When selecting a new file the result is: 

![Screenshot 2020-05-04 at 11 53 18](https://user-images.githubusercontent.com/62876614/80955159-0b100e80-8dff-11ea-8f65-30f3c50927db.png)


