### PR TITLE
Drop-down menu in diagram fixed (issue#9267)

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1951,7 +1951,7 @@ input {
   color: rgb(0, 0, 0);
   text-decoration: none;
   display: inline-block;
-  width: 100%;
+  width: 252px;
   padding: 8px 0px 8px 8px;
 }
 


### PR DESCRIPTION
Blue border now aligns with drop-down menu

Before: 
![image](https://user-images.githubusercontent.com/62878243/82042950-0d9a2000-96ab-11ea-99bc-8052947af73d.png)

After: 
![image](https://user-images.githubusercontent.com/62878243/82042982-1ab70f00-96ab-11ea-81d8-49fbc76572bf.png)

