### PR TITLE
G4 2020 W20 fixed ISSUE#7419

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -85,6 +85,7 @@
   var owner = <?php echo json_encode($username); ?>;
   var filePath = <?php echo json_encode($putFileHere); ?>;
   var operatingSystem = <?php echo json_encode(PHP_OS_FAMILY); ?>;
+  var isPermissionsSat = <?php echo json_encode($isPermissionsSat); ?>;
   var modalDialogText = document.getElementById('dialogText'); // Get the dialogText of the modal
   var modal = document.getElementById('warning'); // Get the modal
 
@@ -100,7 +101,7 @@
     </div>`;
   }
 
-  if (operatingSystem != "Windows"){
+  if (operatingSystem != "Windows" && isPermissionsSat != true){
     modal.style.display = "block";
   }
 </script>

--- a/install/install.php
+++ b/install/install.php
@@ -69,7 +69,8 @@
   //---------------------------------------------------------------------------------------------------
   $putFileHere = cdirname(getcwd(), 1); // Path to lenasys
   $operatingSystem = PHP_OS_FAMILY;
-  $username = getUsername($putFileHere)
+  $username = getUsername($putFileHere);
+  $isPermissionsSat = isPermissionsSat($putFileHere);
 ?>
 
 <!-- Modal used for the permission-popup -->

--- a/install/install.php
+++ b/install/install.php
@@ -65,6 +65,24 @@
   }
 
   //---------------------------------------------------------------------------------------------------
+  // Function that checks if permissions (chown/chgrp) are sat.
+  //---------------------------------------------------------------------------------------------------
+  function isPermissionsSat($crntFilePath){
+    $permissionsSat = false;
+    if(!mkdir("{$crntFilePath}/testPermissionsForInstallationToStartDir", 0060)) {
+      $permissionsSat = false;
+    }
+    else {
+      if (!rmdir("{$crntFilePath}/testPermissionsForInstallationToStartDir")) {
+        $permissionsSat = false;
+      } else {
+        $permissionsSat = true;
+      }
+    }
+    return $permissionsSat;
+  }
+
+  //---------------------------------------------------------------------------------------------------
   // systemVariables: Sets the system variables, path, operatingSystem and username (these are used all over the code right now)
   //---------------------------------------------------------------------------------------------------
   $putFileHere = cdirname(getcwd(), 1); // Path to lenasys
@@ -418,6 +436,7 @@
       if($isPermissionsSat) {
         echo "<span id='successText' />Permissions on {$putFileHere} sat correctly.</span><br>";
       } else {
+        $errors++;
         exit ("<span id='failText' />Permissions on {$putFileHere} not sat correctly, please restart the installation.</span><br>
           <a title='Try again' href='install.php' class='returnButton'>Try again.</a>");
       }
@@ -711,26 +730,6 @@
       }
     }
     return $isAllCredentialsFilled;
-  }
-
-  //---------------------------------------------------------------------------------------------------
-  // Function that checks if permissions (chown/chgrp) are sat.
-  //---------------------------------------------------------------------------------------------------
-  function isPermissionsSat($crntFilePath){
-    $permissionsSat = false;
-    if(!mkdir("{$crntFilePath}/testPermissionsForInstallationToStartDir", 0060)) {
-      $errors++;
-      $permissionsSat = false;
-    }
-    else {
-      if (!rmdir("{$crntFilePath}/testPermissionsForInstallationToStartDir")) {
-        $errors++;
-        $permissionsSat = false;
-      } else {
-        $permissionsSat = true;
-      }
-    }
-    return $permissionsSat;
   }
 
   //---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The permissions-modal (popup at start) now only shows if permissions are not sat. 

To tester: navigate to http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%237419/install/ and open the installer. The permissions-modal should show right away. Follow the instructions (i.e: run the sudo chgrp/chown commands in putty on testserver). Then try running the installer again, now the modal shouldnt show.