### PR TITLE
Resizing function in submitAppearanceFrom removed ISSUE#8556

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6014,11 +6014,6 @@ function getGroupsByTypes(typesToShow) {
 // submitAppearanceForm: Submits appearance form, saving state and closes appearance menu.
 //----------------------------------------------------------------------------------------
 function submitAppearanceForm() {
-    selected_objects.forEach(object => {
-        if(object.symbolkind === symbolKind.uml) {
-            object.resizeUMLToMinHeight();
-        }
-    });
     if(globalappearanceMenuOpen) {
         setGlobalProperties();
     }


### PR DESCRIPTION
removed the resize function from submitAppearance form to prevent custom sized UML classes from resizing when the appearance or content of it is changed. Closes#8556