### PR TITLE
Fix so that appearanceform is opened for freedraw objects, issue #9359

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5024,6 +5024,9 @@ function doubleclick() {
             freedrawObject.segments.splice(clickedSegmentId, 0, {kind:kind.path, pa:clickedSegment.pa, pb:newPoint});
             freedrawObject.segments.splice(clickedSegmentId+1, 0, {kind:kind.path, pa:newPoint, pb:clickedSegment.pb});
         }
+        else {
+            loadAppearanceForm(); 
+        }
     }
     else if (lastSelectedObject != -1 && diagram[lastSelectedObject].targeted == true) {
         loadAppearanceForm();
@@ -5053,7 +5056,7 @@ function pointOnLine(pointX, pointY, segment) {
     let pointB = {x:points[segment.pb].x, y:points[segment.pb].y};
 
     if (distance(pointA, pointBetween) + distance(pointB, pointBetween) 
-    <= distance(pointA, pointB) + 0.1) {
+    <= distance(pointA, pointB) + 0.6) {
         return true;
     }
 }


### PR DESCRIPTION
Fix so that when a freedraw object is double clicked, the appearance form is opened as it is supposed to. Also made it a little easier to double click lines accurately.
**To test:** Create a freedraw object and double click in the middle of the object. The appearance form should appear.