### PR TITLE
Defined global error where needed FIXES issue#9247

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -381,6 +381,7 @@
       echo "<div id='installationProgressWrap'>";
         $isPermissionsSat = isPermissionsSat($putFileHere);
         $isAllCredentialsFilled = isAllCredentialsFilled();
+        global $errors;
 
         //---------------------------------------------------------------------------------------------------
         // Check permissions.
@@ -697,6 +698,7 @@
     // Function that checks if all credentials are filled out (on the first page).
     //---------------------------------------------------------------------------------------------------
     function isAllCredentialsFilled(){
+      global $errors;
       $isAllCredentialsFilled = true;
       $fields = array("newUser", "password", "DBName", "hostname", "mysqlRoot", "rootPwd");
       foreach ($fields AS $fieldname) {
@@ -712,6 +714,7 @@
     // Function that deletes a user from database
     //---------------------------------------------------------------------------------------------------
     function deleteUser($connection, $username){
+      global $errors;
       try {
         $connection->query("DELETE FROM mysql.user WHERE user='{$username}';");
         echo "<span id='successText' />Successfully removed old user, {$username}.</span><br>";
@@ -726,6 +729,7 @@
     // Function that deletes a user from database
     //---------------------------------------------------------------------------------------------------
     function deleteDatabase($connection, $databaseName){
+      global $errors;
       try {
         $connection->query("DROP DATABASE {$databaseName}");
         echo "<span id='successText' />Successfully removed old database, {$databaseName}.</span><br>";


### PR DESCRIPTION
Problem:
![Before](https://user-images.githubusercontent.com/62878146/82028421-e7b65080-9695-11ea-86e4-3404c45e48d0.png)


Because root doesn't have access it cant create stuff. And error was undefinied.

Solution:
![After](https://user-images.githubusercontent.com/62878146/82028178-93ab6c00-9695-11ea-8afb-e6852cf79d13.png)

Now $errors is definied properly.

**For tester:** 
Go to http://group4.webug.his.se:20001/G4-2020-W21-ISSUE%239247/install/ and run the installer. When prompted for root-credentials use:

username: uselessroot
password: galvaniseradapa

Verify that no error-message for undefined $errors are printed.