### PR TITLE
G2 2020 w21 #9335: Made it easier to close the legend 

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1752,7 +1752,7 @@ function showLegend(){
 	}
 }
 
-// Function that makes it possible to click both on and outside the div to close it 
+// Function that makes it possible to click on the div to close it 
 document.addEventListener('mouseup', function(e) {
 	var closeLegend = document.getElementById('resultedLegendContainer');
 	if (closeLegend.contains(e.target)) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1755,7 +1755,7 @@ function showLegend(){
 // Function that makes it possible to click both on and outside the div to close it 
 document.addEventListener('mouseup', function(e) {
 	var closeLegend = document.getElementById('resultedLegendContainer');
-	if (!closeLegend.contains(e.target) || closeLegend.contains(e.target)) {
+	if (closeLegend.contains(e.target)) {
 		closeLegend.style.right = "-323px";
 	}
   });

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1760,6 +1760,14 @@ function showLegend(){
 	}
 }
 
+// Function that makes it possible to click both on and outside the div to close it 
+document.addEventListener('mouseup', function(e) {
+	var closeLegend = document.getElementById('resultedLegendContainer');
+	if (!closeLegend.contains(e.target) || closeLegend.contains(e.target)) {
+		closeLegend.style.right = "-323px";
+	}
+  });
+
 function compare(firstCell, secoundCell) {
 	let col = myTable.getSortcolumn(); // Get column name
 	let status = myTable.getSortkind(); // Get if the sort arrow is up or down.

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1743,21 +1743,20 @@ function hideSSN(ssn){
 	return hiddenSSN;
 }
 
-//Shows element describing the icons and colours
-function showLegend(){
-	var legendBox = $('#resultedLegendContainer');
-	if (!legendIsHidden == false){
-		legendBox.css("right", "0px");
-		legendIsHidden = true;
-	}
-}
 
-// Function that makes it possible to click on the div to close it 
+// Function that makes it possible to click on the div to close and open it 
 document.addEventListener('mouseup', function(e) {
-	var closeLegend = document.getElementById('resultedLegendContainer');
-	if (closeLegend.contains(e.target)) {
-		closeLegend.style.right = "-323px";
-	}
+    var legendDiv = document.getElementById('resultedLegendContainer');
+    var legendBtn = document.getElementById('legendBtn');
+    if (legendDiv.contains(e.target) || legendBtn.contains(e.target)) {
+        if (legendIsHidden == true) {
+            legendDiv.style.right = "0px";
+            legendIsHidden = false;
+        } else {
+            legendDiv.style.right = "-323px";
+            legendIsHidden = true;
+        }
+    }
   });
 
 function compare(firstCell, secoundCell) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1743,20 +1743,12 @@ function hideSSN(ssn){
 	return hiddenSSN;
 }
 
-//Shows and hides element describing the icons and colours
+//Shows element describing the icons and colours
 function showLegend(){
 	var legendBox = $('#resultedLegendContainer');
-	if (legendIsHidden == false){
-
-		legendBox.css("right", "-323px");
-		legendIsHidden = true;
-	}
-	else if (legendIsHidden == true){
+	if (!legendIsHidden == false){
 		legendBox.css("right", "0px");
-		legendIsHidden = false;
-	}
-	else{
-		//alert(legendIsHidden);
+		legendIsHidden = true;
 	}
 }
 

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -50,7 +50,7 @@ pdoConnect();
 	<div id="content">
 	
 	<div id="resultedLegendContainer" >
-		<div id="legendBtn" onmouseover="showLegend();"> ? </div>
+		<div id="legendBtn"> ? </div>
 		<ul class="legendList">
 			<li class="legendListItem"><img src="../Shared/icons/Uh.png"><img src="../Shared/icons/G.png"> Pass</li>
 			<li class="legendListItem"><img src="../Shared/icons/U.png"><img src="../Shared/icons/Gc.png"> Fail</li>

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -50,7 +50,7 @@ pdoConnect();
 	<div id="content">
 	
 	<div id="resultedLegendContainer" >
-		<div id="legendBtn" onclick="showLegend();"> ? </div>
+		<div id="legendBtn" onmouseover="showLegend();"> ? </div>
 		<ul class="legendList">
 			<li class="legendListItem"><img src="../Shared/icons/Uh.png"><img src="../Shared/icons/G.png"> Pass</li>
 			<li class="legendListItem"><img src="../Shared/icons/U.png"><img src="../Shared/icons/Gc.png"> Fail</li>


### PR DESCRIPTION
It's now possible to click on the legend to close it. Also changed to `onmouseover` to make it more fluid but if the reviewers prefer `onclick` it can always be changed back. 
**But**, if you use `onclick` instead of `onmouseover` you can't close the legend by clicking on the question mark. 