### PR TITLE
Adding tabs for itemKind 'group activity' and 'message' | Fix for issue #9400

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -700,12 +700,17 @@ function returnedSection(data) {
         else if (parseInt(item['visible']) === 3) hideState = " deleted"
         else if (parseInt(item['visible']) === 2) hideState = " login";
 
-        // kind 0 == Header || 1 == Section || 2 == Code  ||�3 == Test (Dugga)|| 4 == Moment�|| 5 == Link || 6 Group-Moment
+        // kind 0 == Header || 1 == Section || 2 == Code  ||�3 == Test (Dugga)|| 4 == Moment�|| 5 == Link || 6 Group-Moment || 7 Message
         var itemKind = parseInt(item['kind']);
 
         if(itemKind === 2 || itemKind == 5){
           str += "<td style='width:0px'><div class='spacerLeft'></div></td><td id='indTab' class='tabs" + item["tabs"] + "'><div class='spacerRight'></div></td>";
         }
+
+        if(itemKind === 6 || itemKind == 7){
+          str += "<td style='width:0px'><div class='spacerLeft'></div></td><td id='indTab' class='tabs" + item["tabs"] + "'><div class='spacerRight'></div></td>";
+        }
+
         if (itemKind === 3 || itemKind === 4) {
 
           // Styling for quiz row e.g. add a tab spacer


### PR DESCRIPTION
Adding tabs indentation for itemKind 6 and 7 (group activity and message). 

Now when you add items 'group activity' and 'message' they won't break the vertical line and can be indented the same way tests (duggas) can.

This is how it looked before:
![image](https://user-images.githubusercontent.com/49142028/82197123-dcb02a00-98fa-11ea-8dd8-399f35783fa7.png)

This is how it looks after this fix:
![image](https://user-images.githubusercontent.com/49142028/82197268-0ff2b900-98fb-11ea-863a-1241a25c2827.png)
