### PR TITLE
G2 2020 w19 #8830 Accessed dropdowns now open/close on click instead of hover

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -777,7 +777,9 @@ document.addEventListener('click', function(e){
 			}
 		}
 	}else{
-		activeDropdown.style.display = "none";
+		if(activeDropdown){
+			activeDropdown.style.display = "none";
+		}
 		activeDropdown = undefined;
 	}
 });

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -10,6 +10,7 @@ var myTable;
 var accessFilter = "WRST";
 var trueTeacher;
 var examinerName;
+var activeDropdown;
 
 //----------------------------------------------------------------------------
 //----------==========########## User Interface ##########==========----------
@@ -742,6 +743,44 @@ function mouseUp(e) {
  		clearUpdateCellInternal();
  	}
 }
+
+//----------------------------------------------------------------------------------
+// Eventlistener for handling dropdowns
+//----------------------------------------------------------------------------------
+
+document.addEventListener('click', function(e){
+	if(e.target.classList.contains('access-dropdown') || e.target.parentElement.classList.contains('access-dropdown')){
+		var dropdown = e.target.closest('.access-dropdown').querySelector('.access-dropdown-content');
+		if(activeDropdown === undefined){
+			if(window.getComputedStyle(dropdown, null).getPropertyValue("display") === "none"){
+				dropdown.style.display = "block";
+				activeDropdown = dropdown;
+			}else{
+				dropdown.style.display = "none";
+				activeDropdown = undefined;
+			}
+		}else{
+			if(e.target != activeDropdown){
+				if(activeDropdown.style.display === "none"){
+					activeDropdown.style.display = "block";
+					activeDropdown = e.target.closest('.access-dropdown').querySelector('.access-dropdown-content');
+				}else{
+					if(activeDropdown != dropdown){
+						activeDropdown.style.display = "none";
+						e.target.closest('.access-dropdown').querySelector('.access-dropdown-content').style.display = "block";
+						activeDropdown = e.target.closest('.access-dropdown').querySelector('.access-dropdown-content')
+					}else{
+						activeDropdown.style.display = "none";
+						activeDropdown = undefined;
+					}
+				}
+			}
+		}
+	}else{
+		activeDropdown.style.display = "none";
+		activeDropdown = undefined;
+	}
+});
 
 //----------------------------------------------------------------------------------
 // createQuickItem: Handle "fast" click on FAB button

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2896,9 +2896,6 @@ span.arrow {
 
 padding: 10px;
 }
-.access-dropdown:hover .access-dropdown-content {
-  display: block;
-}
 
 #reset-pw{
   width:70%; 


### PR DESCRIPTION
Solves #8830.

Dropdowns in Access Editor now open/close on click instead of hover according to issue suggestions. 

There are still some styling issues with the dropdowns, a separate issue should/will be opened for this. This pull request only fixes behavioural issues for the dropdowns.