### PR TITLE
Fixes #9063 - Rulers showing selected object point coordinates

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6194,6 +6194,7 @@ function canConnectLine(startObj, endObj){
 function createRulers() {
     createRuler(document.querySelector("#ruler-x .ruler-lines"), canvas.width, origoOffsetX, "marginLeft");
     createRuler(document.querySelector("#ruler-y .ruler-lines"), canvas.height, origoOffsetY, "marginTop");
+    createRulerLinesObjectPoints();
 }
 
 //------------------------------------------------------------------------------
@@ -6258,7 +6259,18 @@ function createRulerLinesObjectPoints() {
     const selectedPoints = getSelectedObjectsPoints();
 
     selectedPoints.forEach(point => {
+        const canvasCoordinate = pixelsToCanvas(point.x, point.y);
+        const lineX = document.createElement("div");
+        const lineY = document.createElement("div");
 
+        lineX.classList.add("point-line");
+        lineY.classList.add("point-line");
+
+        lineX.style.left = `${canvasCoordinate.x}px`;
+        lineY.style.top = `${canvasCoordinate.y}px`;
+
+        rulerExtraLinesX.appendChild(lineX);
+        rulerExtraLinesY.appendChild(lineY);
     });
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3690,8 +3690,7 @@ function mousemoveevt(ev) {
 
     //Update the moving mouse line positions for x-axis and y-axis rulers when rulers are active
     if(isRulersActive) {
-        document.querySelector("#ruler-x .ruler-extra-lines .mouse-line").style.left = `${ev.offsetX}px`;
-        document.querySelector("#ruler-y .ruler-extra-lines .mouse-line").style.top = `${ev.offsetY}px`;
+        setRulerMouseLinesPosition(ev.offsetX, ev.offsetY);
     }
 
     // deltas are used to determine the range of which the mouse is allowed to move when pressed.
@@ -6195,6 +6194,15 @@ function canConnectLine(startObj, endObj){
 function createRulers() {
     createRuler(document.querySelector("#ruler-x .ruler-lines"), canvas.width, origoOffsetX, "marginLeft");
     createRuler(document.querySelector("#ruler-y .ruler-lines"), canvas.height, origoOffsetY, "marginTop");
+}
+
+//------------------------------------------------------------------------------
+// setRulerMouseLinesPosition: Move rulers mouse position lines to passed value.
+//------------------------------------------------------------------------------
+
+function setRulerMouseLinesPosition(x, y) {
+    document.querySelector("#ruler-x .ruler-extra-lines .mouse-line").style.left = `${x}px`;
+    document.querySelector("#ruler-y .ruler-extra-lines .mouse-line").style.top = `${y}px`;
 }
 
 //--------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6246,6 +6246,22 @@ function createRuler(element, length, origoOffset, marginProperty) {
     }
 }
 
+//-------------------------------------------------------------------------------------
+// createRulerLinesObjectPoints: Creates lines on ruler for all selected object points.
+//-------------------------------------------------------------------------------------
+
+function createRulerLinesObjectPoints() {
+
+}
+
+//------------------------------------------------------------------------------------
+// getSelectedObjectsPoints: Returns unique points for all currently selected objects.
+//------------------------------------------------------------------------------------
+
+function getSelectedObjectsPoints() {
+
+}
+
 //------------------------------------------------------------------------------------------------
 // toggleRulers: Hides rulers if isRulersActive is true and shows them if isRulersActive is false.
 //------------------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -687,6 +687,7 @@ function keyDownHandler(e) {
                 selected_objects.push(diagram[i]);
                 diagram[i].targeted = true;
             }
+            createRulerLinesObjectPoints();
             updateGraphics();
         } else if(key == keyMap.ctrlKey || key == keyMap.windowsKey) {
             ctrlIsClicked = true;
@@ -2528,6 +2529,7 @@ function eraseSelectedObject(event) {
     }
     selected_objects = [];
     lastSelectedObject = -1;
+    createRulerLinesObjectPoints();
     updateGraphics();
 }
 
@@ -3274,6 +3276,7 @@ function undoDiagram(event) {
     selected_objects = diagram.filter(object => object.targeted);
     cloneTempArray = [];
     hoveredObject = undefined;
+    createRulerLinesObjectPoints();
 }
 
 //----------------------------------------------------------------------
@@ -3294,6 +3297,7 @@ function redoDiagram(event) {
     selected_objects = diagram.filter(object => object.targeted);
     cloneTempArray = [];
     hoveredObject = undefined;
+    createRulerLinesObjectPoints();
 }
 
 //----------------------------------------------------------------------
@@ -4068,6 +4072,7 @@ function mousemoveevt(ev) {
             }
         }
     }
+    createRulerLinesObjectPoints();
 }
 
 //----------------------------------------------------------
@@ -4134,6 +4139,7 @@ function mousedownevt(ev) {
             }
             lastSelectedObject = -1;
             selected_objects = [];
