### PR TITLE
G2 2020 w21 #9440 Frågedugga quiz number is now centered properly

### DIFF
--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -35,7 +35,7 @@ function quiz(parameters) {
 			//app += idunique+" -----------------------------------------------------";
 			for(var i = 0;i < inputSplit.length;i++){
 				
-				var splited = inputSplit[i].split("*");
+				var splited = inputSplit[i].split('"');
 				answerID= splited[0].trim();
 				answerValue = splited[1];
 				answerID = answerID.replace(/^\s+|\s+$/g, '') ;

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -299,8 +299,9 @@ strong {font-weight: bold;}
 	-webkit-border-radius:15px;
 	border-radius: 20px;
 	border:1px solid #fff;
-	text-align: center;
-	display: inline-block;
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
 	margin-right: 5px;
 }
 


### PR DESCRIPTION
**Note: #9363 should be merged before this (this branch is branched from that issuebranch).**

Solves #9440.

Updates styling in dugga.css. Changed display to inline-flex and centered the number with justify-content and align-items. Removed text-align.

![image](https://user-images.githubusercontent.com/49141758/82297952-b1d5dc80-99b3-11ea-9443-27e48d9e605b.png)
