### PR TITLE
Added section in general stats that displays most recently edited file.

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -189,10 +189,10 @@ function loadGeneralStats() {
             'Created: ' + data['stats']['newestFileTimestamp']
     	]);
 
-		// Most recent edited file
+		// Most recently edited file
         tableData.push([
-            'Most recent edited file: ' + data['stats']['recentlyEditedFile'],
-            'Edited: ' + data['stats']['recentlyEditedFileTimestamp']
+			'Most recently edited file: ' + data['stats']['recentlyEditedFile'],
+            'Edited: ' + new Date(data['stats']['recentlyEditedFileTimestamp'].replace(' ', 'T') + "Z").toLocaleString()
     	]);
 		$('#analytic-info').append(renderTable(tableData));
 		

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -189,6 +189,11 @@ function loadGeneralStats() {
             'Created: ' + data['stats']['newestFileTimestamp']
     	]);
 
+		// Most recent edited file
+        tableData.push([
+            'Most recent edited file: ' + data['stats']['recentlyEditedFile'],
+            'Edited: ' + data['stats']['recentlyEditedFileTimestamp']
+    	]);
 		$('#analytic-info').append(renderTable(tableData));
 		
 		// Disk usage

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -207,6 +207,20 @@ function generalStats($dbCon) {
         ORDER BY timestamp DESC LIMIT 1;
    ')->fetchAll(PDO::FETCH_ASSOC);
 
+   	$recentlyEditedFile = $GLOBALS['log_db']->query('
+       SELECT
+           username,
+           timestamp,
+           eventType,
+           description AS description,
+            substr(description,    instr(description, ",") + 1) AS filename
+       FROM userLogEntries
+       WHERE eventType = '.EventTypes::EditFile.'
+        ORDER BY timestamp DESC LIMIT 1;
+   ')->fetchAll(PDO::FETCH_ASSOC);
+
+
+
 	$generalStats = [];
 	$generalStats['stats']['loginFails'] = $LoginFail[0];
 	$generalStats['stats']['numOnline'] = count($activeUsers);
@@ -220,6 +234,9 @@ function generalStats($dbCon) {
 	$generalStats['stats']['newestFile'] = $newestFile[0]['filename'];
     $generalStats['stats']['newestFileTimestamp'] = $newestFile[0]['timestamp'];
  
+	$generalStats['stats']['recentlyEditedFile'] = $recentlyEditedFile[0]['filename'];
+	$generalStats['stats']['recentlyEditedFileTimestamp'] = $recentlyEditedFile[0]['timestamp'];
+
     $generalStats['stats']['topViewedDugga'] = $topViewedDugga[0]['quizid'];
 	$generalStats['stats']['topViewedDuggaHits'] = $topViewedDugga[0]['hits'];
  

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -213,7 +213,7 @@ function generalStats($dbCon) {
            timestamp,
            eventType,
            description AS description,
-            substr(description,    instr(description, ",") + 1) AS filename
+		   substr(description, instr(description, " ") + 1) AS filename
        FROM userLogEntries
        WHERE eventType = '.EventTypes::EditFile.'
         ORDER BY timestamp DESC LIMIT 1;


### PR DESCRIPTION
Added a section that displays the name of the most recently edited file in LenaSYS, along with the time it was edited. 

Test by editing a file in the fileed-section and then observing the general stats section of analytic after the edit has been made. The new section should look like the following image:

![image](https://user-images.githubusercontent.com/49142833/82329490-b0bba400-99e1-11ea-8e9f-3426adad919a.png)
