### PR TITLE
Reworked page information and added table with hits for each page - G1-2020-W20-ISSUE#9106

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -513,61 +513,62 @@ function loadPageInformation() {
         .append('<option value="codeviewer">codeviewer</option>')
         .appendTo($('#analytic-info'));
    
-    function updatePageHitInformation(page){
-        loadAnalytics(page + "Percentage", function(data) {
-            var tableData = [["Page", "Hits"]];
-            for (var i = 0; i < data.length; i++) {
-                tableData.push([
-                    page,
-                    data[i].pageLoads
-                ]);
-            }
-           
-            $('#analytic-info').append("<p>Page information.</p>");
-            $('#analytic-info').append(selectPage);
-            $('#analytic-info').append(renderTable(tableData));
-            updatePieChartInformation(page, tableData);
+    function updatePageHitInformation(pages, page){
+        loadAnalytics("pageInformation", function(data) {
+
+			var tableData = [["Page", "Hits"]];
+			for(var i = 0; i < pages.length; i++){
+				tableData.push([
+					pages[i],
+					data['hits'][pages[i]].pageLoads
+				]);
+			}
+
+            updatePieChartInformation(page, tableData, data);
         });
     }
  
-    function updatePieChartInformation(page, tableData){
-        loadAnalytics(page + "Percentage", function(data) {
-            var tablePercentage = [["Courseid", "Percentage"]];
-            for (var i = 0; i < data.length; i++) {
-                tablePercentage.push([
-                    data[i].courseid,
-                    data[i].percentage
-                ]);
-            }
+    function updatePieChartInformation(page, tableData, data){
+
+        var tablePercentage = [["Courseid", "Percentage"]];
+        for (var i = 0; i < data['percentage'][page].length; i++) {
+            tablePercentage.push([
+                data['percentage'][page][i].courseid,
+                data['percentage'][page][i].percentage
+            ]);
+        }
  
-            var chartData = [];
-            for (var i = 0; i < data.length; i++) {
-                chartData.push({
-                    label: "courseid:" + " " + data[i].courseid,
-                    value: data[i].percentage
-                });
-            }
-            $('#analytic-info').append("<p>Page information.</p>");
-            $('#analytic-info').append(selectPage);
-            $('#analytic-info').append(renderTable(tableData));
-            $('#analytic-info').append(renderTable(tablePercentage));
-            $('#analytic-info').append(drawPieChart(chartData));
-            updateState();
-        });
+        var chartData = [];
+        for (var i = 0; i < data['percentage'][page].length; i++) {
+            chartData.push({
+                label: "courseid:" + " " + data['percentage'][page][i].courseid,
+                value: data['percentage'][page][i].percentage
+            });
+		}
+		
+        $('#analytic-info').append("<p>Page information.</p>");
+        $('#analytic-info').append(selectPage);
+		$('#analytic-info').append(renderTable(tableData));
+        $('#analytic-info').append(renderTable(tablePercentage));
+        $('#analytic-info').append(drawPieChart(chartData, "Hit spread for " + page + " page loads:"));
+        updateState();
     }
  
     function updateState(){
+		// Add additonal pages here
+		var pages = ["dugga", "codeviewer", "sectioned", "courseed"];
+
 		if(firstLoad === true){
-			updatePageHitInformation("dugga");
+			updatePageHitInformation(pages, pages[0]);
 			firstLoad = false;
 		} 
         selectPage.change(function(){
             switch(selectPage.val()){
                 case "showDugga":
-                    updatePageHitInformation("dugga");
+                    updatePageHitInformation(pages, pages[0]);
                     break;
                 case "codeviewer":
-                    updatePageHitInformation("codeviewer");
+                    updatePageHitInformation(pages, pages[1]);
                     break;
             }
         });

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -69,6 +69,9 @@ if (isset($_SESSION['uid']) && checklogin() && isSuperUser($_SESSION['uid'])) {
 			case 'userLogInformation':
 				userLogInformation();
 				break;
+			case 'pageInformation':
+				pageInformation();
+				break;
 		}
 	} else {
 		echo 'N/A';
@@ -420,40 +423,6 @@ function codeviewerInformation(){
 }
  
 //------------------------------------------------------------------------------------------------
-// Retrieves dugga percentage          
-//------------------------------------------------------------------------------------------------
- 
-function duggaPercentage(){
-    $result = $GLOBALS['log_db']->query('
-        SELECT
-			cid AS courseid,
-			COUNT(*) AS pageLoads,
-            COUNT(*) * 100.0 / (SELECT COUNT(*) FROM duggaLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
-        FROM duggaLoadLogEntries
-        GROUP BY courseid
-        ORDER BY percentage DESC;
-    ')->fetchAll(PDO::FETCH_ASSOC);
-    echo json_encode($result);
-}
- 
-//------------------------------------------------------------------------------------------------
-// Retrieves example percentage        
-//------------------------------------------------------------------------------------------------
- 
-function codeviewerPercentage(){
-    $result = $GLOBALS['log_db']->query('
-        SELECT
-			courseid,
-			COUNT(*) AS pageLoads,
-            COUNT(*) * 100.0 / (SELECT COUNT(*) FROM exampleLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
-        FROM exampleLoadLogEntries
-        GROUP BY courseid
-        ORDER BY percentage DESC;
-    ')->fetchAll(PDO::FETCH_ASSOC);
-    echo json_encode($result);
-}
-
-//------------------------------------------------------------------------------------------------
 // Retrieves sectioned log information      
 //------------------------------------------------------------------------------------------------
  
@@ -505,4 +474,68 @@ function userLogInformation(){
 	   ORDER BY timestamp;
    ')->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode($result);
+}
+
+//------------------------------------------------------------------------------------------------
+// Retrieves page information      
+//------------------------------------------------------------------------------------------------
+ 
+function pageInformation(){
+    $dugga= $GLOBALS['log_db']->query('
+		SELECT
+			cid AS courseid,
+			COUNT(*) AS pageLoads,
+			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM duggaLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
+		FROM 
+			duggaLoadLogEntries
+		GROUP BY 
+			courseid
+		ORDER BY 
+			percentage DESC;
+	')->fetchAll(PDO::FETCH_ASSOC);
+	
+	$codeviewer = $GLOBALS['log_db']->query('
+		SELECT
+			courseid,
+			COUNT(*) AS pageLoads,
+			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM duggaLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
+		FROM 
+			exampleLoadLogEntries
+		GROUP BY 
+			courseid
+		ORDER BY 
+			percentage DESC;
+	')->fetchAll(PDO::FETCH_ASSOC);
+ 
+	$sectioned = $GLOBALS['log_db']->query('
+		SELECT
+			refer,
+			COUNT(*) AS pageLoads
+		FROM 
+			userHistory
+		WHERE 
+			refer LIKE "%sectioned%";
+	')->fetchAll(PDO::FETCH_ASSOC);
+
+	$courseed = $GLOBALS['log_db']->query('
+		SELECT
+			refer,
+			COUNT(*) AS pageLoads
+		FROM 
+			userHistory
+		WHERE 
+			refer LIKE "%courseed%";
+	')->fetchAll(PDO::FETCH_ASSOC); 
+	
+	$result = [];
+	$result['hits']['dugga'] = $dugga[0];
+	$result['hits']['codeviewer'] = $codeviewer[0];
+	$result['hits']['sectioned'] = $sectioned[0];
+	$result['hits']['courseed'] = $courseed[0]; 
+
+
+	$result['percentage']['dugga'] = $dugga;
+	$result['percentage']['codeviewer'] = $codeviewer;
+
+	echo json_encode($result);
 }


### PR DESCRIPTION
Reworked page retrieve of all necessary db data from a single function, that is pageInformation() located in analyticService. This was not part of the issue but had to be done to get it to work properly. The part which was added for the linked issue is the the table presenting an overall view of all pages hit information. Not all pages have been added due to that being a separate issue https://github.com/HGustavs/LenaSYS/issues/9077 . 

![Screenshot 2020-05-12 at 15 21 11](https://user-images.githubusercontent.com/62876614/81696483-3c728500-9464-11ea-9e3e-4e602cd3ccc1.png)
