### PR TITLE
Max login fails changed from 10 to 3 #9006

### DIFF
--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -231,7 +231,7 @@ function passwordGuessing(){
 		FROM userLogEntries
 		WHERE eventType = '.EventTypes::LoginFail.'
 		GROUP BY uid, remoteAddress
-		HAVING tries > 10;
+		HAVING tries >= 3;
 	')->fetchAll(PDO::FETCH_ASSOC);
 	echo json_encode($result);
 }

--- a/Shared/loginlogout.php
+++ b/Shared/loginlogout.php
@@ -24,7 +24,7 @@ if($opt=="REFRESH"){
 	$password=getOP('password');
   
     // Login barrier
-    $maxLoginTries = 10;
+    $maxLoginTries = 3;
     $IP = getIP();
     $timeInterval = 10; // in minutes
 


### PR DESCRIPTION
Having logging for 10 fails seems a bit to much, reduced to 3 fails to make it easier to spot bruteforce.