### PR TITLE
fix issue#9376 UML text size problem solved

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -399,9 +399,23 @@ function Symbol(kindOfSymbol) {
             }
 
             console.log(widestStr);
-            
-            ctx.font = "14px Arial";
-            this.minWidth = ctx.measureText(widestStr).width;
+            //Determine size of UML text
+            let umlTextSize;
+            switch (this.properties['sizeOftext']) {
+                case 'Tiny':
+                    umlTextSize = 14;
+                    break;
+                case 'Small':
+                    umlTextSize = 20;
+                    break;
+                case 'Medium':
+                    umlTextSize = 30;
+                    break;
+              case 'Large':
+                    umlTextSize = 50;
+            }
+            ctx.font = umlTextSize + "px Arial";
+            this.minWidth = ctx.measureText(widestStr).width + umlTextSize;
             console.log(this.minWidth);
             if(points[this.bottomRight].y-points[this.topLeft].y < this.minHeight) {
                 // If the height is less than the minimum, push out the

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -397,8 +397,6 @@ function Symbol(kindOfSymbol) {
                         longestStr = this.attributes[i].text;
                 }
             }
-
-            console.log(widestStr);
             //Determine size of UML text
             let umlTextSize;
             switch (this.properties['sizeOftext']) {
@@ -416,7 +414,7 @@ function Symbol(kindOfSymbol) {
             }
             ctx.font = umlTextSize + "px Arial";
             this.minWidth = ctx.measureText(widestStr).width + umlTextSize;
-            console.log(this.minWidth);
+            // console.log(this.minWidth);
             if(points[this.bottomRight].y-points[this.topLeft].y < this.minHeight) {
                 // If the height is less than the minimum, push out the
                 // point that the user is dragging

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -348,16 +348,30 @@ function Symbol(kindOfSymbol) {
             }
             this.minHeight = attrHeight + opHeight;
             
-            //Finding the longest string
+            //Finding the longest and widest string
             var longestStr = "";
-            //Check if any attribute is the longest
+            let widestStr = "";
+            let widestValue = 0;
+            //Check if any attribute is the longest and widest
             for (var i = 0; i < this.attributes.length; i++) {
+                let tempWidth = this.attributes[i].text;
+                tempWidth = ctx.measureText(tempWidth).width;
+                if (tempWidth > widestValue) {
+                    widestStr = this.attributes[i].text;
+                    widestValue = ctx.measureText(widestStr).width;
+                }
                 if (this.attributes[i].text.length > longestStr.length) {
                     longestStr = this.attributes[i].text;
                 }
             }
-            //check if any operation is the longest
+            //check if any operation is the longest and widest
             for (var i = 0; i < this.operations.length; i++) {
+                let tempWidth = this.operations[i].text;
+                tempWidth = ctx.measureText(tempWidth).width;
+                if (tempWidth > widestValue) {
+                    widestStr = this.operations[i].text;
+                    widestValue = ctx.measureText(widestStr).width;
+                }
                 if (this.operations[i].text.length > longestStr.length) {
                     longestStr = this.operations[i].text;
                 }
@@ -366,7 +380,13 @@ function Symbol(kindOfSymbol) {
             if(this.name.length > longestStr.length){
                 longestStr = this.name;
             }
-
+            //check if name is the widest
+            let tempWidth = this.name;
+            tempWidth = ctx.measureText(tempWidth).width;
+            if (tempWidth > widestValue) {
+                widestStr = this.name;
+                widestValue = ctx.measureText(widestStr).width;
+            }
             if(!this.UMLCustomResize) {
                 for(var i = 0; i < this.operations.length; i++) {
                     if(this.operations[i].text.length > longestStr.length)
@@ -377,31 +397,12 @@ function Symbol(kindOfSymbol) {
                         longestStr = this.attributes[i].text;
                 }
             }
-            //Finding the widest string
-            var widestStr = 0;
-            var calcWidth;
-            for (var i = 0; i < this.attributes.length; i++) {
-                calcWidth = this.attributes[i].text;
-                calcWidth = ctx.measureText(calcWidth).width;
-                if (calcWidth > widestStr) {
-                    widestStr = calcWidth;
-                }
-            }
-            for (var i = 0; i < this.operations.length; i++) {
-                calcWidth = this.operations[i].text;
-                calcWidth = ctx.measureText(calcWidth).width;
-                if (calcWidth > widestStr) {
-                    widestStr = calcWidth;
-                }
-            }
-            calcWidth = this.name;
-            calcWidth = ctx.measureText(calcWidth).width;
-            if (calcWidth > widestStr) {
-                 widestStr = calcWidth;
-            }
+
+            console.log(widestStr);
+            
             ctx.font = "14px Arial";
-            this.minWidth = widestStr + 25;
-            //console.log(this.minWidth);
+            this.minWidth = ctx.measureText(widestStr).width;
+            console.log(this.minWidth);
             if(points[this.bottomRight].y-points[this.topLeft].y < this.minHeight) {
                 // If the height is less than the minimum, push out the
                 // point that the user is dragging

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -377,8 +377,30 @@ function Symbol(kindOfSymbol) {
                         longestStr = this.attributes[i].text;
                 }
             }
+            //Finding the widest string
+            var widestStr = 0;
+            var calcWidth;
+            for (var i = 0; i < this.attributes.length; i++) {
+                calcWidth = this.attributes[i].text;
+                calcWidth = ctx.measureText(calcWidth).width;
+                if (calcWidth > widestStr) {
+                    widestStr = calcWidth;
+                }
+            }
+            for (var i = 0; i < this.operations.length; i++) {
+                calcWidth = this.operations[i].text;
+                calcWidth = ctx.measureText(calcWidth).width;
+                if (calcWidth > widestStr) {
+                    widestStr = calcWidth;
+                }
+            }
+            calcWidth = this.name;
+            calcWidth = ctx.measureText(calcWidth).width;
+            if (calcWidth > widestStr) {
+                 widestStr = calcWidth;
+            }
             ctx.font = "14px Arial";
-            this.minWidth = ctx.measureText(longestStr).width + 15;
+            this.minWidth = widestStr + 25;
             //console.log(this.minWidth);
             if(points[this.bottomRight].y-points[this.topLeft].y < this.minHeight) {
                 // If the height is less than the minimum, push out the

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -315,19 +315,19 @@ function Symbol(kindOfSymbol) {
                 //Height of text + padding on attributes textfield
                 if(this.properties['sizeOftext'] == 'Tiny'){
                     textHeight = 14;
-                    attrHeight = (this.attributes.length*textHeight) +35;
+                    attrHeight = (this.attributes.length*textHeight) + 30;
                 }
                 else if (this.properties['sizeOftext'] == 'Small'){
                     textHeight = 20;
-                    attrHeight = (this.attributes.length*textHeight) +35;
+                    attrHeight = (this.attributes.length*textHeight) + 45;
                 }
                 else if (this.properties['sizeOftext'] == 'Medium'){
                     textHeight = 30;
-                    attrHeight = (this.attributes.length*textHeight)+50;
+                    attrHeight = (this.attributes.length*textHeight) + 60;
                 }
                 else if (this.properties['sizeOftext'] == 'Large'){
                     textHeight = 50;
-                    attrHeight = (this.attributes.length*textHeight)+100;
+                    attrHeight = (this.attributes.length*textHeight) + 100;
                 } 
             }
             if(this.operations.length > 0) {


### PR DESCRIPTION
**Problem 1:** Before fix when changing font size in global appearance to something other than tiny the UML's min width didn't fit with the longest string anymore.

After fix this should be solved. All the font sizes should fit with the UML boxes, and it should be impossible to resize the boxes smaller than the text. 

**Problem 2:** Before fix the min width of the UML box didn't look at the longest string. It looked at the string with most characters. This is illustrated in the GIF below.

![e03857de286c2b84fb8e78218b6e1d24](https://user-images.githubusercontent.com/49142301/82203879-3701b880-9904-11ea-93d5-4e75d8cf7295.gif)

After fix this should not be a problem anymore. The minWidth should be limited by the longest string,

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W21-ISSUE%239376/DuggaSys/diagram.php

**Test this:** Create a UML-class and change the font size in global appearance to small, medium and large. Make sure you can't resize the UML-class smaller than the longest string in the box. 

**Test this:** Create a scenario like in the GIF above. Make sure that the box can't be resized smaller  than the longest string, even though the longer string contains less characters.

**Before:**

<img width="128" alt="Screenshot_46" src="https://user-images.githubusercontent.com/49142301/82203993-6c0e0b00-9904-11ea-96df-86ab47968373.png">

**After:**

<img width="588" alt="Screenshot_51" src="https://user-images.githubusercontent.com/49142301/82204047-7e884480-9904-11ea-9b12-3f53cbe56281.png">

**Before:** 

![e03857de286c2b84fb8e78218b6e1d24](https://user-images.githubusercontent.com/49142301/82203879-3701b880-9904-11ea-93d5-4e75d8cf7295.gif)

**After:**

![ed5feebe8dfe57b39aa5ed07d39c917a](https://user-images.githubusercontent.com/49142301/82204258-de7eeb00-9904-11ea-9f74-99e7163ac8c9.gif)

