### PR TITLE
Fix colors for diagram layers | G4 2020 W20 issue #9144

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -93,7 +93,7 @@ const mouseState = {
     insideMovableObject: 3,         // mouse pressed down inside a movable object
     boxSelectOrCreateMode: 4        // Box select or Create mode
 };
-var colorArray = ["#000000","#ffffff","#64B5F6","#81C784","#e6e6e6","#E57373","#FFF176","#FFB74D","#BA68C8","#366922"]
+var colorArray = ["#ff6958","#ffffff","#64B5F6","#81C784","#e6e6e6","#E57373","#FFF176","#FFB74D","#BA68C8","#366922"]
 var valueArray = ["Layer Zero","Layer One", "Layer Two", "Layer Three", "Layer Four", "Layer Five", "Layer Six", "Layer Seven", "Layer Eight", "Layer Nine", "Layer Ten"]
 var writeToLayer = getcorrectlayer();
 var showLayer = ["Layer_1"];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -93,6 +93,7 @@ const mouseState = {
     insideMovableObject: 3,         // mouse pressed down inside a movable object
     boxSelectOrCreateMode: 4        // Box select or Create mode
 };
+var colorArray = ["#000000","#ffffff","#64B5F6","#81C784","#e6e6e6","#E57373","#FFF176","#FFB74D","#BA68C8","#366922"]
 var valueArray = ["Layer Zero","Layer One", "Layer Two", "Layer Three", "Layer Four", "Layer Five", "Layer Six", "Layer Seven", "Layer Eight", "Layer Nine", "Layer Ten"]
 var writeToLayer = getcorrectlayer();
 var showLayer = ["Layer_1"];
@@ -5989,6 +5990,7 @@ function createLayer(){
     document.getElementById("layerActive").appendChild(activeDropdown);
     fixWriteToLayer();
     addLayersToApperence(id);
+
 }
 function loadLayer(localStorageID){
     let parentNode = document.getElementById("viewLayer");
@@ -6121,6 +6123,9 @@ function setlayer(object){
     let fixID = object.id.replace('_Active','');
     toggleBackgroundLayer(document.getElementById(fixID), true)
     writeToLayer = fixID;
+    let fixColor = fixID.replace('Layer_','');
+    console.log(fixColor)
+    settings.properties.strokeColor = colorArray[fixColor]; 
 }
 
 function addLayersToApperence(localStorageID){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -93,7 +93,7 @@ const mouseState = {
     insideMovableObject: 3,         // mouse pressed down inside a movable object
     boxSelectOrCreateMode: 4        // Box select or Create mode
 };
-var colorArray = ["#ff6958","#ffffff","#64B5F6","#81C784","#e6e6e6","#E57373","#FFF176","#FFB74D","#BA68C8","#366922"]
+var colorArray = ["#000000","#496e63","#64B5F6","#81C784","#e6e6e6","#E57373","#FFF176","#FFB74D","#BA68C8","#366922"]
 var valueArray = ["Layer Zero","Layer One", "Layer Two", "Layer Three", "Layer Four", "Layer Five", "Layer Six", "Layer Seven", "Layer Eight", "Layer Nine", "Layer Ten"]
 var writeToLayer = getcorrectlayer();
 var showLayer = ["Layer_1"];
@@ -6125,7 +6125,7 @@ function setlayer(object){
     writeToLayer = fixID;
     let fixColor = fixID.replace('Layer_','');
     console.log(fixColor)
-    settings.properties.strokeColor = colorArray[fixColor]; 
+    settings.properties.strokeColor = colorArray[fixColor-1]; 
 }
 
 function addLayersToApperence(localStorageID){

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6343,6 +6343,7 @@ textarea#filecont {
 }
 .isActive {
   background-color: #775886;
+  color:white;
 }
 
 .analytic-buttons{


### PR DESCRIPTION
Link http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239144/DuggaSys/diagram.php

*Needs testing*

*Font colors should be white while element is active in drop-down menu "view layer" and "write to layer"
*Creating diagram objects within a layer should result in having different board-colors depending on which layer the object was created in.