### PR TITLE
Tabs indentation for code examples and links | Fix for issue #9192

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -703,7 +703,7 @@ function returnedSection(data) {
         // kind 0 == Header || 1 == Section || 2 == Code  ||�3 == Test (Dugga)|| 4 == Moment�|| 5 == Link || 6 Group-Moment
         var itemKind = parseInt(item['kind']);
 
-        if(itemKind === 2){
+        if(itemKind === 2 || itemKind == 5){
           str += "<td style='width:0px'><div class='spacerLeft'></div></td><td id='indTab' class='tabs" + item["tabs"] + "'><div class='spacerRight'></div></td>";
         }
         if (itemKind === 3 || itemKind === 4) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -693,6 +693,7 @@ function returnedSection(data) {
           str += " class='lo' ";
         }
         str += " >";
+  
 
         var hideState = "";
         if (parseInt(item['visible']) === 0) hideState = " hidden"
@@ -702,6 +703,9 @@ function returnedSection(data) {
         // kind 0 == Header || 1 == Section || 2 == Code  ||�3 == Test (Dugga)|| 4 == Moment�|| 5 == Link || 6 Group-Moment
         var itemKind = parseInt(item['kind']);
 
+        if(itemKind === 2){
+          str += "<td style='width:0px'><div class='spacerLeft'></div></td><td id='indTab' class='tabs" + item["tabs"] + "'><div class='spacerRight'></div></td>";
+        }
         if (itemKind === 3 || itemKind === 4) {
 
           // Styling for quiz row e.g. add a tab spacer


### PR DESCRIPTION
The items "code examples" and "links" now follow the vertical line and do not break it. 

You can indentate (push) tabs to the right to create a workflow if you want a certain code example or link to belong to a certain sub-test or similar things.

![image](https://user-images.githubusercontent.com/49142028/81934787-d286e680-95ef-11ea-9a18-3f0eb73f86f0.png)

The borders (the black lines) are a little bit off-centered but there's a pre-existing separate issue for that and it's not created by this pull request.