### PR TITLE
fix issue#9125 Drag required for flash to appear

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4300,6 +4300,14 @@ function mouseupevt(ev) {
     }
     markedObject = diagram.indexOf(diagram.checkForHover(currentMouseCoordinateX, currentMouseCoordinateY));
 
+    // Check if there's difference in mouse start position and end position.
+    let mouseDifference;
+    if (startMouseCoordinateX != currentMouseCoordinateX || startMouseCoordinateY != currentMouseCoordinateY) {
+        mouseDifference = true;
+    } else {
+        mouseDifference = false;
+    }
+  
     if(ev.button == leftMouseClick){
         canvasLeftClick = false;
     } else if (ev.button == rightMouseClick) {
@@ -4349,7 +4357,7 @@ function mouseupevt(ev) {
     if (movobj > -1) {
         if (diagram[movobj].symbolkind != symbolKind.line && uimode == "Moved") saveState = true;
     }
-    if (symbolStartKind != symbolKind.uml && uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode) {
+    if (symbolStartKind != symbolKind.uml && uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode && mouseDifference) {
         saveState = false;
         //Check if you release on canvas or try to draw a line from entity to entity
         if (markedObject == -1 || diagram[lineStartObj].symbolkind == symbolKind.erEntity && diagram[markedObject].symbolkind == symbolKind.erEntity) {
@@ -4446,7 +4454,7 @@ function mouseupevt(ev) {
         }
     }
   
-    if (symbolStartKind == symbolKind.uml && uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode && startMouseCoordinateX != currentMouseCoordinateX && startMouseCoordinateY != currentMouseCoordinateY) {
+    if (symbolStartKind == symbolKind.uml && uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode && mouseDifference) {
         saveState = false;
         uimode = "CreateUMLLine";
         //Check if you release on canvas or try to draw a line from entity to entity


### PR DESCRIPTION
The fix to ISSUE#8856 created flashes if invalid line realtionsships were attempted to be created. The problem is that these flashes shows up when the user selects different objects with the line tool selected. This is displayed in the GIF below

![410e3eea34b87e892dc1c8aa52052080](https://user-images.githubusercontent.com/49142301/81680756-e4cc1d80-9453-11ea-8205-23b1c1017805.gif)

The flashes should only appear if the user tries to make a line (by dragging the mouse), not when selecting (by clicking).

**Test this:** Create a bunch of different objects, attributes, entities, relations, etc. Select the Create Line tool and try select the different objects. The flashes should NOT appear when clicking on them. Now try to create invalid relations by  dragging the mouse to the same or between two invalid objects. The flashes should appear as usual. 

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239125/DuggaSys/diagram.php

**Expected result when selecting or dragging to same object:**

![684422efe8326ff331f0402092196a75](https://user-images.githubusercontent.com/49142301/81682517-2ad5b100-9455-11ea-9489-4793495f9427.gif)


