### PR TITLE
Solution for branch G1-2020-W19-ISSUE#9299

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1227,7 +1227,7 @@ div .navButt:hover {
         color:white;
         margin-top: 50px;
         background:#927b9e;
-        padding: 5px;
+        padding: 4px;
         font-weight: bold;
         
     }
@@ -1251,6 +1251,16 @@ div .navButt:hover {
     .box{
         overflow: hidden;
     }
+    .maximizebtn, .minimizebtn, .resetbtn{
+        display: none;
+    }
+    .buttomenu2{
+        height: 35px;
+    }
+    .box{
+        margin-top: 30px !important;
+    }
+    
     
 }
 


### PR DESCRIPTION
The resize,minimize and maximize buttons is now removed from the mobile view. 
Result:[![Image from Gyazo](https://i.gyazo.com/ab02ea14650c5a5235e2adb1bb25a7fe.png)](https://gyazo.com/ab02ea14650c5a5235e2adb1bb25a7fe)