### PR TITLE
Solves issue#9072, error in console when generating example diagrams

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -502,7 +502,6 @@ function init() {
 
 function generateERExampleCode() {
     var fileContent = $.get("exampleER.txt", data => LoadImport(data));
-    LoadImport(fileContent);
 }
 
 //--------------------------------------------------------------------
@@ -511,7 +510,6 @@ function generateERExampleCode() {
 
 function generateUMLExampleCode() {
     var fileContent = $.get("exampleUML.txt", data => LoadImport(data));
-    LoadImport(fileContent);
 }
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
The issue was solved by removing two uneccessary lines of code that made the diagrams load twice, causing the error. The error should no longer appear in the console when generating example diagrams.
Tester: go to help-generate example ER/UML-diagram and check the console for errors. 