### PR TITLE
Added userid to showDugga and codeviewer page load logging - G1-2020-W20-ISSUE#8882

### DIFF
--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -374,7 +374,7 @@ Testing Link:
 		<!-- Template Choosing Box -->
 		<?php
 			// Adding page logging
-			logExampleLoadEvent($courseID, $exampleid, EventTypes::pageLoad);
+			logExampleLoadEvent($courseID, $userid, $exampleid, EventTypes::pageLoad);
 
 			include '../Shared/loginbox.php';
 		?>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -52,7 +52,7 @@
 	}
 
 
-	logDuggaLoadEvent($cid, $vers, $quizid, EventTypes::pageLoad);
+	logDuggaLoadEvent($cid, $userid, $vers, $quizid, EventTypes::pageLoad);
 
 if($cid != "UNK") $_SESSION['courseid'] = $cid;
 	$hr=false;

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -168,6 +168,7 @@ $sql = '
 		id INTEGER PRIMARY KEY,
 		type INTEGER,
 		courseid INTEGER,
+		uid INTEGER(10),
 		exampleid INTEGER,
 		timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
@@ -175,6 +176,7 @@ $sql = '
 		id INTEGER PRIMARY KEY,
 		type INTEGER,
 		cid INTEGER,
+		uid INTEGER(10),
 		vers INTEGER,
 		quizid INTEGER,
 		timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -279,9 +281,10 @@ function logMousemoveEvent($page, $mouseX, $mouseY) {
 // Log page load for examples. - Creates a new entry to the exampleLoadLogEntries when a user opens a new example.
 //------------------------------------------------------------------------------------------------
 
-function logExampleLoadEvent($courseid, $exampleid, $type) {
-	$query = $GLOBALS['log_db']->prepare('INSERT INTO exampleLoadLogEntries (courseid, exampleid, type) VALUES (:courseid, :exampleid, :type)');
+function logExampleLoadEvent($courseid, $uid, $exampleid, $type) {
+	$query = $GLOBALS['log_db']->prepare('INSERT INTO exampleLoadLogEntries (courseid, uid, exampleid, type) VALUES (:courseid, :uid, :exampleid, :type)');
 	$query->bindParam(':courseid', $courseid);
+	$query->bindParam(':uid', $uid);
 	$query->bindParam(':exampleid', $exampleid);
 	$query->bindParam(':type', $type);
 	$query->execute();
@@ -291,9 +294,10 @@ function logExampleLoadEvent($courseid, $exampleid, $type) {
 // Log page load for examples. - Creates a new entry to the duggaLoadLogEntries when a user opens a new dugga.
 //------------------------------------------------------------------------------------------------
 
-function logDuggaLoadEvent($cid, $vers, $quizid, $type) {
-	$query = $GLOBALS['log_db']->prepare('INSERT INTO duggaLoadLogEntries (cid, vers, quizid, type) VALUES (:cid, :vers, :quizid, :type)');
+function logDuggaLoadEvent($cid, $uid, $vers, $quizid, $type) {
+	$query = $GLOBALS['log_db']->prepare('INSERT INTO duggaLoadLogEntries (cid, uid, vers, quizid, type) VALUES (:cid, :uid, :vers, :quizid, :type)');
 	$query->bindParam(':cid', $cid);
+	$query->bindParam(':uid', $uid);
 	$query->bindParam(':vers', $vers);
 	$query->bindParam(':quizid', $quizid);
 	$query->bindParam(':type', $type);


### PR DESCRIPTION
Added userid to page load logging for showDugga and codeviewer pages. This required the attribute userid to be added to table creation along with modifications to the logging function to also include the userid when inserting log data into the db. 

Before:
![Screenshot 2020-05-05 at 13 45 08](https://user-images.githubusercontent.com/62876614/81189565-02623880-8fb7-11ea-968f-70447bef95e3.png)
![Screenshot 2020-05-05 at 13 45 16](https://user-images.githubusercontent.com/62876614/81189577-05f5bf80-8fb7-11ea-8c30-678e80c64afa.png)

After:
![Screenshot 2020-05-06 at 16 24 08](https://user-images.githubusercontent.com/62876614/81188779-10638980-8fb6-11ea-9e1a-e846fc94c6b7.png)
![Screenshot 2020-05-06 at 16 24 14](https://user-images.githubusercontent.com/62876614/81188796-16f20100-8fb6-11ea-95fe-46ca9794728c.png)


How to test:
Download https://sqlitebrowser.org/dl/

Choose open database
![Screenshot 2020-04-17 at 12 08 08](https://user-images.githubusercontent.com/62876614/79558244-23182c00-80a4-11ea-87f3-2cd1147def6c.png)

Open the db file located in the log dir
![Screenshot 2020-04-17 at 12 07 14](https://user-images.githubusercontent.com/62876614/79558338-417e2780-80a4-11ea-9a02-7524b8e0ad53.png)
![Screenshot 2020-04-17 at 12 07 25](https://user-images.githubusercontent.com/62876614/79558345-4511ae80-80a4-11ea-9746-817755b62e7e.png)

inspect the tables previously mention, these will lack userid. Then remove the log dir located in htcdos, now navigate to a codeviewer or a dugga. Reopen the db file. The tables will now include the userid. 