### PR TITLE
Fixes #9061- Rulers adapt to zoom

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6294,6 +6294,14 @@ function createRuler(element, length, origoOffset, marginProperty) {
     steps.mini = 5;
     steps.small = steps.mini * 2;
     steps.big = Math.round((steps.mini * steps.small) * zoomValue);
+    
+    if(zoomValue <= 0.7 && zoomValue >= 0.5) {
+        steps.big *= 2;
+    } else if(zoomValue <= 0.4 && zoomValue >= 0.3) {
+        steps.big *= 4;
+    } else if(zoomValue <= 0.2) {
+        steps.big *= 8;
+    }
 
     element.innerHTML = "";
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6291,7 +6291,7 @@ function createRuler(element, length, origoOffset) {
             if(i % 8 === 0) {
                 if(i % 32 === 0) {
                     line.classList.add("big");
-                    line.innerText = i;
+                    line.innerText = Math.round(i / zoomValue);
                 } else {
                     line.classList.add("small");
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6309,6 +6309,7 @@ function createRuler(element, length, origoOffset, marginProperty) {
         if(i % steps.mini === 0) {
             const line = document.createElement("div");
             line.classList.add("ruler-line");
+            line.style[marginProperty] = `${steps.mini - 1}px`;
             if(i % steps.small === 0 || i % steps.big === 0) {
                 if(i % steps.big === 0) {
                     line.classList.add("big");
@@ -6322,10 +6323,6 @@ function createRuler(element, length, origoOffset, marginProperty) {
             element.appendChild(line);
         }
     }
-
-    element.querySelectorAll(".ruler-line").forEach(line => {
-        line.style[marginProperty] = `${steps.mini - 1}px`;
-    });
 }
 
 //------------------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6306,18 +6306,16 @@ function createRuler(element, length, origoOffset, marginProperty) {
     element.innerHTML = "";
 
     for(let i = from; i < to; i++) {
-        if(i % steps.mini === 0) {
+        if(i % steps.big === 0 || i % steps.small === 0 || i % steps.mini === 0) {
             const line = document.createElement("div");
             line.classList.add("ruler-line");
             line.style[marginProperty] = `${steps.mini - 1}px`;
-            if(i % steps.small === 0 || i % steps.big === 0) {
-                if(i % steps.big === 0) {
-                    line.classList.add("big");
-                    line.innerText = Math.round(i / zoomValue);
-                } else {
-                    line.classList.add("small");
-                }
-            } else {
+            if(i % steps.big === 0) {
+                line.classList.add("big");
+                line.innerText = Math.round(i / zoomValue);
+            } else if(i % steps.small === 0) {
+                line.classList.add("small");
+            } else if(i % steps.mini === 0) {
                 line.classList.add("mini");
             }
             element.appendChild(line);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6291,21 +6291,18 @@ function createRuler(element, length, origoOffset, marginProperty) {
     const to = Math.round(length - origoOffset);
 
     const steps = {};
-    steps.first = 5;
-    steps.second = steps.first * 2;
-    steps.third = steps.first * steps.second;
-
-    const margin = steps.first - 1;
+    steps.mini = 5;
+    steps.small = steps.mini * 2;
+    steps.big = Math.round((steps.mini * steps.small) * zoomValue);
 
     element.innerHTML = "";
 
-    for(let i = from; i < to; i++) { 
-        if(i % steps.first === 0) {
+    for(let i = from; i < to; i++) {
+        if(i % steps.mini === 0) {
             const line = document.createElement("div");
             line.classList.add("ruler-line");
-            
-            if(i % steps.second === 0) {
-                if(i % steps.third === 0) {
+            if(i % steps.small === 0 || i % steps.big === 0) {
+                if(i % steps.big === 0) {
                     line.classList.add("big");
                     line.innerText = Math.round(i / zoomValue);
                 } else {
@@ -6319,7 +6316,7 @@ function createRuler(element, length, origoOffset, marginProperty) {
     }
 
     element.querySelectorAll(".ruler-line").forEach(line => {
-        line.style[marginProperty] = `${margin}px`;
+        line.style[marginProperty] = `${steps.mini - 1}px`;
     });
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3621,6 +3621,10 @@ function zoomInMode(event) {
         origoOffsetY -= centerY * zoomDifference - centerY;
     }
 
+    if(isRulersActive) {
+        createRulers();
+    }
+
     reWrite();
     updateGraphics();
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6278,26 +6278,34 @@ function canConnectLine(startObj, endObj){
 //-----------------------------------------------
 
 function createRulers() {
-    createRuler(document.getElementById("ruler-x"), canvas.width, origoOffsetX);
-    createRuler(document.getElementById("ruler-y"), canvas.height, origoOffsetY);
+    createRuler(document.getElementById("ruler-x"), canvas.width, origoOffsetX, "marginLeft");
+    createRuler(document.getElementById("ruler-y"), canvas.height, origoOffsetY, "marginTop");
 }
 
 //--------------------------------------------------------------------------------------
 // createRuler: Fills the passed ruller container with lines according to passed length.
 //--------------------------------------------------------------------------------------
 
-function createRuler(element, length, origoOffset) {
+function createRuler(element, length, origoOffset, marginProperty) {
     const from = Math.round(-origoOffset);
     const to = Math.round(length - origoOffset);
 
+    const steps = {};
+    steps.first = 5;
+    steps.second = steps.first * 2;
+    steps.third = steps.first * steps.second;
+
+    const margin = steps.first - 1;
+
     element.innerHTML = "";
 
-    for(let i = from; i < to; i++) {
-        if(i % 4 === 0) {
+    for(let i = from; i < to; i++) { 
+        if(i % steps.first === 0) {
             const line = document.createElement("div");
             line.classList.add("ruler-line");
-            if(i % 8 === 0) {
-                if(i % 32 === 0) {
+            
+            if(i % steps.second === 0) {
+                if(i % steps.third === 0) {
                     line.classList.add("big");
                     line.innerText = Math.round(i / zoomValue);
                 } else {
@@ -6309,6 +6317,10 @@ function createRuler(element, length, origoOffset) {
             element.appendChild(line);
         }
     }
+
+    element.querySelectorAll(".ruler-line").forEach(line => {
+        line.style[marginProperty] = `${margin}px`;
+    });
 }
 
 //------------------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4846,6 +4846,10 @@ function touchMoveEvent(event) {
         
         localStorage.setItem("cameraPosX", origoOffsetX);
         localStorage.setItem("cameraPosY", origoOffsetY);
+        
+        if(isRulersActive) {
+            createRulers();
+        }
     }
 
     // Moves an object

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5156,12 +5156,10 @@ only screen and (max-device-width: 320px) {
 
 #ruler-x .ruler-line {
   width: 1px;
-  margin-left: 3px;
 }
 
 #ruler-y .ruler-line {
   height: 1px;
-  margin-top: 3px;
 }
 
 #ruler-x .ruler-line:first-of-type {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5134,15 +5134,15 @@ only screen and (max-device-width: 320px) {
 }
 
 #ruler-x {
-  height: 32px;
+  height: var(--ruler-size);
   flex-direction: row;
   margin-right: var(--canvas-margin);
   border-right: 1px solid #000000;
 }
 
 #ruler-y {
-  width: 32px;
-  margin-top: 32px;
+  width: var(--ruler-size);
+  margin-top: var(--ruler-size);
   margin-bottom: var(--canvas-margin);
   flex-direction: column;
   border-bottom: 1px solid #000000;


### PR DESCRIPTION
The rulers do now adapt to the zoom. The spacing increases instead of the values changing which is the intended functionality. I made some special cases for smaller zoom values since a bigger value difference is needed between each big step to prevent cramped text and lines. Seems to be working well.

- Test to activate the rulers, move around and zoom a lot to test every possible zoom value so the rulers show the right values and so text and lines never gets cramped.

Link: http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239061/DuggaSys/diagram.php### 