### PR TITLE
Initialize permissionModal to none FIXED #8987

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -122,6 +122,8 @@
 
   if (operatingSystem != "Windows" && isPermissionsSat != true){
     modal.style.display = "block";
+  } else {
+    modal.style.display = "none";
   }
 </script>
 


### PR DESCRIPTION
The enter-key functionality only works if `modal.style.display = 'none'` so now this value is set if the modal isn't shown.

For tester: checkout the branch G4-2020-W20-ISSUE#8987-2 on windows and see so you can move forward with the installer by pressing enter-key.