### PR TITLE
Solution for branch G1-2020-W19-ISSUE#9444

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6354,7 +6354,7 @@ textarea#mrkdwntxt {
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);
 }
 
-@media only screen and (max-width: 900px) {
+@media only screen and (max-width: 1350px) {
   .previewWindow {
     height: 89%;
   }


### PR DESCRIPTION
Fixed the media query to response to resize before the markdown collapses. 
result:[![Image from Gyazo](https://i.gyazo.com/5f6b04b497a801c395290febb4c3f5e1.gif)](https://gyazo.com/5f6b04b497a801c395290febb4c3f5e1)