### PR TITLE
Changed to changeCourseVersURL from changeURL | Issue #8874

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -491,7 +491,7 @@ function accessCourse() {
 function returnedCourse(data) {
   if (data['debug'] != "NONE!") alert(data['debug']);
   window.setTimeout(function () {
-    changeURL("sectioned.php?courseid=" + querystring["courseid"] +
+    changeCourseVersURL("sectioned.php?courseid=" + querystring["courseid"] +
       "&coursename=" + querystring["coursename"] + "&coursevers=" + newversid);
   }, 1000);
 }


### PR DESCRIPTION
When creating a new course-version you will get sent to the new version. This will only work when choosing Copy content from None 