### PR TITLE
You can no longer create a new course version with an existing version ID | Fix for issue #8771

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1069,9 +1069,9 @@ function returnedSection(data) {
   addClasses();
   showMOTD();
 
-  for(var i = 0; i < data["versions"].length; i++){
+  /*for(var i = 0; i < data["versions"].length; i++){
     versIdArray.push(data["versions"][i].vers);
-  }
+  }*/
 }
 // Displays MOTD if there in no MOTD cookie or if the cookie dosen't have the correcy values
 function showMOTD(){
@@ -1706,6 +1706,7 @@ function validateCourseID(courseid, dialogid) {
   var code = document.getElementById(courseid);
   var x2 = document.getElementById(dialogid);
   var val = document.getElementById("versid").value;
+  console.log(retdata["courseid"]);
 
   if (code.value.match(Code)) {
     code.style.borderColor = "#383";
@@ -1721,14 +1722,24 @@ function validateCourseID(courseid, dialogid) {
     window.bool = false;
   }
 
-  if(versIdArray.indexOf(val)!== -1){
+  const versionIsValid = retdata["versions"].some(object => object.cid === retdata["courseid"] && object.vers === val);
+  if(versionIsValid) {
     console.log("popop");
     code.style.borderColor = "#E54";
     x2.innerHTML = "Version ID already exists, try another";
     x2.style.display = "block";
     code.style.borderWidth = "2px";
     window.bool = false;
-  } 
+  }
+
+  /*if(versIdArray.indexOf(val)!== -1){
+    console.log("popop");
+    code.style.borderColor = "#E54";
+    x2.innerHTML = "Version ID already exists, try another";
+    x2.style.display = "block";
+    code.style.borderWidth = "2px";
+    window.bool = false;
+  }*/ 
 }
 
 function validateMOTD(motd, dialogid){

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -14,6 +14,7 @@ var resave = false;
 var versnme = "UNKz";
 var versnr;
 var motd;
+var versIdArray = [];
 
 // Stores everything that relates to collapsable menus and their state.
 var menuState = {
@@ -1067,7 +1068,10 @@ function returnedSection(data) {
 
   addClasses();
   showMOTD();
-  
+
+  for(var i = 0; i < data["versions"].length; i++){
+    versIdArray.push(data["versions"][i].vers);
+  }
 }
 // Displays MOTD if there in no MOTD cookie or if the cookie dosen't have the correcy values
 function showMOTD(){
@@ -1701,6 +1705,7 @@ function validateCourseID(courseid, dialogid) {
   var Code = /^[0-9]{3,6}$/;
   var code = document.getElementById(courseid);
   var x2 = document.getElementById(dialogid);
+  var val = document.getElementById("versid").value;
 
   if (code.value.match(Code)) {
     code.style.borderColor = "#383";
@@ -1710,10 +1715,20 @@ function validateCourseID(courseid, dialogid) {
   } else {
 
     code.style.borderColor = "#E54";
+    x2.innerHTML = "Only numbers(between 3-6 numbers)";
     x2.style.display = "block";
     code.style.borderWidth = "2px";
     window.bool = false;
   }
+
+  if(versIdArray.indexOf(val)!== -1){
+    console.log("popop");
+    code.style.borderColor = "#E54";
+    x2.innerHTML = "Version ID already exists, try another";
+    x2.style.display = "block";
+    code.style.borderWidth = "2px";
+    window.bool = false;
+  } 
 }
 
 function validateMOTD(motd, dialogid){
@@ -1838,6 +1853,7 @@ function validateForm(formid) {
   if (formid === 'newCourseVersion') {
     var versName = document.getElementById("versname").value;
     var versId = document.getElementById("versid").value;
+    console.log(versId);
 
     //If fields empty
     if (versName == null || versName == "", versId == null || versId == "") {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1702,7 +1702,6 @@ function validateCourseID(courseid, dialogid) {
   var code = document.getElementById(courseid);
   var x2 = document.getElementById(dialogid);
   var val = document.getElementById("versid").value;
-  console.log(retdata["courseid"]);
 
   if (code.value.match(Code)) {
     code.style.borderColor = "#383";
@@ -1720,7 +1719,6 @@ function validateCourseID(courseid, dialogid) {
 
   const versionIsValid = retdata["versions"].some(object => object.cid === retdata["courseid"] && object.vers === val);
   if(versionIsValid) {
-    console.log("popop");
     code.style.borderColor = "#E54";
     x2.innerHTML = "Version ID already exists, try another";
     x2.style.display = "block";
@@ -1852,7 +1850,6 @@ function validateForm(formid) {
   if (formid === 'newCourseVersion') {
     var versName = document.getElementById("versname").value;
     var versId = document.getElementById("versid").value;
-    console.log(versId);
 
     //If fields empty
     if (versName == null || versName == "", versId == null || versId == "") {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -14,7 +14,6 @@ var resave = false;
 var versnme = "UNKz";
 var versnr;
 var motd;
-var versIdArray = [];
 
 // Stores everything that relates to collapsable menus and their state.
 var menuState = {
@@ -1069,9 +1068,6 @@ function returnedSection(data) {
   addClasses();
   showMOTD();
 
-  /*for(var i = 0; i < data["versions"].length; i++){
-    versIdArray.push(data["versions"][i].vers);
-  }*/
 }
 // Displays MOTD if there in no MOTD cookie or if the cookie dosen't have the correcy values
 function showMOTD(){
@@ -1732,14 +1728,6 @@ function validateCourseID(courseid, dialogid) {
     window.bool = false;
   }
 
-  /*if(versIdArray.indexOf(val)!== -1){
-    console.log("popop");
-    code.style.borderColor = "#E54";
-    x2.innerHTML = "Version ID already exists, try another";
-    x2.style.display = "block";
-    code.style.borderWidth = "2px";
-    window.bool = false;
-  }*/ 
 }
 
 function validateMOTD(motd, dialogid){


### PR DESCRIPTION
It is no longer possible to create a new course version with a version ID that already exists **for the selected course**. 

You can, however, create a version with an ID that exists in **another** course, but not in the same course. I.e. you can have the course version with ID "1337" in both IT118G and DV12G but you can't have **two** course versions with the ID "1337" in  IT118G.


In "**Webbprogrammering DV12G**" there is a course version by the id "1337". So when we try to add a new course version with the same ID, we get a warning and we are unable to create it.
![image](https://user-images.githubusercontent.com/49142028/81053737-d915af80-8ec5-11ea-9bbd-e2cba2905589.png)

![image](https://user-images.githubusercontent.com/49142028/81053873-12e6b600-8ec6-11ea-8ab4-c43a91444291.png)
 -----
In "**Webbutveckling datorgrafik IT118G**" we have a course version with the ID "1337", which also exists in "Webbprogrammering DV12G". This is allowed because they are two different courses with different course ID's.
![image](https://user-images.githubusercontent.com/49142028/81054120-7ffa4b80-8ec6-11ea-9dd3-438417b13c13.png)



