### PR TITLE
åäö characters in name are now displayed correctly in Edit dugga window

### DIFF
--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -206,7 +206,7 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid))){
 		$entry = array(
 			'variants' => $mass,
 			'did' => $row['id'],
-			'qname' => $row['qname'],
+			'qname' => html_entity_decode($row['qname']),
 			'autograde' => $row['autograde'],
 			'gradesystem' => $row['gradesystem'],
 			'quizFile' => $row['quizFile'],


### PR DESCRIPTION
Solves #9113.

Added decoding in duggaedservice.php for qname.

Tested with å/ä/ö/Å/Ä/Ö characters. Not sure how it handles other characters like ß for example. I felt that it was not needed since I doubt such characters will ever be used, unlike åäö. But feel free to look into it if you'd like.

Screenshot shows the dugganame "ööö" after the fix. Before the decoding this would be written out as `"&ouml;&ouml;&ouml;"`.

![image](https://user-images.githubusercontent.com/49141758/81648294-c6076000-942e-11ea-88fb-fd3658c1354f.png)
