### PR TITLE
Sorting in Dugga Editor should now sort uppercase and lowercase characters properly

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -980,10 +980,10 @@ function compare(a, b) {
 	}
 	
 	if(tempA != null){
-		tempA = tempA.replace(/&aring/g,"å").replace(/&auml/g,"ä").replace(/&ouml/g,"ö").replace(/&Aring/g,"Å").replace(/&Auml/g,"Ä").replace(/&Ouml/g,"Ö");
+		tempA = tempA.toLowerCase().replace(/&aring/g,"å").replace(/&auml/g,"ä").replace(/&ouml/g,"ö").replace(/&Aring/g,"Å").replace(/&Auml/g,"Ä").replace(/&Ouml/g,"Ö");
 	}
 	if(tempB != null){
-		tempB = tempB.replace(/&aring/g,"å").replace(/&auml/g,"ä").replace(/&ouml/g,"ö").replace(/&Aring/g,"Å").replace(/&Auml/g,"Ä").replace(/&Ouml/g,"Ö");
+		tempB = tempB.toLowerCase().replace(/&aring/g,"å").replace(/&auml/g,"ä").replace(/&ouml/g,"ö").replace(/&Aring/g,"Å").replace(/&Auml/g,"Ä").replace(/&Ouml/g,"Ö");
 	}
 
 	if (tempA > tempB) {


### PR DESCRIPTION
Solves #8908.

Added .toLowerCase() to the values being compared, which means all strings are handled as all lowercase. The Dugga Editor table should now sort properly regardless of character casing.

![image](https://user-images.githubusercontent.com/49141758/81178282-469a0c80-8fa8-11ea-8d39-9ad1aff0f372.png)
