### PR TITLE
Logging when a teacher mark a dugga

### DIFF
--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -459,6 +459,9 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 					}
 				}
 			}
+        // Logging for mark a dugga
+        $description=$coursename." ".$coursecode." ".$duggaid." ".$mark." ".$duggauser;
+        logUserEvent($userid, $loginname, EventTypes::MarkedDugga, $description);
 		}
 
 	if(strcmp($opt,"DUGGA")==0){

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -378,7 +378,7 @@ abstract class EventTypes {
     const DuggaFileupload = 21;
 	const DownloadAllCourseVers = 22;
 	const EditFile = 23; 
-    const SubmitDugga = 24;
+    const MarkedDugga = 24;
 }
 
 //------------------------------------------------------------------------------------------------

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -377,7 +377,8 @@ abstract class EventTypes {
     const ResetPW = 20;
     const DuggaFileupload = 21;
 	const DownloadAllCourseVers = 22;
-	const EditFile = 23;  
+	const EditFile = 23; 
+    const SubmitDugga = 24;
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A log occurs when a teacher pass(green) or fail(red) a dugga.

Logging which teacher who marked dugga and a timestamp:
![image](https://user-images.githubusercontent.com/49142935/81545896-df9aa000-9379-11ea-8f8f-892f0da9343f.png)

Logging description with corse, duggaID, mark(1=fail, 2=pass) and which user who did the dugga.
![image](https://user-images.githubusercontent.com/49142935/81546302-78312000-937a-11ea-8bda-28771b6380ce.png)
![image](https://user-images.githubusercontent.com/49142935/81546309-7b2c1080-937a-11ea-8490-ab3f043d654b.png)

Logging when a student does a submit of a dugga is already implemented with eventtype DuggaFileupload.