### PR TITLE
All pages on page information now retrives data from userHistory - G1-2020-W21-ISSUE#9306

### DIFF
--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -665,26 +665,40 @@ function userLogInformation($pdo){
 function pageInformation(){
     $dugga= $GLOBALS['log_db']->query('
 		SELECT
-			cid AS courseid,
-			COUNT(*) AS pageLoads,
-			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM duggaLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
+			refer,
+			substr(
+				refer, 
+				INSTR(refer, "courseid=")+9, 
+				INSTR(refer, "&coursename=")-18 - INSTR(refer, "courseid=")+9
+			) courseid,
+			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM userHistory WHERE refer LIKE "%showDugga%") AS percentage,
+			COUNT(*) AS pageLoads
 		FROM 
-			duggaLoadLogEntries
+			userHistory
+		WHERE 
+			refer LIKE "%showDugga%"
 		GROUP BY 
-			courseid
+			courseid;
 		ORDER BY 
 			percentage DESC;
 	')->fetchAll(PDO::FETCH_ASSOC);
 	
 	$codeviewer = $GLOBALS['log_db']->query('
 		SELECT
-			courseid,
-			COUNT(*) AS pageLoads,
-			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM duggaLoadLogEntries WHERE type = '.EventTypes::pageLoad.') AS percentage
+			refer,
+			substr(
+				refer, 
+				INSTR(refer, "courseid=")+9, 
+				INSTR(refer, "&coursename=")-18 - INSTR(refer, "courseid=")+9
+			) courseid,
+			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM userHistory WHERE refer LIKE "%codeviewer%") AS percentage,
+			COUNT(*) AS pageLoads
 		FROM 
-			exampleLoadLogEntries
+			userHistory
+		WHERE 
+			refer LIKE "%codeviewer%"
 		GROUP BY 
-			courseid
+			courseid;
 		ORDER BY 
 			percentage DESC;
 	')->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
All pages now retrieves data from userHistory. This can be seen by navigating to analyticService.php and going through the function pageInformation(). 

How to test:
Check the queries in pageInfromation() that they retrieve FROM userHistory like in the picture below and make sure that the page information tab on analytic is functional.

![Screenshot 2020-05-15 at 09 43 07](https://user-images.githubusercontent.com/62876614/82024750-8dff5780-9690-11ea-9908-4299e071a68b.png)


