### PR TITLE
Changed styling on 'x' button in MOTD banner | Fix for issue #8781

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6371,15 +6371,17 @@ textarea#filecont {
   cursor: pointer;
   background-color:#614875;
   font-family: arial;
-  font-weight: bold;
+  margin: 5px;
+  border-radius:4px;
+  border-collapse:collapse;
   position: absolute;
   right:0%;
 }
 
 .motdBoxheader div:hover {
-  background-color: #694e7e;
-  border: 2px;
-  border-style: solid;
-  border-color: white;
+  background-color: #815e9d;
+  -webkit-transition: background-color 100ms linear;
+    -ms-transition: background-color 100ms linear;
+    transition: background-color 100ms linear;
 }
 


### PR DESCRIPTION
I fixed the styling of the MOTD banner button inside a course so that it matches with the one on the home page.

This is what the button on the home page looks like:
<a href="https://gyazo.com/518fc5b4c5d91ea00bb364a798fae51d"><img src="https://i.gyazo.com/518fc5b4c5d91ea00bb364a798fae51d.gif" alt="Image from Gyazo" width="156"/></a>

This is what the old styling looked like that doesn't match the home page:
<a href="https://gyazo.com/0ff7fd151bcea54641c4c93acf914d83"><img src="https://i.gyazo.com/0ff7fd151bcea54641c4c93acf914d83.gif" alt="Image from Gyazo" width="92"/></a>


This is what the new styling looks like to match the home page:
<a href="https://gyazo.com/987cb93d3e012588d78258a6ead12409"><img src="https://i.gyazo.com/987cb93d3e012588d78258a6ead12409.gif" alt="Image from Gyazo" width="124"/></a>