### PR TITLE
Fix Generate example writes to active layer - Issue 9170

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6232,6 +6232,13 @@ function fixActiveLayer(){
         correctSpan.id = "Layer_" + i +"_Active";
     }
 }
+function fixExampleLayer(){
+    for(let i = 0; i <diagram.length;i++){
+        diagram[i].properties.setLayer = writeToLayer;
+    }
+    updateGraphics();
+    SaveState();
+}
 //A check if line should connect to a object when loose line is released inside a object
 function canConnectLine(startObj, endObj){
     var okToMakeLine = false;

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -160,6 +160,7 @@ function SaveFile(el) {
 function LoadImport(fileContent) {
     a = fileContent;
     Load();
+    fixExampleLayer()
 }
 
 //---------------------------------------------


### PR DESCRIPTION
We should now be able to write a generate example diagram to a given layer. select a layer and see if the diagram is created within that layer. Before this fix the example diagrams where always written to layer one.

Link: http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239170/DuggaSys/diagram.php