### PR TITLE
#9281 Last Modified date now correctly gets seconds cut off when rendering to table

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -707,6 +707,7 @@ function renderCell(col, celldata, cellid) {
 		case "qstart":		// DUGGA-TABLE - Startdate
 		case "deadline":	// DUGGA-TABLE - Deadline
 		case "qrelease":	// DUGGA-TABLE - Result date
+		case "modified":  // DUGGA-TABLE - Last Modified
 			if(!celldata) {	// if null - return string "N/A"
 				retString = "N/A";
 			} else if(celldata.length > 10){		// when there is time included - return date without seconds (i.e. last three charachters)


### PR DESCRIPTION
Solves #9281.

Last Modified is now included in the switch cases that gets their seconds cut off in renderCell. See screenshot.

'Before' screenshot can be found in linked issue.

![image](https://user-images.githubusercontent.com/49141758/81929881-0bbb5880-95e8-11ea-85f7-f7d895af2787.png)
