### PR TITLE
Added page information to analytic - G1-2020-W19-ISSUE#2178

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -368,6 +368,80 @@ function loadFileInformation() {
     updateFileInformation();
 }
 
+function loadPageInformation() {
+    resetAnalyticsChart();
+    $('#analytic-info').empty();
+    $('#analytic-info').append("<p>Page information.</p>");
+ 
+    var selectPage = $("<select></select>")
+        .append('<option value="showDugga" selected>showDugga</option>')
+        .append('<option value="codeviewer">codeviewer</option>')
+        .appendTo($('#analytic-info'));
+   
+       
+   
+    function updatePageHitInformation(page){
+        loadAnalytics(page + "Information", function(data) {
+            console.log(page);
+            var tableData = [["Page", "Hits"]];
+            for (var i = 0; i < data.length; i++) {
+                tableData.push([
+                    page,
+                    data[i].pageLoads
+                ]);
+            }
+           
+            $('#analytic-info').append("<p>Page information.</p>");
+            $('#analytic-info').append(selectPage);
+            $('#analytic-info').append(renderTable(tableData));
+            updatePieChartInformation(page, tableData);
+        });
+    }
+ 
+    function updatePieChartInformation(page, tableData){
+        console.log(page + "Percentage");
+        loadAnalytics(page + "Percentage", function(data) {
+ 
+            var tablePercentage = [["Courseid", "Percentage"]];
+            for (var i = 0; i < data.length; i++) {
+                tablePercentage.push([
+                    data[i].courseid,
+                    data[i].percentage
+                ]);
+            }
+ 
+            var chartData = [];
+            for (var i = 0; i < data.length; i++) {
+                chartData.push({
+                    label: "courseid:" + " " + data[i].courseid,
+                    value: data[i].percentage
+                });
+            }
+            $('#analytic-info').append("<p>Page information.</p>");
+            $('#analytic-info').append(selectPage);
+            $('#analytic-info').append(renderTable(tableData));
+            $('#analytic-info').append(renderTable(tablePercentage));
+            $('#analytic-info').append(drawPieChart(chartData));
+            updateState();
+        });
+    }
+ 
+    function updateState(){
+        selectPage.change(function(){
+            switch(selectPage.val()){
+                case "showDugga":
+                    updatePageHitInformation("dugga");
+                    break;
+                case "codeviewer":
+                    updatePageHitInformation("codeviewer");
+                    break;
+            }
+        });
+    }
+ 
+    updateState();
+}
+
 //------------------------------------------------------------------------------------------------
 // Analytic loaders END	
 //------------------------------------------------------------------------------------------------

--- a/DuggaSys/analytic.php
+++ b/DuggaSys/analytic.php
@@ -46,6 +46,7 @@ pdoConnect();
 			<input class="submit-button" style="float:left" type="button" value="Service speed" onclick="loadServiceAvgDuration()">
 			<input class="submit-button" style="float:left" type="button" value="Service crashes" onclick="loadServiceCrashes()">
 			<input class="submit-button" style="float:left" type="button" value="File information" onclick="loadFileInformation()">
+			<input class="submit-button" style="float:left" type="button" value="Page information" onclick="loadPageInformation()">
 		</div>
 		<div id="analytic-info" style="clear: both; padding: 15px;"></div>
 		<div style="height: 300px">

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -44,7 +44,19 @@ if (isset($_SESSION['uid']) && checklogin() && isSuperUser($_SESSION['uid'])) {
 				break;
 			case 'fileInformation':
 				fileInformation();
-			break;
+				break;
+			case 'duggaInformation':
+                duggaInformation();
+                break;
+            case 'codeviewerInformation':
+                codeviewerInformation();
+                break;
+            case 'duggaPercentage':
+                duggaPercentage();
+                break;
+            case 'codeviewerPercentage':
+                codeviewerPercentage();
+                break;
 		}
 	} else {
 		echo 'N/A';
@@ -209,4 +221,65 @@ function serviceCrashes(){
 		WHERE uuid NOT IN (SELECT DISTINCT uuid FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceServerEnd.');
 	')->fetchAll(PDO::FETCH_ASSOC);
 	echo json_encode($result);
+}
+
+//------------------------------------------------------------------------------------------------
+// Retrieves dugga information         
+//------------------------------------------------------------------------------------------------
+function duggaInformation(){
+    $result = $GLOBALS['log_db']->query('
+        SELECT
+            COUNT(*) AS pageLoads,
+            timestamp AS timestamp
+        FROM duggaLoadLogEntries
+        ORDER BY timestamp;
+    ')->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($result);
+}
+ 
+//------------------------------------------------------------------------------------------------
+// Retrieves codeviewer information        
+//------------------------------------------------------------------------------------------------
+ 
+function codeviewerInformation(){
+    $result = $GLOBALS['log_db']->query('
+        SELECT
+            COUNT(*) AS pageLoads,
+            timestamp AS timestamp
+        FROM exampleLoadLogEntries
+        ORDER BY timestamp;
+    ')->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($result);
+}
+ 
+//------------------------------------------------------------------------------------------------
+// Retrieves dugga percentage          
+//------------------------------------------------------------------------------------------------
+ 
+function duggaPercentage(){
+    $result = $GLOBALS['log_db']->query('
+        SELECT
+            cid AS courseid,
+            COUNT(*) * 100.0 / (SELECT COUNT(*) FROM duggaLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
+        FROM duggaLoadLogEntries
+        GROUP BY courseid
+        ORDER BY percentage DESC;
+    ')->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($result);
+}
+ 
+//------------------------------------------------------------------------------------------------
+// Retrieves example percentage        
+//------------------------------------------------------------------------------------------------
+ 
+function codeviewerPercentage(){
+    $result = $GLOBALS['log_db']->query('
+        SELECT
+            courseid,
+            COUNT(*) * 100.0 / (SELECT COUNT(*) FROM exampleLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
+        FROM exampleLoadLogEntries
+        GROUP BY courseid
+        ORDER BY percentage DESC;
+    ')->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($result);
 }


### PR DESCRIPTION
Added page information to analytic for Showdugga and codeviewer page with information about total page hits and additional information how those hits are divided among different courses. This can be seen in the picture below. 

![Screenshot 2020-05-05 at 11 08 45](https://user-images.githubusercontent.com/62876614/81050947-31967e00-8ec1-11ea-8533-ff24631c57e2.png)

More pages are suppose to be track but currently we lack the logging for all of them. Additionally the issue linked with this pull request request additional features besides page hit but without any clear explanation on what those features should be. 

THIS requires us creating additional issues with what pages should be track and what features should be added to page information. 