### PR TITLE
SaveStated called only when deleting objects (solves 9187)

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -547,6 +547,7 @@ function deleteFreedrawObject() {
             // If a point isn't hovered, delete object
             if (point.distance > 10 / zoomValue){
                 eraseObject(point.attachedSymbol);
+                SaveState();
                 return;
             }
             // Freedraw objects need at least 3 points
@@ -555,7 +556,8 @@ function deleteFreedrawObject() {
             }
             // Remove hovered point
             else {
-                removeFreedrawPoint(point.attachedSymbol, pointId); 
+                removeFreedrawPoint(point.attachedSymbol, pointId);
+                SaveState(); 
             }
         }
     }
@@ -616,7 +618,6 @@ function keyDownHandler(e) {
     if ((key == keyMap.deleteKey || key == keyMap.backspaceKey)) {
         deleteFreedrawObject();
         eraseSelectedObject(event);
-        SaveState();
     }  
     //Check if enter is pressed when "focused" on an item in the dropdown menu
     if(key == keyMap.enterKey) {
@@ -2530,6 +2531,7 @@ function eraseSelectedObject(event) {
     for(var i = 0; i < selected_objects.length; i++) {
         if (selected_objects[i].figureType != "Free") {
             eraseObject(selected_objects[i]);
+            SaveState();
         }
     }
     selected_objects = [];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2528,11 +2528,15 @@ function eraseObject(object) {
 
 function eraseSelectedObject(event) {
     event.stopPropagation();
+    var objectDeleted = false;
     for(var i = 0; i < selected_objects.length; i++) {
         if (selected_objects[i].figureType != "Free") {
             eraseObject(selected_objects[i]);
-            SaveState();
+            objectDeleted = true;
         }
+    }
+    if(objectDeleted){
+        SaveState();
     }
     selected_objects = [];
     lastSelectedObject = -1;


### PR DESCRIPTION
SaveState is no longer called everytime you hit 'delete', only when an object/point actually is removed.
To test, watch for console output "State is saved" as you delete objects and as you hit delete when nothing is selected.