### PR TITLE
Fixes #9233 - unwanted line coordinates show on ruler when ER entity selected

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1464,48 +1464,6 @@ diagram.getObjectsByType = function(type) {
 }
 
 //--------------------------------------------------------------------
-// getEntityObjects: Returns a list of all entities
-//--------------------------------------------------------------------
-
-diagram.getEntityObjects = function() {
-    var entities = [];
-    for (var i = 0; i < diagram.length; i++) {
-        if (diagram[i].symbolkind == symbolKind.erEntity) {
-            entities.push(diagram[i]);
-        }
-    }
-    return entities;
-}
-
-//--------------------------------------------------------------------
-// getLineObjects: Returns a list of all lines
-//--------------------------------------------------------------------
-
-diagram.getLineObjects = function() {
-    var lines = [];
-    for (var i = 0; i < this.length; i++) {
-        if (diagram[i].symbolkind == symbolKind.line) {
-            lines.push(diagram[i]);
-        }
-    }
-    return lines;
-}
-
-//--------------------------------------------------------------------
-// getRelationObjects: Returns a list of all relations
-//--------------------------------------------------------------------
-
-diagram.getRelationObjects = function() {
-    var relations = [];
-    for (var i = 0; i < diagram.length; i++) {
-        if (diagram[i].symbolkind == symbolKind.erRelation) {
-            relations.push(diagram[i]);
-        }
-    }
-    return relations;
-}
-
-//--------------------------------------------------------------------
 // updateLineRelations: Updates a line's relation depending on
 //                      what object it is connected to
 //--------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1511,7 +1511,7 @@ diagram.getRelationObjects = function() {
 //--------------------------------------------------------------------
 
 diagram.updateLineRelations = function() {
-    var privateLines = this.getLineObjects();
+    var privateLines = this.getObjectsByType(symbolKind.line);
     for (var i = 0; i < privateLines.length; i++) {
         privateLines[i].type = "idek";
         var connected_objects = connectedObjects(privateLines[i]);
@@ -2440,7 +2440,7 @@ function disableShortcuts(event){
 
 function getConnectedLines(object) {
     var privatePoints = object.getPoints();
-    var lines = diagram.getLineObjects();
+    var lines = diagram.getObjectsByType(symbolKind.line);
     var objectLines = [];
     for (var i = 0; i < lines.length; i++) {
         var line = lines[i];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1420,41 +1420,6 @@ diagram.checkForHover = function(posX, posY) {
     return hoveredObjects[hoveredObjects.length - 1];
 }
 
-//--------------------------------------------------------------------
-// eraseLines: removes all the lines connected to an object
-//--------------------------------------------------------------------
-
-diagram.eraseLines = function(privateLines) {
-    for (var i = 0; i < privateLines.length; i++) {
-        var eraseLeft = false;
-        var eraseRight = false;
-        for (var j = 0; j < diagram.length;j++) {
-            if (points[diagram[j].centerPoint] == points[privateLines[i].topLeft] ||
-                points[diagram[j].middleDivider] == points[privateLines[i].topLeft]) {
-                eraseLeft = true;
-            }
-            if (points[diagram[j].centerPoint] == points[privateLines[i].bottomRight] ||
-                points[diagram[j].middleDivider] == points[privateLines[i].bottomRight]) {
-                eraseRight = true;
-            }
-        }
-        var connected_objects = privateLines[i].getConnectedObjects();
-        if(!eraseLeft) {
-            for(var j = 0; j < connected_objects.length; j++) {
-                connected_objects[j].removePointFromConnector(privateLines[i].topLeft);
-            }
-            points[privateLines[i].topLeft] = waldoPoint;
-        }
-        if(!eraseRight) {
-            for(var j = 0; j < connected_objects.length; j++) {
-                connected_objects[j].removePointFromConnector(privateLines[i].bottomRight);
-            }
-            points[privateLines[i].bottomRight] = waldoPoint;
-        }
-        diagram.deleteObject(privateLines[i]);
-    }
-}
-
 //-----------------------------------------------------------------------------------------------------
 // getObjectsByType: Returns an array of all diagram objects with the passed symbolKind. (0 for paths).
 //-----------------------------------------------------------------------------------------------------
@@ -2436,7 +2401,6 @@ function eraseObject(object) {
             if(removeBottomright) points[object.bottomRight] = "";
         }
         object.erase();
-        diagram.eraseLines(object, object.getConnectedLines());
     } else if (object.kind == kind.path) {
         object.erase();
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2376,62 +2376,15 @@ function eraseLine(line) {
 //------------------------------------------------
 
 function eraseObject(object) {
-    var objectsToDelete = [];
-    if (object.kind == kind.symbol) {
-        // None lines
-        if(object.symbolkind != symbolKind.line && object.symbolkind != symbolKind.umlLine) {
-            var lines = diagram.getObjectsByType(symbolKind.line);
-            var umlLines = diagram.getObjectsByType(symbolKind.umlLine);
-            if(object.symbolkind != symbolKind.uml) {
-            objectsToDelete = lines.filter(
-                line => line.topLeft == object.middleDivider
-                || line.topLeft == object.centerPoint
-                || line.bottomRight == object.middleDivider
-                || line.bottomRight == object.centerPoint
-                || (object.hasConnectorFromPoint(line.topLeft) && (object.symbolkind == symbolKind.erEntity || object.symbolkind == symbolKind.erRelation))
-                || (object.hasConnectorFromPoint(line.bottomRight) && (object.symbolkind == symbolKind.erEntity || object.symbolkind == symbolKind.erRelation))
-            );  
-            } else if (object.symbolkind == symbolKind.uml) {
-            objectsToDelete = umlLines.filter(
-                umlLine => umlLine.topLeft == object.middleDivider
-                || (object.hasConnectorFromPoint(umlLine.topLeft) && (object.symbolkind == symbolKind.uml))
-                || (object.hasConnectorFromPoint(umlLine.bottomRight) && (object.symbolkind == symbolKind.uml))
-            );
-            }
-        // lines
+    if (object.kind === kind.symbol) {
+        if(object.isLineType()) {
+            eraseLine(object);
         } else {
-            diagram.filter(
-                symbol => symbol.symbolkind == symbolKind.erEntity || symbol.symbolkind == symbolKind.erRelation || symbol.symbolkind == symbolKind.uml || symbol.symbolkind == symbolKind.erAttribute)
-                    .filter(symbol =>   symbol.hasConnectorPoint(object.topLeft)
-                                     && symbol.hasConnectorPoint(object.bottomRight))
-                    .forEach(symbol => {
-                        if(symbol.symbolkind == symbolKind.erAttribute){
-                            symbol.removePointFromConnector(symbol.centerPoint, object);
-                        } else{
-                            symbol.removePointFromConnector(object.topLeft);
-                            symbol.removePointFromConnector(object.bottomRight);
-                        }
-                    });
-
-            var attributesAndRelations = diagram.filter(symbol => symbol.symbolkind == symbolKind.erAttribute || symbol.symbolkind == symbolKind.erRelation || symbol.symbolkind == symbolKind.uml);
-            // Check if the line has a common point with a centerpoint of attributes or relations.
-            var removeTopleft = attributesAndRelations
-                        .filter(symbol => symbol.centerPoint == object.topLeft
-                                       || symbol.middleDivider == object.topLeft
-                               ).length == 0;
-            var removeBottomright = attributesAndRelations
-                        .filter(symbol => symbol.centerPoint == object.bottomRight
-                                        || symbol.middleDivider == object.bottomRight
-                               ).length == 0;
-            if(removeTopleft) points[object.topLeft] = "";
-            if(removeBottomright) points[object.bottomRight] = "";
+            object.getConnectedLines().forEach(eraseObject);
         }
-        object.erase();
-    } else if (object.kind == kind.path) {
-        object.erase();
     }
+    object.erase();
     diagram.deleteObject(object);
-    objectsToDelete.forEach(eraseObject);
     updateGraphics();
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -760,10 +760,10 @@ function setConnectedLines(temp) {
     for (var y = 0; y < cloneTempArray.length; y++) {
         for (var x = 0; x < cloneTempArray.length; x++) {
             if(cloneTempArray[x].kind !== kind.path && cloneTempArray[y].kind !== kind.path) {
-                if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].bottomRight)) {
+                if(x != y && cloneTempArray[y].getConnectedFrom().includes(cloneTempArray[x].bottomRight)) {
                     var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].bottomRight);
                     connected.push({from:y, to:x, loc: location, lineloc: "bottomRight", lineloc2: "topLeft"});
-                } else if(x != y && cloneTempArray[y].getConnectedTo().includes(cloneTempArray[x].topLeft)) {
+                } else if(x != y && cloneTempArray[y].getConnectedFrom().includes(cloneTempArray[x].topLeft)) {
                     var location = cloneTempArray[y].getConnectorNameFromPoint(cloneTempArray[x].topLeft);
                     connected.push({from:y, to:x, loc: location, lineloc: "topLeft", lineloc2: "bottomRight"});   
                 }
@@ -2448,8 +2448,8 @@ function eraseObject(object) {
         } else {
             diagram.filter(
                 symbol => symbol.symbolkind == symbolKind.erEntity || symbol.symbolkind == symbolKind.erRelation || symbol.symbolkind == symbolKind.uml || symbol.symbolkind == symbolKind.erAttribute)
-                    .filter(symbol =>   symbol.hasConnector(object.topLeft)
-                                     && symbol.hasConnector(object.bottomRight))
+                    .filter(symbol =>   symbol.hasConnectorPoint(object.topLeft)
+                                     && symbol.hasConnectorPoint(object.bottomRight))
                     .forEach(symbol => {
                         if(symbol.symbolkind == symbolKind.erAttribute){
                             symbol.removePointFromConnector(symbol.centerPoint, object);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6280,11 +6280,7 @@ function createRulerLinesObjectPoints() {
 
 function getSelectedObjectsPoints() {
     const selectedPoints = selected_objects.reduce((set, object) => {
-        object.getPoints().forEach(pointIndex => {
-            if(typeof pointIndex !== "undefined") {
-                set.add(points[pointIndex]);
-            }
-        });
+        object.getPoints().forEach(pointIndex => set.add(points[pointIndex]));
         return set;
     }, new Set());
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1438,7 +1438,7 @@ diagram.eraseLines = function(privateLines) {
                 eraseRight = true;
             }
         }
-        var connected_objects = connectedObjects(privateLines[i]);
+        var connected_objects = privateLines[i].getConnectedObjects();
         if(!eraseLeft) {
             for(var j = 0; j < connected_objects.length; j++) {
                 connected_objects[j].removePointFromConnector(privateLines[i].topLeft);
@@ -1479,8 +1479,7 @@ diagram.getObjectsByTypes = function(types = []) {
 diagram.updateLineRelations = function() {
     var privateLines = this.getObjectsByType(symbolKind.line);
     for (var i = 0; i < privateLines.length; i++) {
-        privateLines[i].type = "idek";
-        var connected_objects = connectedObjects(privateLines[i]);
+        var connected_objects = privateLines[i].getConnectedObjects();
         if (connected_objects.length >= 2) {
             for (var j = 0; j < connected_objects.length; j++) {
                 if (connected_objects[j].type == "weak") {
@@ -2510,31 +2509,6 @@ $(document).ready(function() {
         }
     });
 });
-
-//--------------------------------------------------
-// Returns connected that are connected to the line
-//--------------------------------------------------
-
-function connectedObjects(line) {
-    var privateObjects = [];
-    for (var i = 0; i < diagram.length; i++) {
-        if (diagram[i].kind == kind.symbol && diagram[i].symbolkind != symbolKind.line) {
-            var objectPoints = diagram[i].getPoints();
-            for (var j = 0; j < objectPoints.length; j++) {
-                if (objectPoints[j] == line.topLeft || objectPoints[j] == line.bottomRight) {
-                    privateObjects.push(diagram[i]);
-                }
-                if (privateObjects.length >= 2) {
-                    break;
-                }
-            }
-            if (privateObjects.length >= 2) {
-                break;
-            }
-        }
-    }
-    return privateObjects;
-}
 
 //-----------------------------------
 // Draws the gridlines of the canvas

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1459,8 +1459,16 @@ diagram.eraseLines = function(privateLines) {
 // getObjectsByType: Returns an array of all diagram objects with the passed symbolKind. (0 for paths).
 //-----------------------------------------------------------------------------------------------------
 
-diagram.getObjectsByType = function(type) {
+diagram.getObjectsByType = function(type = 0) {
     return diagram.filter(object => (object.symbolkind || 0) === type);
+}
+
+//-------------------------------------------------------------------------------------------------------------------
+// getObjectsByTypes: Returns an array of all diagram objects included in passed array of symbolKinds. (0 for paths).
+//-------------------------------------------------------------------------------------------------------------------
+
+diagram.getObjectsByTypes = function(types = []) {
+    return diagram.filter(object => types.includes(object.symbolkind || 0));
 }
 
 //--------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2392,31 +2392,6 @@ function disableShortcuts(event){
     updateGraphics();
 }
 
-//-------------------------------------------
-// Returns lines connected to the object
-//--------------------------------------------
-
-function getConnectedLines(object) {
-    var privatePoints = object.getPoints();
-    var lines = diagram.getObjectsByType(symbolKind.line);
-    var objectLines = [];
-    for (var i = 0; i < lines.length; i++) {
-        var line = lines[i];
-        //Lines connected to object's centerPoint
-        //Line always have topLeft and bottomRight if symbolkind == 4, because that means it's a line object
-        if (line.topLeft == object.centerPoint || line.bottomRight == object.centerPoint) {
-            objectLines.push(line);
-        }
-        //Connected to connectors top, right, bottom and left.
-        for (var j = 0; j < privatePoints.length; j++) {
-            if (line.topLeft == privatePoints[j] || line.bottomRight == privatePoints[j]) {
-                objectLines.push(line);
-            }
-        }
-    }
-    return objectLines;
-}
-
 //---------------------------------
 // Erases the object from diagram
 //---------------------------------
@@ -2426,8 +2401,8 @@ function eraseObject(object) {
     if (object.kind == kind.symbol) {
         // None lines
         if(object.symbolkind != symbolKind.line && object.symbolkind != symbolKind.umlLine) {
-            var lines = diagram.filter(symbol => symbol.symbolkind == symbolKind.line);
-            var umlLines = diagram.filter(symbol => symbol.symbolkind == symbolKind.umlLine);
+            var lines = diagram.getObjectsByType(symbolKind.line);
+            var umlLines = diagram.getObjectsByType(symbolKind.umlLine);
             if(object.symbolkind != symbolKind.uml) {
             objectsToDelete = lines.filter(
                 line => line.topLeft == object.middleDivider

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1455,6 +1455,14 @@ diagram.eraseLines = function(privateLines) {
     }
 }
 
+//-----------------------------------------------------------------------------------------------------
+// getObjectsByType: Returns an array of all diagram objects with the passed symbolKind. (0 for paths).
+//-----------------------------------------------------------------------------------------------------
+
+diagram.getObjectsByType = function(type) {
+    return diagram.filter(object => (object.symbolkind || 0) === type);
+}
+
 //--------------------------------------------------------------------
 // getEntityObjects: Returns a list of all entities
 //--------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1472,25 +1472,6 @@ diagram.getObjectsByTypes = function(types = []) {
 }
 
 //--------------------------------------------------------------------
-// updateLineRelations: Updates a line's relation depending on
-//                      what object it is connected to
-//--------------------------------------------------------------------
-
-diagram.updateLineRelations = function() {
-    var privateLines = this.getObjectsByType(symbolKind.line);
-    for (var i = 0; i < privateLines.length; i++) {
-        var connected_objects = privateLines[i].getConnectedObjects();
-        if (connected_objects.length >= 2) {
-            for (var j = 0; j < connected_objects.length; j++) {
-                if (connected_objects[j].type == "weak") {
-                    privateLines[i].type = "weak";
-                }
-            }
-        }
-    }
-}
-
-//--------------------------------------------------------------------
 // sortConnectors: Sort all connectors related to entity.
 //--------------------------------------------------------------------
 
@@ -4601,7 +4582,6 @@ function mouseupevt(ev) {
     
     hashFunction();
     updateGraphics();
-    diagram.updateLineRelations();
     // Clear mouse state
     md = mouseState.empty;
     if(saveState) SaveState();
@@ -4895,7 +4875,6 @@ function touchEndEvent(event) {
     }
     hashFunction();
     updateGraphics();
-    diagram.updateLineRelations();
     md = mouseState.empty;
     if(saveState) SaveState();
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2345,9 +2345,35 @@ function disableShortcuts(event){
     updateGraphics();
 }
 
-//---------------------------------
-// Erases the object from diagram
-//---------------------------------
+//-------------------------------------------------------------------------------------------------------
+// eraseLine: Erases passed line from diagram. Makes sure line points are no longer in object connectors.
+//-------------------------------------------------------------------------------------------------------
+
+function eraseLine(line) {
+    const connectedObjects = line.getConnectedObjects();
+
+    connectedObjects.forEach(symbol => {
+        if(symbol.symbolkind == symbolKind.erAttribute){
+            symbol.removePointFromConnector(symbol.centerPoint, line);
+        } else{
+            symbol.removePointFromConnector(line.topLeft);
+            symbol.removePointFromConnector(line.bottomRight);
+        }
+    });
+
+    // Check if the line has a common point with a center point of attributes or relations.
+    const removeTopLeft = !connectedObjects.some(symbol => symbol.centerPoint === line.topLeft || symbol.middleDivider === line.topLeft);
+    const removeBottomRight = !connectedObjects.some(symbol => symbol.centerPoint === line.bottomRight || symbol.middleDivider === line.bottomRight);
+
+    if(removeTopLeft) points[line.topLeft] = "";
+    if(removeBottomRight) points[line.bottomRight] = "";
+
+    diagram.deleteObject(line);
+}
+
+//------------------------------------------------
+// eraseObject: Erases passed object from diagram.
+//------------------------------------------------
 
 function eraseObject(object) {
     var objectsToDelete = [];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6247,6 +6247,9 @@ function createRuler(element, length, origoOffset, marginProperty) {
 //-------------------------------------------------------------------------------------
 
 function createRulerLinesObjectPoints() {
+    //Remove all current point liens
+    document.querySelectorAll(".point-line").forEach(element => element.remove());
+
     if(!isRulersActive || selected_objects.length < 1) return;
 
     const rulerExtraLinesX = document.querySelector("#ruler-x .ruler-extra-lines");
@@ -6254,9 +6257,6 @@ function createRulerLinesObjectPoints() {
 
     //Get an array of points used by all selected objects
     const selectedPoints = getSelectedObjectsPoints();
-
-    //Remove all current point liens
-    document.querySelectorAll(".point-line").forEach(element => element.remove());
 
     selectedPoints.forEach(point => {
         const canvasCoordinate = pixelsToCanvas(point.x, point.y);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1083,11 +1083,7 @@ function copySymbol(symbol) {
 function copyPath(path) {
     const clone = Object.assign(new Path, JSON.parse(JSON.stringify(path)));
 
-    const oldPointIndexes = clone.segments.reduce((result, segment) => {
-        result.push(segment.pa);
-        result.push(segment.pb);
-        return [...new Set(result)];
-    }, []);
+    const oldPointIndexes = clone.getPoints();
 
     const pointIndexes = oldPointIndexes.reduce((result, pointIndex) => {
         const point = points[pointIndex];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2473,7 +2473,7 @@ function eraseObject(object) {
             if(removeBottomright) points[object.bottomRight] = "";
         }
         object.erase();
-        diagram.eraseLines(object, object.getLines());
+        diagram.eraseLines(object, object.getConnectedLines());
     } else if (object.kind == kind.path) {
         object.erase();
     }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1210,6 +1210,21 @@ function Symbol(kindOfSymbol) {
         return privatePoints;
     }
 
+    //-------------------------------------------------------------------------------------
+    // getConnectedLinePoints: Adds all connected line points to an array and returns the array.
+    //-------------------------------------------------------------------------------------
+
+    this.getConnectedLinePoints = function() {
+        const points = [this.connectorTop, this.connectorRight, this.connectorBottom, this.connectorLeft].reduce((set, connector) => {
+            connector.forEach(coordinate => {
+                set.add(coordinate.to);
+                set.add(coordinate.from);
+            });
+            return set;
+        }, new Set());
+        return [...points];
+    }
+
     //-----------------------------------------------------------------------
     // isLineType: Checks if this is a line (ER or UML)
     //-----------------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1335,7 +1335,7 @@ function Symbol(kindOfSymbol) {
     //--------------------------------------------------------------------
     this.getLines = function() {
         var privatePoints = this.getPoints();
-        var lines = diagram.getLineObjects();
+        var lines = diagram.getObjectsByType(symbolKind.line);
         var objectLines = [];
         for (var i = 0; i < lines.length; i++) {
             //Connected to connectors top, right, bottom and left; topLeft, bottomRight, centerPoint or middleDivider.
@@ -2673,7 +2673,7 @@ function Symbol(kindOfSymbol) {
 //checkLineIntersection: checks if any two lines does intersect
 //--------------------------------------------------------------
 function checkLineIntersection(line1StartX, line1StartY, line1EndX, line1EndY) {
-	var	lines	=	diagram.getLineObjects();
+    var	lines = diagram.getObjectsByType(symbolKind.line);
 	var results = [];
 	for (var i = 0; i < lines.length; i++) {
 		var	line2StartX = pixelsToCanvas(points[lines[i].topLeft].x).x;

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -641,6 +641,16 @@ function Symbol(kindOfSymbol) {
         }, []);
     }
 
+    //-----------------------------------------------------------------------
+    // getConnectedTo: Returns the line points connected to the other symbol.
+    //-----------------------------------------------------------------------
+    this.getConnectedTo = function() {
+        return [this.connectorTop, this.connectorRight, this.connectorBottom, this.connectorLeft].reduce((result, connector) => {
+            connector.forEach(coordinate => result.push(coordinate.to));
+            return result;
+        }, []);
+    }
+
     //--------------------------------------------------------------------
     // isClicked: Returns true if xk,yk is inside the bounding box of the symbol
     //--------------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1183,79 +1183,18 @@ function Symbol(kindOfSymbol) {
     //                      function is used on line objects
     //----------------------------------------------------------------
     this.getConnectedObjects = function () {
-        if (this.isLineType()) {
-            var privateObjects = [];
+        const types = [symbolKind.erAttribute, symbolKind.erEntity, symbolKind.erRelation, symbolKind.uml];
+        const objects = diagram.getObjectsByTypes(types);
 
-            // Compare values of all symbols in diagram with current line
-            for (var i = 0; i < diagram.length; i++) {
-                if (diagram[i].kind == kind.symbol && !diagram[i].isLineType()) {
-                    // Top left and bottom right corners for the current object
-                    dtlx = diagram[i].corners().tl.x;
-                    dtly = diagram[i].corners().tl.y;
-                    dbrx = diagram[i].corners().br.x;
-                    dbry = diagram[i].corners().br.y;
-
-                    // Top left and bottom right corners (end points) for the clicked line
-                    ltlx = this.corners().tl.x;
-                    ltly = this.corners().tl.y;
-                    lbrx = this.corners().br.x;
-                    lbry = this.corners().br.y;
-
-                    if (diagram[i].symbolkind == symbolKind.uml) { // UML
-                        // If line's either end point is within the corners of the UML symbol
-                        // Can possibly be optimised, currently uses coordinates because the connector
-                        // points aren't saved somehow to the UML's points
-                        if ((ltlx >= dtlx && ltlx <= dbrx) || (lbrx >= dtlx && lbrx <= dbrx)) {
-                            if ((ltly >= dtly && ltly <= dbry) || (lbry >= dtly && lbry <= dbry)) {
-                                privateObjects.push(diagram[i]);
-                            }
-                        }
-                    } else if (diagram[i].symbolkind == symbolKind.erAttribute) { // Attribute
-                        // If line's either end point is the same as an attribute's center point
-                        if (diagram[i].centerPoint == this.topLeft || diagram[i].centerPoint == this.bottomRight) {
-                            privateObjects.push(diagram[i]);
-                        }
-                    } else if (diagram[i].symbolkind == symbolKind.erEntity) { // Entity
-                        // If line's both end points are included in the entity's list of connectors
-                        if (diagram[i].getPoints().includes(this.topLeft) && diagram[i].getPoints().includes(this.bottomRight)) {
-                            privateObjects.push(diagram[i]);
-                        }
-                    } else if (diagram[i].symbolkind == symbolKind.erRelation) { // Relation
-                        // If line's either end points matches the coordinates of the Relation symbol's connector pointsSelected
-                        // This can be optimised if these points are added when a Relation symbol is created
-                        var connectedToRelation = false;
-
-                        // Finds middle point coordinates for relation symbols
-                        var relationMiddleX = ((dbrx - dtlx) / 2) + dtlx;
-                        var relationMiddleY = ((dbry - dtly) / 2) + dtly;
-
-                        // Line is connected to object if any of these are true
-                        if ((relationMiddleX == ltlx || relationMiddleX == lbrx) && (dtly == ltly || dtly == lbry)) {
-                            // Top point of diamond
-                            connectedToRelation = true;
-                        } else if ((relationMiddleY == ltly || relationMiddleY == lbry) && (dbrx == ltlx || dbrx == lbrx)) {
-                            // Right point of diamond
-                            connectedToRelation = true;
-                        } else if ((relationMiddleX == ltlx || relationMiddleX == lbrx) && (dbry == ltly || dbry == lbry)) {
-                            // Bottom point of diamond
-                            connectedToRelation = true;
-                        } else if ((relationMiddleY == ltly || relationMiddleY == lbry) && (dtlx == ltlx || dtlx == lbrx)) {
-                            // Left point of diamond
-                            connectedToRelation = true;
-                        }
-
-                        if (connectedToRelation) {
-                            privateObjects.push(diagram[i]);
-                        }
-                    }
-
-                    if (privateObjects.length >= 2) {
-                        break;
-                    }
+        return objects.reduce((result, object) => {
+            const connectedLines = object.getConnectedLines();
+            connectedLines.forEach(line => {
+                if(Object.is(this, line)) {
+                    result.push(object);
                 }
-            }
-            return privateObjects;
-        }
+            });
+            return result;
+        }, []);
     }
 
     //------------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -564,28 +564,13 @@ function Symbol(kindOfSymbol) {
         this.sortConnector(this.connectorBottom, 2, x1, x2, y2);
     }
 
-    // return true if connector contains a certain point
+    //-------------------------------------------------------------------
+    // hasConnector: Returns true if any connector contains passed point.
+    //-------------------------------------------------------------------
     this.hasConnector = function(point) {
-        for (var i = 0; i < this.connectorTop.length; i++) {
-            if(this.connectorTop[i].to == point || this.connectorTop[i].from == point) {
-                return true;
-            }
-        }
-        for(var i = 0; i < this.connectorRight.length; i++) {
-            if(this.connectorRight[i].to == point || this.connectorRight[i].from == point) {
-                return true;
-            }
-        }
-        for (var i = 0; i < this.connectorBottom.length; i++) {
-            if(this.connectorBottom[i].to == point || this.connectorBottom[i].from == point) {
-                return true;
-            }
-        }
-        for (var i = 0; i < this.connectorLeft.length; i++) {
-            if(this.connectorLeft[i].to == point || this.connectorLeft[i].from == point) {
-                return true;
-            }
-        }
+        return [this.connectorTop, this.connectorRight, this.connectorBottom, this.connectorLeft].some(connector => {
+            return connector.some(coordinate => coordinate.to === point || coordinate.from === point);
+        });
     }
 
     //--------------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1263,7 +1263,7 @@ function Symbol(kindOfSymbol) {
     //------------------------------------------------------------------
     this.getConnectedLines = function() {
         const points = this.getConnectedFrom();
-        const lines = diagram.getObjectsByType(symbolKind.line);
+        const lines = diagram.getObjectsByTypes([symbolKind.line, symbolKind.umlLine]);
 
         const connectedLines = lines.reduce((set, line) => {
             points.forEach(point => {
@@ -1274,7 +1274,7 @@ function Symbol(kindOfSymbol) {
             return set;
         }, new Set());
 
-        return connectedLines;
+        return [...connectedLines];
     }
 
     //--------------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -596,30 +596,13 @@ function Symbol(kindOfSymbol) {
         return count;
     }
 
-    //--------------------------------------------------------------------
-    // hasConnectorFromPoint: returns if this symbol has a connector to the point
-    //--------------------------------------------------------------------
+    //---------------------------------------------------------------------------------
+    // hasConnectorFromPoint: Returns true if this symbol has a connector from the point.
+    //---------------------------------------------------------------------------------
     this.hasConnectorFromPoint = function(point) {
-        for (var i = 0; i < this.connectorTop.length; i++) {
-            if(this.connectorTop[i].from == point) {
-                return true;
-            }
-        }
-        for(var i = 0; i < this.connectorRight.length; i++) {
-            if(this.connectorRight[i].from == point) {
-                return true;
-            }
-        }
-        for (var i = 0; i < this.connectorBottom.length; i++) {
-            if(this.connectorBottom[i].from == point) {
-                return true;
-            }
-        }
-        for (var i = 0; i < this.connectorLeft.length; i++) {
-            if(this.connectorLeft[i].from == point) {
-                return true;
-            }
-        }
+        return [this.connectorTop, this.connectorRight, this.connectorBottom, this.connectorLeft].some(connector => {
+            return connector.some(coordinate => coordinate.from === point);
+        });
     }
 
     //--------------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1258,25 +1258,23 @@ function Symbol(kindOfSymbol) {
         }
     }
 
-    //--------------------------------------------------------------------
-    // getLines: Returns all the lines connected to the object
-    //--------------------------------------------------------------------
-    this.getLines = function() {
-        var privatePoints = this.getPoints();
-        var lines = diagram.getObjectsByType(symbolKind.line);
-        var objectLines = [];
-        for (var i = 0; i < lines.length; i++) {
-            //Connected to connectors top, right, bottom and left; topLeft, bottomRight, centerPoint or middleDivider.
-            for (var j = 0; j < privatePoints.length; j++) {
-                if (lines[i].topLeft == privatePoints[j] || lines[i].bottomRight == privatePoints[j]) {
-                    if(objectLines.indexOf(lines[i])==-1) {
-                        objectLines.push(lines[i]);
-                        break;
-                    }
+    //------------------------------------------------------------------
+    // getConnectedLines: Returns all the lines connected to the object.
+    //------------------------------------------------------------------
+    this.getConnectedLines = function() {
+        const points = this.getConnectedFrom();
+        const lines = diagram.getObjectsByType(symbolKind.line);
+
+        const connectedLines = lines.reduce((set, line) => {
+            points.forEach(point => {
+                if(line.topLeft === point || line.bottomRight === point) {
+                    set.add(line);
                 }
-            }
-        }
-        return objectLines;
+            });
+            return set;
+        }, new Set());
+
+        return connectedLines;
     }
 
     //--------------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1167,47 +1167,14 @@ function Symbol(kindOfSymbol) {
     //-----------------------------------------------------------------------
     // getPoints: Adds each corner point to an array and returns the array
     //-----------------------------------------------------------------------
+
     this.getPoints = function() {
-        var privatePoints = [];
-        if(this.symbolkind  == symbolKind.erEntity) {
-            for (var i = 0; i < this.connectorTop.length; i++) {
-                if(this.getquadrant(this.connectorTop[i].to.x,this.connectorTop[i].to.y) != -1) {
-                    privatePoints.push(this.connectorTop[i].to);
-                }
-                if(this.getquadrant(this.connectorTop[i].from.x,this.connectorTop[i].from.y) != -1) {
-                    privatePoints.push(this.connectorTop[i].from);
-                }
+        return [this.topLeft, this.bottomRight, this.middleDivider, this.centerPoint].reduce((result, pointIndex) => {
+            if(typeof pointIndex !== "undefined" && pointIndex !== null) {
+                result.push(pointIndex);
             }
-            for (var i = 0; i < this.connectorRight.length; i++) {
-                if(this.getquadrant(this.connectorRight[i].to.x,this.connectorRight[i].to.y) != -1) {
-                    privatePoints.push(this.connectorRight[i].to);
-                }
-                if(this.getquadrant(this.connectorRight[i].from.x,this.connectorRight[i].from.y) != -1) {
-                    privatePoints.push(this.connectorRight[i].from);
-                }
-            }
-            for (var i = 0; i < this.connectorBottom.length; i++) {
-                if(this.getquadrant(this.connectorBottom[i].to.x,this.connectorBottom[i].to.y) != -1) {
-                    privatePoints.push(this.connectorBottom[i].to);
-                }
-                if(this.getquadrant(this.connectorBottom[i].from.x,this.connectorBottom[i].from.y) != -1) {
-                    privatePoints.push(this.connectorBottom[i].from);
-                }
-            }
-            for (var i = 0; i < this.connectorLeft.length; i++) {
-                if(this.getquadrant(this.connectorLeft[i].to.x,this.connectorLeft[i].to.y) != -1) {
-                    privatePoints.push(this.connectorLeft[i].to);
-                }
-                if(this.getquadrant(this.connectorLeft[i].from.x,this.connectorLeft[i].from.y) != -1) {
-                    privatePoints.push(this.connectorLeft[i].from);
-                }
-            }
-        }
-        privatePoints.push(this.topLeft);
-        privatePoints.push(this.bottomRight);
-        privatePoints.push(this.middleDivider);
-        privatePoints.push(this.centerPoint);
-        return privatePoints;
+            return result;
+        }, []);
     }
 
     //-------------------------------------------------------------------------------------

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -565,9 +565,9 @@ function Symbol(kindOfSymbol) {
     }
 
     //-------------------------------------------------------------------
-    // hasConnector: Returns true if any connector contains passed point.
+    // hasConnectorPoint: Returns true if any connector contains passed point.
     //-------------------------------------------------------------------
-    this.hasConnector = function(point) {
+    this.hasConnectorPoint = function(point) {
         return [this.connectorTop, this.connectorRight, this.connectorBottom, this.connectorLeft].some(connector => {
             return connector.some(coordinate => coordinate.to === point || coordinate.from === point);
         });
@@ -631,36 +631,14 @@ function Symbol(kindOfSymbol) {
         }
     }
 
-    //--------------------------------------------------------------------
-    // Gets connected lines
-    //--------------------------------------------------------------------
-    this.getConnectedTo = function(){
-        var connected = [];
-        //top
-        if(this.connectorTop.length > 0){
-            for(var j = 0 ; j < this.connectorTop.length ; j++){
-                connected.push(this.connectorTop[j].from);
-            }
-        }
-        //right
-        if(this.connectorRight.length > 0){
-            for(var j = 0 ; j < this.connectorRight.length ; j++){
-                connected.push(this.connectorRight[j].from);
-            }
-        }
-        //bottom
-        if(this.connectorBottom.length > 0){
-            for(var j = 0 ; j < this.connectorBottom.length ; j++){
-                connected.push(this.connectorBottom[j].from);
-            }
-        }
-        //left
-        if(this.connectorLeft.length > 0){
-            for(var j = 0 ; j < this.connectorLeft.length ; j++){
-                connected.push(this.connectorLeft[j].from);
-            }
-        }
-        return connected;
+    //------------------------------------------------------------------------------------------------
+    // getConnectedFrom: Returns the line points connected from this symbol only (not to other symbols).
+    //------------------------------------------------------------------------------------------------
+    this.getConnectedFrom = function() {
+        return [this.connectorTop, this.connectorRight, this.connectorBottom, this.connectorLeft].reduce((result, connector) => {
+            connector.forEach(coordinate => result.push(coordinate.from));
+            return result;
+        }, []);
     }
 
     //--------------------------------------------------------------------

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5392,6 +5392,10 @@ only screen and (max-device-width: 320px) {
   display: flex;
 }
 
+#diagram-container * {
+  box-sizing: border-box;
+}
+
 #diagram-sidebar-container {
   width: var(--diagram-sidebar-width);
 }
@@ -5506,10 +5510,6 @@ only screen and (max-device-width: 320px) {
   flex-direction: column;
   width: calc(100vw - var(--diagram-sidebar-width));
   overflow: hidden;
-}
-
-#diagram-content * {
-  box-sizing: border-box;
 }
 
 #diagram-content.rulers-active {


### PR DESCRIPTION
This removes many previous functions that did not work as expected. Some of them returned the wrong values. Some functions were also quite unreadable so a few were simplified a lot making it possible to easily understand them. This makes it easy for future development to implement new functionality around it.

The fix for all of these functions also fixed what I originally created the issue for. When selecting ER entities that have lines connected, the line points also showed on the rulers even though they were not selected. Test this. 

Since I reworked quite a few functions. Also test the diagram generally. Especially line connections to different types of objects, especially attributes and try to delete the line. Also try to delete an object that a line is connected to. All lines should be removed and no points remain.

Link: http://group4.webug.his.se:20001/G4-2020-W21-ISSUE%239233/DuggaSys/diagram.php