### PR TITLE
fix issue#9284 Text alignment independent of string size

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2344,7 +2344,7 @@ function Symbol(kindOfSymbol) {
 			}
 			
 
-			ctx.textAlign = this.textAlign;
+			ctx.textAlign = this.properties['textAlign'];
 			for (var i = 0; i < this.textLines.length; i++) {
 				ctx.fillText(this.textLines[i].text, this.getTextX(x1, midx, x2), y1 + (this.properties['textSize'] * 1.99) / 2 + (this.properties['textSize'] * i));
 			}

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2610,14 +2610,8 @@ function Symbol(kindOfSymbol) {
     //---------------------------------------------------------
     this.getTextX = function(x1, midX, x2) {
         var textX = 0;
-        if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Large') textX = x1 + 70 * diagram.getZoomValue();
-        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Large') textX = x2 - 70 * diagram.getZoomValue();
-        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Medium') textX = x1 + 43 * diagram.getZoomValue();
-        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Medium') textX = x2 - 43 * diagram.getZoomValue();
-        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Small') textX = x1 + 30 * diagram.getZoomValue();
-        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Small') textX = x2 - 30 * diagram.getZoomValue();
-        else if (this.properties['textAlign'] == "start" && this.properties['sizeOftext'] == 'Tiny') textX = x1 + 22 * diagram.getZoomValue();
-        else if (this.properties['textAlign'] == "end" && this.properties['sizeOftext'] == 'Tiny') textX = x2 - 22 * diagram.getZoomValue();
+        if (this.properties['textAlign'] == "start") textX = x1;
+        else if (this.properties['textAlign'] == "end") textX = x2;
         else textX = midX;
         return textX;
     }


### PR DESCRIPTION
Before fix the Left and Right text alignment options would not position the text correctly. This is clear when typing long and/or short strings. After fix Left and Right text alignment options should position the text in a correct position regardless of the length of the text. 

**Test this:** Create a text object and change the Text alignment option to left and right. Make sure the text is properly aligned. Also try different text sizes, font families, text lengths and zoom positions. 

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W21-ISSUE%239284/DuggaSys/diagram.php

**Before:**

![5833592cdb1c11553a9aef6ed6ba9cf3](https://user-images.githubusercontent.com/49142301/81944332-e71dab80-95fc-11ea-9f36-d93b080d6bf2.gif)

**After:**

![814c4fa232c3737544ce2ea09663bfd9](https://user-images.githubusercontent.com/49142301/81944636-55fb0480-95fd-11ea-9a72-efedef7c1542.gif)