+            createRulerLinesObjectPoints();
         }
         startMouseCoordinateX = currentMouseCoordinateX;
         startMouseCoordinateY = currentMouseCoordinateY;
@@ -4182,6 +4188,7 @@ function handleSelect() {
             lastSelectedObject = diagram.indexOf(selected_objects[selected_objects.length-1]);
         }
     }
+    createRulerLinesObjectPoints();
 }
 
 function mouseupevt(ev) {
@@ -6243,6 +6250,8 @@ function createRuler(element, length, origoOffset, marginProperty) {
 //-------------------------------------------------------------------------------------
 
 function createRulerLinesObjectPoints() {
+    if(!isRulersActive) return;
+
     const rulerExtraLinesX = document.querySelector("#ruler-x .ruler-extra-lines");
     const rulerExtraLinesY = document.querySelector("#ruler-y .ruler-extra-lines");
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6258,6 +6258,9 @@ function createRulerLinesObjectPoints() {
     //Get an array of points used by all selected objects
     const selectedPoints = getSelectedObjectsPoints();
 
+    //Remove all current point liens
+    document.querySelectorAll(".point-line").forEach(element => element.remove());
+
     selectedPoints.forEach(point => {
         const canvasCoordinate = pixelsToCanvas(point.x, point.y);
         const lineX = document.createElement("div");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6251,7 +6251,15 @@ function createRuler(element, length, origoOffset, marginProperty) {
 //-------------------------------------------------------------------------------------
 
 function createRulerLinesObjectPoints() {
+    const rulerExtraLinesX = document.querySelector("#ruler-x .ruler-extra-lines");
+    const rulerExtraLinesY = document.querySelector("#ruler-y .ruler-extra-lines");
 
+    //Get an array of points used by all selected objects
+    const selectedPoints = getSelectedObjectsPoints();
+
+    selectedPoints.forEach(point => {
+
+    });
 }
 
 //------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2370,9 +2370,7 @@ function canvasSize() {
     canvas.width = diagramContainer.offsetWidth;
     canvas.height = diagramContainer.offsetHeight;
     boundingRect = canvas.getBoundingClientRect();
-    if(isRulersActive) {
-        createRulers();
-    }
+    createRulers();
     updateGraphics();
 }
 
@@ -3521,11 +3519,7 @@ function zoomInMode(event) {
         origoOffsetX -= centerX * zoomDifference - centerX;
         origoOffsetY -= centerY * zoomDifference - centerY;
     }
-
-    if(isRulersActive) {
-        createRulers();
-    }
-
+    createRulers();
     reWrite();
     updateGraphics();
 }
@@ -3724,9 +3718,7 @@ function mousemoveevt(ev) {
         startMouseCoordinateY = canvasToPixels(0, ev.clientY - boundingRect.top).y;
         localStorage.setItem("cameraPosX", origoOffsetX);
         localStorage.setItem("cameraPosY", origoOffsetY);
-        if(isRulersActive) {
-            createRulers();
-        }
+        createRulers();
     }
     reWrite();
     updateGraphics();
@@ -4761,9 +4753,7 @@ function touchMoveEvent(event) {
         localStorage.setItem("cameraPosX", origoOffsetX);
         localStorage.setItem("cameraPosY", origoOffsetY);
         
-        if(isRulersActive) {
-            createRulers();
-        }
+        createRulers();
     }
 
     // Moves an object
@@ -6192,6 +6182,7 @@ function canConnectLine(startObj, endObj){
 //-----------------------------------------------
 
 function createRulers() {
+    if(!isRulersActive) return;
     createRuler(document.querySelector("#ruler-x .ruler-lines"), canvas.width, origoOffsetX, "marginLeft");
     createRuler(document.querySelector("#ruler-y .ruler-lines"), canvas.height, origoOffsetY, "marginTop");
     createRulerLinesObjectPoints();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6259,7 +6259,7 @@ function createRulerLinesObjectPoints() {
 //------------------------------------------------------------------------------------
 
 function getSelectedObjectsPoints() {
-    return selected_objects.reduce((set, object) => {
+    const selectedPoints = selected_objects.reduce((set, object) => {
         object.getPoints().forEach(pointIndex => {
             if(typeof pointIndex !== "undefined") {
                 set.add(points[pointIndex]);
@@ -6267,6 +6267,8 @@ function getSelectedObjectsPoints() {
         });
         return set;
     }, new Set());
+
+    return [...selectedPoints];
 }
 
 //------------------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6259,7 +6259,14 @@ function createRulerLinesObjectPoints() {
 //------------------------------------------------------------------------------------
 
 function getSelectedObjectsPoints() {
-
+    return selected_objects.reduce((set, object) => {
+        object.getPoints().forEach(pointIndex => {
+            if(typeof pointIndex !== "undefined") {
+                set.add(points[pointIndex]);
+            }
+        });
+        return set;
+    }, new Set());
 }
 
 //------------------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4717,6 +4717,7 @@ function touchStartEvent(event) {
         }
         lastSelectedObject = -1;
         selected_objects = [];
+        createRulerLinesObjectPoints();
         startMouseCoordinateX = currentMouseCoordinateX;
         startMouseCoordinateY = currentMouseCoordinateY;
     }
@@ -4817,9 +4818,9 @@ function touchMoveEvent(event) {
         ctx.stroke();
         ctx.setLineDash([]);
     }
+    createRulerLinesObjectPoints();
     reWrite();
     updateGraphics();
-
 }
 
 // Takes the closest selected point and resizes the object
@@ -6257,6 +6258,7 @@ function createRulerLinesObjectPoints() {
 
     //Get an array of points used by all selected objects
     const selectedPoints = getSelectedObjectsPoints();
+    console.log(selectedPoints);
 
     //Remove all current point liens
     document.querySelectorAll(".point-line").forEach(element => element.remove());

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6251,7 +6251,7 @@ function createRuler(element, length, origoOffset, marginProperty) {
 //-------------------------------------------------------------------------------------
 
 function createRulerLinesObjectPoints() {
-    if(!isRulersActive) return;
+    if(!isRulersActive || selected_objects.length < 1) return;
 
     const rulerExtraLinesX = document.querySelector("#ruler-x .ruler-extra-lines");
     const rulerExtraLinesY = document.querySelector("#ruler-y .ruler-extra-lines");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6258,7 +6258,6 @@ function createRulerLinesObjectPoints() {
 
     //Get an array of points used by all selected objects
     const selectedPoints = getSelectedObjectsPoints();
-    console.log(selectedPoints);
 
     //Remove all current point liens
     document.querySelectorAll(".point-line").forEach(element => element.remove());

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -3395,6 +3395,20 @@ function Path() {
         }
         return str;
     }
+    
+    //--------------------------------------------------
+    // getPoints: Returns all unique points in the path.
+    //--------------------------------------------------
+
+    this.getPoints = function() {
+        const points = this.segments.reduce((set, segment) => {
+            set.add(segment.pa); 
+            set.add(segment.pb); 
+            return set;
+        }, new Set());
+
+        return [...points];
+    }
 }
 
 var figurePath = new Path();

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5040,23 +5040,48 @@ only screen and (max-device-width: 320px) {
   left: 0;
 }
 
-.ruler-extra-lines .mouse-line {
+.ruler-extra-lines .mouse-line,
+.ruler-extra-lines .point-line {
   position: absolute;
+}
+
+.ruler-extra-lines .mouse-line {
   background-color: var(--color-text-primary);
 }
 
-#ruler-x .ruler-extra-lines .mouse-line {
-  width: 4px;
+.ruler-extra-lines .point-line {
+  background-color: var(--color-red);
+}
+
+#ruler-x .ruler-extra-lines .mouse-line,
+#ruler-x .ruler-extra-lines .point-line {
   height: calc(var(--ruler-size) / 4);
   bottom: 0;
   left: 0;
 }
 
-#ruler-y .ruler-extra-lines .mouse-line {
-  height: 4px;
+#ruler-y .ruler-extra-lines .mouse-line,
+#ruler-y .ruler-extra-lines .point-line {
   width: calc(var(--ruler-size) / 4);
   top: 0;
   right: 0;
+}
+
+
+#ruler-x .ruler-extra-lines .mouse-line {
+  width: 4px;
+}
+
+#ruler-x .ruler-extra-lines .point-line {
+  width: 3px;
+}
+
+#ruler-y .ruler-extra-lines .mouse-line {
+  height: 4px;
+}
+
+#ruler-y .ruler-extra-lines .point-line {
+  height: 3px;
 }
 
 /* --------------================################================-------------- *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4950,6 +4950,7 @@ only screen and (max-device-width: 320px) {
   border-top: 1px solid #000000;
   border-left: 1px solid #000000;
   position: relative;
+  overflow: hidden;
 }
 
 .ruler.hidden {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5001,11 +5001,11 @@ only screen and (max-device-width: 320px) {
 }
 
 #ruler-x .ruler-line:first-of-type {
-  margin-left: 0;
+  margin-left: 0 !important;
 }
 
 #ruler-y .ruler-line:first-of-type {
-  margin-top: 0;
+  margin-top: 0 !important;
 }
 
 #ruler-x .big {


### PR DESCRIPTION
The rulers do now show the points for the selected objects. Test to select one and multiple objects to see so all points show up at all times when the objects are selected. Try to move around the selected objects and the lines should follow on the rulers. Move camera and test zoom. 

I know one problem which I will solve in a new issue after weekly merge since I want to get this into the weekly branch. That problem is that connected lines to a selected ER entity that are not selected also show up on the rulers. This is due to previously faulty functions not returning the correct values. The intention is to fix these functions in a new issue to also prevent this problem.

Link: http://group4.webug.his.se:20001/G4-2020-W20-ISSUE%239063/DuggaSys/diagram.php
