### PR TITLE
Added most recent created file to general stats - G1-2020-W21-ISSUE#9448

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -183,6 +183,12 @@ function loadGeneralStats() {
 			'Hits: ' + data['stats']['topViewedDuggaHits']
 		]);
 
+		// Newest file
+        tableData.push([
+            'Newest file: ' + data['stats']['newestFile'],
+            'Created: ' + data['stats']['newestFileTimestamp']
+    	]);
+
 		$('#analytic-info').append(renderTable(tableData));
 		
 		// Disk usage

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -195,6 +195,17 @@ function generalStats($dbCon) {
 	FROM serviceLogEntries ORDER BY avgDuration DESC LIMIT 1;
 	')->fetchAll(PDO::FETCH_ASSOC);
 	
+	$newestFile = $GLOBALS['log_db']->query('
+       SELECT
+           username,
+           timestamp,
+           eventType,
+           description AS description,
+            substr(description,    instr(description, ",") + 1) AS filename
+       FROM userLogEntries
+       WHERE eventType = '.EventTypes::AddFile.'
+        ORDER BY timestamp DESC LIMIT 1;
+   ')->fetchAll(PDO::FETCH_ASSOC);
 
 	$generalStats = [];
 	$generalStats['stats']['loginFails'] = $LoginFail[0];
@@ -205,6 +216,9 @@ function generalStats($dbCon) {
 
 	$generalStats['stats']['topPage'] = $topPage[0]['refer'];
 	$generalStats['stats']['topPageHits'] = $topPage[0]['hits'];
+
+	$generalStats['stats']['newestFile'] = $newestFile[0]['filename'];
+    $generalStats['stats']['newestFileTimestamp'] = $newestFile[0]['timestamp'];
  
     $generalStats['stats']['topViewedDugga'] = $topViewedDugga[0]['quizid'];
 	$generalStats['stats']['topViewedDuggaHits'] = $topViewedDugga[0]['hits'];


### PR DESCRIPTION
The newest file now is shown in the general stats table along with the timestamp when it was created. 

![Screenshot 2020-05-19 at 11 11 34](https://user-images.githubusercontent.com/62876614/82308084-95d93780-99c1-11ea-81f8-30fc20a884a2.png)
