### PR TITLE
Piechart scale

### DIFF
--- a/Shared/css/analytics.css
+++ b/Shared/css/analytics.css
@@ -4,7 +4,8 @@
 }
 
 #canvas-area {
-    height: 300px;
+    height: auto;
+    padding-left: 2%;
 }
 
 #home{


### PR DESCRIPTION
Canvas element scale in height.
Changed the position of the piechart slightly to the left to better fit with the table.

Before:
![image](https://user-images.githubusercontent.com/49142935/82300739-8d7bff00-99b7-11ea-8843-ee0fe166c1a6.png)
![image](https://user-images.githubusercontent.com/49142935/82300768-94a30d00-99b7-11ea-9812-a18a9b6e3a48.png)

After:
![image](https://user-images.githubusercontent.com/49142935/82300787-9a98ee00-99b7-11ea-8a40-47eebea8bd6f.png)
![image](https://user-images.githubusercontent.com/49142935/82300795-9e2c7500-99b7-11ea-9990-d863f80d08e6.png)
