### PR TITLE
fix issue#9509 line jump zoom compatibility

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -2661,7 +2661,7 @@ function drawLineJump(positionX, positionY, mOfLine1, mOfLine2){
 	var angelOfIntersection = Math.atan((mOfLine1 - mOfLine2)/(1+mOfLine1*mOfLine2));
 	if(angelOfIntersection > 0){
 		ctx.beginPath();
-		ctx.arc(positionX,positionY,5,angelOfIntersection+(0.5*Math.PI),angelOfIntersection+(1.5*Math.PI));
+		ctx.arc(positionX,positionY,5*zoomValue,angelOfIntersection+(0.5*Math.PI),angelOfIntersection+(1.5*Math.PI));
 		ctx.closePath();
 		ctx.stroke();
  }


### PR DESCRIPTION
Before fix the size of the line jump changed while zooming in and out. The size should now be compatible with the zoom value of the diagram. 

**Test this:** Create a line jump by intersecting two different lines in a ER-diagram. Zoom in and out and make sure the size of the line jump stays the same. 

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%239509/DuggaSys/diagram.php

**Before:** 

![b7baf4fc5ea0a65042b76f009fe640a3](https://user-images.githubusercontent.com/49142301/82424884-13ff1200-9a86-11ea-85e0-cf81fda55a21.gif)

**After:** 

![36d0d978ac1b48d91331f47249c80c08](https://user-images.githubusercontent.com/49142301/82425010-3bee7580-9a86-11ea-9e19-3cbac676e5f0.gif)
