### PR TITLE
Updating the styling for borders | Fix for issue #9264

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -776,8 +776,8 @@ p {
 /*Vertical line for end tabs for "1 tab + end"*/
 #Sectionlist .tabs4 .spacerRight {
   height: 19px;
-  width: 22px;
-  margin: 0px 0px 12px 45px;
+  width: 19px;
+  margin: 0px 0px 11px 47px;
   border-left: 2px solid black;
   border-bottom: 2px solid black;
   border-bottom-left-radius: 6px;
@@ -785,8 +785,8 @@ p {
 /*Vertical line for end tabs for "2 tabs + end"*/
 #Sectionlist .tabs5 .spacerRight {
   height: 19px;
-  width: 22px;
-  margin: 0px 0px 12px 77px;
+  width: 19px;
+  margin: 0px 0px 11px 79px;
   border-left: 2px solid black;
   border-bottom: 2px solid black;
   border-bottom-left-radius: 6px;
@@ -794,8 +794,8 @@ p {
 /*Vertical line for end tabs for "3 tabs + end"*/
 #Sectionlist .tabs6 .spacerRight {
   height: 19px;
-  width: 22px;
-  margin: 0px 0px 12px 109px;
+  width: 19px;
+  margin: 0px 0px 11px 111px;
   border-left: 2px solid black;
   border-bottom: 2px solid black;
   border-bottom-left-radius: 6px;


### PR DESCRIPTION
The spacerRight border stylings for 'end tabs' were off again. Hopefully they stay the way they're supposed to this time. 

This is what it looked like before the fix:
![image](https://user-images.githubusercontent.com/49142028/81939417-94d98c00-95f6-11ea-8ce5-38674e3b9da2.png)



This is what it looks like after the fix:
![image](https://user-images.githubusercontent.com/49142028/81939342-80958f00-95f6-11ea-9840-7d2733c5673a.png)
