### PR TITLE
#9014 Added export functions.

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1533,6 +1533,18 @@ function ladexport(gradeData = "NONE") {
 	 document.getElementById('lastExportedDate').innerHTML = gradeLastExported;
 
 	 localStorage.setItem('lastExpDate', gradeLastExported);
+
+	 // Check if "gradeData" is the default value
+	 // If it's not, then loop through and update the specific grades that have been exported.
+	 // If it is, then just update everything.
+	 if (gradeData !== "NONE") {
+		for (var i = 0; i < gradeData.length; i++) {
+			console.log(gradeData[i].uid + " " + gradeData[i].moment);
+			AJAXService("updateunexported", { exportType: "restricted", luid: gradeData[i].uid, moment: gradeData[i].moment }, "GEXPORT");
+		}
+	 } else {
+		AJAXService("updateunexported", {}, "GEXPORT");
+	 }
 	}
 }
 
@@ -1563,9 +1575,6 @@ function copyLadexport() {
 	 setInterval(function(){
 		lastExpDate.style.color  = '#000';
 	 }, 5000);
-
-	AJAXService("updateunexported", {}, "GEXPORT");
-
 }
 
 function addZero(i) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -690,7 +690,7 @@ function returnedExportedGrades(gradeData){
 	// Tries to write out the last exported date.
 	// If it fails, then log the error.
 	try {
-		if (typeof gradeData.gradeLastExported !== 'undefined' && typeof gradeData === 'object') {
+		if (typeof gradeData[0].gradeLastExported !== 'undefined') {
 			document.getElementById('lastExpDate').innerHTML = gradeData[0].gradeLastExported;
 		}
 	} catch (error) {
@@ -1476,6 +1476,7 @@ function exportColumnHeading(format, heading, colname) {
 
 //Function for exporting grades to ladoc
 function ladexport() {
+	AJAXService("getunexported", {}, "GEXPORT");
 	let expo = "";
 
 	expo += document.getElementById("ladselect").value + "\n";
@@ -1501,8 +1502,6 @@ function ladexport() {
 	 document.getElementById('lastExportedDate').innerHTML = gradeLastExported;
 
 	 localStorage.setItem('lastExpDate', gradeLastExported);
-
-	AJAXService("getunexported", {}, "GEXPORT");
 }
 
 function copyLadexport() {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -690,8 +690,14 @@ function returnedExportedGrades(gradeData){
 	// Tries to write out the last exported date.
 	// If it fails, then log the error.
 	try {
-		if (typeof gradeData[0].gradeLastExported !== 'undefined') {
-			document.getElementById('lastExpDate').innerHTML = gradeData[0].gradeLastExported;
+		if (typeof gradeData[0] === 'undefined') {
+			console.log("There are no unexported grades");
+		} else {
+			console.log(gradeData[0]);
+			if (typeof gradeData[0].gradeLastExported !== 'undefined') {
+				document.getElementById('lastExpDate').innerHTML = gradeData[0].gradeLastExported;
+				ladexport(gradeData);
+			}
 		}
 	} catch (error) {
 		console.log(error);
@@ -1407,7 +1413,7 @@ function onToggleFilter(colId) {
 
 }
 
-function exportCell(format, cell, colname) {
+function exportCell(format, cell, colname, gradeData = "NONE") {
 	str = "";
 	if (format === "csv") {
 		if (colname == "FnameLname") {
@@ -1428,14 +1434,33 @@ function exportCell(format, cell, colname) {
 					str = "-";
 				} else {
 					if (cell.gradeSystem === 1 || cell.gradeSystem === 2) {
-						if (cell.grade === 1) {
-							str = "U";
-						} else if (cell.grade === 2) {
-							str = "G";
-						} else if (cell.grade === 3) {
-							str = "VG";
+						if (gradeData !== "NONE") {
+							for (var i = 0; i < gradeData.length; i++) {
+								if (cell.uid == gradeData[i].uid && cell.lid == gradeData[i].moment) {
+									if (cell.grade === 1) {
+										str = "U";
+									} else if (cell.grade === 2) {
+										str = "G";
+									} else if (cell.grade === 3) {
+										str = "VG";
+									} else {
+										str = "-";
+									}
+									return str;
+								} else {
+									str = "-";
+								}
+							}
 						} else {
-							str = "-";
+							if (cell.grade === 1) {
+								str = "U";
+							} else if (cell.grade === 2) {
+								str = "G";
+							} else if (cell.grade === 3) {
+								str = "VG";
+							} else {
+								str = "-";
+							}
 						}
 					} else {
 						str = "UNK";
@@ -1475,14 +1500,20 @@ function exportColumnHeading(format, heading, colname) {
 //----------------------------------------
 
 //Function for exporting grades to ladoc
-function ladexport() {
-	AJAXService("getunexported", {}, "GEXPORT");
+function ladexport(gradeData = "NONE") {
+	if (document.getElementById("exportType").value === "restricted" && gradeData === "NONE") {
+		AJAXService("getunexported", {}, "GEXPORT");
+	} else {
 	let expo = "";
 
 	expo += document.getElementById("ladselect").value + "\n";
 	expo += document.getElementById("ladgradescale").value + "\n";
 	expo += document.getElementById("laddate").value + "\n";
-	expo += myTable.export("csv", ";");
+	if (gradeData !== "NONE") {
+		expo += myTable.export("csv", ";", gradeData);
+	} else {
+		expo += myTable.export("csv", ";");
+	}
 
 	//alert(expo);
 	document.getElementById("resultlistheader").innerHTML = "Results for: " + document.getElementById("ladselect").value;
@@ -1502,6 +1533,7 @@ function ladexport() {
 	 document.getElementById('lastExportedDate').innerHTML = gradeLastExported;
 
 	 localStorage.setItem('lastExpDate', gradeLastExported);
+	}
 }
 
 function copyLadexport() {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -690,7 +690,7 @@ function returnedExportedGrades(gradeData){
 	// Tries to write out the last exported date.
 	// If it fails, then log the error.
 	try {
-		if (typeof gradeData[0].gradeLastExported !== 'undefined' && typeof gradeData[0] === 'object') {
+		if (typeof gradeData.gradeLastExported !== 'undefined' && typeof gradeData === 'object') {
 			document.getElementById('lastExpDate').innerHTML = gradeData[0].gradeLastExported;
 		}
 	} catch (error) {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -1533,9 +1533,7 @@ function copyLadexport() {
 		lastExpDate.style.color  = '#000';
 	 }, 5000);
 
-	AJAXService("updateunexported", {
-		gradeLastExported: gradeLastExported,
-	}, "GEXPORT");
+	AJAXService("updateunexported", {}, "GEXPORT");
 
 }
 

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -691,7 +691,9 @@ function returnedExportedGrades(gradeData){
 	// If it fails, then log the error.
 	try {
 		if (typeof gradeData[0] === 'undefined') {
-			console.log("There are no unexported grades");
+			// Show the "gradeExportPopUp" div and insert the message.
+			document.getElementById("gradeExportPopUp").style.display = "block";
+			document.getElementById("exportPopUpMessage").innerHTML = "There are no unexported grades";
 		} else {
 			console.log(gradeData[0]);
 			if (typeof gradeData[0].gradeLastExported !== 'undefined') {

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -688,14 +688,16 @@ function returnedResults(data) {
 //----------------------------------------
 function returnedExportedGrades(gradeData){
 	// Tries to write out the last exported date.
-	// If it fails, then log the error.
+	// Also checks if the object is undefined.
+	// If it's undefined then show the popup.
+	// If it's not, try to write out the gradeLastExported value.
+	// If this fails, then log the error.
 	try {
 		if (typeof gradeData[0] === 'undefined') {
 			// Show the "gradeExportPopUp" div and insert the message.
 			document.getElementById("gradeExportPopUp").style.display = "block";
 			document.getElementById("exportPopUpMessage").innerHTML = "There are no unexported grades";
 		} else {
-			console.log(gradeData[0]);
 			if (typeof gradeData[0].gradeLastExported !== 'undefined') {
 				document.getElementById('lastExpDate').innerHTML = gradeData[0].gradeLastExported;
 				ladexport(gradeData);
@@ -1436,6 +1438,9 @@ function exportCell(format, cell, colname, gradeData = "NONE") {
 					str = "-";
 				} else {
 					if (cell.gradeSystem === 1 || cell.gradeSystem === 2) {
+						// Checks if there data in "gradeData".
+						// If there is, then loop through the array and write out the correct grade.
+						// If there is not, then write out the grades as usual.
 						if (gradeData !== "NONE") {
 							for (var i = 0; i < gradeData.length; i++) {
 								if (cell.uid == gradeData[i].uid && cell.lid == gradeData[i].moment) {
@@ -1503,6 +1508,9 @@ function exportColumnHeading(format, heading, colname) {
 
 //Function for exporting grades to ladoc
 function ladexport(gradeData = "NONE") {
+	// Checks if the exportType is restricted.
+	// If it is, then ask for data from the database.
+	// If not, then continue as normal.
 	if (document.getElementById("exportType").value === "restricted" && gradeData === "NONE") {
 		AJAXService("getunexported", {}, "GEXPORT");
 	} else {
@@ -1511,13 +1519,15 @@ function ladexport(gradeData = "NONE") {
 	expo += document.getElementById("ladselect").value + "\n";
 	expo += document.getElementById("ladgradescale").value + "\n";
 	expo += document.getElementById("laddate").value + "\n";
+	// Checks if there's data in gradeData.
+	// If there's data in gradeData, then write out the grades depending on the data.
+	// If there's not, then just write out all the grades.
 	if (gradeData !== "NONE") {
 		expo += myTable.export("csv", ";", gradeData);
 	} else {
 		expo += myTable.export("csv", ";");
 	}
 
-	//alert(expo);
 	document.getElementById("resultlistheader").innerHTML = "Results for: " + document.getElementById("ladselect").value;
 	document.getElementById("resultlistarea").value = expo;
 	document.getElementById("resultlistpopover").style.display = "flex";

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -218,6 +218,17 @@ pdoConnect();
 		</div>
 	</div>
 
+	<!-- This popup is for alerts about LadExport -->
+	<div id="gradeExportPopUp" style="display: none;">
+		<div class="loginBoxheader">
+			<h3>Alert</h3>
+			<div class='cursorPointer' onclick="closeWindows()" title="Close window">x</div>
+		</div>
+		<!-- The message should go into this p tag -->
+		<p id="exportPopUpMessage"></p>
+		<input type="button" id="gradeExportPopUpButton" value="Ok" class="submit-button" onclick="closeWindows();">
+	</div>
+
 
 </body>
 </html>

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -91,6 +91,13 @@ pdoConnect();
         <input id="laddate" type="date" style="font-size:12px;">
         </div>
 		<div class="resultedFormsFlex">
+			<label>Typ</label>
+			<select id="exportType">
+				<option value="restricted">Ej exported</option>
+				<option value="all">Allt</option>
+			</select>
+		</div>
+		<div class="resultedFormsFlex">
       <button class="resultedbuttons" onclick="ladexport();">LadExport</button>
 	  <span id="lastExportedDate"></span>
 	  </div>

--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -39,7 +39,6 @@ $coursevers=getOP('coursevers');
 $qvariant=getOP("qvariant");
 $quizId=getOP("quizId");
 $teacher = getOP('teacher');
-$gradeLastExported=getOP('gradeLastExported');
 $responsetext=getOP('resptext');
 $responsefile=getOP('respfile');
 $access = false;
@@ -112,8 +111,7 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 
 	// Check if opt == updateunexported
 	if ($opt === getunexported_service_name) {
-		$statement = $pdo->prepare("UPDATE userAnswer SET gradeLastExported = :gradeLastExported");
-		$statement->bindParam(':gradeLastExported', $gradeLastExported);
+		$statement = $pdo->prepare("UPDATE userAnswer SET gradeLastExported = CURRENT_TIMESTAMP");
 		
 		if ($statement === false) {
 			// Failed to prepare query, log and return an error message

--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -112,7 +112,7 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 
 	// Check if opt == updateunexported
 	if ($opt === getunexported_service_name) {
-		$statement = $pdo->prepare("	UPDATE userAnswer SET gradeLastExported = :gradeLastExported");
+		$statement = $pdo->prepare("UPDATE userAnswer SET gradeLastExported = :gradeLastExported");
 		$statement->bindParam(':gradeLastExported', $gradeLastExported);
 		
 		if ($statement === false) {

--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -110,7 +110,7 @@ if($requestType == "mail" && checklogin() && (hasAccess($_SESSION['uid'], $cid, 
 if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESSION['uid']))) {
 
 	// Check if opt == updateunexported
-	if ($opt === getunexported_service_name) {
+	if ($opt === updateunexported_service_name) {
 		$statement = $pdo->prepare("UPDATE userAnswer SET gradeLastExported = CURRENT_TIMESTAMP");
 		
 		if ($statement === false) {

--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -41,6 +41,7 @@ $quizId=getOP("quizId");
 $teacher = getOP('teacher');
 $responsetext=getOP('resptext');
 $responsefile=getOP('respfile');
+$exportType = getOP('exportType');
 $access = false;
 
 $duggaid = getOP('duggaid');
@@ -111,7 +112,20 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 
 	// Check if opt == updateunexported
 	if ($opt === updateunexported_service_name) {
-		$statement = $pdo->prepare("UPDATE userAnswer SET gradeLastExported = CURRENT_TIMESTAMP");
+		$statement = "";
+
+		// Checks if the export was only unexported or if it exported everything
+		// If it only exported the unexported then update the specific grades.
+		// If it exported everything, them update everything.
+		if ($exportType === "restricted") {
+			$statement = $pdo->prepare("UPDATE userAnswer SET gradeLastExported = CURRENT_TIMESTAMP WHERE uid = :luid AND moment = :moment");
+			$statement->bindParam(":luid", $luid);
+			$statement->bindParam(":moment", $listentry);
+			$statement->execute();
+			return;
+		} else {
+			$statement = $pdo->prepare("UPDATE userAnswer SET gradeLastExported = CURRENT_TIMESTAMP");
+		}
 		
 		if ($statement === false) {
 			// Failed to prepare query, log and return an error message

--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -155,7 +155,7 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 		where marked is null or gradeLastExported is null or marked > gradeLastExported';
 
 		*/
-		$statement = $pdo->prepare("SELECT * FROM userAnswer");
+		$statement = $pdo->prepare("SELECT * FROM userAnswer WHERE gradeLastExported IS NULL OR marked IS NOT NULL AND gradeLastExported IS NOT NULL AND marked > gradeLastExported");
 		
 		if ($statement === false) {
 			// Failed to prepare query, log and return an error message

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -774,7 +774,7 @@ function SortableTable(param) {
 		*/ 
 }
 
-	this.export = function (format, del) {
+	this.export = function (format, del, gradeData = "NONE") {
 		var str = "";
 
 		if (del === "undefined" || del === null) {
@@ -805,7 +805,7 @@ function SortableTable(param) {
 				if (columnfilter[columnOrderIdx] !== null) {
 					if (rendcnt !== 0)
 						str += del;
-					str += exportCell(format, row[colname], colname);
+					str += exportCell(format, row[colname], colname, gradeData);
 					rendcnt++;
 				}
 			}

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1074,6 +1074,41 @@ div .navButt:hover {
   border-radius: 2px;
 }
 
+#gradeExportPopUp {
+  display: block;
+  padding: 4px;
+  background-color: var(--color-background-2);
+  border: 2px solid var(--color-border);
+  width: 350px;
+  min-height: 100px;
+  z-index: 9000;
+  position: fixed;
+  top: 30%;
+  left: 50%;
+  margin-left: -178px;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.5), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+}
+
+#gradeExportPopUpButton {
+  background-color: var(--color-primary);
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  border: 0px;
+  width: 110px;
+  height: 30px;
+  color: #fff;
+  cursor: pointer;
+  margin-top: 6px;
+  margin-bottom: 2px;
+  margin-left: 115px;
+  font-size: 14px;
+  transition: 1s background-color;
+}
+
+#gradeExportPopUpButton:hover {
+  background-color: var(--color-primary-hover);
+  border-radius: 2px;
+}
+
 #editSection {
   /*top: 50%;
   left: 50%;


### PR DESCRIPTION
This solves issue #9014.

You can now choose to only export grades that are unexported, and choose to export all the grades. 
![exportType](https://user-images.githubusercontent.com/49142651/82056937-eea78800-96c2-11ea-8a59-98cd5952ce84.PNG)

This is what pops up if you choose to export only unexported grades when there are no unexported grades.
![exportPopUp](https://user-images.githubusercontent.com/49142651/82056941-f0714b80-96c2-11ea-9d53-984c4a474205.PNG)

This is an example of what pops up if you choose to export only unexported grades when there are unexported grades available.
![unexportedPopUp](https://user-images.githubusercontent.com/49142651/82056945-f1a27880-96c2-11ea-9f49-8333fe6dc65f.PNG)

This is an example of what pops up if you choose to export all the grades.
![exportAll](https://user-images.githubusercontent.com/49142651/82056948-f23b0f00-96c2-11ea-85c8-0547fc108257.PNG)

There are some issues that have been discovered when solving this issue. New issues will be opened for those.

If anything is unclear, feel free to ask.

Co-Authored-By: a18eripi <a18eripi@users.noreply.github.com>