### PR TITLE
G2 2020 w21 #9133

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -255,6 +255,17 @@ function validateSSN(ssn)
 	return null;	// The provided SSN is correct!
 }
 
+//---------------------------------------------------------------------------------------------------
+// validateEmail(email)
+// Returns null if there are NO errors, otherwise a descripitve error message as string.
+//---------------------------------------------------------------------------------------------------
+function validateEmail(email)
+{
+	const delimiter = email.indexOf('@');		// Delimiter of the @ in an email
+
+	return null;	// The provided email is correct!
+}
+
 //-------------------------------------------------------------
 // updateErrorMessage()
 // Updates the error message shown inside the "Add user" window
@@ -262,12 +273,19 @@ function validateSSN(ssn)
 function updateErrorMessage()
 {
 	var errorMsg = '';
-	var testString = '';
+	var validationError = '';
 
-	if(testString = validateSSN(document.getElementById('addSsn').value))	// Check SSN for errors if input has been given
-		errorMsg += testString;
+	validationError = validateSSN(document.getElementById('addSsn').value);		// Check SSN for errors if input has been given
+	if(validationError && document.getElementById('addSsn').value.length > 0)
+		errorMsg += validationError;
 
-	document.getElementById('addErrorMessage').innerHTML = errorMsg + ' ';	// Updates label
+	if(errorMsg.length > 0) errorMsg += '\n';									// Adds a new line if previous errors has been found
+
+	validationError = validateEmail(document.getElementById('addEmail').value);	// Check email for errors if input has been given
+	if(validationError && document.getElementById('addEmail').value.length > 0)
+		errorMsg += validationError;
+
+	document.getElementById('addErrorMessage').innerHTML = errorMsg + ' ';		// Updates label
 }
 
 var inputVerified;

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -280,6 +280,9 @@ function validateEmail(email)
 	if(!formatTest.test(email))
 		return 'Email error! Format is invalid';
 
+	if(email.lastIndexOf('@')!==delimiter)	// Only one @ allowed to separate local and domain parts
+		return 'Email error! Only one "@" is allowed';
+
 	return null;	// The provided email is correct!
 }
 

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -267,7 +267,12 @@ function validateSSN(ssn)
 //---------------------------------------------------------------------------------------------------
 function validateEmail(email)
 {
-	const delimiter = email.indexOf('@');		// Delimiter of the @ in an email
+	const length = email.length;
+	const delimiter = email.indexOf('@');	// Delimiter of the @ in an email
+
+	const formatTest = /[A-z0-9]{1,64}@[A-z0-9]{1,}[.]{1}[A-z0-9]{2,}/;		// Expected format
+	if(!formatTest.test(email))
+		return 'Email error! Format is invalid';
 
 	return null;	// The provided email is correct!
 }

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -161,9 +161,10 @@ function addSingleUser() {
 }
 
 function verifyUserInputForm(input) {
-	// Verify SSN using validateSSN function
 	var errorString = '';
-	if(verifyString = validateSSN(input[0])) {	// Returns null if there is no error
+
+	// Verify SSN using validateSSN function
+	if(verifyString = validateSSN(input[0])) {		// Returns null if there is no error
 		alert(verifyString);
 		return false;
 	}
@@ -180,8 +181,13 @@ function verifyUserInputForm(input) {
 		return false;
 	}
 
+	// Verify email
+	if(verifyString = validateEmail(input[3])) {	// Returns null if there is no error
+		alert(verifyString);
+		return false;
+	}
 	// Verify Email <= 256 characters, contains '@' and <= 80 characters before '@'
-	if (input[3].length > 256) {
+	/*if (input[3].length > 256) {
 		alert('Input exceeded max length for Email (256)');
 		return false;
 	}
@@ -196,7 +202,7 @@ function verifyUserInputForm(input) {
 	if (input[3] && input[3].indexOf('@') == 0) {
 		alert('Email input must contain at least 1 character before "@" to create a username');
 		return false;
-	}
+	}*/
 
 	return true;
 }

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -273,6 +273,9 @@ function validateEmail(email)
 	if((length-delimiter) > 255)			// Domain part of email can't exceed 255 charachters
 		return 'Email error! Domain part is too long (maximum 255)';
 
+	if(email.indexOf('..') > 0)				// Consecutive . are not allowed
+		return 'Email error! Consecutive "." are not allowed';
+
 	const formatTest = /[A-z0-9]{1,64}@[A-z0-9]{1,}[.]{1}[A-z0-9]{2,}/;		// Expected format
 	if(!formatTest.test(email))
 		return 'Email error! Format is invalid';

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -270,6 +270,9 @@ function validateEmail(email)
 	const length = email.length;
 	const delimiter = email.indexOf('@');	// Delimiter of the @ in an email
 
+	if((length-delimiter) > 255)			// Domain part of email can't exceed 255 charachters
+		return 'Email error! Domain part is too long (maximum 255)';
+
 	const formatTest = /[A-z0-9]{1,64}@[A-z0-9]{1,}[.]{1}[A-z0-9]{2,}/;		// Expected format
 	if(!formatTest.test(email))
 		return 'Email error! Format is invalid';

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -186,23 +186,6 @@ function verifyUserInputForm(input) {
 		alert(verifyString);
 		return false;
 	}
-	// Verify Email <= 256 characters, contains '@' and <= 80 characters before '@'
-	/*if (input[3].length > 256) {
-		alert('Input exceeded max length for Email (256)');
-		return false;
-	}
-	if (input[3] && input[3].indexOf('@') == -1) {
-		alert('Email input must contain "@"');
-		return false;
-	}
-	if (input[3] && input[3].indexOf('@') >= 80) {
-		alert('Email input too large to create a valid username\nMax allowed characters before "@" is 80');
-		return false;
-	}
-	if (input[3] && input[3].indexOf('@') == 0) {
-		alert('Email input must contain at least 1 character before "@" to create a username');
-		return false;
-	}*/
 
 	return true;
 }

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -94,7 +94,7 @@
       			<div class='inputwrapper'><span>Ny:</span><input placeholder="Ny" class='textinput' id='addNy'></div>
       			<div class='inputwrapper'><span>PID:</span><input placeholder="WEBUG" class='textinput' id='addPid'></div>
       			<div class='inputwrapper'><span>Term:</span><input placeholder="H11" class='textinput' id='addTerm'></div>
-      			<div class='inputwrapper'><span>Email:</span><input placeholder="b17mahgo@student.his.se" class='textinput' id='addEmail'></div>
+      			<div class='inputwrapper'><span>Email:</span><input placeholder="b17mahgo@student.his.se" class='textinput' id='addEmail' onchange="updateErrorMessage()" onkeyup="updateErrorMessage()"></div>
       		</div>
 			<div style='padding:5px;'>
 				<div class='accessTableAddUserWarning'>


### PR DESCRIPTION
Pull request to solve issue #9133, upgrading the email verifier.

When this email verifier has been developed, the example emails on [this Microsoft page](https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format) has been used. After this pull request all invalid examples on that page shows as invalid plus the bottom two, though I'd argue that doesn't really matter since we can expect LenaSYS users to only have latin characters in their email anyway.

Screenshot of the [Microsoft](https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format) page
<img width="462" alt="Skärmavbild 2020-05-15 kl  13 35 18" src="https://user-images.githubusercontent.com/62876260/82046603-8308ef00-96b1-11ea-98f0-94910cb17432.png">