### PR TITLE
Canvas element in Transformationsduggas should now scale properly on both Chrome and Firefox

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -602,6 +602,11 @@ p {
   #dugga4Container #toolbox{
     margin: 15px 0;
   }
+  
+  #dugga4Container canvas{
+    min-width: 75%;
+    height: auto;
+  }
 }
 
 /* Instruction and submission of dugga */


### PR DESCRIPTION
Solves #8922.

The canvas element now scales properly for smaller screen sizes on both Chrome and Firefox.

Screenshot is from Firefox Dev Tools. See linked issue for a "before" picture.

The Save/Reset buttons are not properly positioned. This should be handled/solved separately.

Please test this using at least both Chrome and Firefox (and resizing the window/using dev tool mobile tool functionality), but feel free to try it in other browers as well.

![image](https://user-images.githubusercontent.com/49141758/81262809-ce325a80-903e-11ea-9bbc-ecbb33c80b1c.png)
