### PR TITLE
Fixed the issue where coursename is gone when returning from coideviewer

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -851,6 +851,7 @@ function returnedSection(data) {
           var param = {
             'exampleid': item['link'],
             'courseid': querystring['courseid'],
+            'coursename' : querystring['coursename'],
             'cvers': querystring['coursevers'],
             'lid': item['lid']
           };


### PR DESCRIPTION
The issue was that coursename never existed when entering codeviewer so when returning it did not know what the coursename is

Now when returning from a dugga or codeviewer with the button in navheader the cid, coursename and coursevers are all there. The issue was that coursename was not there when returning from a codeviewer.

Co-Authored-By: Emil <b18emigu@users.noreply.github.com>