### PR TITLE
Service crashes shown

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -152,6 +152,12 @@ function loadGeneralStats() {
 			'Top OS',
 			data['stats']['topOS']
 		]);
+     
+        // Number of service crashes
+		tableData.push([
+			'Service crashes',
+			data['stats']['serviceCrashes']
+		]);
 
 		// Fastest Service
 		tableData.push([

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -128,7 +128,7 @@ function generalStats($dbCon) {
 		WHERE eventType = '.EventTypes::ServiceServerStart.'
 		GROUP BY browser
 		ORDER BY percentage DESC LIMIT 1
-		')->fetchAll(PDO::FETCH_ASSOC);
+    ')->fetchAll(PDO::FETCH_ASSOC);
 	
     $topOS = $GLOBALS['log_db']->query('
         SELECT
@@ -154,7 +154,7 @@ function generalStats($dbCon) {
         FROM duggaLoadLogEntries 
         GROUP BY quizid 
         ORDER BY COUNT(*) DESC LIMIT 1;
-      ')->fetchAll(PDO::FETCH_ASSOC);
+    ')->fetchAll(PDO::FETCH_ASSOC);
 
     $topViewedExample = $GLOBALS['log_db']->query('
         SELECT 
@@ -163,7 +163,7 @@ function generalStats($dbCon) {
         FROM exampleLoadLogEntries 
         GROUP BY exampleid 
         ORDER BY COUNT(*) DESC LIMIT 1;
-      ')->fetchAll(PDO::FETCH_ASSOC);
+    ')->fetchAll(PDO::FETCH_ASSOC);
 
 	$fastestService = $GLOBALS['log_db']->query('
 	SELECT DISTINCT

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -130,36 +130,40 @@ function generalStats($dbCon) {
 		ORDER BY percentage DESC LIMIT 1
 		')->fetchAll(PDO::FETCH_ASSOC);
 	
-  $topOS = $GLOBALS['log_db']->query('
-		SELECT
-			operatingSystem,
-			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceServerStart.') AS percentage
-		FROM serviceLogEntries
-		WHERE eventType = '.EventTypes::ServiceServerStart.'
-		GROUP BY operatingSystem
-		ORDER BY percentage DESC
-	')->fetchAll(PDO::FETCH_ASSOC);
+    $topOS = $GLOBALS['log_db']->query('
+        SELECT
+            operatingSystem,
+            COUNT(*) * 100.0 / (SELECT COUNT(*) FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceServerStart.') AS percentage
+        FROM serviceLogEntries
+        WHERE eventType = '.EventTypes::ServiceServerStart.'
+        GROUP BY operatingSystem
+        ORDER BY percentage DESC
+    ')->fetchAll(PDO::FETCH_ASSOC);
 
-  $serviceCrashes = $log_db->query('
-    SELECT 
-      COUNT(*) as serviceCrashes
-		FROM serviceLogEntries
-		WHERE uuid NOT IN (SELECT DISTINCT uuid FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceServerEnd.');
-  ')->fetchAll(PDO::FETCH_ASSOC);
-    
-  $topViewedDugga = $GLOBALS['log_db']->query('
-    SELECT quizid, COUNT(*) as hits
-		FROM duggaLoadLogEntries 
-		GROUP BY quizid 
-		ORDER BY COUNT(*) DESC LIMIT 1;
-	')->fetchAll(PDO::FETCH_ASSOC);
- 
-  $topViewedExample = $GLOBALS['log_db']->query('
-	  SELECT exampleid, COUNT(*) as hits
-		FROM exampleLoadLogEntries 
-		GROUP BY exampleid 
-		ORDER BY COUNT(*) DESC LIMIT 1;
-	')->fetchAll(PDO::FETCH_ASSOC);
+    $serviceCrashes = $log_db->query('
+        SELECT 
+             COUNT(*) as serviceCrashes
+        FROM serviceLogEntries
+        WHERE uuid NOT IN (SELECT DISTINCT uuid FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceServerEnd.');
+    ')->fetchAll(PDO::FETCH_ASSOC);
+
+    $topViewedDugga = $GLOBALS['log_db']->query('
+        SELECT 
+             quizid, 
+             COUNT(*) as hits
+        FROM duggaLoadLogEntries 
+        GROUP BY quizid 
+        ORDER BY COUNT(*) DESC LIMIT 1;
+      ')->fetchAll(PDO::FETCH_ASSOC);
+
+    $topViewedExample = $GLOBALS['log_db']->query('
+        SELECT 
+             exampleid, 
+             COUNT(*) as hits
+        FROM exampleLoadLogEntries 
+        GROUP BY exampleid 
+        ORDER BY COUNT(*) DESC LIMIT 1;
+      ')->fetchAll(PDO::FETCH_ASSOC);
 
 	$fastestService = $GLOBALS['log_db']->query('
 	SELECT DISTINCT

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -139,6 +139,13 @@ function generalStats($dbCon) {
 		GROUP BY operatingSystem
 		ORDER BY percentage DESC
 	')->fetchAll(PDO::FETCH_ASSOC);
+ 
+ 	$serviceCrashes = $log_db->query('
+		SELECT 
+            COUNT(*) as serviceCrashes
+		FROM serviceLogEntries
+		WHERE uuid NOT IN (SELECT DISTINCT uuid FROM serviceLogEntries WHERE eventType = '.EventTypes::ServiceServerEnd.');
+	')->fetchAll(PDO::FETCH_ASSOC);
 
 	$fastestService = $GLOBALS['log_db']->query('
 	SELECT DISTINCT
@@ -183,6 +190,8 @@ function generalStats($dbCon) {
 
 	$generalStats['stats']['topBrowser'] = $topBrowser[0]['browser'];
 	$generalStats['stats']['topOS'] = $topOS[0]['operatingSystem'];
+ 
+    $generalStats['stats']['serviceCrashes'] = $serviceCrashes[0]['serviceCrashes'];
 
 	$generalStats['stats']['fastestService'] = $fastestService[0]['service'];
 	$generalStats['stats']['fastestServiceSpeed'] = round($fastestService[0]['avgDuration'], 2);


### PR DESCRIPTION
Number of service crashes is now shown in general stats table.
![image](https://user-images.githubusercontent.com/49142935/82192020-a9b66800-98f3-11ea-8a14-7ba60b087bf9.png)
