### PR TITLE
Added user information to analytic - G1-2020-W20-ISSUE#8850

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -451,8 +451,7 @@ function loadPageInformation() {
        
    
     function updatePageHitInformation(page){
-        loadAnalytics(page + "Information", function(data) {
-            console.log(page);
+        loadAnalytics(page + "Percentage", function(data) {
             var tableData = [["Page", "Hits"]];
             for (var i = 0; i < data.length; i++) {
                 tableData.push([
@@ -469,7 +468,6 @@ function loadPageInformation() {
     }
  
     function updatePieChartInformation(page, tableData){
-        console.log(page + "Percentage");
         loadAnalytics(page + "Percentage", function(data) {
  
             var tablePercentage = [["Courseid", "Percentage"]];
@@ -514,6 +512,223 @@ function loadPageInformation() {
     }
  
     updateState();
+}
+
+function loadUserInformation(){
+    resetAnalyticsChart();
+    $('#analytic-info').empty();
+	$('#analytic-info').append("<p>User information.</p>");
+
+	var firstLoad = true;
+	
+	var selectPage = $("<select></select>")
+        .append('<option value="sectioned" selected>sectioned</option>')
+		.append('<option value="courseed">courseed</option>')
+		.append('<option value="showDugga" selected>showDugga</option>')
+		.append('<option value="codeviewer">codeviewer</option>')
+		.append('<option value="events">events</option>')
+        .appendTo($('#analytic-info'));
+ 
+ 
+    function updateSectionedInformation(){
+        loadAnalytics("sectionedInformation", function(data) {
+            var users = {};
+            $.each(data, function(i, row) {
+				var user = row.username;
+				var pageParts;
+				var pageLoad;
+				var cid;
+				var vers;
+
+				//Retrives the page 
+				if(row.refer.includes("/DuggaSys/")){
+					pageParts = row.refer.split("/DuggaSys/");
+					pageLoad = pageParts[1];
+
+					if(pageLoad.includes("?")){
+						pageParts = pageParts[1].split("?");
+						pageLoad = pageParts[0];
+					}
+				}
+
+				//Retrives the coursid
+				if(row.refer.includes("courseid=")){
+					pageParts = row.refer.split("courseid=");
+					pageParts = pageParts[1].split("&");
+					cid = pageParts[0];
+				}
+
+				//Retrives the course version
+				if(row.refer.includes("coursevers=")){
+					pageParts = row.refer.split("coursevers=");
+					vers = pageParts[1];
+
+					if(vers.includes("&")){
+						pageParts = pageParts[1].split("&");
+						vers = pageParts[0];
+					}
+				}
+
+                if (!users.hasOwnProperty(user)) {
+                    users[user] = [["Userid", "Username", "Page", "Courseid", "Course Version", "Timestamp"]];
+                }
+                users[user].push([
+					row.uid,
+					row.username,
+					pageLoad,
+					cid,
+					vers,
+                    row.timestamp
+                ]);
+            });
+            updateState(users);
+        });
+	}
+	
+	function updateCourseedInformation(){
+        loadAnalytics("courseedInformation", function(data) {
+			var users = {};
+            $.each(data, function(i, row) {
+				var user = row.username;
+				var pageParts;
+				var pageLoad;
+
+				//Retrives the page 
+				if(row.refer.includes("/DuggaSys/")){
+					pageParts = row.refer.split("/DuggaSys/");
+					pageLoad = pageParts[1];
+
+					if(pageLoad.includes("?")){
+						pageParts = pageParts[1].split("?");
+						pageLoad = pageParts[0];
+					}
+				}
+
+                if (!users.hasOwnProperty(user)) {
+                    users[user] = [["Userid", "Username", "Event", "Timestamp"]];
+                }
+                users[user].push([
+					row.uid,
+					row.username,
+                    pageLoad,
+                    row.timestamp
+				]);
+            });
+            updateState(users);
+        });
+    }
+ 
+    function updateCodeviewerInformation(){
+		var users = {};
+        loadAnalytics("codeviewerInformation", function(data) {
+            $.each(data, function(i, row) {
+                var user = row.username;
+               
+                if (!users.hasOwnProperty(user)) {
+                    users[user] = [["Userid", "Username", "Page", "Courseid", "Exampleid", "Timestamp"]];
+                }
+                users[user].push([
+					row.uid,
+					row.username,
+					"codeviewer.php",
+					row.cid,
+					row.exampleid,
+                    row.timestamp
+                ]);
+            });
+            updateState(users);
+        });
+	} 
+	
+
+    function updateDuggaInformation(){
+		var users = {};
+        loadAnalytics("duggaInformation", function(data) {
+            $.each(data, function(i, row) {
+                var user = row.username;
+               
+                if (!users.hasOwnProperty(user)) {
+                    users[user] = [["Userid", "Username", "Page", "Courseid", "Duggaid", "Timestamp"]];
+                }
+                users[user].push([
+					row.uid,
+					row.username,
+					"showDugga.php",
+					row.cid,
+					row.quizid,
+                    row.timestamp
+                ]);
+            });
+            updateState(users);
+        });
+    } 
+ 
+    function updateUserLogInformation(users){
+		var users = {};
+        loadAnalytics("userLogInformation", function(data) {
+            $.each(data, function(i, row) {
+                var user = row.username;
+               
+                if (!users.hasOwnProperty(user)) {
+                    users[user] = [["Userid", "Username", "EventType", "Description", "Timestamp"]];
+                }
+                users[user].push([
+					row.uid,
+					row.username,
+					row.eventType,
+					row.description,
+                    row.timestamp
+                ]);
+            });
+            updateState(users);
+        });
+    } 
+   
+    function updateState(users){
+        $('#analytic-info > select.file-select').remove();
+        var userSelect = $('<select class="file-select"></select>');
+        for (var user in users) {
+            if (users.hasOwnProperty(user)) {
+                userSelect.append('<option value="' + user + '">' + user + '</option>')
+            }
+        }
+        userSelect.change(function() {
+			deleteTable();
+			$('#analytic-info').append(selectPage);
+            $('#analytic-info').append(renderTable(users[$(this).val()]));
+        });
+        $('#analytic-info').append(userSelect);
+		userSelect.change();
+		pageSelect();
+	}
+	
+	function pageSelect(){
+		if(firstLoad === true){
+			updateSectionedInformation();
+			firstLoad = false;
+		} 
+        selectPage.change(function(){
+            switch(selectPage.val()){
+                case "sectioned":
+                    updateSectionedInformation();
+                    break;
+                case "courseed":
+                    updateCourseedInformation();
+					break;
+				case "showDugga":
+					updateDuggaInformation();
+					break;
+				case "codeviewer":
+					updateCodeviewerInformation();
+					break;
+				case "events":
+					updateUserLogInformation();
+					break;
+            }
+        });
+    }
+ 
+    pageSelect();
 }
 
 //------------------------------------------------------------------------------------------------

--- a/DuggaSys/analytic.php
+++ b/DuggaSys/analytic.php
@@ -71,6 +71,7 @@ setcookie("sessionEndTimeLogOut", "expireC", time() + 3600, "/"); // Ends sessio
 			<input class="submit-button" style="float:left" type="button" value="Service crashes" onclick="loadServiceCrashes()">
 			<input class="submit-button" style="float:left" type="button" value="File information" onclick="loadFileInformation()">
 			<input class="submit-button" style="float:left" type="button" value="Page information" onclick="loadPageInformation()">
+			<input class="submit-button" style="float:left" type="button" value="User information" onclick="loadUserInformation()">
 		</div>
 		<div id="analytic-info" style="clear: both; padding: 15px;"></div>
 		<div id="canvas-area" style="height: 300px;">

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -56,7 +56,16 @@ if (isset($_SESSION['uid']) && checklogin() && isSuperUser($_SESSION['uid'])) {
                 break;
             case 'codeviewerPercentage':
                 codeviewerPercentage();
-                break;
+				break;
+			case 'sectionedInformation':
+				sectionedInformation();
+				break;
+			case 'courseedInformation':
+				courseedInformation();
+				break;
+			case 'userLogInformation':
+				userLogInformation();
+				break;
 		}
 	} else {
 		echo 'N/A';
@@ -343,8 +352,11 @@ function serviceCrashes(){
 //------------------------------------------------------------------------------------------------
 function duggaInformation(){
     $result = $GLOBALS['log_db']->query('
-        SELECT
-            COUNT(*) AS pageLoads,
+		SELECT
+			cid,
+			uid,
+			username,
+			quizid,
             timestamp AS timestamp
         FROM duggaLoadLogEntries
         ORDER BY timestamp;
@@ -358,8 +370,11 @@ function duggaInformation(){
  
 function codeviewerInformation(){
     $result = $GLOBALS['log_db']->query('
-        SELECT
-            COUNT(*) AS pageLoads,
+		SELECT
+			courseid AS cid,
+			uid,
+			username,
+			exampleid,
             timestamp AS timestamp
         FROM exampleLoadLogEntries
         ORDER BY timestamp;
@@ -374,7 +389,8 @@ function codeviewerInformation(){
 function duggaPercentage(){
     $result = $GLOBALS['log_db']->query('
         SELECT
-            cid AS courseid,
+			cid AS courseid,
+			COUNT(*) AS pageLoads,
             COUNT(*) * 100.0 / (SELECT COUNT(*) FROM duggaLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
         FROM duggaLoadLogEntries
         GROUP BY courseid
@@ -390,11 +406,66 @@ function duggaPercentage(){
 function codeviewerPercentage(){
     $result = $GLOBALS['log_db']->query('
         SELECT
-            courseid,
+			courseid,
+			COUNT(*) AS pageLoads,
             COUNT(*) * 100.0 / (SELECT COUNT(*) FROM exampleLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
         FROM exampleLoadLogEntries
         GROUP BY courseid
         ORDER BY percentage DESC;
     ')->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($result);
+}
+
+//------------------------------------------------------------------------------------------------
+// Retrieves sectioned log information      
+//------------------------------------------------------------------------------------------------
+ 
+function sectionedInformation(){
+    $result = $GLOBALS['log_db']->query('
+       SELECT
+		   userid AS uid,
+		   username,
+		   refer,
+		   timestamp 
+	   FROM userHistory
+	   WHERE refer LIKE "%sectioned%"
+	   ORDER BY timestamp;
+   ')->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($result);
+}
+
+//------------------------------------------------------------------------------------------------
+// Retrieves courseed log information      
+//------------------------------------------------------------------------------------------------
+ 
+function courseedInformation(){
+    $result = $GLOBALS['log_db']->query('
+       SELECT
+		   userid AS uid,
+		   username,
+		   refer,
+		   timestamp 
+	   FROM userHistory
+	   WHERE refer LIKE "%courseed%"
+	   ORDER BY timestamp;
+   ')->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($result);
+}
+
+//------------------------------------------------------------------------------------------------
+// Retrieves userLog information      
+//------------------------------------------------------------------------------------------------
+ 
+function userLogInformation(){
+    $result = $GLOBALS['log_db']->query('
+       SELECT
+		   uid,
+		   username,
+		   eventType,
+		   description,
+		   timestamp 
+	   FROM userLogEntries
+	   ORDER BY timestamp;
+   ')->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode($result);
 }

--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -374,7 +374,7 @@ Testing Link:
 		<!-- Template Choosing Box -->
 		<?php
 			// Adding page logging
-			logExampleLoadEvent($courseID, $userid, $exampleid, EventTypes::pageLoad);
+			logExampleLoadEvent($courseID, $userid, $username, $exampleid, EventTypes::pageLoad);
 
 			include '../Shared/loginbox.php';
 		?>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -51,8 +51,18 @@
 		$userid="UNK";
 	}
 
+	// Gets username based on uid, USED FOR LOGGING
+	$query = $pdo->prepare( "SELECT username FROM user WHERE uid = :uid");
+	$query->bindParam(':uid', $userid);
+	$query-> execute();
 
-	logDuggaLoadEvent($cid, $userid, $vers, $quizid, EventTypes::pageLoad);
+	// This while is only performed if userid was set through _SESSION['uid'] check above, a guest will not have it's username set, USED FOR LOGGING
+	while ($row = $query->fetch(PDO::FETCH_ASSOC)){
+		$username = $row['username'];
+	}
+
+
+	logDuggaLoadEvent($cid, $userid, $username, $vers, $quizid, EventTypes::pageLoad);
 
 if($cid != "UNK") $_SESSION['courseid'] = $cid;
 	$hr=false;

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -154,6 +154,7 @@ $sql = '
 		type INTEGER,
 		courseid INTEGER,
 		uid INTEGER(10),
+		username VARCHAR(15),
 		exampleid INTEGER,
 		timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
@@ -162,6 +163,7 @@ $sql = '
 		type INTEGER,
 		cid INTEGER,
 		uid INTEGER(10),
+		username VARCHAR(15),
 		vers INTEGER,
 		quizid INTEGER,
 		timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -293,10 +295,11 @@ function logServiceEvent($uuid, $eventType, $service, $userid, $info, $timestamp
 // Log page load for examples. - Creates a new entry to the exampleLoadLogEntries when a user opens a new example.
 //------------------------------------------------------------------------------------------------
 
-function logExampleLoadEvent($courseid, $uid, $exampleid, $type) {
-	$query = $GLOBALS['log_db']->prepare('INSERT INTO exampleLoadLogEntries (courseid, uid, exampleid, type) VALUES (:courseid, :uid, :exampleid, :type)');
+function logExampleLoadEvent($courseid, $uid, $username, $exampleid, $type) {
+	$query = $GLOBALS['log_db']->prepare('INSERT INTO exampleLoadLogEntries (courseid, uid, username, exampleid, type) VALUES (:courseid, :uid, :username, :exampleid, :type)');
 	$query->bindParam(':courseid', $courseid);
 	$query->bindParam(':uid', $uid);
+	$query->bindParam(':username', $username);
 	$query->bindParam(':exampleid', $exampleid);
 	$query->bindParam(':type', $type);
 	$query->execute();
@@ -306,10 +309,11 @@ function logExampleLoadEvent($courseid, $uid, $exampleid, $type) {
 // Log page load for examples. - Creates a new entry to the duggaLoadLogEntries when a user opens a new dugga.
 //------------------------------------------------------------------------------------------------
 
-function logDuggaLoadEvent($cid, $uid, $vers, $quizid, $type) {
-	$query = $GLOBALS['log_db']->prepare('INSERT INTO duggaLoadLogEntries (cid, uid, vers, quizid, type) VALUES (:cid, :uid, :vers, :quizid, :type)');
+function logDuggaLoadEvent($cid, $uid, $username, $vers, $quizid, $type) {
+	$query = $GLOBALS['log_db']->prepare('INSERT INTO duggaLoadLogEntries (cid, uid, username, vers, quizid, type) VALUES (:cid, :uid, :username, :vers, :quizid, :type)');
 	$query->bindParam(':cid', $cid);
 	$query->bindParam(':uid', $uid);
+	$query->bindParam(':username', $username);
 	$query->bindParam(':vers', $vers);
 	$query->bindParam(':quizid', $quizid);
 	$query->bindParam(':type', $type);


### PR DESCRIPTION
Added user information tab to analytic which present information of selected users. The information includes page loads for various parts of lenaSyS and users events. 

![Screenshot 2020-05-08 at 14 21 15](https://user-images.githubusercontent.com/62876614/81405202-7cb9c680-9137-11ea-93c5-5e1d0ef4e5f1.png)

___ 
How to test:
Download https://sqlitebrowser.org/dl/

Choose open database
![Screenshot 2020-04-17 at 12 08 08](https://user-images.githubusercontent.com/62876614/79558244-23182c00-80a4-11ea-87f3-2cd1147def6c.png)

Open the db file located in the log dir
![Screenshot 2020-04-17 at 12 07 14](https://user-images.githubusercontent.com/62876614/79558338-417e2780-80a4-11ea-9a02-7524b8e0ad53.png)
![Screenshot 2020-04-17 at 12 07 25](https://user-images.githubusercontent.com/62876614/79558345-4511ae80-80a4-11ea-9746-817755b62e7e.png)

Before testing remove the log dir located in htcdocs, the tables have been modified so a fresh db is required. 