### PR TITLE
Fixing the fab button icons placements | Fix for issue #9216

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -826,7 +826,7 @@ p {
   padding: 6px;
   text-align: center;
   color: var(--color-text-header);
-  font-size: 24px;
+  font-size: 20px;
   background-color: var(--color-primary);
 }
 .glow {


### PR DESCRIPTION
The only solution I found to center the icons in the fab buttons was to make the title text slightly smaller. This centers the fab buttons. It now looks like this:

![image](https://user-images.githubusercontent.com/49142028/82034582-a9715f00-969e-11ea-9ea5-7f5bea4a51d2.png)


Before it looked like this:
![image](https://user-images.githubusercontent.com/49142028/82034606-b2623080-969e-11ea-8a10-806b16a49bdf.png)
