### PR TITLE
Added correct updating of longestStr to UML resizing ISSUE#8594

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4014,6 +4014,7 @@ function mousemoveevt(ev) {
                 // for locking proportions of object when resizing it
                 if(shiftIsClicked) {
                     var object;
+                    obejct.minWidth = ctx.measureText(longestStr).width + 15
                     // the movement change we wan't to make
                     var change = ((currentMouseCoordinateX - sel.point.x) + (currentMouseCoordinateY - sel.point.y)) / 2;
                     // find the object that has the point we want to move

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -349,7 +349,23 @@ function Symbol(kindOfSymbol) {
             this.minHeight = attrHeight + opHeight;
             
             //Finding the longest string
-            var longestStr = this.name;
+            var longestStr = "";
+            //Check if any attribute is the longest
+            for (var i = 0; i < this.attributes.length; i++) {
+                if (this.attributes[i].text.length > longestStr.length) {
+                    longestStr = this.attributes[i].text;
+                }
+            }
+            //check if any operation is the longest
+            for (var i = 0; i < this.operations.length; i++) {
+                if (this.operations[i].text.length > longestStr.length) {
+                    longestStr = this.operations[i].text;
+                }
+            }
+            //check if name is the longest
+            if(this.name.length > longestStr.length){
+                longestStr = this.name;
+            }
 
             if(!this.UMLCustomResize) {
                 for(var i = 0; i < this.operations.length; i++) {
@@ -363,7 +379,7 @@ function Symbol(kindOfSymbol) {
             }
             ctx.font = "14px Arial";
             this.minWidth = ctx.measureText(longestStr).width + 15;
-
+            //console.log(this.minWidth);
             if(points[this.bottomRight].y-points[this.topLeft].y < this.minHeight) {
                 // If the height is less than the minimum, push out the
                 // point that the user is dragging


### PR DESCRIPTION
The longestStr variable should update correctly now, taking all string into account and not just the name of the UML class. This should prevent the class from shrinking below the length of the longest string