### PR TITLE
fix issue#8787 crosshair in developer mode moved to front

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2392,15 +2392,13 @@ function updateGraphics() {
     diagram.updateQuadrants();
     drawGrid();
     drawOrigoLine();
+   if(developerModeActive) drawOrigo();
     diagram.sortConnectors();
     diagram.updateQuadrants();
     diagram.draw();
     points.drawPoints();
     drawVirtualPaper();
-    if(developerModeActive) {
-        drawOrigo();
-        drawCrosshair();
-    }
+    if(developerModeActive) drawCrosshair();
 }
 
 //---------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2392,15 +2392,15 @@ function updateGraphics() {
     diagram.updateQuadrants();
     drawGrid();
     drawOrigoLine();
-    if(developerModeActive) {
-        drawOrigo();
-        drawCrosshair();
-    }
     diagram.sortConnectors();
     diagram.updateQuadrants();
     diagram.draw();
     points.drawPoints();
     drawVirtualPaper();
+    if(developerModeActive) {
+        drawOrigo();
+        drawCrosshair();
+    }
 }
 
 //---------------------------------------------------------------------------------


### PR DESCRIPTION
Before fix when navigating in developer mode the central crosshair gets positioned behind objects that are drawn onto the canvas. After fix the crosshair should always be in front of all the other objects which means that it will always be visible. 

**Test this:** Enter developer mode and draw a couple of different objects like enteties, attributes and classes. Drag the crosshair over the objects by rightclicking and dragging the mouse. If the crosshair is visible when positioned on the object the issue is fixed. 

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W19-ISSUE%238787/DuggaSys/diagram.php

**Before:** 

![d030e43d2727f71a6f237dcb7998b8ae](https://user-images.githubusercontent.com/49142301/81048351-7966d680-8ebc-11ea-95d4-ef9dc25b03f7.gif)

**After:** 

![5ab04d38484fdf1b85ba0729a756a507](https://user-images.githubusercontent.com/49142301/81048470-b337dd00-8ebc-11ea-8286-8dc4cee53f3f.gif)

