### PR TITLE
Solve issue 9159 | Diagram Layers

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6119,6 +6119,7 @@ function toggleActiveBackgroundLayer(object) {
             object.classList.remove("drop-down-option-hover");
             localStorage.setItem("writeToActiveLayers", object.id);
             setlayer(object);
+            activeLocalStorage();
         }
     }
     updateGraphics();


### PR DESCRIPTION
Link: http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239159/DuggaSys/diagram.php

*Needs testing*

*Activating a layer with drop-down menu "Write to layer" results in selected layer being added to drop-down menu "View layer". it's important that this layers is still active in "View layer" after a page refresh

Note layer one will always be active after a page reload as this was intended design during construction of layer functionality. This was done just to avoid so the diagram never would start up without a viewing layer being active. perhaps this should be change but its not important for this pull-request.