### PR TITLE
Fixes #8510 - Object names in line direction select change according to name input

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5546,7 +5546,7 @@ function loadAppearanceForm() {
             }
             document.getElementById("typeLine").focus();
         } else if(object.symbolkind === symbolKind.umlLine) {
-            setLineDirectionElementUML(object);
+            setLineDirectionElementUML(object, indexes[symbolKind.umlLine]);
             document.getElementById("typeLineUML").focus();
         } else if(object.symbolkind === symbolKind.text) {
             indexes[symbolKind.text].current++;
@@ -5629,15 +5629,23 @@ function setNameElement(object, index) {
 // setLineDirectionElementUML: Runs for UML line objects. Appends the name of connected object names to correct option in the lineDirection select. Takes recursive lines into consideration.
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-function setLineDirectionElementUML(object) {
+function setLineDirectionElementUML(object, index) {
+    //Get objects connected to uml-line and sets name in appearance menu(used for Line direction)
     const connectedObjectsArray = object.getConnectedObjects();
-    document.getElementById("First").innerHTML += connectedObjectsArray[0].name + ", ";
+    const options = document.getElementById("lineDirection").options;
 
-    //Check if relation is to the same entity. If so: both are named from object 0.
+    index.current++;
+    options[0].innerHTML += connectedObjectsArray[0].name;
+
+    //Selection to check if relation is to the same entity. If so: both are named from object 0
     if(typeof connectedObjectsArray[1] == "undefined"){
-        document.getElementById("Second").innerHTML +=  connectedObjectsArray[0].name + ", ";
+        options[1].innerHTML +=  connectedObjectsArray[0].name;
     } else {
-        document.getElementById("Second").innerHTML += connectedObjectsArray[1].name + ", ";
+        options[1].innerHTML += connectedObjectsArray[1].name;
+    }
+    if(index.max > index.current) {
+        options[0].innerHTML += ", ";
+        options[1].innerHTML += ", "
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5863,6 +5863,12 @@ function setSelectedObjectsProperties(element) {
             }
         }
     });
+
+    const umlLineExists = appearanceObjects.some(object => object.symbolkind === symbolKind.umlLine);
+    if(umlLineExists) {
+        
+    }
+
     updateGraphics();
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5868,6 +5868,11 @@ function setSelectedObjectsProperties(element) {
     if(umlLineExists) {
         const lineDirectionElement = document.getElementById("lineDirection");
         [...lineDirectionElement.options].forEach(option => option.text = "");
+        appearanceObjects.forEach(object => {
+            if(object.symbolkind === symbolKind.umlLine) {
+                setLineDirectionElementUML(object, indexes[symbolKind.umlLine]);
+            }
+        });
     }
 
     updateGraphics();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5866,7 +5866,8 @@ function setSelectedObjectsProperties(element) {
 
     const umlLineExists = appearanceObjects.some(object => object.symbolkind === symbolKind.umlLine);
     if(umlLineExists) {
-        
+        const lineDirectionElement = document.getElementById("lineDirection");
+        [...lineDirectionElement.options].forEach(option => option.text = "");
     }
 
     updateGraphics();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5499,6 +5499,7 @@ function loadGlobalAppearanceForm() {
 
 const separators = {
     input: "~",
+    option: "~",
     textarea: "~\n"
 };
 
@@ -5644,8 +5645,8 @@ function setLineDirectionElementUML(object, index) {
         options[1].innerHTML += connectedObjectsArray[1].name;
     }
     if(index.max > index.current) {
-        options[0].innerHTML += ", ";
-        options[1].innerHTML += ", "
+        options[0].innerHTML += `${separators.option} `;
+        options[1].innerHTML += `${separators.option} `;
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5864,15 +5864,19 @@ function setSelectedObjectsProperties(element) {
         }
     });
 
-    const umlLineExists = appearanceObjects.some(object => object.symbolkind === symbolKind.umlLine);
-    if(umlLineExists) {
-        const lineDirectionElement = document.getElementById("lineDirection");
-        [...lineDirectionElement.options].forEach(option => option.text = "");
-        appearanceObjects.forEach(object => {
-            if(object.symbolkind === symbolKind.umlLine) {
-                setLineDirectionElementUML(object, indexes[symbolKind.umlLine]);
-            }
-        });
+    //Special case after change of name element to change UML line direction according to names in name element
+    if(element.id === "name") {
+        const umlLineExists = appearanceObjects.some(object => object.symbolkind === symbolKind.umlLine);
+        if(umlLineExists) {
+            const indexes = getSelectedObjectsMaxIndexes(appearanceObjects);
+            const lineDirectionElement = document.getElementById("lineDirection");
+            [...lineDirectionElement.options].forEach(option => option.text = "");
+            appearanceObjects.forEach(object => {
+                if(object.symbolkind === symbolKind.umlLine) {
+                    setLineDirectionElementUML(object, indexes[symbolKind.umlLine]);
+                }
+            });
+        }
     }
 
     updateGraphics();

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -580,8 +580,8 @@
                     <div class="form-group" data-types="7">
                         <label for="lineDirection">UML line direction:</label>
                         <select id="lineDirection" data-access="lineDirection">
-                            <option value="First" id="First"></option>
-                            <option value="Second" id="Second"></option>
+                            <option value="First"></option>
+                            <option value="Second"></option>
                         </select>
                     </div>
                     <div class="form-group" data-types="4">


### PR DESCRIPTION
This makes the line direction select for UML follow changing names in the name input.

This gif shows what you should test:
![64472ad59e7077d35f2ce76e28c844f7](https://user-images.githubusercontent.com/49121839/81154435-2fe1be80-8f84-11ea-89d4-95d217721b85.gif)

Link: http://group4.webug.his.se:20001/G4-2020-W19-ISSUE%238510/DuggaSys/diagram.php
