### PR TITLE
G2 2020 w20 #9070 access dropdowns should now look/behave more consistently

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2909,7 +2909,9 @@ span.arrow {
   display: none;
   position: absolute;
   background-color: #f1f1f1;
-  min-width: 160px;
+  left:0;
+  top: 100%;
+  width: 100%;
   overflow: auto;
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
   z-index: 1;


### PR DESCRIPTION
Solves #9070.

Changed some styling to Access Editor dropdowns. 

They now open at the bottom of the clicked cell and spans the whole width of the cell, similar to the group dropdowns. This ensures the cell is not covered by the dropdown like what would sometimes happen before. Since there is no way to see what option is selected in the dropdown I feel like this is a good thing, although I think it would be good to also show what value is selected in the dropdown itself. But that should be it's own, separate issue.