### PR TITLE
Styling the top fab button | Fix for issue #9419

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -169,7 +169,7 @@
 
 			<div class='fixed-action-button2 sectioned2'  id="FABStatic2" style="display:none">
 				<input id='addElement'  type='button' value='+' style="top:-493px" class='submit-button-newitem' title='New Item' >
-				<ol class='fab-btn-list2' style='margin: 0; padding: 0; display: none;'  reversed id='fabBtnList2'>
+				<ol class='fab-btn-list2' style='display: none;'  reversed id='fabBtnList2'>
 							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' data-tooltip='Heading' onclick='createFABItem("0","New Heading","TOP");'><img class='fab-icon' src='../Shared/icons/heading-icon.svg'></a></li>
 							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' data-tooltip='Section' onclick='createFABItem("1","New Section","TOP");'><img class='fab-icon' src='../Shared/icons/section-icon.svg'></a></li>
 							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' data-tooltip='Moment' onclick='createFABItem("4","New Moment","TOP");'><img class='fab-icon' src='../Shared/icons/moment-icon.svg'></a></li>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5819,6 +5819,8 @@ only screen and (max-device-width: 320px) {
 
 .fab-btn-list2 {
   position: absolute;
+  padding: 18px 0px 0px;
+  margin: 0px 0px 0px -3px;
   left: auto;
   width: 100%;
   list-style: none;


### PR DESCRIPTION
The top tab button is now styled to have a larger space from the start of the drop-down and the button itself.

This is how it looked before:
![image](https://user-images.githubusercontent.com/49142028/82221287-17788900-9920-11ea-8b47-790b66958e30.png)


This is how it looks after this fix:
![image](https://user-images.githubusercontent.com/49142028/82221255-0b8cc700-9920-11ea-8682-f2a701f591b0.png)
(the button is only green because it's selected)
