### PR TITLE
Solves issue#8218, read-only functionality

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -508,51 +508,67 @@ function isNumber(n) { return /^-?[\d.]+(?:e-?\d+)?$/.test(n); }
 //----------------------------------------------------------------------------------
 function saveDuggaResult(citstr)
 {
-		citstr=querystring['moment']+" "+citstr;
-		citstr=querystring['coursevers']+" "+citstr;
-		citstr=querystring['cid']+" "+citstr;
-		citstr+= "##!!##" + timeUsed;
-		citstr+= "##!!##" + stepsUsed;
-		citstr+= "##!!##" + score;
-		hexstr="";
-		for(i=0;i<citstr.length;i++){
-				hexstr+=citstr.charCodeAt(i).toString(16)+" ";
+	var readonly;
+	$.ajax({
+		url: "courseedservice.php",
+		dataType: "json"
+	}).done(response => {
+		readonly=response.readonly;
+		//Read-only is active
+		if(readonly == 1)
+		{
+			console.log("Read-only is active, duggas cannot be submitted at this time");
 		}
+		//Read-only is not active
+		else
+		{
+			citstr=querystring['moment']+" "+citstr;
+			citstr=querystring['coursevers']+" "+citstr;
+			citstr=querystring['cid']+" "+citstr;
+			citstr+= "##!!##" + timeUsed;
+			citstr+= "##!!##" + stepsUsed;
+			citstr+= "##!!##" + score;
+			hexstr="";
+			for(i=0;i<citstr.length;i++){
+					hexstr+=citstr.charCodeAt(i).toString(16)+" ";
+			}
 
-		AJAXService("SAVDU",{answer:citstr},"PDUGGA");
+			AJAXService("SAVDU",{answer:citstr},"PDUGGA");
 
-		document.getElementById('receipt').value = hexstr;
+			document.getElementById('receipt').value = hexstr;
 
-		var dateTime = new Date(); // Get the current date and time
+			var dateTime = new Date(); // Get the current date and time
 
- 		var comment = querystring['comment']; //Get the comment
+			var comment = querystring['comment']; //Get the comment
 
-		var deadline = querystring['deadline']; //Get deadlinedate from URL
+			var deadline = querystring['deadline']; //Get deadlinedate from URL
 
 
-		Number.prototype.padLeft = function(base,chr){
-			var  len = (String(base || 10).length - String(this).length)+1;
-			return len > 0? new Array(len).join(chr || '0')+this : this;
+			Number.prototype.padLeft = function(base,chr){
+				var  len = (String(base || 10).length - String(this).length)+1;
+				return len > 0? new Array(len).join(chr || '0')+this : this;
+			}
+
+			dateTimeFormat = [dateTime.getFullYear(),(dateTime.getMonth()+1).padLeft(),dateTime.getDate().padLeft()].join('-') +' ' +[dateTime.getHours().padLeft(),dateTime.getMinutes().padLeft(),dateTime.getSeconds().padLeft()].join(':');
+
+			if(deadline > dateTimeFormat){	//Check if deadline has past
+
+				document.getElementById('receiptInfo').innerHTML = "<p>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.\n\n</p>";
+
+			}
+			else{ //Check if deadline has past
+
+				if(comment == "UNK" || comment == "undefined" || comment == "null"){
+					document.getElementById('receiptInfo').innerHTML = "<p style='margin:15px 5px;'>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.</p><img style='width:40px;float:left;margin-right:10px;' title='Warning' src='../Shared/icons/warningTriangle.svg'/><p>OBS! Denna inlämning har gjorts efter att deadline har passerat. Läraren kommer att rätta duggan vid nästa ordinarie rättningstillfälle ELLER i mån av tid.</p>";
+				}
+				else{
+					document.getElementById('receiptInfo').innerHTML = "<p>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.</p><img style='width:40px;float:left;margin-right:10px;' title='Warning' src='../Shared/icons/warningTriangle.svg'/><p>"+comment+"</p>";
+				}
+
+			}
+			showReceiptPopup();
 		}
-
-		dateTimeFormat = [dateTime.getFullYear(),(dateTime.getMonth()+1).padLeft(),dateTime.getDate().padLeft()].join('-') +' ' +[dateTime.getHours().padLeft(),dateTime.getMinutes().padLeft(),dateTime.getSeconds().padLeft()].join(':');
-
-		if(deadline > dateTimeFormat){	//Check if deadline has past
-
-			document.getElementById('receiptInfo').innerHTML = "<p>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.\n\n</p>";
-
-		}
-		else{ //Check if deadline has past
-
-			if(comment == "UNK" || comment == "undefined" || comment == "null"){
- 				document.getElementById('receiptInfo').innerHTML = "<p style='margin:15px 5px;'>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.</p><img style='width:40px;float:left;margin-right:10px;' title='Warning' src='../Shared/icons/warningTriangle.svg'/><p>OBS! Denna inlämning har gjorts efter att deadline har passerat. Läraren kommer att rätta duggan vid nästa ordinarie rättningstillfälle ELLER i mån av tid.</p>";
- 			}
- 			else{
- 				document.getElementById('receiptInfo').innerHTML = "<p>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.</p><img style='width:40px;float:left;margin-right:10px;' title='Warning' src='../Shared/icons/warningTriangle.svg'/><p>"+comment+"</p>";
- 			}
-
-		}
-		showReceiptPopup();
+	});
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
If readonly is active on the server, students won't be able to submit duggas, an error will be shown instead.
[Issue 8218](https://github.com/HGustavs/LenaSYS/issues/8218)
Tester: login as a teacher and click the cog next to LenaSYS Course Organization System in courseed. Check the read only box and save. Then log in as a student and try to submit answers to a dugga. It should not work, and an error should be displayed in the console.
There seemed to be some inconsistensies whether checking the box works or not, sometimes I had to go back and check it again. This is most likely not caused by my solution. But keep that in mind if a student is still allowed to submit a dugga, log in as a teacher and check the readonly box again. 