### PR TITLE
#9249 now only runs validateDuggaName on selection for existing duggas

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -109,8 +109,10 @@ function selectDugga(qid) {
 	$("#releasem").html(makeoptions(quiz['qrelease'].substr(14,2),marro,marrv));
 
 	$("#editDugga").css("display", "flex");
-	/* Validates name as soon as a dugga is selected.*/
-	validateDuggaName();
+	/* Validates name as soon as a dugga is selected, but only if dugga already exists (new duggas will not be validated here).*/
+	if(qid != "UNK"){
+		validateDuggaName();
+	}
 }
 
 


### PR DESCRIPTION
Solves #9249. 

Added a check for qid. If qid != "UNK", validateDuggaName is run when a dugga is selected in the Dugga Editor which means new duggas (where qid === "UNK") will not have their name validated right away (only onChange).