### PR TITLE
Fixes so that path objects can be deleted correctly, issue #9360

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2461,6 +2461,9 @@ function eraseSelectedObject(event) {
             eraseObject(selected_objects[i]);
         }
     }
+    if (selected_objects.length <= 1 && selected_objects[0].figureType == "Free") {
+        deleteFreedrawObject();
+    }
     selected_objects = [];
     lastSelectedObject = -1;
     createRulerLinesObjectPoints();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2456,7 +2456,8 @@ function eraseObject(object) {
 function eraseSelectedObject(event) {
     event.stopPropagation();
     for(var i = 0; i < selected_objects.length; i++) {
-        if (selected_objects[i].figureType != "Free") {
+        if (selected_objects[i].figureType != "Free" || 
+        (selected_objects[i].figureType == "Free" && selected_objects.length > 1)) {
             eraseObject(selected_objects[i]);
         }
     }


### PR DESCRIPTION
Deleting freedraw objects together with other objects was not working properly. Should now be possible to delete them together. Deleting them with the menu option was not working either. 

**To test:** Try to delete freedraw objects together with other objects in different ways. Also try to delete them with the menu option.