### PR TITLE
G2 2020 w21 #9357 Frågedugga should now render properly

### DIFF
--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -35,7 +35,7 @@ function quiz(parameters) {
 			//app += idunique+" -----------------------------------------------------";
 			for(var i = 0;i < inputSplit.length;i++){
 				
-				var splited = inputSplit[i].split("*");
+				var splited = inputSplit[i].split('"');
 				answerID= splited[0].trim();
 				answerValue = splited[1];
 				answerID = answerID.replace(/^\s+|\s+$/g, '') ;


### PR DESCRIPTION
Solves #9357. 

String inputSplit[i] was split on wrong characters causing question/answer options to render as 'undefined' (see linked issue for screenshot). Corrected this and now the dugga should render properly.

![image](https://user-images.githubusercontent.com/49141758/82052214-8f924500-96bb-11ea-82bf-cdc02cc7ea82.png)
