### PR TITLE
Updating the style for tabs | Fix for issue #9169

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -755,27 +755,27 @@ p {
 
 /*Vertical line for end tabs for "1 tab + end"*/
 #Sectionlist .tabs4 .spacerRight {
-  height: 17px;
-  width: 18px;
-  margin: 0px 0px 12px 47px;
+  height: 19px;
+  width: 22px;
+  margin: 0px 0px 12px 45px;
   border-left: 2px solid black;
   border-bottom: 2px solid black;
   border-bottom-left-radius: 6px;
 }
 /*Vertical line for end tabs for "2 tabs + end"*/
 #Sectionlist .tabs5 .spacerRight {
-  height: 17px;
-  width: 20px;
-  margin: 0px 0px 12px 79px;
+  height: 19px;
+  width: 22px;
+  margin: 0px 0px 12px 77px;
   border-left: 2px solid black;
   border-bottom: 2px solid black;
   border-bottom-left-radius: 6px;
 }
 /*Vertical line for end tabs for "3 tabs + end"*/
 #Sectionlist .tabs6 .spacerRight {
-  height: 17px;
-  width: 20px;
-  margin: 0px 0px 12px 111px;
+  height: 19px;
+  width: 22px;
+  margin: 0px 0px 12px 109px;
   border-left: 2px solid black;
   border-bottom: 2px solid black;
   border-bottom-left-radius: 6px;


### PR DESCRIPTION
Updating the styling for the border-right for tabs indentation. The pixels were off for some reason after the merge. 

This is how it looked before:
![image](https://user-images.githubusercontent.com/49142028/81701306-1d76f180-946a-11ea-8258-997e8e960349.png)


This is how it looks now:
![image](https://user-images.githubusercontent.com/49142028/81701334-25cf2c80-946a-11ea-81a7-f8d6c6b05f1c.png)
