### PR TITLE
Added $completeQuery to broader scope FIXES issue#9324

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -497,6 +497,7 @@
           # Split the sql file at semi-colons to send each query separated.
           $initQueryArray = explode(";", $initQuery);
           $initSuccess = false;
+          $completeQuery = null;
           try {
             if (isset($_POST["InitTransaction"]) && $_POST["InitTransaction"] == 'Yes'){
               $connection->beginTransaction();


### PR DESCRIPTION
Added $completeQuery to scope outside try-clause so we can access it from catch-clause.

For tester: run installer at http://group4.webug.his.se:20001/G4-2020-W21-ISSUE%239324/install/install.php 

when prompted for root login use:
username: uselessroot
password: galvaniseradapa

Verify that the below undefined variable is not there.

![82028178-93ab6c00-9695-11ea-8afb-e6852cf79d13 (1)](https://user-images.githubusercontent.com/62878146/82044568-e133d300-96ad-11ea-81df-a362c783745a.png)

