### PR TITLE
Headings are now placed more to the right 

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3129,6 +3129,7 @@ padding: 10px;
 #resultedFormContainer {
   display: flex;
   flex-direction: column;
+  margin-left: 10px;
 }
 
 #ladexportContainer {
@@ -4952,6 +4953,7 @@ only screen and (max-device-width: 320px) {
   width: 100%;
   display: flex;
   flex-wrap: wrap;
+  margin-left: 10px;
 }
 
 .titles h1 {


### PR DESCRIPTION
Added 10px margin-left to give the headings more space to the left.

![image](https://user-images.githubusercontent.com/49142704/82308124-a25d9000-99c1-11ea-8ed4-6af778cc32be.png)
