### PR TITLE
Now possible to add and remove points to/from freedraw objects, issue#6891

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5305,9 +5305,49 @@ function createSymbol(p1BeforeResize, p2BeforeResize){
 }
 
 function doubleclick() {
-    if (lastSelectedObject != -1 && diagram[lastSelectedObject].targeted == true) {
+    if (lastSelectedObject != -1 && diagram[lastSelectedObject].targeted == true 
+    && diagram[lastSelectedObject].figureType == "Free") {
+        let clickedSegmentId = clickedOnLine(diagram[lastSelectedObject]);
+        if (clickedSegmentId != -1) {
+            let freedrawObject = diagram[lastSelectedObject];
+            let newPoint = points.addPoint(currentMouseCoordinateX, currentMouseCoordinateY, false);
+            let clickedSegment = freedrawObject.segments[clickedSegmentId];
+            
+            freedrawObject.segments.splice(clickedSegmentId, 1);
+            freedrawObject.segments.splice(clickedSegmentId, 0, {kind:kind.path, pa:clickedSegment.pa, pb:newPoint});
+            freedrawObject.segments.splice(clickedSegmentId+1, 0, {kind:kind.path, pa:newPoint, pb:clickedSegment.pb});
+        }
+    }
+    else if (lastSelectedObject != -1 && diagram[lastSelectedObject].targeted == true) {
         loadAppearanceForm();
     }
+}
+
+function clickedOnLine(clickedObject) {
+    let clickedLine = -1;
+    
+    for (let i = 0; i < clickedObject.segments.length; i++) {
+        if (pointOnLine(currentMouseCoordinateX, currentMouseCoordinateY, clickedObject.segments[i])) {
+            clickedLine = i;
+        }
+    }
+    return clickedLine;
+}
+
+function pointOnLine(pointX, pointY, segment) {
+    let pointBetween = {x:pointX, y:pointY};
+    let pointA = {x:points[segment.pa].x, y:points[segment.pa].y};
+    let pointB = {x:points[segment.pb].x, y:points[segment.pb].y};
+
+    if (distance(pointA, pointBetween) + distance(pointB, pointBetween) 
+    <= distance(pointA, pointB) + 0.1) {
+        return true;
+    }
+
+}
+
+function distance(point1, point2) {     
+    return Math.sqrt((Math.pow((point1.x - point2.x),2) + Math.pow((point1.y - point2.y),2)));
 }
 
 function createText(posX, posY) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5323,6 +5323,9 @@ function doubleclick() {
     }
 }
 
+//--------------------------------------------------------------------
+// clickedOnLine: Checks if a line of an object is clicked, returns segment index
+//--------------------------------------------------------------------
 function clickedOnLine(clickedObject) {
     let clickedLine = -1;
     
@@ -5334,6 +5337,9 @@ function clickedOnLine(clickedObject) {
     return clickedLine;
 }
 
+//--------------------------------------------------------------------
+// pointOnLine: Checks if a point is positioned on a segment
+//--------------------------------------------------------------------
 function pointOnLine(pointX, pointY, segment) {
     let pointBetween = {x:pointX, y:pointY};
     let pointA = {x:points[segment.pa].x, y:points[segment.pa].y};
@@ -5343,9 +5349,11 @@ function pointOnLine(pointX, pointY, segment) {
     <= distance(pointA, pointB) + 0.1) {
         return true;
     }
-
 }
 
+//--------------------------------------------------------------------
+// distance: Returns distance between two points 
+//--------------------------------------------------------------------
 function distance(point1, point2) {     
     return Math.sqrt((Math.pow((point1.x - point2.x),2) + Math.pow((point1.y - point2.y),2)));
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -659,21 +659,27 @@ function resetToolButtonsPressed() {
     }
 }
 
+//--------------------------------------------------------------------
+// deleteFreedrawObject: Checks if a point of a selected freedraw object
+//                       or entire object should be removed
+//--------------------------------------------------------------------
 function deleteFreedrawObject() {
-
     let pointId = points.closestPoint(currentMouseCoordinateX, currentMouseCoordinateY).index;
     let point = diagram.closestPoint(currentMouseCoordinateX, currentMouseCoordinateY);
     
     if (typeof point.attachedSymbol != "undefined") {
-        console.log(point);
+        // A freedraw object needs to be selected
         if (point.attachedSymbol.figureType == "Free" && point.attachedSymbol.targeted) {
-            if (point.distance > 20){
+            // If a point isn't hovered, delete object
+            if (point.distance > 10 / zoomValue){
                 eraseObject(point.attachedSymbol);
-            }
-            if (point.attachedSymbol.segments.length <= 3) {
-                console.log("too few points");
                 return;
             }
+            // Freedraw objects need at least 3 points
+            if (point.attachedSymbol.segments.length <= 3) {
+                return;
+            }
+            // Remove hovered point
             else {
                 removeFreedrawPoint(point.attachedSymbol, pointId); 
             }
@@ -681,29 +687,33 @@ function deleteFreedrawObject() {
     }
 }
 
+//--------------------------------------------------------------------
+// removeFreedrawPoint: Removes a point from a freedraw object and
+//                      Reorganizes the segments
+//--------------------------------------------------------------------
 function removeFreedrawPoint(symbol , pointId) {
-    console.log(pointId);
-    let seg = {kind:kind.path, pa:-1, pb:-1};
+    let newSegment = {kind:kind.path, pa:-1, pb:-1};
     let toRemove = [];
+    // Finds the segments where the point is used
     for (let i = 0; symbol.segments.length > i; i++) {
         if (symbol.segments[i].pa == pointId) {
-            seg.pb = symbol.segments[i].pb;
+            newSegment.pb = symbol.segments[i].pb;
             toRemove.push(i);
         }
         if (symbol.segments[i].pb == pointId) {
-            seg.pa = symbol.segments[i].pa;
+            newSegment.pa = symbol.segments[i].pa;
             toRemove.push(i);
         }
     }
-    console.log(seg);
+    // Removes the segments to and from the point to remove
     symbol.segments.splice(toRemove[1], 1);
     symbol.segments.splice(toRemove[0], 1);
-    symbol.segments.splice(toRemove[0], 0, seg);
-    //points.splice(pointId, 1);
-    console.log(points);
-    console.log(symbol.segments);
-    
+    // Adds new segment between the points that were connected to removed point
+    symbol.segments.splice(toRemove[0], 0, newSegment);
 
+    // Hide removed point in center
+    points[pointId].x = 0;
+    points[pointId].y = 0;
 }
 
 //--------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -710,7 +710,7 @@ function removeFreedrawPoint(symbol , pointId) {
     symbol.segments.splice(toRemove[0], 1);
     // Adds new segment between the points that were connected to removed point
     symbol.segments.splice(toRemove[0], 0, newSegment);
-
+    symbol.targeted = false;
     // Hide removed point in center
     points[pointId].x = 0;
     points[pointId].y = 0;


### PR DESCRIPTION
It should now be possible to add and remove points to/from existing freedraw objects. 

**To add points:** Double-click on a line where the point should be added. The freedraw object needs to be selected for this to work.
**To remove points:** Select a freedraw object and hover a point and press delete. If no points are hovered the object will just be deleted. 