### PR TITLE
G2 2020 w19 #8761 Transformationsduggas should now be more useable on smaller screens

### DIFF
--- a/DuggaSys/templates/dugga4.html
+++ b/DuggaSys/templates/dugga4.html
@@ -4,19 +4,17 @@
 				<div id="feedbackTable" style="margin-top: -3px;"></div>	
 		</div>
 </div>
-<div id="container" style="display:flex; justify-content:center;">
-    <div id='duggaInfoBox2' style="display: inline-block; width:300px;">
-      
-          <div class='loginBoxheader'>
-                <h3>Dugga 4 - Transformationer</h3>
-          </div>
-                <p style="margin-left: 4px;">Transformationsduggan går ut på att skapa samma animation som ni redan ser framför er. 
-                    Till ert förfogande finns de klassiska transformationerna: transelera (T), rotera (R) och skala (S). För att rita ut planeter så väljer ni draw R/G/B beroende på vilken färg som önskas.</p>
-                <p style="margin-left: 4px;">Lägg till operationer genom att välja en operation och tryck på "Add Op.". Ni kan byta ordning på operationerna med pilarna upp och ner. Ta bort en operation genom att klicka på "X" för önskad operation. Genom att klicka på en befintlig operation så kan man ändra dess innehåll.</p>
-                <p style="margin-left: 4px;">Lycka till!</p>
-            
+<div class='instructions-container'>
+    <div class='instructions-button' onclick='toggleInstructions(this)'><h3>Instructions</h3></div>	
+    <div class="instructions-content">
+        <p style="margin-left: 4px;">Transformationsduggan går ut på att skapa samma animation som ni redan ser framför er. 
+                Till ert förfogande finns de klassiska transformationerna: transelera (T), rotera (R) och skala (S). För att rita ut planeter så väljer ni draw R/G/B beroende på vilken färg som önskas.</p>
+        <p style="margin-left: 4px;">Lägg till operationer genom att välja en operation och tryck på "Add Op.". Ni kan byta ordning på operationerna med pilarna upp och ner. Ta bort en operation genom att klicka på "X" för önskad operation. Genom att klicka på en befintlig operation så kan man ändra dess innehåll.</p>
+        <p style="margin-left: 4px;">Lycka till!</p>
     </div>
+</div>
 
+<div id="container" style="display:flex; justify-content:center;"> 
     <canvas id='a' style='background-color:#FFFFFF; border:2px solid black; display:block;'></canvas>
 
     <div id="toolbox" style="min-width:340px;width:340px;display:inline-block;">

--- a/DuggaSys/templates/dugga4.html
+++ b/DuggaSys/templates/dugga4.html
@@ -14,7 +14,7 @@
     </div>
 </div>
 
-<div id="container" style="display:flex; justify-content:center;"> 
+<div id="dugga4Container"> 
     <canvas id='a' style='background-color:#FFFFFF; border:2px solid black; display:block;'></canvas>
 
     <div id="toolbox" style="min-width:340px;width:340px;display:inline-block;">

--- a/DuggaSys/templates/dugga4.js
+++ b/DuggaSys/templates/dugga4.js
@@ -271,7 +271,7 @@ function fitToContainer()
 	}
 
 	document.getElementById("opTableContainer").style.maxHeight=(canvas.height-25-38)+"px";
-	document.getElementById("container").style.height=(canvas.height-50)+"px";
+	document.getElementById("dugga4Container").style.height=(canvas.height-50)+"px";
 
 	sf = canvas.width / 200;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -584,6 +584,18 @@ p {
   justify-content: center;
 }
 
+@media screen and (max-width: 1050px){
+  #dugga4Container{
+    flex-direction: column;
+    justify-content: initial;
+    align-items: center;
+  }
+
+  #dugga4Container #toolbox{
+    margin: 15px 0;
+  }
+}
+
 /* Instruction and submission of dugga */
 
 #leftDivDialog,

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -579,6 +579,11 @@ p {
   color: #612;
 }
 
+#dugga4Container{
+  display:flex;
+  justify-content: center;
+}
+
 /* Instruction and submission of dugga */
 
 #leftDivDialog,


### PR DESCRIPTION
Solves #8761.

Transformationsduggor should now be more useable on small screens (<1050px wide). Before this change the content would overflow horizontally. When the screen is small enough the content will now be displayed in a column fashion and the horizontal scroll should be no more.

I also replaced the instructions window with an accordion (the one used in for example bitduggas and färgduggas) for consistency. The transformationsdugga uses an accordion for feedback anyway. This is always displayed on the top of the page which made positioning everything else easier.

**Note:** during development this was tested in both Chrome and Firefox Dev Tools. They did not behave the same way when resizing (for example the canvas would become very small when resizing somewhere below 1000px width in Firefox, this did not happen in Chrome, where the canvas was resized to a more viewable size). I chose to trust Chrome this time.

It should look something like this on small screens:
![image](https://user-images.githubusercontent.com/49141758/80965998-e8d4bb80-8e13-11ea-883d-7e8f41849c18.png)

and something like this on bigger screens:
![image](https://user-images.githubusercontent.com/49141758/80966339-a2cc2780-8e14-11ea-9f29-4a0005966577.png)

