### PR TITLE
Resolved data not showing up on page information - G1-2020-W21-ISSUE#9266

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -570,10 +570,19 @@ function loadPageInformation() {
 
 			var tableData = [["Page", "Hits"]];
 			for(var i = 0; i < pages.length; i++){
-				tableData.push([
-					pages[i],
-					data['hits'][pages[i]].pageLoads
-				]);
+
+				if(data['hits'][pages[i]] !== null){
+					tableData.push([
+						pages[i],
+						data['hits'][pages[i]].pageLoads
+					]);
+				}
+				else{
+					tableData.push([
+						pages[i],
+						"0"
+					]);
+				}
 			}
 
             updatePieChartInformation(page, tableData, data);
@@ -606,7 +615,6 @@ function loadPageInformation() {
 					cid: parseInt(courseID[i])
 				},success: function(data){
 					loopCounter++;
-					console.log("success");
 					for (var i = 0; i < data.length; i++) {
 						courseName.push([
 							data[i].coursename
@@ -621,7 +629,9 @@ function loadPageInformation() {
 						]);
 					}
 					if(loopCounter == numberOfCourses){
-						$('#analytic-info').append(renderTable(tablePercentage));
+						if(courseName.length !== 0){
+							$('#analytic-info').append(renderTable(tablePercentage));
+						}
 					}
 				}, error: function(){
 					console.log(" AJAX error");
@@ -640,7 +650,9 @@ function loadPageInformation() {
         $('#analytic-info').append("<p>Page information.</p>");
         $('#analytic-info').append(selectPage);
 		$('#analytic-info').append(renderTable(tableData));
-        $('#analytic-info').append(drawPieChart(chartData, "Hit spread for " + page + " page loads:"));
+		if(chartData !== 0){
+		$('#analytic-info').append(drawPieChart(chartData, "Hit spread for " + page + " page loads:"));
+		}
         updateState();
     }
  

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -576,8 +576,7 @@ function loadPageInformation() {
 						pages[i],
 						data['hits'][pages[i]].pageLoads
 					]);
-				}
-				else{
+				}else{
 					tableData.push([
 						pages[i],
 						"0"

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -665,7 +665,7 @@ function pageInformation(){
 				INSTR(refer, "courseid=")+9, 
 				INSTR(refer, "&coursename=")-18 - INSTR(refer, "courseid=")+9
 			) courseid,
-			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM duggaLoadLogEntries WHERE refer LIKE "%sectioned%") AS percentage,
+			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM userHistory WHERE refer LIKE "%sectioned%") AS percentage,
 			COUNT(*) AS pageLoads
 		FROM 
 			userHistory


### PR DESCRIPTION
Now logged data is presented again in page information:

![Screenshot 2020-05-14 at 12 20 24](https://user-images.githubusercontent.com/62876614/81923039-571c3980-95dd-11ea-9b7c-febce45f550a.png)
