### PR TITLE
G1-2020-W21-ISSUE#9099-V2

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -889,36 +889,28 @@ function loadUserInformation(){
 		var event;
 		var users = {};
 		var user;
+		eventNames = ['arrayStartOn0','DuggaRead','DuggaWrite','LoginSuccess','LoginFail','ServiceClientStart','ServiceServerStart',
+		'ServiceServerEnd','ServiceClientEnd','Logout','pageLoad','PageNotFound','RequestNewPW','CheckSecQuestion','SectionItems',
+		'AddFile','EditCourseVers','AddCourseVers','AddCourse','EditCourse','ResetPW','DuggaFileupload','DownloadAllCourseVers',
+		'EditFile','MarkedDugga'];
         loadAnalytics("userLogInformation", function(data) {
             $.each(data, function(i, row) {
                 user = row.username;
                 if (!users.hasOwnProperty(user)) {
                     users[user] = [["Userid", "Username", "EventType", "Description", "Timestamp", "EventDescription"]];
 				}
+				eventNumber = row.eventType;
+				event = eventNames[eventNumber];
 				if(row.eventType != "") {
-					$.ajax({
-						url:"../Shared/basic.php", 
-						type: "POST", 
-						dataType: 'json',
-						   data: {
-							test: "success",
-							ev: row.eventType
-						},success:function(data){
-							event = data;
-							console.log(data);
-							users[user].push([
-								row.uid,
-								row.username,
-								row.eventType,
-								row.description,
-								row.timestamp,
-								event
-							]);
-							updateState(users);
-						},error: function(){
-						   console.log("AJAX error");
-						}
-					});
+					users[user].push([
+						row.uid,
+						row.username,
+						row.eventType,
+						row.description,
+						row.timestamp,
+						event
+					]);
+					updateState(users);		
 				}
             });
 		});

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -371,32 +371,6 @@ function logDuggaLoadEvent($cid, $uid, $username, $vers, $quizid, $type) {
 // EventTypes - Contains constants for log event types
 //------------------------------------------------------------------------------------------------
 
-$test = $_POST['test'];
-
-
-if ($test == "success"){
-	test();
-}
-function test() {
-	$ev = $_POST['ev'];
-	$input = $ev;
-	$EventTypesClass = new ReflectionClass ( 'EventTypes' );
-	$constants = $EventTypesClass->getConstants();
-
-	$constName = null;
-	foreach ( $constants as $name => $value )
-	{
-		if ( $value == $input )
-		{
-			$constName = $name;
-			break;
-		}
-	}
-
-	$result = $constName;
-	echo json_encode($result);
-}
-
 abstract class EventTypes {
 	const DuggaRead = 1;
 	const DuggaWrite = 2;


### PR DESCRIPTION
Removed AJAX call and made it with a local array instead. This removes any complications and the need to connect to other sources.
Once again the events table should show evendescription and the name of the event
![bild](https://user-images.githubusercontent.com/49142342/82214975-eba4d580-9916-11ea-9f48-dc05730a7f76.png)
