### PR TITLE
fix issue#8971 Primary and Partial key lines consistent with text size and zoom

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1565,9 +1565,23 @@ function Symbol(kindOfSymbol) {
             ctx.stroke();
             this.properties['key_type'] == 'Partial key' ? ctx.setLineDash([5, 4]) : ctx.setLineDash([]);
             var linelength = ctx.measureText(this.name).width;
+            var linePosY = 0;
+            switch (this.properties['sizeOftext']) {
+                case 'Tiny':
+                    linePosY = 10;
+                     break;
+                case 'Small':
+                    linePosY = 12;
+                    break;
+                case 'Medium':
+                    linePosY = 15;
+                    break;
+                case 'Large':
+                    linePosY = 22; 
+            }
             ctx.beginPath(1);
-            ctx.moveTo(x1 + ((x2 - x1) * 0.5) - (linelength * 0.5), (y1 + ((y2 - y1) * 0.5)) + 10);
-            ctx.lineTo(x1 + ((x2 - x1) * 0.5) + (linelength * 0.5), (y1 + ((y2 - y1) * 0.5)) + 10);
+            ctx.moveTo(x1 + ((x2 - x1) * 0.5) - (linelength * 0.5), (y1 + ((y2 - y1) * 0.5)) + linePosY);
+            ctx.lineTo(x1 + ((x2 - x1) * 0.5) + (linelength * 0.5), (y1 + ((y2 - y1) * 0.5)) + linePosY);
             ctx.strokeStyle = this.properties['strokeColor'];
 
         }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1580,8 +1580,8 @@ function Symbol(kindOfSymbol) {
                     linePosY = 22; 
             }
             ctx.beginPath(1);
-            ctx.moveTo(x1 + ((x2 - x1) * 0.5) - (linelength * 0.5), (y1 + ((y2 - y1) * 0.5)) + linePosY);
-            ctx.lineTo(x1 + ((x2 - x1) * 0.5) + (linelength * 0.5), (y1 + ((y2 - y1) * 0.5)) + linePosY);
+            ctx.moveTo(x1 + ((x2 - x1) * 0.5) - (linelength * 0.5), (y1 + ((y2 - y1) * 0.5)) + linePosY * zoomValue);
+            ctx.lineTo(x1 + ((x2 - x1) * 0.5) + (linelength * 0.5), (y1 + ((y2 - y1) * 0.5)) + linePosY * zoomValue);
             ctx.strokeStyle = this.properties['strokeColor'];
 
         }


### PR DESCRIPTION
The primary and partial key line position for attributes should now be correctly placed when changing text size or when zooming the canvas. 

**Test this:** Create an attribute and enter its appearance menu. Select Primary key as Attribute type. Switch between all the different text sizes and make sure the line under the text is never positioned on the text. Also try to zoom in and out and make sure the line doesn't change position. Try the same with  Partial key as Attribute Type. 

**Link to test:**  http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%238971/DuggaSys/diagram.php

Before:

![967f6ba94c29fde6ce3a29a3679cc714](https://user-images.githubusercontent.com/49142301/81390956-9d285780-911c-11ea-8fc0-1d51854e7a2d.gif)

After:

![691ed987a415770f82db1cf48403b759](https://user-images.githubusercontent.com/49142301/81390965-a1ed0b80-911c-11ea-8c8e-a387f6e5d869.gif)

