### PR TITLE
Logging now also includes eventual guest IDs.

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -250,12 +250,13 @@ function loadPasswordGuessing() {
 		$('#pageTitle').text("Password Guessing");
 		$('#analytic-info').append("<p class='analyticsDesc'>Potential brute force attacks.</p>");
 
-		var tableData = [["Username", "Remote address", "User agent", "Tries"]];
+		var tableData = [["Username", "Remote address", "User agent", "Guest ID", "Tries"]];
 		for (var i = 0; i < data.length; i++) {
 			tableData.push([
 				data[i].userName,
 				data[i].remoteAddress,
 				data[i].userAgent,
+				data[i].guestID,
 				data[i].tries
 			]);
 		}

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -410,6 +410,7 @@ function passwordGuessing(){
 			uid AS userName,
 			remoteAddress AS remoteAddress,
 			userAgent AS userAgent,
+			description as guestID,
 			COUNT(*) AS tries
 		FROM userLogEntries
 		WHERE eventType = '.EventTypes::LoginFail.'

--- a/Shared/loginlogout.php
+++ b/Shared/loginlogout.php
@@ -78,8 +78,13 @@ if($opt=="REFRESH"){
 			addlogintry(); // If to many attempts has been commited, it will jump to this
 			// As login has failed we log the attempt
 
-			// Logging for failed login
-			logUserEvent($username, $username, EventTypes::LoginFail,"");
+			// Logging for failed login, include guest id if guest cookie is set.
+			if(isset($_COOKIE["cookie_guest"])){
+				logUserEvent($username, $username, EventTypes::LoginFail, $_COOKIE["cookie_guest"]);
+			}
+			else{
+				logUserEvent($username, $username, EventTypes::LoginFail,"");
+			}
 		}
     }else{
 		$res = array("login" => "limit");


### PR DESCRIPTION
Added new section to the table containing data logged when someone tries to password guess. This section contains the guest ID (if one is set) of the client that's trying to login. 

Test by making 3 consecutive login fails using the same username (thus forcing a password guess log). Then view the password guessing section of the analytic page and observe the guest ID that's been logged.