### PR TITLE
Solution for clearing attributes connectorTop

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2485,12 +2485,16 @@ function eraseObject(object) {
         // lines
         } else {
             diagram.filter(
-                symbol => symbol.symbolkind == symbolKind.erEntity || symbol.symbolkind == symbolKind.erRelation || symbol.symbolkind == symbolKind.uml)
+                symbol => symbol.symbolkind == symbolKind.erEntity || symbol.symbolkind == symbolKind.erRelation || symbol.symbolkind == symbolKind.uml || symbol.symbolkind == symbolKind.erAttribute)
                     .filter(symbol =>   symbol.hasConnector(object.topLeft)
                                      && symbol.hasConnector(object.bottomRight))
                     .forEach(symbol => {
-                        symbol.removePointFromConnector(object.topLeft);
-                        symbol.removePointFromConnector(object.bottomRight);
+                        if(symbol.symbolkind == symbolKind.erAttribute){
+                            symbol.removePointFromConnector(symbol.centerPoint, object);
+                        } else{
+                            symbol.removePointFromConnector(object.topLeft);
+                            symbol.removePointFromConnector(object.bottomRight);
+                        }
                     });
 
             var attributesAndRelations = diagram.filter(symbol => symbol.symbolkind == symbolKind.erAttribute || symbol.symbolkind == symbolKind.erRelation || symbol.symbolkind == symbolKind.uml);

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1152,13 +1152,23 @@ function Symbol(kindOfSymbol) {
     // removePointFromConnector: Removes a point from this symbols connector
     //                           Used when lines are removed from an object
     //--------------------------------------------------------------------
-    this.removePointFromConnector = function(point) {
+    this.removePointFromConnector = function(point, line) {
         var broken = false;
         for(var i = 0; i < this.connectorTop.length; i++) {
             if(this.connectorTop[i].to == point || this.connectorTop[i].from == point) {
-                this.connectorTop.splice(i,1);
-                broken = true;
-                break;
+                //Extra check for attributes since many lines can share the same value (due to how lines many lines can connect to the same attributes centerpoint)
+                if(this.symbolkind == symbolKind.erAttribute){
+                    if((this.connectorTop[i].to == line.bottomRight && this.connectorTop[i].from == line.topLeft) || (this.connectorTop[i].from == line.bottomRight && this.connectorTop[i].to == line.topLeft)){
+                        this.connectorTop.splice(i,1);
+                        broken = true;
+                        break;
+                    }
+                }
+                else{
+                    this.connectorTop.splice(i,1);
+                    broken = true;
+                    break; 
+                }
             }
         }
         if(!broken) {


### PR DESCRIPTION
Removing lines from attributes now also deletes appropriate connection from connectorTop.

Function "removePointFromConnector" had to be modified to achieve this since more information was needed to delete correct connection when many lines can share the same startpoint due to how attributes work.

Tester:
Make connections to and from an ER-attribute and play around with deleting and adding connections while console logging the attribute. Also make sure that connection references the correct line in all situations.
http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239185/DuggaSys/diagram.php