### PR TITLE
G2 2020 w20 #8935

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -160,9 +160,9 @@ function addSingleUser() {
 }
 
 function verifyUserInputForm(input) {
-	// Verify SSN using checkSsnError function
+	// Verify SSN using validateSSN function
 	var errorString = '';
-	if(verifyString = checkSsnError(input[0])) {	// Returns null if there is no error
+	if(verifyString = validateSSN(input[0])) {	// Returns null if there is no error
 		alert(verifyString);
 		return false;
 	}
@@ -201,12 +201,12 @@ function verifyUserInputForm(input) {
 }
 
 //---------------------------------------------------------------------------------------------------
-// checkSsnError(ssn)
+// validateSSN(ssn)
 // Returns null if there are NO errors, otherwise a descripitve error message as string.
 // For information regarding Swedish personal identity numbers visit:
 // https://www.scb.se/contentassets/8d9d985ca9c84c6e8d879cc89a8ae479/ov9999_2016a01_br_be96br1601.pdf
 //---------------------------------------------------------------------------------------------------
-function checkSsnError(ssn)
+function validateSSN(ssn)
 {
 	const length = ssn.length;
 	const delimiter = length-5;	// The expected position of the '-' in the ssn
@@ -263,7 +263,7 @@ function updateErrorMessage()
 	var errorMsg = '';
 	var testString = '';
 
-	if(testString = checkSsnError(document.getElementById('addSsn').value))	// Check SSN for errors
+	if(testString = validateSSN(document.getElementById('addSsn').value))	// Check SSN for errors if input has been given
 		errorMsg += testString;
 
 	document.getElementById('addErrorMessage').innerHTML = errorMsg + ' ';	// Updates label

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -204,7 +204,7 @@ function verifyUserInputForm(input) {
  * For information regarding Swedish personal identity numbers visit:
  * https://www.scb.se/contentassets/8d9d985ca9c84c6e8d879cc89a8ae479/ov9999_2016a01_br_be96br1601.pdf
  ****************************************************************************************************/
-function checkSsnErrors(ssn)
+function checkSsnError(ssn)
 {
 	const length = ssn.length;
 	const delimiter = length-5;	// The expected position of the '-' in the ssn
@@ -212,11 +212,12 @@ function checkSsnErrors(ssn)
 	switch(length) {
 		case 11: case 13:
 			const formatTest = /\d{6,8}-\d{4}/;	// Expected format
-			if(formatTest.test(ssn))
+			if(formatTest.test(ssn)) {
 				break;
+			}
 			
 		default:
-			return 'Incorrect SSN format. Should be ######-#### or ########-####';
+			return 'Incorrect SSN format. Should be ######-#### or ########-####.';
 	}
 
 	const dd = ssn.substring(delimiter-2, delimiter);
@@ -226,15 +227,21 @@ function checkSsnErrors(ssn)
 	const controlDigit = ssn.substring(length-1);
 	const ssnDate = new Date(yyyy + '-' + mm + '-' + dd);
 
-	if(ssnDate.getTime() > Date.now())	// Make sure date of SSN is not in the future
+	if(ssnDate.getTime() > Date.now()) {			// Make sure date of SSN is not in the future
 		return 'Incorrect date in SSN. The future is not here yet';
+	}
+
+	if(isNaN(ssnDate)								// Make sure date is valid (i.e. not 87th April)
+		|| (parseInt(dd) !== ssnDate.getDate())) {	// Ensures leap years are handled correctly
+		return 'Invalid date in SSN.';
+	}
 
 	return null;	// The provided SSN is correct!
 }
 
-const testSSN = '200712-1234';
+const testSSN = '970229-1234';
 console.log(testSSN);
-console.log(checkSsnErrors(testSSN));
+console.log(checkSsnError(testSSN));
 
 var inputVerified;
 

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -200,12 +200,12 @@ function verifyUserInputForm(input) {
 	return true;
 }
 
-/*****************************************************************************************************
- * checkSsnError(ssn)
- * Returns null if there are NO errors, otherwise a descripitve error message.
- * For information regarding Swedish personal identity numbers visit:
- * https://www.scb.se/contentassets/8d9d985ca9c84c6e8d879cc89a8ae479/ov9999_2016a01_br_be96br1601.pdf
- ****************************************************************************************************/
+//---------------------------------------------------------------------------------------------------
+// checkSsnError(ssn)
+// Returns null if there are NO errors, otherwise a descripitve error message as string.
+// For information regarding Swedish personal identity numbers visit:
+// https://www.scb.se/contentassets/8d9d985ca9c84c6e8d879cc89a8ae479/ov9999_2016a01_br_be96br1601.pdf
+//---------------------------------------------------------------------------------------------------
 function checkSsnError(ssn)
 {
 	const length = ssn.length;
@@ -218,7 +218,7 @@ function checkSsnError(ssn)
 				break;
 						
 		default:
-			return 'SSN Error! Format should be ######-#### or ########-####.';
+			return 'SSN Error! Should be ######-#### or ########-####.';
 	}
 
 	const dd = ssn.substring(delimiter-2, delimiter);
@@ -252,6 +252,21 @@ function checkSsnError(ssn)
 		return 'SSN Error! Incorrect control digit (last digit). Expected: ' + ccd;
 
 	return null;	// The provided SSN is correct!
+}
+
+//-------------------------------------------------------------
+// updateErrorMessage()
+// Updates the error message shown inside the "Add user" window
+//-------------------------------------------------------------
+function updateErrorMessage()
+{
+	var errorMsg = '';
+	var testString = '';
+
+	if(testString = checkSsnError(document.getElementById('addSsn').value))	// Check SSN for errors
+		errorMsg += testString;
+
+	document.getElementById('addErrorMessage').innerHTML = errorMsg + ' ';	// Updates label
 }
 
 var inputVerified;

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -198,14 +198,16 @@ function verifyUserInputForm(input) {
 	return true;
 }
 
-/******************************************************************************
+/*****************************************************************************************************
  * checkSsnErrors(ssn)
- * Returns null if there are NO errors, otherwise a descripitve error message
- *****************************************************************************/
+ * Returns null if there are NO errors, otherwise a descripitve error message.
+ * For information regarding Swedish personal identity numbers visit:
+ * https://www.scb.se/contentassets/8d9d985ca9c84c6e8d879cc89a8ae479/ov9999_2016a01_br_be96br1601.pdf
+ ****************************************************************************************************/
 function checkSsnErrors(ssn)
 {
 	const length = ssn.length;
-	const delimiter = length-5;		// The expected position of the '-' in the ssn
+	const delimiter = length-5;	// The expected position of the '-' in the ssn
 
 	switch(length) {
 		case 11: case 13:
@@ -214,13 +216,23 @@ function checkSsnErrors(ssn)
 				break;
 			
 		default:
-			return 'Incorrect format. Should be ######-#### or ########-####';
+			return 'Incorrect SSN format. Should be ######-#### or ########-####';
 	}
 
-	return null;	// The provided ssn is correct
+	const dd = ssn.substring(delimiter-2, delimiter);
+	const mm = ssn.substring(delimiter-4, delimiter-2);
+	const yyyy = (length === 13) ? ssn.substring(0, 4) : 19+ssn.substring(0, 2);	// Ensure yyyy
+	const birthNum = ssn.substring(delimiter+1, delimiter+4);
+	const controlDigit = ssn.substring(length-1);
+	const ssnDate = new Date(yyyy + '-' + mm + '-' + dd);
+
+	if(ssnDate.getTime() > Date.now())	// Make sure date of SSN is not in the future
+		return 'Incorrect date in SSN. The future is not here yet';
+
+	return null;	// The provided SSN is correct!
 }
 
-const testSSN = '85555555-1234';
+const testSSN = '200712-1234';
 console.log(testSSN);
 console.log(checkSsnErrors(testSSN));
 

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -218,7 +218,7 @@ function checkSsnError(ssn)
 				break;
 						
 		default:
-			return 'SSN Error! Should be ######-#### or ########-####.';
+			return 'SSN Error! Should be ######-#### or ########-####';
 	}
 
 	const dd = ssn.substring(delimiter-2, delimiter);
@@ -228,11 +228,11 @@ function checkSsnError(ssn)
 	const ssnDate = new Date(`${yyyy}-${mm}-${dd}`);
 
 	if(ssnDate.getTime() > Date.now())			// Make sure date of SSN is not in the future
-		return 'SSN Error! Impossible date in SSN. The future is not here yet.';
+		return 'SSN Error! Impossible date in SSN. The future is not here yet';
 
 	if(isNaN(ssnDate)								// Make sure date is valid (i.e. not 87th April)
 		|| (parseInt(dd) !== ssnDate.getDate())) {	// Ensures leap years are handled correctly
-		return 'SSN Error! Invalid date.';
+		return 'SSN Error! Invalid date';
 	}
 
 	const controlDigitString = yyyy.substring(2, 4) + mm + dd + birthNum;

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -212,10 +212,9 @@ function checkSsnError(ssn)
 	switch(length) {
 		case 11: case 13:
 			const formatTest = /\d{6,8}-\d{4}/;	// Expected format
-			if(formatTest.test(ssn)) {
+			if(formatTest.test(ssn))
 				break;
-			}
-			
+						
 		default:
 			return 'Incorrect SSN format. Should be ######-#### or ########-####.';
 	}
@@ -224,24 +223,34 @@ function checkSsnError(ssn)
 	const mm = ssn.substring(delimiter-4, delimiter-2);
 	const yyyy = (length === 13) ? ssn.substring(0, 4) : 19+ssn.substring(0, 2);	// Ensure yyyy
 	const birthNum = ssn.substring(delimiter+1, delimiter+4);
-	const controlDigit = ssn.substring(length-1);
-	const ssnDate = new Date(yyyy + '-' + mm + '-' + dd);
+	const ssnDate = new Date(`${yyyy}-${mm}-${dd}`);
 
-	if(ssnDate.getTime() > Date.now()) {			// Make sure date of SSN is not in the future
+	if(ssnDate.getTime() > Date.now())			// Make sure date of SSN is not in the future
 		return 'Incorrect date in SSN. The future is not here yet';
-	}
 
 	if(isNaN(ssnDate)								// Make sure date is valid (i.e. not 87th April)
 		|| (parseInt(dd) !== ssnDate.getDate())) {	// Ensures leap years are handled correctly
 		return 'Invalid date in SSN.';
 	}
 
+	const controlDigitString = yyyy.substring(2, 4) + mm + dd + birthNum;
+	var ccd = 0;	// Calculated Control Digit
+	for(var i = 0; i < controlDigitString.length; i++) {
+		var n = parseInt(controlDigitString.charAt(i));
+		if(i%2 === 0) n *= 2;			// Every other digit should be multiplied by 2
+		if(n >= 10) n -= 9;				// If value is >= 10, 9 should be removed
+
+		ccd += n;	// Add value to the calculation in progress
+	}
+
+	ccd = 10 - (ccd%10);		// 10 - the last digit of the calculation
+	if(ccd === 10) ccd = 0;		// If value is 10, remove the left digit... Leads to ccd = 0
+
+	if(ccd != ssn.substring(length-1))	// Compare calculated to given control digit
+		return 'Incorrect control digit in SSN. Expected value: ' + ccd;
+
 	return null;	// The provided SSN is correct!
 }
-
-const testSSN = '970229-1234';
-console.log(testSSN);
-console.log(checkSsnError(testSSN));
 
 var inputVerified;
 

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -207,11 +207,22 @@ function checkSsnErrors(ssn)
 	const length = ssn.length;
 	const delimiter = length-5;		// The expected position of the '-' in the ssn
 
+	switch(length) {
+		case 11: case 13:
+			const formatTest = /\d{6,8}-\d{4}/;	// Expected format
+			if(formatTest.test(ssn))
+				break;
+			
+		default:
+			return 'Incorrect format. Should be ######-#### or ########-####';
+	}
+
 	return null;	// The provided ssn is correct
 }
 
