### PR TITLE
fix issue#9103 localStorage for Hide comment

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -491,6 +491,7 @@ function init() {
     refreshVirtualPaper();
     setPaperSizeOnRefresh();
     setIsRulersActiveOnRefresh();
+    setHideCommentOnRefresh();
     initAppearanceForm();
     setPaperSize(event, paperSize);
     updateGraphics(); 
@@ -2142,6 +2143,23 @@ function toggleComments(event) {
       	setCheckbox($(".drop-down-option:contains('Hide Comments')"), hideComment);
     }
 	updateGraphics();
+    localStorage.setItem("hideComment", hideComment);
+}
+
+//---------------------------------------------------------------
+// Stores if the comments are hidden or not in localStorage
+//---------------------------------------------------------------
+
+function setHideCommentOnRefresh() {
+    const tempHideComment = localStorage.getItem("hideComment");
+    if (tempHideComment != null) {
+        if (tempHideComment == 'true') {
+            hideComment = false;
+        } else {
+            hideComment = true;
+        }
+    toggleComments(event);
+  }
 }
 //--------------------------------------------
 //Sets the size of the paper on the canvas

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2142,7 +2142,7 @@ function toggleComments(event) {
 		hideComment = true;
       	setCheckbox($(".drop-down-option:contains('Hide Comments')"), hideComment);
     }
-	updateGraphics();
+    updateGraphics();
     localStorage.setItem("hideComment", hideComment);
 }
 


### PR DESCRIPTION
Added localStorage to Hide Comment option. If the user hide comments they should still be hidden when the page is updated. 

**Test this:** Create a text object, load its appearance menu and select the comment checkbox. Now select Hide Comments from the toolbar. View -> Hide Comments. Now that the comment is hidden try to update the page and make sure that the comment is still hidden. 

Another way to check if the value has been stored in localStorage is to enter the browsers inspect mode: Inspect -> Application -> Local Storage. Make sure the hideComment is stored.

![Screenshot_43](https://user-images.githubusercontent.com/49142301/81562692-96584980-9395-11ea-8483-3710596d77cd.png)

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239103/DuggaSys/diagram.php