### PR TITLE
Putting box shadow on MOTD banners | Fix for issue #9194

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4112,6 +4112,7 @@ rect[class*="activitymarker"]:hover {
 }
 
 #servermsgcontainer{
+  box-shadow:1px 1px 6px grey;
   display: flex;
   justify-content: center;
   flex-direction: column;
@@ -6969,10 +6970,7 @@ textarea#filecont {
   width: 100%;
 }
 #motdArea{
-  /*border: 1px;
-  border-radius: 2px;
-  border-style: solid;
-  border-color: #614875;*/
+  box-shadow: 1px 1px 6px grey;
   border-collapse:collapse;
   background-color: #FECC56;
   justify-content: center;


### PR DESCRIPTION
Putting a tasteful box shadow on MOTD banners to make them look less one-dimensional.

![image](https://user-images.githubusercontent.com/49142028/81918152-69df4000-95d6-11ea-8454-12be38a60845.png)
![image](https://user-images.githubusercontent.com/49142028/81918186-75326b80-95d6-11ea-8d64-4b165ae4ef1f.png)
