### PR TITLE
Recursive lines can now be hovered

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -952,6 +952,11 @@ function Symbol(kindOfSymbol) {
                 }
             }
         }
+        
+        //handles recursive lines
+        if(this.isRecursiveLine){
+            return this.entityhover(mx, my);
+        }
 
         //If nothing applies, return false
         return false;


### PR DESCRIPTION
Fixes #9048

Recursive UML-lines should now also be possible to hover.

For tester:
http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239048/DuggaSys/diagram.php
-Simply create a recursive UML-line and try to hover it.