### PR TITLE
G2 2020 w21 #9391 Frågadugga now has submission info in navheader

### DIFF
--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -103,6 +103,7 @@ function returnedDugga(data)
 			});
 		}
 	}		
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
 }
 //----------------------------------------------------------------------------------
 // getCheckedBoxes: checks if all questions are answered and alerts each of them


### PR DESCRIPTION
Solves #9391.

Frågedugga should now display submission info (dugga not submitted, dugga submitted, dugga passed/failed etc.) in the navheader identical to how other duggas do.

![image](https://user-images.githubusercontent.com/49141758/82184006-39094e80-98e7-11ea-9f69-8addcba47ffb.png)
