### PR TITLE
Updating styling for 'x' button on MOTD banner | Fix for issue #8781

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6476,13 +6476,10 @@ textarea#filecont {
 }
 
 .motdBoxheader div:hover {
-  border: 2px;
-  border-style: solid;
-  border-color: white;
   background-color: #815e9d;
   -webkit-transition: background-color 100ms linear;
-    -ms-transition: background-color 100ms linear;
-    transition: background-color 100ms linear;
+  -ms-transition: background-color 100ms linear;
+  transition: background-color 100ms linear;
 }
 .notActive {
   background-color:white;


### PR DESCRIPTION
Updating styling for 'x' button on MOTD banner inside a course again.

It now looks like this:
<a href="https://gyazo.com/e437cb47037297867fbdc89e2ab9cb93"><img src="https://i.gyazo.com/e437cb47037297867fbdc89e2ab9cb93.gif" alt="Image from Gyazo" width="88"/></a>

Which matches the 'home' page MOTD button that looks like this:
<a href="https://gyazo.com/ef9eafeb781d04685067517ce06706f8"><img src="https://i.gyazo.com/ef9eafeb781d04685067517ce06706f8.gif" alt="Image from Gyazo" width="128"/></a>