### PR TITLE
User feedback when incorrect line is attempted

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4417,6 +4417,12 @@ function mouseupevt(ev) {
         saveState = false;
         //Check if you release on canvas or try to draw a line from entity to entity
         if (markedObject == -1 || diagram[lineStartObj].symbolkind == symbolKind.erEntity && diagram[markedObject].symbolkind == symbolKind.erEntity) {
+            if(diagram[lineStartObj] == diagram[markedObject]){
+                flash("Can not draw line between the same object", "danger");
+            }
+            else if(markedObject != -1 && diagram[lineStartObj].symbolkind == symbolKind.erEntity && diagram[markedObject].symbolkind == symbolKind.erEntity){
+                flash("Can not draw line between two ER-entities", "danger");
+            }
             md = mouseState.empty;
         }else {
             //Get which kind of symbol mouseupevt execute on
@@ -4439,27 +4445,49 @@ function mouseupevt(ev) {
                 if (symbolEndKind == symbolKind.erEntity && symbolStartKind == symbolKind.erAttribute) {
                     if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) > 0) {
                         okToMakeLine= false;
+                        flash("Can not draw multiple lines between these objects", "danger");
                     }
                 }else if (symbolEndKind == symbolKind.erAttribute && symbolStartKind == symbolKind.erEntity) {
                     if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) > 0) {
                         okToMakeLine= false;
+                        flash("Can not draw multiple lines between these objects", "danger");
                     }
                 }else if (symbolEndKind == symbolKind.erEntity && symbolStartKind == symbolKind.erRelation) {
-                    if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) >= 2) okToMakeLine = false;
+                    if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) >= 2){
+                        okToMakeLine = false;
+                        flash("A max of two lines can be drawn between these objects", "danger");
+                    }
                 }else if (symbolEndKind == symbolKind.erRelation && symbolStartKind == symbolKind.erEntity) {
-                    if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) >= 2) okToMakeLine = false;
+                    if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) >= 2){
+                        okToMakeLine = false;
+                        flash("A max of two lines can be drawn between these objects", "danger");
+                    } 
                 }else if (symbolEndKind == symbolKind.erRelation && symbolStartKind == symbolKind.erAttribute) {
-                    if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) > 0) okToMakeLine = false;
+                    if (diagram[markedObject].connectorCountFromSymbol(diagram[lineStartObj]) > 0){
+                        okToMakeLine = false;
+                        flash("Can not draw multiple lines between these objects", "danger");
+                    }
                 }else if (symbolEndKind == symbolKind.erAttribute && symbolStartKind == symbolKind.erRelation) {
-                    if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) > 0) okToMakeLine = false;
+                    if (diagram[lineStartObj].connectorCountFromSymbol(diagram[markedObject]) > 0){
+                        okToMakeLine = false;
+                        flash("Can not draw multiple lines between these objects", "danger");
+                    }
                 }else if (symbolEndKind == symbolKind.erRelation && symbolStartKind == symbolKind.erRelation) {
                     okToMakeLine = false;
+                    flash("Can not draw line between two ER-relations", "danger");
                 }else if ((symbolEndKind == symbolKind.uml && symbolStartKind != symbolKind.uml) || (symbolEndKind != symbolKind.uml && symbolStartKind == symbolKind.uml)) {
                     okToMakeLine = false;
+                    flash("Can not draw line between ER- and UML-objects", "danger");
                 }
-                if(diagram[lineStartObj] == diagram[markedObject]) okToMakeLine = false;
+                if(diagram[lineStartObj] == diagram[markedObject]){
+                    okToMakeLine = false;
+                    flash("Can not draw line between the same object", "danger");
+                }
 
-                if(diagram[lineStartObj].kind == 1 || diagram[markedObject].kind == 1) okToMakeLine = false;
+                if(diagram[lineStartObj].kind == 1 || diagram[markedObject].kind == 1){
+                    okToMakeLine = false;
+                    flash("Can not draw line to/from a freedraw object", "danger");
+                }
 
                 if (okToMakeLine) {
                     saveState = true;
@@ -4504,6 +4532,7 @@ function mouseupevt(ev) {
 
                 if (symbolEndKind != symbolKind.uml) {
                     okToMakeLine = false;
+                    flash("Can not draw line between UML- and ER-objects", "danger");
                 }
                 if (okToMakeLine) {
                     saveState = true;


### PR DESCRIPTION
Solves issue #8856

Using a flash message on screen the user now gets feedback on why line could not be created.

Tester:
Try to draw all different types of incorrect lines to see if appropriate error message shows up. Also try drawing correct lines to make sure we don't show en error by mistake.
http://group4.webug.his.se:20001/G4-2020-W19-ISSUE%238856/DuggaSys/diagram.php