### PR TITLE
fix issue#9196 Text object flash / Savestate issue solved

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4262,6 +4262,8 @@ function mouseupevt(ev) {
     if (movobj > -1) {
         if (diagram[movobj].symbolkind != symbolKind.line && uimode == "Moved") saveState = true;
     }
+    // Selecting objects in Create Line mode returns false saveState
+    if (uimode == "CreateLine" && !mouseDifference) saveState = false;
     if (symbolStartKind != symbolKind.uml && uimode == "CreateLine" && md == mouseState.boxSelectOrCreateMode && mouseDifference) {
         saveState = false;
         //Check if you release on canvas or try to draw a line from entity to entity

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4282,8 +4282,7 @@ function mouseupevt(ev) {
             // if then, set point1 and point2
             //okToMakeLine is a flag for this
             var okToMakeLine = true;
-            if (symbolStartKind != symbolKind.line && symbolEndKind != symbolKind.line &&
-                symbolStartKind != symbolKind.text && symbolEndKind != symbolKind.text) {
+            if (symbolStartKind != symbolKind.line && symbolEndKind != symbolKind.line) {
                 var createNewPoint = false;
                 if (diagram[lineStartObj].symbolkind == symbolKind.erAttribute) {
                     p1 = diagram[lineStartObj].centerPoint;
@@ -4342,6 +4341,11 @@ function mouseupevt(ev) {
                 if(diagram[lineStartObj].kind == 1 || diagram[markedObject].kind == 1){
                     okToMakeLine = false;
                     flash("Can not draw line to/from a freedraw object", "danger");
+                }
+              
+                if(symbolEndKind == symbolKind.text || symbolStartKind == symbolKind.text) {
+                    okToMakeLine = false;
+                    flash("Can not draw line to/from a text object", "danger");
                 }
 
                 if (okToMakeLine) {


### PR DESCRIPTION
**Link to test:** http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239196/DuggaSys/diagram.php

Before fix there were flashes when creating incorrect relations between all object except for text objects. Now there should flashes for when trying to create lines to/from text objects. 

**Test this:** Create a couple of different object including a text object, select the "Create Line" tool and try to create relations with the text object by dragging the mouse to or from the text object. 

Before: 

![024e6714520dc382c20903ce038ae03a](https://user-images.githubusercontent.com/49142301/81797969-bd3a8b00-950f-11ea-8209-63bd51bc306d.gif)

After: 

![a590e918eaf19dabedc625aa9e531da9](https://user-images.githubusercontent.com/49142301/81798142-fc68dc00-950f-11ea-976f-ba0ac38111d0.gif)

Before fix the Savestate would trigger everytime the user selected different objects with the "Create Line" tool selected. After fix this should not happen anymore.

**Test this:**  Create a couple of different objects, then open the web browser's insepect mode and view the local storage. Inspect --> Application --> Local Storage. Select the "Create Line" tool and try to select the different objects on the canvas by clicking on them. Make sure the program doesn't store any new savestates while selecting. 

Before:

![ad6e27d437f97c36bd8d635502b0a909](https://user-images.githubusercontent.com/49142301/81799155-3b4b6180-9511-11ea-9368-6d9a6d213f1e.gif)

After:

![7ff4f54dffb6925865eae18a1d2d3bd0](https://user-images.githubusercontent.com/49142301/81799350-86fe0b00-9511-11ea-8d9b-e89e3d8c9217.gif)

