### PR TITLE
Added seassion cookie to analytic.php - G1-2020-W20-ISSUE#8881

### DIFF
--- a/DuggaSys/analytic.php
+++ b/DuggaSys/analytic.php
@@ -14,6 +14,11 @@ $js = array(
 	'jquery-ui-1.10.4.min.js'
 );
 
+// refreshes session cookies, thereby extending the time before users sees the alert or get logged out
+// refreshes takes place when navigating to codeviewer.php, courseed.php, and sectioned.php
+setcookie("sessionEndTime", "expireC", time() + 2700, "/"); // Alerts user in 45min
+setcookie("sessionEndTimeLogOut", "expireC", time() + 3600, "/"); // Ends session in 60min, user gets logged out
+
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
When entering analytic.php the season cookies should now be refreshed. 

![Screenshot 2020-05-06 at 15 10 30](https://user-images.githubusercontent.com/62876614/81180779-c83f6980-8fab-11ea-89f2-a82e2ef4d80a.png)
![Screenshot 2020-05-06 at 15 10 41](https://user-images.githubusercontent.com/62876614/81180799-d1c8d180-8fab-11ea-9c1b-55187acb4ba0.png)

