### PR TITLE
G3 2020#9260 | Removed styling that caused the error

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -638,14 +638,6 @@ function returnedSection(data) {
     if (data['studentteacher']) {
       // Show FAB / Menu
       document.getElementById("FABStatic").style.display = "Block";
-      document.querySelector("td.results.menuButton").style.display = "none";
-      document.querySelector("td.tests.menuButton").style.display = "none";
-      document.querySelector("td.access.menuButton").style.display = "none";
-      document.querySelector(".course-dropdown-div").style.display = "none";
-      document.querySelector("td.editVers").style.display = "none";
-      document.querySelector("td.newVers").style.display = "none";
-      document.querySelector("td.coursePage").style.display = "none";
-
       // Show addElement Button
       document.getElementById("addElement").style.display = "Block";
     }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -602,7 +602,7 @@ function returnedSection(data) {
 
     var str = "";
 
-    if (data['writeaccess']) {
+    if (data['writeaccess'] || data['studentteacher']) {
       // Build dropdowns
       var bstr = "";
       for (var i = 0; i < retdata['versions'].length; i++) {
@@ -635,20 +635,6 @@ function returnedSection(data) {
       document.getElementById("FABStatic2").style.display = "None";
     }
 
-    if (data['studentteacher']) {
-      // Show FAB / Menu
-      document.getElementById("FABStatic").style.display = "Block";
-      document.querySelector("td.results.menuButton").style.display = "none";
-      document.querySelector("td.tests.menuButton").style.display = "none";
-      document.querySelector("td.access.menuButton").style.display = "none";
-      document.querySelector(".course-dropdown-div").style.display = "none";
-      document.querySelector("td.editVers").style.display = "none";
-      document.querySelector("td.newVers").style.display = "none";
-      document.querySelector("td.coursePage").style.display = "none";
-
-      // Show addElement Button
-      document.getElementById("addElement").style.display = "Block";
-    }
 
     // hide som elements if to narrow
     var hiddenInline = "";

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -602,7 +602,7 @@ function returnedSection(data) {
 
     var str = "";
 
-    if (data['writeaccess'] || data['studentteacher']) {
+    if (data['writeaccess']) {
       // Build dropdowns
       var bstr = "";
       for (var i = 0; i < retdata['versions'].length; i++) {
@@ -635,6 +635,20 @@ function returnedSection(data) {
       document.getElementById("FABStatic2").style.display = "None";
     }
 
+    if (data['studentteacher']) {
+      // Show FAB / Menu
+      document.getElementById("FABStatic").style.display = "Block";
+      document.querySelector("td.results.menuButton").style.display = "none";
+      document.querySelector("td.tests.menuButton").style.display = "none";
+      document.querySelector("td.access.menuButton").style.display = "none";
+      document.querySelector(".course-dropdown-div").style.display = "none";
+      document.querySelector("td.editVers").style.display = "none";
+      document.querySelector("td.newVers").style.display = "none";
+      document.querySelector("td.coursePage").style.display = "none";
+
+      // Show addElement Button
+      document.getElementById("addElement").style.display = "Block";
+    }
 
     // hide som elements if to narrow
     var hiddenInline = "";


### PR DESCRIPTION
This error should not be visible anymore 
![image](https://user-images.githubusercontent.com/49142669/82307709-0469c580-99c1-11ea-994a-c11f1f38b12e.png)
Removed the styling that didn't work and was not needed as ST/SV users should be able to see the navheader.
Test with these two users

Studentteacher: Got 'ST' access for all courses.
mofre

Supervisor: Got SV access for all courses.
ryrey

Password is ‘password’.
