### PR TITLE
G4 2020 w20 issue#7360

### DIFF
--- a/Shared/resetpw.php
+++ b/Shared/resetpw.php
@@ -13,7 +13,6 @@ if($opt=="GETQUESTION"){
   
   // Request barrier
   $maxRequestTries = 5;
-  //$log_db = new PDO('sqlite:../../log/loglena4.db');
   $IP = getIP();
   $timeInterval = 5; // in minutes
 
@@ -71,7 +70,6 @@ if($opt=="GETQUESTION"){
 
   // Security question barrier
   $maxQuestionTries = 5;
-  //$log_db = new PDO('sqlite:../../log/loglena4.db');
   $IP = getIP();
   $timeInterval = 5; // in minutes
 

--- a/Shared/resetpw.php
+++ b/Shared/resetpw.php
@@ -13,7 +13,7 @@ if($opt=="GETQUESTION"){
   
   // Request barrier
   $maxRequestTries = 5;
-  $log_db = new PDO('sqlite:../../log/loglena4.db');
+  //$log_db = new PDO('sqlite:../../log/loglena4.db');
   $IP = getIP();
   $timeInterval = 5; // in minutes
 
@@ -71,7 +71,7 @@ if($opt=="GETQUESTION"){
 
   // Security question barrier
   $maxQuestionTries = 5;
-  $log_db = new PDO('sqlite:../../log/loglena4.db');
+  //$log_db = new PDO('sqlite:../../log/loglena4.db');
   $IP = getIP();
   $timeInterval = 5; // in minutes
 


### PR DESCRIPTION
Removed the redundant code. To test download sqlite and open the database after attempting to reset your password, event 12 is the event created by the request barrier(if the reset request failed because of a invalid username etc) and 13 is a log entry for security question entires after a valid username was entered. I didn't manage to find a valid username in my install after several attempts so I'm not sure how the solution works in there but the code looks the same in both spots.