-console.log('851226-5912');
-console.log(checkSsnErrors('851226-5912'));
+const testSSN = '85555555-1234';
+console.log(testSSN);
+console.log(checkSsnErrors(testSSN));
 
 var inputVerified;
 

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -198,6 +198,21 @@ function verifyUserInputForm(input) {
 	return true;
 }
 
+/******************************************************************************
+ * checkSsnErrors(ssn)
+ * Returns null if there are NO errors, otherwise a descripitve error message
+ *****************************************************************************/
+function checkSsnErrors(ssn)
+{
+	const length = ssn.length;
+	const delimiter = length-5;		// The expected position of the '-' in the ssn
+
+	return null;	// The provided ssn is correct
+}
+
+console.log('851226-5912');
+console.log(checkSsnErrors('851226-5912'));
+
 var inputVerified;
 
 function addClass() {

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -160,9 +160,10 @@ function addSingleUser() {
 }
 
 function verifyUserInputForm(input) {
-	// Verify SSN <= 20 characters
-	if (input[0].length > 20) {
-		alert('Input exceeded max length for SSN (20)');
+	// Verify SSN using checkSsnError function
+	var errorString = '';
+	if(verifyString = checkSsnError(input[0])) {	// Returns null if there is no error
+		alert(verifyString);
 		return false;
 	}
 
@@ -195,11 +196,12 @@ function verifyUserInputForm(input) {
 		alert('Email input must contain at least 1 character before "@" to create a username');
 		return false;
 	}
+
 	return true;
 }
 
 /*****************************************************************************************************
- * checkSsnErrors(ssn)
+ * checkSsnError(ssn)
  * Returns null if there are NO errors, otherwise a descripitve error message.
  * For information regarding Swedish personal identity numbers visit:
  * https://www.scb.se/contentassets/8d9d985ca9c84c6e8d879cc89a8ae479/ov9999_2016a01_br_be96br1601.pdf
@@ -216,7 +218,7 @@ function checkSsnError(ssn)
 				break;
 						
 		default:
-			return 'Incorrect SSN format. Should be ######-#### or ########-####.';
+			return 'SSN Error! Format should be ######-#### or ########-####.';
 	}
 
 	const dd = ssn.substring(delimiter-2, delimiter);
@@ -226,11 +228,11 @@ function checkSsnError(ssn)
 	const ssnDate = new Date(`${yyyy}-${mm}-${dd}`);
 
 	if(ssnDate.getTime() > Date.now())			// Make sure date of SSN is not in the future
-		return 'Incorrect date in SSN. The future is not here yet';
+		return 'SSN Error! Impossible date in SSN. The future is not here yet.';
 
 	if(isNaN(ssnDate)								// Make sure date is valid (i.e. not 87th April)
 		|| (parseInt(dd) !== ssnDate.getDate())) {	// Ensures leap years are handled correctly
-		return 'Invalid date in SSN.';
+		return 'SSN Error! Invalid date.';
 	}
 
 	const controlDigitString = yyyy.substring(2, 4) + mm + dd + birthNum;
@@ -247,7 +249,7 @@ function checkSsnError(ssn)
 	if(ccd === 10) ccd = 0;		// If value is 10, remove the left digit... Leads to ccd = 0
 
 	if(ccd != ssn.substring(length-1))	// Compare calculated to given control digit
-		return 'Incorrect control digit in SSN. Expected value: ' + ccd;
+		return 'SSN Error! Incorrect control digit (last digit). Expected: ' + ccd;
 
 	return null;	// The provided SSN is correct!
 }

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -230,7 +230,7 @@ function validateSSN(ssn)
 	if(ssnDate.getTime() > Date.now())			// Make sure date of SSN is not in the future
 		return 'SSN Error! Impossible date in SSN. The future is not here yet';
 
-	if(isNaN(ssnDate)								// Make sure date is valid (i.e. not 87th April)
+	if(isNaN(ssnDate)					// Make sure date is valid (i.e. not 87th April)
 		|| (parseInt(dd) !== ssnDate.getDate())) {	// Ensures leap years are handled correctly
 		return 'SSN Error! Invalid date';
 	}
@@ -240,7 +240,7 @@ function validateSSN(ssn)
 	for(var i = 0; i < controlDigitString.length; i++) {
 		var n = parseInt(controlDigitString.charAt(i));
 		if(i%2 === 0) n *= 2;			// Every other digit should be multiplied by 2
-		if(n >= 10) n -= 9;				// If value is >= 10, 9 should be removed
+		if(n >= 10) n -= 9;			// If value is >= 10, 9 should be subtracted
 
 		ccd += n;	// Add value to the calculation in progress
 	}

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -87,7 +87,7 @@
       		</div>
       		<div style='padding:5px;'>
       			<input type='hidden' id='uid' value='Toddler' />
-      			<div class='inputwrapper'><span>SSN:</span><input placeholder="990102-5578" class='textinput' type='text' id='addSsn'/></div>
+      			<div class='inputwrapper'><span>SSN:</span><input placeholder="990102-5578" class='textinput' type='text' id='addSsn' onchange="updateErrorMessage()"/></div>
       			<div class='inputwrapper'><span>First Name:</span><input placeholder="Greger" class='textinput' type='text' id='addFirstname'/></div>
       			<div class='inputwrapper'><span>Last Name:</span><input placeholder="Gregersson" class='textinput' type='text' id='addLastname'/></div>
       			<div class='inputwrapper'><span>CID:</span><input placeholder="91001" class='textinput' id='addCid'></div>
@@ -96,7 +96,12 @@
       			<div class='inputwrapper'><span>Term:</span><input placeholder="H11" class='textinput' id='addTerm'></div>
       			<div class='inputwrapper'><span>Email:</span><input placeholder="b17mahgo@student.his.se" class='textinput' id='addEmail'></div>
       		</div>
-      		<div style='padding:5px;'>
+			<div style='padding:5px;'>
+				<div>
+					<label id='addErrorMessage'> </label>
+				</div>
+			</div>  
+			<div style='padding:5px;'>
       			<input class='submit-button' type='button' value='Add' onclick='addSingleUser();' />
       		</div>
       </div>

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -87,7 +87,7 @@
       		</div>
       		<div style='padding:5px;'>
       			<input type='hidden' id='uid' value='Toddler' />
-      			<div class='inputwrapper'><span>SSN:</span><input placeholder="999102-5571" class='textinput' type='text' id='addSsn'/></div>
+      			<div class='inputwrapper'><span>SSN:</span><input placeholder="990102-5578" class='textinput' type='text' id='addSsn'/></div>
       			<div class='inputwrapper'><span>First Name:</span><input placeholder="Greger" class='textinput' type='text' id='addFirstname'/></div>
       			<div class='inputwrapper'><span>Last Name:</span><input placeholder="Gregersson" class='textinput' type='text' id='addLastname'/></div>
       			<div class='inputwrapper'><span>CID:</span><input placeholder="91001" class='textinput' id='addCid'></div>

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -87,7 +87,7 @@
       		</div>
       		<div style='padding:5px;'>
       			<input type='hidden' id='uid' value='Toddler' />
-      			<div class='inputwrapper'><span>SSN:</span><input placeholder="990102-5578" class='textinput' type='text' id='addSsn' onchange="updateErrorMessage()"/></div>
+      			<div class='inputwrapper'><span>SSN:</span><input placeholder="990102-5578" class='textinput' type='text' id='addSsn' onchange="updateErrorMessage()" onkeyup="updateErrorMessage()"/></div>
       			<div class='inputwrapper'><span>First Name:</span><input placeholder="Greger" class='textinput' type='text' id='addFirstname'/></div>
       			<div class='inputwrapper'><span>Last Name:</span><input placeholder="Gregersson" class='textinput' type='text' id='addLastname'/></div>
       			<div class='inputwrapper'><span>CID:</span><input placeholder="91001" class='textinput' id='addCid'></div>
@@ -97,7 +97,7 @@
       			<div class='inputwrapper'><span>Email:</span><input placeholder="b17mahgo@student.his.se" class='textinput' id='addEmail'></div>
       		</div>
 			<div style='padding:5px;'>
-				<div>
+				<div class='accessTableAddUserWarning'>
 					<label id='addErrorMessage'> </label>
 				</div>
 			</div>  

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2893,6 +2893,10 @@ span.arrow {
   margin-right: 3px;
 }
 
+.accessTableAddUserWarning {
+  color: var(--color-red-hover);
+}
+
 .accessTableCell {
   height: 60px;
   text-align: center;


### PR DESCRIPTION
To test this pull request create a new user and input invalid personal identification number and a warning should appear on the bottom. The following criterion should be checked:
1. Format is expected to be `######-####` or `########-####`
2. Year cannot be in the future
3. Only correct dates should be ok. 1997 was not a leap year so 29th of February that year should give an error. For example `970229-1313`.
4. The last digit of an SSN is a control digit. Make sure it doesn't give an error when you enter yours.