### PR TITLE
Fixes #8681- Separation should take the possibility of removing a separator into account

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5499,9 +5499,7 @@ function getTextareaText(array) {
 function getTextareaArray(element, index) {
     const objectText = element.value.split(",\n");
     const indexTextLines = objectText[index].split("\n");
-    const array = [];
-    indexTextLines.forEach(text => array.push({"text": text}));
-    return array;
+    return indexTextLines.map(text => ({"text": text}));
 }
 
 function setGlobalSelections() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5566,10 +5566,10 @@ function setSelectedObjectsProperties(element) {
                 if(numberOfSeparators === originalNumberOfSeparators) {
                     element.dataset.originalvalue = element.value;
                     object[access[0]] = getTextareaArray(element, textareaIndex);
-                    textareaIndex++;
                 } else {
                     element.value = element.dataset.originalvalue;
                 }
+                textareaIndex++;
             } else if(element.type === "range") {
                 object[access[0]] = element.value / 100;
             } else if(access[0] === "cardinality") {
@@ -5585,10 +5585,10 @@ function setSelectedObjectsProperties(element) {
                 if(numberOfSeparators === originalNumberOfSeparators) {
                     element.dataset.originalvalue = element.value;
                     object[access[0]] = element.value.split(",")[nameIndex].trim();
-                    nameIndex++;
                 } else {
                     element.value = element.dataset.originalvalue;
                 }
+                nameIndex++;
             } else if(access.length === 1) {
                 object[access[0]] = element.value;
             } else if(access.length === 2) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5565,8 +5565,13 @@ function setSelectedObjectsProperties(element) {
             if(element.nodeName === "TEXTAREA") {
                 const numberOfSeparators = (element.value.match(/,\n/g) || []).length;
                 const originalNumberOfSeparators = (element.dataset.originalvalue.match(/,\n/g) || []).length;
-                object[access[0]] = getTextareaArray(element, textareaIndex);
-                textareaIndex++;
+                if(numberOfSeparators === originalNumberOfSeparators) {
+                    element.dataset.originalvalue = element.value;
+                    object[access[0]] = getTextareaArray(element, textareaIndex);
+                    textareaIndex++;
+                } else {
+                    element.value = element.dataset.originalvalue;
+                }
             } else if(element.type === "range") {
                 object[access[0]] = element.value / 100;
             } else if(access[0] === "cardinality") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5423,6 +5423,7 @@ function loadAppearanceForm() {
             if(indexes[symbolKind.text].max > indexes[symbolKind.text].current) {
                 freeTextElement.value += ",\n";
             }
+            freeTextElement.dataset.originalvalue = freeTextElement.value;
             freeTextElement.focus();
         } else if(object.symbolkind === symbolKind.uml) {
             indexes[symbolKind.uml].current++;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5563,6 +5563,8 @@ function setSelectedObjectsProperties(element) {
         if((types.includes((object.symbolkind || 0).toString()))) {
             const access = element.dataset.access.split(".");
             if(element.nodeName === "TEXTAREA") {
+                const numberOfSeparators = (element.value.match(/,\n/g) || []).length;
+                const originalNumberOfSeparators = (element.dataset.originalvalue.match(/,\n/g) || []).length;
                 object[access[0]] = getTextareaArray(element, textareaIndex);
                 textareaIndex++;
             } else if(element.type === "range") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5326,6 +5326,11 @@ function loadGlobalAppearanceForm() {
     setGlobalSelections();
 }
 
+const separators = {
+    input: "~",
+    textarea: "~\n"
+};
+
 let appearanceObjects = [];
 
 function loadAppearanceForm() {
@@ -5387,7 +5392,7 @@ function loadAppearanceForm() {
             indexes.name.current++;
             nameElement.value += object.name;
             if(indexes.name.max > indexes.name.current) {
-                nameElement.value += ", ";
+                nameElement.value += `${separators.input} `;
             }
             nameElement.dataset.originalvalue = nameElement.value;
             nameElement.focus();
@@ -5421,7 +5426,7 @@ function loadAppearanceForm() {
             indexes[symbolKind.text].current++;
             freeTextElement.value += getTextareaText(object.textLines);
             if(indexes[symbolKind.text].max > indexes[symbolKind.text].current) {
-                freeTextElement.value += ",\n";
+                freeTextElement.value += separators.textarea;
             }
             freeTextElement.dataset.originalvalue = freeTextElement.value;
             freeTextElement.focus();
@@ -5430,8 +5435,8 @@ function loadAppearanceForm() {
             umlOperationsElement.value += getTextareaText(object.operations);
             umlAttributesElement.value += getTextareaText(object.attributes);
             if(indexes[symbolKind.uml].max > indexes[symbolKind.uml].current) {
-                umlOperationsElement.value += ",\n";
-                umlAttributesElement.value += ",\n";
+                umlOperationsElement.value += separators.textarea;
+                umlAttributesElement.value += separators.textarea;
             }
             umlOperationsElement.dataset.originalvalue = umlOperationsElement.value;
             umlAttributesElement.dataset.originalvalue = umlAttributesElement.value;
@@ -5490,14 +5495,14 @@ function getTextareaText(array) {
     for (let i = 0; i < array.length; i++) {
         text += array[i].text;
         if (i < array.length - 1) {
-            text += "\n";
+            text += separators.textarea;
         }
     }
     return text;
 }
 
 function getTextareaArray(element, index) {
-    const objectText = element.value.split(",\n");
+    const objectText = element.value.split(separators.textarea);
     const indexTextLines = objectText[index].split("\n");
     return indexTextLines.map(text => ({"text": text}));
 }
@@ -5561,8 +5566,9 @@ function setSelectedObjectsProperties(element) {
         if((types.includes((object.symbolkind || 0).toString()))) {
             const access = element.dataset.access.split(".");
             if(element.nodeName === "TEXTAREA") {
-                const numberOfSeparators = (element.value.match(/,\n/g) || []).length;
-                const originalNumberOfSeparators = (element.dataset.originalvalue.match(/,\n/g) || []).length;
+                const numberOfSeparators = (element.value.match(new RegExp(separators.textarea, "g")) || []).length;
+                const originalNumberOfSeparators = (element.dataset.originalvalue.match(new RegExp(separators.textarea, "g")) || []).length;
+                console.log(numberOfSeparators, originalNumberOfSeparators);
                 if(numberOfSeparators === originalNumberOfSeparators) {
                     element.dataset.originalvalue = element.value;
                     object[access[0]] = getTextareaArray(element, textareaIndex);
@@ -5580,11 +5586,11 @@ function setSelectedObjectsProperties(element) {
             } else if(element.id == "commentCheck") {
                 object[access[0]][access[1]] = element.checked;
             } else if(element.id === "name") {
-                const numberOfSeparators = (element.value.match(/,/g) || []).length;
-                const originalNumberOfSeparators = (element.dataset.originalvalue.match(/,/g) || []).length;
+                const numberOfSeparators = (element.value.match(new RegExp(separators.input, "g")) || []).length;
+                const originalNumberOfSeparators = (element.dataset.originalvalue.match(new RegExp(separators.input, "g")) || []).length;
                 if(numberOfSeparators === originalNumberOfSeparators) {
                     element.dataset.originalvalue = element.value;
-                    object[access[0]] = element.value.split(",")[nameIndex].trim();
+                    object[access[0]] = element.value.split(separators.input)[nameIndex].trim();
                 } else {
                     element.value = element.dataset.originalvalue;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5433,6 +5433,8 @@ function loadAppearanceForm() {
                 umlOperationsElement.value += ",\n";
                 umlAttributesElement.value += ",\n";
             }
+            umlOperationsElement.dataset.originalvalue = umlOperationsElement.value;
+            umlAttributesElement.dataset.originalvalue = umlAttributesElement.value;
         } else if(object.kind === kind.path) {
             document.getElementById("figureOpacity").value = object.opacity * 100;
             document.getElementById("fillColor").focus();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5376,11 +5376,14 @@ function loadAppearanceForm() {
     showFormGroups(types);
     toggleApperanceElement(true);
     
+    const nameElement = document.getElementById("name");
+    const freeTextElement = document.getElementById("freeText");
+    const umlOperationsElement = document.getElementById("umlOperations");
+    const umlAttributesElement = document.getElementById("umlAttributes");
     let erCardinalityVisible = false;
 
     appearanceObjects.forEach(object => {
         if(object.symbolkind === symbolKind.uml || object.symbolkind === symbolKind.erAttribute || object.symbolkind === symbolKind.erEntity || object.symbolkind === symbolKind.erRelation) {
-            const nameElement = document.getElementById("name");
             indexes.name.current++;
             nameElement.value += object.name;
             if(indexes.name.max > indexes.name.current) {
@@ -5414,20 +5417,19 @@ function loadAppearanceForm() {
             }
             document.getElementById("typeLineUML").focus();
         } else if(object.symbolkind === symbolKind.text) {
-            const textarea = document.getElementById("freeText");
             indexes[symbolKind.text].current++;
-            textarea.value += getTextareaText(object.textLines);
+            freeTextElement.value += getTextareaText(object.textLines);
             if(indexes[symbolKind.text].max > indexes[symbolKind.text].current) {
-                textarea.value += ",\n";
+                freeTextElement.value += ",\n";
             }
-            textarea.focus();
+            freeTextElement.focus();
         } else if(object.symbolkind === symbolKind.uml) {
             indexes[symbolKind.uml].current++;
-            document.getElementById("umlOperations").value += getTextareaText(object.operations);
-            document.getElementById("umlAttributes").value += getTextareaText(object.attributes);
+            umlOperationsElement.value += getTextareaText(object.operations);
+            umlAttributesElement.value += getTextareaText(object.attributes);
             if(indexes[symbolKind.uml].max > indexes[symbolKind.uml].current) {
-                document.getElementById("umlOperations").value += ",\n";
-                document.getElementById("umlAttributes").value += ",\n";
+                umlOperationsElement.value += ",\n";
+                umlAttributesElement.value += ",\n";
             }
         } else if(object.kind === kind.path) {
             document.getElementById("figureOpacity").value = object.opacity * 100;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5389,6 +5389,7 @@ function loadAppearanceForm() {
             if(indexes.name.max > indexes.name.current) {
                 nameElement.value += ", ";
             }
+            nameElement.dataset.originalvalue = nameElement.value;
             nameElement.focus();
         }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5582,8 +5582,15 @@ function setSelectedObjectsProperties(element) {
             } else if(element.id == "commentCheck") {
                 object[access[0]][access[1]] = element.checked;
             } else if(element.id === "name") {
-                object[access[0]] = element.value.split(",")[nameIndex].trim();
-                nameIndex++;
+                const numberOfSeparators = (element.value.match(/,/g) || []).length;
+                const originalNumberOfSeparators = (element.dataset.originalvalue.match(/,/g) || []).length;
+                if(numberOfSeparators === originalNumberOfSeparators) {
+                    element.dataset.originalvalue = element.value;
+                    object[access[0]] = element.value.split(",")[nameIndex].trim();
+                    nameIndex++;
+                } else {
+                    element.value = element.dataset.originalvalue;
+                }
             } else if(access.length === 1) {
                 object[access[0]] = element.value;
             } else if(access.length === 2) {


### PR DESCRIPTION
Before, it was possible to remove separators. This would cause errors as an attempt to access an index in an array based on separator was made and when the separator no longer exist, this will cause problems. This solution makes it impossible to remove a separator to help the user. Removing a separator can easily happen and a mistake should not matter. Now the user can be more careless when working with multiple objects at the same time in the appearance menu. This affects text inputs and textareas where the user can freely enter information.

- Create many types of objects; entities, relations, attributes, UML classes and free text. And several of each. Select all of the objects at the same time and open the apperance menu. In the name input there should be many names separated by ~. Try to edit the several names and see if the correct object is affected by the change. Then attempt to delete the separators ~, it should not be possible and no errors should occur. Test with the different textareas as well, a separator here is ~ followed by a new line. Try to edit the different objects values in the textarea and see so it affects the correct object. Attempt to delete the separator.

Link: http://group4.webug.his.se:20001/G4-2020-W19-ISSUE%238681/DuggaSys/diagram.php