### PR TITLE
G2 2020 w21 #9436 Frågedugga will now show the correct variant 

### DIFF
--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -246,7 +246,7 @@ if($demo){
 			$param="NONE!";
 	}
 	foreach ($variants as $variant) {
-		if($variant["vid"] == $savedvariant || $quizfile == "kryss"){
+		if($variant["vid"] == $savedvariant){
 				$param=html_entity_decode($variant['param']);
 		}
 	}

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -35,7 +35,7 @@ function quiz(parameters) {
 			//app += idunique+" -----------------------------------------------------";
 			for(var i = 0;i < inputSplit.length;i++){
 				
-				var splited = inputSplit[i].split("*");
+				var splited = inputSplit[i].split('"');
 				answerID= splited[0].trim();
 				answerValue = splited[1];
 				answerID = answerID.replace(/^\s+|\s+$/g, '') ;


### PR DESCRIPTION
**Note: https://github.com/HGustavs/LenaSYS/pull/9363 should be merged before this (this branch is branched from that issuebranch).**

Solves #9436.

Changed a faulty if-statement inside a loop in showDuggaservice.php. This loop sets the value of $param which should contain dugga parameters for the correct variant, but because of this faulty if/loop it would loop through all the variants for the Frågedugga and $param would consequently always contain parameters for the last variant. With the if-statements fixed the correct parameters should be saved in $param.

Screenshot one. This is the same user used as an example in linked issue. The variant is 17. Now shows the correct question, where as before it did not.
![image](https://user-images.githubusercontent.com/49141758/82294788-fad76200-99ae-11ea-9b74-e62b625b8826.png)

Screenshot two. Shows all the available variants. Here you can see that the variant displayed matches the variant 17 (see linked issue for an example where this is not true, using the same user and dugga variant).
![image](https://user-images.githubusercontent.com/49141758/82294880-1c384e00-99af-11ea-855e-d8e125cd52ba.png)
