### PR TITLE
Solves issue #8765 - Dummy point created when line is drawn from path-object

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4385,6 +4385,8 @@ function mouseupevt(ev) {
                 }
                 if(diagram[lineStartObj] == diagram[markedObject]) okToMakeLine = false;
 
+                if(diagram[lineStartObj].kind == 1 || diagram[markedObject].kind == 1) okToMakeLine = false;
+
                 if (okToMakeLine) {
                     saveState = true;
                     if (createNewPoint) p1 = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);


### PR DESCRIPTION
Before a dummy point was created when drawing a line from a freedraw-object to a ER-object. This was due to freedraw-objects not being handled in the "okToMakeLine" function.

This also fixed a error only visible in the console when drawing a line to a freedraw-object.

Test by drawing lines from and to free-drawobjects. No errors should occur and no dummy-points should be created.