### PR TITLE
G4 2020 w21 issue#9375 fixed shift resize

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3709,7 +3709,6 @@ function mousemoveevt(ev) {
                 // for locking proportions of object when resizing it
                 if(shiftIsClicked) {
                     var object;
-                    obejct.minWidth = ctx.measureText(longestStr).width + 15
                     // the movement change we wan't to make
                     var change = ((currentMouseCoordinateX - sel.point.x) + (currentMouseCoordinateY - sel.point.y)) / 2;
                     // find the object that has the point we want to move


### PR DESCRIPTION
Shift resize now works and keep proportions, test this by shift resizing a symbol using top left or bottom right points. Closing#9375