### PR TITLE
G1-2020-W21-ISSUE#9367

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -938,15 +938,17 @@ function loadUserInformation(){
 				eventNumber = row.eventType;
 				event = eventNames[eventNumber];
 				if(row.eventType != "") {
-					users[user].push([
-						row.uid,
-						row.username,
-						row.eventType,
-						row.description,
-						row.timestamp,
-						event
-					]);
-					updateState(users);		
+					if(event != 'AddFile' && event != 'EditFile'){
+						users[user].push([
+							row.uid,
+							row.username,
+							row.eventType,
+							row.description,
+							row.timestamp,
+							event
+						]);
+						updateState(users);	
+					}
 				}
             });
 		});

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -955,22 +955,34 @@ function loadUserInformation(){
 	}
 	
 	function apa(users){
+		var event;
 		var users = {};
 		var user;
+		eventNames = ['arrayStartOn0','DuggaRead','DuggaWrite','LoginSuccess','LoginFail','ServiceClientStart','ServiceServerStart',
+		'ServiceServerEnd','ServiceClientEnd','Logout','pageLoad','PageNotFound','RequestNewPW','CheckSecQuestion','SectionItems',
+		'AddFile','EditCourseVers','AddCourseVers','AddCourse','EditCourse','ResetPW','DuggaFileupload','DownloadAllCourseVers',
+		'EditFile','MarkedDugga'];
+
         loadAnalytics("userLogInformation", function(data) {
             $.each(data, function(i, row) {
                 user = row.username;
                 if (!users.hasOwnProperty(user)) {
-                    users[user] = [["Userid", "Username", "EventType", "Description"]];
+                    users[user] = [["Userid", "Username", "EventType", "Description", "Timestamp", "EventDescription"]];
 				}
+				eventNumber = row.eventType;
+				event = eventNames[eventNumber];
 				if(row.eventType != "") {
-					users[user].push([
-						row.uid,
-						row.username,
-						row.eventType,
-						row.description,
-					]);
-					updateState(users);		
+					if(event == 'AddFile' || event == 'EditFile'){
+						users[user].push([
+							row.uid,
+							row.username,
+							row.eventType,
+							row.description,
+							row.timestamp,
+							event
+						]);
+						updateState(users);	
+					}
 				}
             });
 		});

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -775,6 +775,7 @@ function loadUserInformation(){
 		.append('<option value="showDugga" selected>showDugga</option>')
 		.append('<option value="codeviewer">codeviewer</option>')
 		.append('<option value="events">events</option>')
+		.append('<option value="fileEvents">fileEvents</option>')
         .appendTo($('#analytic-info'));
  
  
@@ -949,7 +950,29 @@ function loadUserInformation(){
 				}
             });
 		});
-    } 
+	}
+	
+	function apa(users){
+		var users = {};
+		var user;
+        loadAnalytics("userLogInformation", function(data) {
+            $.each(data, function(i, row) {
+                user = row.username;
+                if (!users.hasOwnProperty(user)) {
+                    users[user] = [["Userid", "Username", "EventType", "Description"]];
+				}
+				if(row.eventType != "") {
+					users[user].push([
+						row.uid,
+						row.username,
+						row.eventType,
+						row.description,
+					]);
+					updateState(users);		
+				}
+            });
+		});
+	}
    
     function updateState(users){
         $('#analytic-info > select.file-select').remove();
@@ -1002,8 +1025,7 @@ function loadUserInformation(){
         $('#analytic-info').append(userSelect);
 		userSelect.change();
 		pageSelect();
-	}
-	
+	}	
 	function pageSelect(){
 		if(firstLoad === true){
 			updateSectionedInformation();
@@ -1025,6 +1047,9 @@ function loadUserInformation(){
 					break;
 				case "events":
 					updateUserLogInformation();
+					break;
+				case "fileEvents":
+					apa();
 					break;
             }
         });

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -954,7 +954,7 @@ function loadUserInformation(){
 		});
 	}
 	
-	function apa(users){
+	function updatefileEvents(users){
 		var event;
 		var users = {};
 		var user;
@@ -1063,7 +1063,7 @@ function loadUserInformation(){
 					updateUserLogInformation();
 					break;
 				case "fileEvents":
-					apa();
+					updatefileEvents();
 					break;
             }
         });


### PR DESCRIPTION
There should now be a new option in the dropdown for fileEvents that should display fileEvents (surprise). FileEvents should also be removed from the 'normal' events table. 
![bild](https://user-images.githubusercontent.com/49142342/82324429-e9577f80-99d9-11ea-9de3-4d19d16e1a70.png)
Picture 1: Normal events without any fileEvents
![bild](https://user-images.githubusercontent.com/49142342/82324480-00966d00-99da-11ea-89b5-56376a40a8fe.png)
Picture 2: New dropdown containing only fileEvents in a table