### PR TITLE
G2 2020 w21 #9410

### DIFF
--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -93,6 +93,7 @@ pdoConnect();
               <div class='flexwrapper'><span>Result release:</span><span><input class='textinput' type='date' id='release' value=''  /><select style='width:55px;' id='releaset'></select><select style='width:55px;' id='releasem'></select></span></div>
         		</div>
         		<div style='padding:5px;display:flex;justify-content:space-between'>
+              <div></div>
         			<input id='saveDugga' class='submit-button' type='button' value='Save' onclick='updateDugga();' />
         		</div>
         </div>
@@ -214,6 +215,7 @@ pdoConnect();
               </div>
             </div>
             <div id='buttonVariantDiv' style='display:flex;justify-content:space-between'>
+            <div></div>
               <div style='display:flex;justify-content:flex-end'>
                   <input id='submitVariant' class='submit-button' type='button' value='Create' onclick='createVariant();'>
                   <input id='saveVariant' class='submit-button' type='button' value='Update' onclick='updateVariant("0");'>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -214,7 +214,6 @@ pdoConnect();
               </div>
             </div>
             <div id='buttonVariantDiv' style='display:flex;justify-content:space-between'>
-              <input id='closeVariant' class='submit-button' type='button' value='Close' onclick='closeWindows();'>
               <div style='display:flex;justify-content:flex-end'>
                   <input id='submitVariant' class='submit-button' type='button' value='Create' onclick='createVariant();'>
                   <input id='saveVariant' class='submit-button' type='button' value='Update' onclick='updateVariant("0");'>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -93,7 +93,6 @@ pdoConnect();
               <div class='flexwrapper'><span>Result release:</span><span><input class='textinput' type='date' id='release' value=''  /><select style='width:55px;' id='releaset'></select><select style='width:55px;' id='releasem'></select></span></div>
         		</div>
         		<div style='padding:5px;display:flex;justify-content:space-between'>
-        			<input id='closeDugga' class='submit-button' type='button' value='Cancel' onclick='closeWindows();' />
         			<input id='saveDugga' class='submit-button' type='button' value='Save' onclick='updateDugga();' />
         		</div>
         </div>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -92,8 +92,7 @@ pdoConnect();
   						<div class='flexwrapper'><span>Comment:</span><input class='textinput' type='text' id='deadlinecomments3' placeholder='Deadline Comments' /></div>
               <div class='flexwrapper'><span>Result release:</span><span><input class='textinput' type='date' id='release' value=''  /><select style='width:55px;' id='releaset'></select><select style='width:55px;' id='releasem'></select></span></div>
         		</div>
-        		<div style='padding:5px;display:flex;justify-content:space-between'>
-              <div></div>
+        		<div style='padding:5px;display:flex;justify-content: flex-end'>
         			<input id='saveDugga' class='submit-button' type='button' value='Save' onclick='updateDugga();' />
         		</div>
         </div>
@@ -214,8 +213,7 @@ pdoConnect();
                 </fieldset>
               </div>
             </div>
-            <div id='buttonVariantDiv' style='display:flex;justify-content:space-between'>
-            <div></div>
+            <div id='buttonVariantDiv' style='display:flex;justify-content: flex-end'>
               <div style='display:flex;justify-content:flex-end'>
                   <input id='submitVariant' class='submit-button' type='button' value='Create' onclick='createVariant();'>
                   <input id='saveVariant' class='submit-button' type='button' value='Update' onclick='updateVariant("0");'>


### PR DESCRIPTION
This pull request removes unnecessary button from the Dugga editor according to the specifications in issue #9410.

The following changes has been made:
<img width="478" alt="Skärmavbild 2020-05-18 kl  11 58 56" src="https://user-images.githubusercontent.com/62876260/82204756-be036080-9905-11ea-8f53-b4af214585a7.png">

<img width="1425" alt="Skärmavbild 2020-05-18 kl  11 59 56" src="https://user-images.githubusercontent.com/62876260/82204767-c491d800-9905-11ea-9487-cd0ba981c20d.png">