### PR TITLE
Fixed displaying CPU usage in analytic - G1-2020-W20-ISSUE#8802

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -121,7 +121,20 @@ function loadGeneralStats() {
 				value: data.ram.freePercent
 			});
 			drawPieChart(chartData, 'RAM Usage on the Server', true);
-		}		
+		}	
+		
+		// CPU Usage
+			var chartData = [];
+			chartData.push({
+				label: 'CPU Load',
+				value: data.cpu.totalPercent
+			});
+		
+			chartData.push({
+				label: 'CPU Free',
+				value: data.cpu.freePercent
+			});
+			drawPieChart(chartData, 'CPU Usage on the Server', true);		
 	});
 }
 
@@ -661,7 +674,7 @@ function drawPieChart(data, title = null, multirow = false) {
 	var ctx = canvas.getContext("2d");
 
 	if(multirow) {
-		fitCanvasToContainer(canvas, 48.5, 75);
+		fitCanvasToContainer(canvas, 33, 80);
 	} else {
 		fitCanvasToContainer(canvas);
 	}


### PR DESCRIPTION
CPU usage is now displayed on the analytic page.

To test, go to the analytic page and it should look like this:

![cpuusage](https://user-images.githubusercontent.com/62876595/81824325-a575fd80-9535-11ea-99a0-0e0e121a1569.jpg)

If having Microsoft Windows: Getting accurate values has been a little tricky since task manager, performance monitor and "wmic cpu get loadpercentage" seem to get slightly different values. What one can do is run "wmic cpu get loadpercentage /every:1" in powershell/the command prompt and refresh the analytic page.


