### PR TITLE
fix issue#8903 fix flash and mutation in FreeDraw

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5372,6 +5372,9 @@ function movemode(e, t) {
     var buttonStyle = document.getElementById("moveButton");
     canvas.removeEventListener("dblclick", doubleclick, false);
     if (button == "unpressed") {
+        if (uimode == "CreateFigure") {
+            cancelFreeDraw();
+        }
         buttonStyle.style.visibility = 'visible';
 		buttonStyle.className = "pressed";
         canvas.style.cursor = "all-scroll";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5372,7 +5372,7 @@ function movemode(e, t) {
     var buttonStyle = document.getElementById("moveButton");
     canvas.removeEventListener("dblclick", doubleclick, false);
     if (button == "unpressed") {
-        if (uimode == "CreateFigure") {
+        if (uimode == "CreateFigure" && numberOfPointsInFigure > 0) {
             cancelFreeDraw();
         }
         buttonStyle.style.visibility = 'visible';

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4354,7 +4354,7 @@ function mousedownevt(ev) {
         handleSelect();
     } else {
         md = mouseState.boxSelectOrCreateMode; // Box select or Create mode.
-        if(ev.button == rightMouseClick && figureType == "Free"){
+        if(ev.button == rightMouseClick && figureType == "Free" && uimode != "normal"){
             endFreeDraw();
         }
         if (uimode != "MoveAround" && !ctrlIsClicked) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4354,9 +4354,6 @@ function mousedownevt(ev) {
         handleSelect();
     } else {
         md = mouseState.boxSelectOrCreateMode; // Box select or Create mode.
-        if(ev.button == rightMouseClick && figureType == "Free" && uimode != "normal"){
-            endFreeDraw();
-        }
         if (uimode != "MoveAround" && !ctrlIsClicked) {
             for (var i = 0; i < selected_objects.length; i++) {
                 selected_objects[i].targeted = false;
@@ -4448,8 +4445,11 @@ function mouseupevt(ev) {
 
         if(figureType == "Free") {
             figureFreeDraw();
+            if(ev.button == rightMouseClick && uimode != "normal"){
+                endFreeDraw();
+            }
             return;
-        }
+        }      
     }
     // Code for creating a new class
     if (md == mouseState.boxSelectOrCreateMode && (uimode == "CreateClass" || uimode == "CreateERAttr" || uimode == "CreateEREntity" || uimode == "CreateERRelation")) {


### PR DESCRIPTION
The flash "Please draw more lines!" should not appear anymore while in normal mode. It should also be impossible to create a mutation when moving the camera in mid-drawing. 

**Test this:** Select Draw Free mode and move around the canvas by holding down rightmouse button and dragging the mouse. Draw free mode should automatically change to normal mode. Now try to rightclick on the canvas. If the flash does not appear on top of the screen the issue is fixed. 

**Test this:** Select Draw Free mode and start to draw two different points. Instead of drawing a third point try to move around the canvas by holding down rightmouse button and dragging the mouse. The drawing should be deleted instead of creating a mutation. 

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%238903/DuggaSys/diagram.php

Before: 

![81175114-43505200-8fa3-11ea-958d-eaa783c407b9](https://user-images.githubusercontent.com/49142301/81275739-5ff79300-9052-11ea-8011-6ff7e97681b6.gif)

After:

![876f3deb9eb803ebea0c5e687282ef12](https://user-images.githubusercontent.com/49142301/81275757-65ed7400-9052-11ea-88c6-7f09b89bd291.gif)

Before:

![81183217-2ae63480-8faf-11ea-8369-fc42ce31d250](https://user-images.githubusercontent.com/49142301/81275792-7271cc80-9052-11ea-98e6-76dac05e56f1.gif)

After:

![c32d044d5b05484aaa5245b51fd93cf1](https://user-images.githubusercontent.com/49142301/81275822-7bfb3480-9052-11ea-900e-3535cfe2b6ac.gif)

