### PR TITLE
iCAL Calendar for mobile and desktop G1 2020 w19 #7892

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -162,10 +162,6 @@
 								<table id="deadlineList" style="table-layout: fixed;width:300px;">
 								</table>
 						</div>
-						<div id='calSubscribeBox' class='statisticsInnerBox' style='padding: 10px;'>
-								<h3 id='calSubscribeBoxTitle'>Export Deadlines to calendar</h3>
-								<p>You can add the upcomming deadlines to your personal calendar by clicking <a href="../Shared/calendar.php?courseid=<?php echo $_GET['courseid']; ?>&coursevers=<?php echo $_GET['coursevers']; ?>">here</a>.</p>
-						</div>
 						<div id='statisticsSwimlanes' class='statisticsInnerBox' style=''>
 								<svg id="swimlaneSVG" width='300px' style='margin: 10px;' viewBox="0 0 300 255" xmlns="http://www.w3.org/2000/svg"></svg>
 						</div>
@@ -185,6 +181,9 @@
 
 		</div>
 	</div>
+	<div class="course">
+	<span style="text-align: center;"><a href="../Shared/calendar.php?courseid=<?php echo $_GET['courseid']; ?>&coursevers=<?php echo $_GET['coursevers']; ?>" style="color:#fff">Subscribe for deadlines in your personal calendar</a></span>
+		</div>
 	<!-- content END -->
 
 	<?php

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -182,8 +182,10 @@
 		</div>
 	</div>
 	<div class="course">
-	<span style="text-align: center;"><a href="../Shared/calendar.php?courseid=<?php echo $_GET['courseid']; ?>&coursevers=<?php echo $_GET['coursevers']; ?>" style="color:#fff">Subscribe for deadlines in your personal calendar</a></span>
-		</div>
+		<span style="text-align: center;">
+			<a href="../Shared/calendar.php?courseid=<?php echo $_GET['courseid']; ?>&coursevers=<?php echo $_GET['coursevers']; ?>" style="color:#fff">Subscribe for deadlines in your personal calendar</a>
+		</span>
+	</div>
 	<!-- content END -->
 
 	<?php

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -162,6 +162,10 @@
 								<table id="deadlineList" style="table-layout: fixed;width:300px;">
 								</table>
 						</div>
+						<div id='calSubscribeBox' class='statisticsInnerBox' style='padding: 10px;'>
+								<h3 id='calSubscribeBoxTitle'>Export Deadlines to calendar</h3>
+								<p>You can add the upcomming deadlines to your personal calendar by clicking <a href="../Shared/calendar.php?courseid=<?php echo $_GET['courseid']; ?>&coursevers=<?php echo $_GET['coursevers']; ?>">here</a>.</p>
+						</div>
 						<div id='statisticsSwimlanes' class='statisticsInnerBox' style=''>
 								<svg id="swimlaneSVG" width='300px' style='margin: 10px;' viewBox="0 0 300 255" xmlns="http://www.w3.org/2000/svg"></svg>
 						</div>

--- a/Shared/calendar.php
+++ b/Shared/calendar.php
@@ -1,0 +1,54 @@
+
+<?php
+    // Include basic application services!
+    include_once "../Shared/sessions.php";
+
+    // Connect to database and start session
+    pdoConnect();
+    session_start();
+
+    $courseid = 2;
+    $coursevers = 97732;
+    $query = $pdo->prepare("SELECT lid, entryname, visible, deadline, qrelease FROM listentries LEFT OUTER JOIN quiz ON listentries.link = quiz.id WHERE deadline IS NOT NULL and visible = 1 and listentries.cid = :cid and listentries.vers = :coursevers ORDER BY pos");
+    $query->bindParam(':cid', $courseid);
+    $query->bindParam(':coursevers', $coursevers);
+    
+    if(!$query->execute() || $query->rowCount() < 1) {
+        echo "There was an error trying to gernerate a calendar for you. Please try again.";
+    } else {
+        $icalBody = "";
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
+        foreach($rows as $row) {
+            // Format the timestamp to a ical format
+            $deadline = DateTime::createFromFormat("Y-m-d H:i:s", $row['deadline'])->format('Ymd\THis\Z');
+            $qrelease = DateTime::createFromFormat("Y-m-d H:i:s", $row['qrelease'])->format('Ymd\THis\Z');
+            
+            // Print out the calendar event
+            $event =  "BEGIN:VEVENT".PHP_EOL;
+            $event .= "DTSTAMP:".$qrelease.PHP_EOL;
+            $event .= "UID:".$row['lid']."-".$courseid."-".$coursevers."@lenasys".PHP_EOL;
+            $event .= "DTSTART:".$deadline.PHP_EOL;
+            $event .= "DTEND:".$deadline.PHP_EOL;
+            $event .= "STATUS:CONFIRMED".PHP_EOL;
+            $event .= "CATEGORIES:LENASYSDEADLINE".PHP_EOL;
+            $event .= "SUMMARY:Deadline ".$row['entryname'].PHP_EOL;
+            $event .= "DESCRIPTION:Deadline for ".$row['entryname'].PHP_EOL;
+            $event .= "LAST-MODIFIED:".$qrelease.PHP_EOL;
+            $event .= "END:VEVENT";
+        
+            $icalBody = $icalBody . PHP_EOL . $event;
+        
+        }
+
+        $icalHeader = "BEGIN:VCALENDAR".PHP_EOL;
+        $icalHeader .= "VERSION:2.0".PHP_EOL;
+        $icalHeader .= "PRODID:-//LenaSYS///NONSGML v1.0//EN";     
+        $icalEnd = PHP_EOL."END:VCALENDAR";
+        
+        // Set the correct content-type-header for the file to be downloaded successfully
+        header('Content-type: text/calendar; charset=utf-8');
+        header('Content-Disposition: inline; filename=lenasys-'.$courseid.'-'.$coursevers.'-calendar.ics');
+        
+        // Print the ical contents
+        echo $icalHeader.$icalBody.$icalEnd;
+    }


### PR DESCRIPTION
Added ability to get all deadlines in the form of iCal, this can be used to in your phone to see deadlines. 

The example screenshot shows how it looks on mobile:  
![image](https://user-images.githubusercontent.com/49141837/80966085-191c5a00-8e14-11ea-9091-fd824326907e.png)

Example on how it looks on a computer:
<img width="1552" alt="Skärmavbild 2020-05-04 kl  14 37 56" src="https://user-images.githubusercontent.com/49141837/80966475-dad36a80-8e14-11ea-8021-4943a8c45625.png">
