### PR TITLE
Solves issue 9208, hidden comments no longer movable or clickable

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3768,6 +3768,9 @@ function mousemoveevt(ev) {
                 } else if (hoveredObject && !hoveredObject.isLocked) {
                     if (hoveredObject.symbolkind == symbolKind.line || hoveredObject.symbolkind == symbolKind.umlLine) {
                         canvas.style.cursor = "pointer";
+                        //If hovering a hidden comment, don't change cursor
+                    } else if (hoveredObject.properties["isComment"] && hideComment) {
+                        canvas.style.cursor = "default";
                     } else {
                         canvas.style.cursor = "all-scroll";
                     }
@@ -5128,7 +5131,9 @@ function doubleclick() {
             freedrawObject.segments.splice(clickedSegmentId+1, 0, {kind:kind.path, pa:newPoint, pb:clickedSegment.pb});
         }
     }
-    else if (lastSelectedObject != -1 && diagram[lastSelectedObject].targeted == true) {
+    //Don't load appearance form if clicked object is a hidden comment
+    else if (lastSelectedObject != -1 && diagram[lastSelectedObject].targeted == true 
+    && !(diagram[lastSelectedObject].properties["isComment"] && hideComment)) {
         loadAppearanceForm();
     }
 }

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1086,6 +1086,7 @@ function Symbol(kindOfSymbol) {
     // move: Updates all points referenced by symbol
     //--------------------------------------------------------------------
     this.move = function (movex, movey) {
+        if(this.properties["isComment"] && hideComment) return; //Don't move hidden comments
         if (this.isLocked) return;
         if (this.symbolkind != symbolKind.line) {
             points[this.topLeft].x += movex;


### PR DESCRIPTION
You can no longer move or click hidden comments, and the cursor does not change when hovering over them.
[Issue 9208](https://github.com/HGustavs/LenaSYS/issues/9208)
Tester: Create a textbox in the diagram, double click it and check the "comment" checkbox. Then go to view->hide comments. The comment should no longer be visible, it should not be movable, clickable, and the cursor should not change when hovering over where the hidden comment.