### PR TITLE
Fix for #9066

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -989,7 +989,12 @@ function copySymbol(symbol) {
                     const connectedAttribute = symbol.getConnectedObjects().find(object => object.symbolkind === symbolKind.erAttribute);
                     if(typeof connectedAttribute !== "undefined") {
                         const isAttributeSelected = cloneTempArray.some(object => Object.is(connectedAttribute, object));
+                        //If one of the connected objects is a attribute, create no second point
                         if(isAttributeSelected && connectedAttribute.connectorTop.find(object => object.from === symbol[key])) {
+                            newPointIndex = null;
+                        }
+                        //If both connected objects are attributes, create no points
+                        else if(symbol.getConnectedObjects()[0].symbolkind == symbolKind.erAttribute && symbol.getConnectedObjects()[1].symbolkind == symbolKind.erAttribute){
                             newPointIndex = null;
                         }
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -987,6 +987,7 @@ function copySymbol(symbol) {
                 //If the attribute will not be copied the point should be created
                 if(symbol.symbolkind === symbolKind.line) {
                     const connectedAttribute = symbol.getConnectedObjects().find(object => object.symbolkind === symbolKind.erAttribute);
+                    const connectedAttributes = symbol.getConnectedObjects().filter(object => object.symbolkind === symbolKind.erAttribute);
                     if(typeof connectedAttribute !== "undefined") {
                         const isAttributeSelected = cloneTempArray.some(object => Object.is(connectedAttribute, object));
                         //If one of the connected objects is a attribute, create no second point
@@ -994,8 +995,11 @@ function copySymbol(symbol) {
                             newPointIndex = null;
                         }
                         //If both connected objects are attributes, create no points
-                        else if(symbol.getConnectedObjects()[0].symbolkind == symbolKind.erAttribute && symbol.getConnectedObjects()[1].symbolkind == symbolKind.erAttribute){
-                            newPointIndex = null;
+                        else if(connectedAttributes.length > 1 && symbol.getConnectedObjects()[0].symbolkind == symbolKind.erAttribute && symbol.getConnectedObjects()[1].symbolkind == symbolKind.erAttribute){
+                            //Both attributes must be selected
+                            if(selected_objects.includes(connectedAttributes[0]) && selected_objects.includes(connectedAttributes[1])){
+                                newPointIndex = null;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #9066 

Special case has been created for when both objects connected to a line is attributes. When this is the case we do not create new points. See linked issue for better detail of what is being solved here.

Test by connecting two attributes with a line, then copying and pasting them. May also be worth connecting other combinations of objects to make sure nothing else broke.
http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239066/DuggaSys/diagram.php