### PR TITLE
G4 2020 w21 issue#9355 Empty points are no longer drawn in origo.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1157,9 +1157,9 @@ points.drawPoints = function() {
     ctx.lineWidth = 2 * zoomValue;
     for (var i = 0; i < this.length; i++) {
         var point = this[i];
-        if (!point.isSelected) {
+        if (!point.isSelected && !point=="") {
             drawCross(point);
-        } else {
+        } else if(!point==""){
             ctx.save();
             ctx.fillStyle = crossFillStyle;
             ctx.strokeStyle = crossStrokeStyle2;

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -210,9 +210,6 @@ function loadDiagram() {
                 diagram[i].setID(JSON.parse(diagramID)[i]);
             }
             // Points fix
-            for (var i = 0; i < b.points.length; i++) {
-                b.points[i] = Object.assign(new Path, b.points[i]);
-            }
             points.length = b.points.length;
             for (var i = 0; i < b.points.length; i++) {
                 points[i] = b.points[i];

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1097,11 +1097,13 @@ function Symbol(kindOfSymbol) {
     //             IMP!: Should not be moved back on canvas after this function is run.
     //--------------------------------------------------------------------
     this.movePoints = function () {
-        if (this.symbolkind == symbolKind.line || this.symbolkind == symbolKind.umlLine) return;
+        if(this.isLineType()) return;
         points[this.topLeft] = waldoPoint;
         points[this.bottomRight] = waldoPoint;
         points[this.centerPoint] = waldoPoint;
-        points[this.middleDivider] = waldoPoint;
+        if(this.symbolkind === symbolKind.uml) {
+            points[this.middleDivider] = waldoPoint;
+        }
     }
 
     //--------------------------------------------------------------------


### PR DESCRIPTION
Test this by turning on dev mode and delete a couple of symbols. There shouldn't be any red crosses at origo