### PR TITLE
Solved resetMOTDCookieForCurrentCourse #9211

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1121,6 +1121,7 @@ function ignoreMOTD(){
 
 function resetMOTDCookieForCurrentCourse(){
   var c_string = getCookie('MOTD');
+  if (c_string != ('') && c_string != null){
   c_array = c_string.split(',');
   for(let i = 0; i<c_array.length;i+=2){
     if(c_array[i] == versnme && c_array[i+1] == versnr){
@@ -1128,6 +1129,7 @@ function resetMOTDCookieForCurrentCourse(){
     }
   }
   document.cookie = 'MOTD=' + c_array;
+}
   showMOTD();
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49182858/82034209-2d771700-969e-11ea-9bb7-66e75be44072.png)
Now when editing a course version you will no longer get the resetMOTDCookieForCurrentCourse error