### PR TITLE
Deleted unused styling of color. #9269

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3024,7 +3024,6 @@ padding: 10px;
 }
 .access-dropdown-selected {
   background-color:var(--color-accent);
-  color:var(--color-primary);
 }
 #reset-pw{
   width:70%; 


### PR DESCRIPTION
Deleted unused styling of color that was overwritten. The group agreed that the text should be black instead of purple, for clarity.