### PR TITLE
G3 2020#7478

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -734,9 +734,6 @@ function deleteFile(fileid, filename, filekind) {
         AJAXService("DELFILE", tempData
         , "FILE");
     }
-    /*Reloads window when deleteFile has been called*/
-    myTable.renderTable();
-    //window.location.reload(true);
 }
 
 function createQuickItem() {

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -729,10 +729,34 @@ function deleteFile(fileid, filename, filekind) {
         filename: filename,
         kind: filekind,
     };
+    //Check if file is in use before deletion
+    alert("CHECK IF FILE IS IN USE: \n fileid: " + fileid + "\n cid: " + querystring['courseid'] + "\n filename: " + filename + "\n kind: " + filekind);
+
+    //select * from  lena.filelink fl, lena.box b
+    //where b.filename = fl.filename
+    //and fl.kind = 2
+    //and fl.fileid = fileid
+    var checkResult = null;
+    $.ajax({
+        url: "fileedservice.php",
+        type: "POST",
+        data: "coursevers=" + querystring['coursevers'] + "&opt=CHECK-IF-IN-USE",
+        dataType: "json",
+        success: function (data) {
+            alert("WOOO");
+            checkResult = data;
+            console.log("check1: " + checkResult);
+        }
+    })
+    console.log("check2: " + checkResult);
+
+    //success: function(data) {
+    //    result = data;
+    //}
 
     if (confirm("Do you really want to delete the file/link: " + filename)) {
-        AJAXService("DELFILE", tempData
-        , "FILE");
+        //AJAXService("DELFILE", tempData
+        //, "FILE");
     }
     /*Reloads window when deleteFile has been called*/
     window.location.reload(true);

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -729,37 +729,13 @@ function deleteFile(fileid, filename, filekind) {
         filename: filename,
         kind: filekind,
     };
-    //Check if file is in use before deletion
-    alert("CHECK IF FILE IS IN USE: \n fileid: " + fileid + "\n cid: " + querystring['courseid'] + "\n filename: " + filename + "\n kind: " + filekind);
-
-    //select * from  lena.filelink fl, lena.box b
-    //where b.filename = fl.filename
-    //and fl.kind = 2
-    //and fl.fileid = fileid
-    var checkResult = null;
-    $.ajax({
-        url: "fileedservice.php",
-        type: "POST",
-        data: "coursevers=" + querystring['coursevers'] + "&opt=CHECK-IF-IN-USE",
-        dataType: "json",
-        success: function (data) {
-            alert("WOOO");
-            checkResult = data;
-            console.log("check1: " + checkResult);
-        }
-    })
-    console.log("check2: " + checkResult);
-
-    //success: function(data) {
-    //    result = data;
-    //}
 
     if (confirm("Do you really want to delete the file/link: " + filename)) {
-        //AJAXService("DELFILE", tempData
-        //, "FILE");
+        AJAXService("DELFILE", tempData
+        , "FILE");
     }
     /*Reloads window when deleteFile has been called*/
-    window.location.reload(true);
+    //window.location.reload(true);
 }
 
 function createQuickItem() {

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -735,6 +735,7 @@ function deleteFile(fileid, filename, filekind) {
         , "FILE");
     }
     /*Reloads window when deleteFile has been called*/
+    myTable.renderTable();
     //window.location.reload(true);
 }
 

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -72,7 +72,7 @@ if (checklogin() && $hasAccess) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
 				}else{
-					$debug = "The file was deleted, refresh the page to see the changes.";
+					$debug = "The file was deleted.";
 				}
 
 				chdir("../");
@@ -84,7 +84,7 @@ if (checklogin() && $hasAccess) {
 				}
 			}
 		}else{
-			$debug = "This file is part of a code example. Remove it from there before removing the file.TEST";
+			$debug = "This file is part of a code example. Remove it from there before removing the file.";
 		}
 		if($kind != 2){
 			$counted = 0;
@@ -106,7 +106,7 @@ if (checklogin() && $hasAccess) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
 				}else{
-					$debug = "The file was deleted, refresh the page to see the changes.";
+					$debug = "The file was deleted.";
 				}
 
 				chdir("../");
