### PR TITLE
Removed line of code breaking the shift resize function ( Old )

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3709,7 +3709,6 @@ function mousemoveevt(ev) {
                 // for locking proportions of object when resizing it
                 if(shiftIsClicked) {
                     var object;
-                    obejct.minWidth = ctx.measureText(longestStr).width + 15
                     // the movement change we wan't to make
                     var change = ((currentMouseCoordinateX - sel.point.x) + (currentMouseCoordinateY - sel.point.y)) / 2;
                     // find the object that has the point we want to move


### PR DESCRIPTION
Removed a line of code breaking the functionallity. Test by shift resizing an object on the canvas.