### PR TITLE
Put shadow on "back" icon | Fix for issue #9197

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -67,7 +67,7 @@
 					echo "<img src='../Shared/icons/Up.svg'></a></td>";
   				echo "<td class='navButt' id='announcement' title='Announcement'><img src='../Shared/icons/announcement_icon.svg'></td>";
 			}else if($noup=='SECTION'){
-					echo "<a href='";
+					echo "<a id='upIcon' href='";
 					echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
 					echo "'>";
 					echo "<img src='../Shared/icons/Up.svg'></a></td>";


### PR DESCRIPTION
Before this fix, the "back" icon in the navheader only had a shadow-hover effect on the **sectioned.php** page and not on all the other pages that the icon existed on.

This fix makes it so that the "back" icon has a shadow-hover effect on all the other pages it exists on as well. These pages include:

- resulted.php
- duggaed.php
- fileed.php
- accessed.php

Image for clarification:
![image](https://user-images.githubusercontent.com/49142028/81798306-2c17e400-9510-11ea-8a08-9bc9a4600fb9.png)

The applied hover effect on the "back" icon:
<a href="https://gyazo.com/0f2e8c0f911a0a022e1888e313ded251"><img src="https://i.gyazo.com/0f2e8c0f911a0a022e1888e313ded251.gif" alt="Image from Gyazo" width="138"/></a>