@@ -123,7 +123,7 @@ if (checklogin() && $hasAccess) {
 				// Unlinks (deletes) a file from the directory given if it exists.
 				if (file_exists($currcwd)) unlink($currcwd);
 			}else{
-				$debug = "This file is part of a code example. Remove it from there before removing the file.TEST";
+				$debug = "This file is part of a code example. Remove it from there before removing the file.";
 			}
 		}
 

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -64,6 +64,7 @@ if (checklogin() && $hasAccess) {
 		$counted = $result->counted;
 		if($counted == 0){
 			// Remove file link from database
+			$succeeded = true;
 			if ($kind == 2 && isSuperUser($userid)){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -71,6 +72,7 @@ if (checklogin() && $hasAccess) {
 				if (!$query->execute()) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
+					$succeeded = false;
 				}
 
 				chdir("../");
@@ -80,6 +82,9 @@ if (checklogin() && $hasAccess) {
 					$currcwd .= "/courses/global/" . $filename;
 					if (file_exists($currcwd)) unlink($currcwd);
 				}
+			}
+			if($succeeded){
+				$debug = "The file was deleted, refresh the page to see the changes.";
 			}
 		}else{
 			$debug = "This file is part of a code example. Remove it from there before removing the file.";
@@ -96,6 +101,7 @@ if (checklogin() && $hasAccess) {
 			}
 			$result = $query0->fetch(PDO::FETCH_OBJ);
 			$counted = $result->counted;
+			$succeeded = true;
 			if($counted == 0){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -103,6 +109,7 @@ if (checklogin() && $hasAccess) {
 				if (!$query->execute()) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
+					$succeeded = false;
 				}
 
 				chdir("../");
@@ -118,6 +125,10 @@ if (checklogin() && $hasAccess) {
 
 				// Unlinks (deletes) a file from the directory given if it exists.
 				if (file_exists($currcwd)) unlink($currcwd);
+
+				if($succeeded){
+					$debug = "The file was deleted, refresh the page to see the changes.";
+				}
 			}else{
 				$debug = "This file is part of a code example. Remove it from there before removing the file.";
 			}

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -64,7 +64,6 @@ if (checklogin() && $hasAccess) {
 		$counted = $result->counted;
 		if($counted == 0){
 			// Remove file link from database
-			$succeeded = true;
 			if ($kind == 2 && isSuperUser($userid)){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -72,7 +71,6 @@ if (checklogin() && $hasAccess) {
 				if (!$query->execute()) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
-					$succeeded = false;
 				}
 
 				chdir("../");
@@ -82,9 +80,6 @@ if (checklogin() && $hasAccess) {
 					$currcwd .= "/courses/global/" . $filename;
 					if (file_exists($currcwd)) unlink($currcwd);
 				}
-			}
-			if($succeeded){
-				$debug = "The file was deleted, refresh the page to see the changes.";
 			}
 		}else{
 			$debug = "This file is part of a code example. Remove it from there before removing the file.";
@@ -101,7 +96,6 @@ if (checklogin() && $hasAccess) {
 			}
 			$result = $query0->fetch(PDO::FETCH_OBJ);
 			$counted = $result->counted;
-			$succeeded = true;
 			if($counted == 0){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -109,7 +103,6 @@ if (checklogin() && $hasAccess) {
 				if (!$query->execute()) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
-					$succeeded = false;
 				}
 
 				chdir("../");
@@ -125,10 +118,6 @@ if (checklogin() && $hasAccess) {
 
 				// Unlinks (deletes) a file from the directory given if it exists.
 				if (file_exists($currcwd)) unlink($currcwd);
-
-				if($succeeded){
-					$debug = "The file was deleted, refresh the page to see the changes.";
-				}
 			}else{
 				$debug = "This file is part of a code example. Remove it from there before removing the file.";
 			}

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -64,7 +64,6 @@ if (checklogin() && $hasAccess) {
 		$counted = $result->counted;
 		if($counted == 0){
 			// Remove file link from database
-			$succeeded = true;
 			if ($kind == 2 && isSuperUser($userid)){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -72,7 +71,8 @@ if (checklogin() && $hasAccess) {
 				if (!$query->execute()) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
-					$succeeded = false;
+				}else{
+					$debug = "The file was deleted, refresh the page to see the changes.";
 				}
 
 				chdir("../");
@@ -82,9 +82,6 @@ if (checklogin() && $hasAccess) {
 					$currcwd .= "/courses/global/" . $filename;
 					if (file_exists($currcwd)) unlink($currcwd);
 				}
-			}
-			if($succeeded){
-				$debug = "The file was deleted, refresh the page to see the changes.";
 			}
 		}else{
 			$debug = "This file is part of a code example. Remove it from there before removing the file.";
@@ -101,7 +98,6 @@ if (checklogin() && $hasAccess) {
 			}
 			$result = $query0->fetch(PDO::FETCH_OBJ);
 			$counted = $result->counted;
-			$succeeded = true;
 			if($counted == 0){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -109,7 +105,8 @@ if (checklogin() && $hasAccess) {
 				if (!$query->execute()) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
-					$succeeded = false;
+				}else{
+					$debug = "The file was deleted, refresh the page to see the changes.";
 				}
 
 				chdir("../");
@@ -125,10 +122,6 @@ if (checklogin() && $hasAccess) {
 
 				// Unlinks (deletes) a file from the directory given if it exists.
 				if (file_exists($currcwd)) unlink($currcwd);
-
-				if($succeeded){
-					$debug = "The file was deleted, refresh the page to see the changes.";
-				}
 			}else{
 				$debug = "This file is part of a code example. Remove it from there before removing the file.";
 			}

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -101,6 +101,7 @@ if (checklogin() && $hasAccess) {
 			}
 			$result = $query0->fetch(PDO::FETCH_OBJ);
 			$counted = $result->counted;
+			$succeeded = true;
 			if($counted == 0){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -108,6 +109,7 @@ if (checklogin() && $hasAccess) {
 				if (!$query->execute()) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
+					$succeeded = false;
 				}
 
 				chdir("../");

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -64,6 +64,7 @@ if (checklogin() && $hasAccess) {
 		$counted = $result->counted;
 		if($counted == 0){
 			// Remove file link from database
+			$debug = "";
 			if ($kind == 2 && isSuperUser($userid)){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -80,6 +81,9 @@ if (checklogin() && $hasAccess) {
 					$currcwd .= "/courses/global/" . $filename;
 					if (file_exists($currcwd)) unlink($currcwd);
 				}
+			}
+			if($debug==""){
+				$debug = "The file was deleted, refresh the page to see the changes.";
 			}
 		}else{
 			$debug = "This file is part of a code example. Remove it from there before removing the file.";

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -64,7 +64,7 @@ if (checklogin() && $hasAccess) {
 		$counted = $result->counted;
 		if($counted == 0){
 			// Remove file link from database
-			$debug = "";
+			$succeeded = true;
 			if ($kind == 2 && isSuperUser($userid)){
 				$querystring = 'DELETE FROM fileLink WHERE fileid=:fid';
 				$query = $pdo->prepare($querystring);
@@ -72,6 +72,7 @@ if (checklogin() && $hasAccess) {
 				if (!$query->execute()) {
 					$error = $query->errorInfo();
 					$debug = "Error updating file list " . $error[2];
+					$succeeded = false;
 				}
 
 				chdir("../");
@@ -82,7 +83,7 @@ if (checklogin() && $hasAccess) {
 					if (file_exists($currcwd)) unlink($currcwd);
 				}
 			}
-			if($debug==""){
+			if($succeeded){
 				$debug = "The file was deleted, refresh the page to see the changes.";
 			}
 		}else{

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -199,26 +199,6 @@ $lfiles = array();
 $gfiles = array();
 $access = False;
 
-if (strcmp($opt, "CHECK-IF-IN-USE") === 0) {
-/*
-	$querystring = 'SELECT COUNT (*) counted FROM fileLink, box WHERE box.filename = filelink.filename AND filelink.kind = 2 AND filelink.fileid =:fid ;';
-	//$querystring = 'SELECT * FROM filelink LIMIT 2';
-    $query = $pdo->prepare($querystring);
-    $query->bindParam(':fid', getOP('fid'));
-    if (!$query->execute()) {
-        $error = $query->errorInfo();
-        $debug = "Error updating file list " . $error[2];
-    }
-	foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
-		$entry = array(
-			'timesInUse' => json_encode($row['counted']),
-			//'isInUse' => $entry,
-		);
-		array_push($entries, $entry);
-	}
-	*/
-}
-
 if (checklogin() && $hasAccess) {
     $query = $pdo->prepare("SELECT fileid,filename,kind, filesize, uploaddate FROM fileLink WHERE ((cid=:cid AND vers is null) OR (cid=:cid AND vers=:vers) OR isGlobal='1') ORDER BY filename;");
     $query->bindParam(':cid', $cid);

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -150,7 +150,21 @@ if (checklogin() && $hasAccess) {
                 $error = True;
             }
         }
-    }
+		
+    } else if (strcmp($opt, "CHECK-IF-IN-USE") === 0) {
+		//$querystring = 'SELECT COUNT (*) FROM fileLink, box ' +
+		//+' WHERE box.filename=filelink.filename ' +
+		//+' AND filelink.kind = 2 ' +
+		//+ 'AND filelink.fileid = :fid ;';
+		$querystring = 'SELECT COUNT (*) FROM fileLink';
+        $query = $pdo->prepare($querystring);
+        $query->bindParam(':fid', $fid);
+        if (!$query->execute()) {
+            $error = $query->errorInfo();
+            $debug = "Error updating file list " . $error[2];
+        }
+	}
+	
 }
 
 //------------------------------------------------------------------------------------------------

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -84,7 +84,7 @@ if (checklogin() && $hasAccess) {
 				}
 			}
 		}else{
-			$debug = "This file is part of a code example. Remove it from there before removing the file.";
+			$debug = "This file is part of a code example. Remove it from there before removing the file.TEST";
 		}
 		if($kind != 2){
 			$counted = 0;
@@ -123,7 +123,7 @@ if (checklogin() && $hasAccess) {
 				// Unlinks (deletes) a file from the directory given if it exists.
 				if (file_exists($currcwd)) unlink($currcwd);
 			}else{
-				$debug = "This file is part of a code example. Remove it from there before removing the file.";
+				$debug = "This file is part of a code example. Remove it from there before removing the file.TEST";
 			}
 		}
 


### PR DESCRIPTION
To test:
Try to delete a file. It should forbid you from doing that with an alert.
Then, go into the code example where that file is used and remove it from there.
Then try to delete the file, it should work.
For example:
If you want to delete the file HTML_Ex1.html in webbprogrammering,
then you must go to the code example "HTML 5 Example 1", then edit the box with HTML_Ex1.html in it, choose a new file there such that HTML_Ex1.html is not in use. Then it can be deleted.

This issue was solved with so many commits due to testing on the server which did not work the way I wanted it to.