### PR TITLE
G2 2020 w22 #9516 Frågedugga results should now be handled properly in Result Editor

### DIFF
--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -564,6 +564,7 @@ $array = array(
 		"files" => $files,
 		"userfeedback" => $userfeedback,
 		"feedbackquestion" => $feedbackquestion,
+		"variant" => $savedvariant,
 	);
 if (strcmp($opt, "GRPDUGGA")==0) $array["group"] = $group;
 

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -366,19 +366,16 @@ if(strcmp($opt,"GETVARIANTANSWER")==0){
 	$variant = $temp[3];
 
 	
-	$query = $pdo->prepare("SELECT variant.variantanswer,useranswer,feedback FROM variant,userAnswer WHERE userAnswer.quiz = variant.quizID and userAnswer.uid = :uid and userAnswer.cid = :cid and userAnswer.vers = :vers and variant.vid = :vid");
-	$query->bindParam(':uid', $userid);
+	$query = $pdo->prepare("SELECT variant.variantanswer,useranswer,feedback FROM variant,userAnswer WHERE userAnswer.quiz = variant.quizID and userAnswer.cid = :cid and userAnswer.vers = :vers and variant.vid = :vid");
 	$query->bindParam(':cid', $first);
 	$query->bindParam(':vers', $second);
 	$query->bindParam(':vid', $variant);
-	$result = $query->execute();
+	$query->execute();
+	$result = $query->fetch();
 	
 	$setanswer="";
 	
-	foreach($query->fetchAll() as $row) {
-		$setanswer=$row['variantanswer'];
-		$savedanswer=$row['useranswer'];
-	}
+	$setanswer=$result['variantanswer'];
 	
 	makeLogEntry($userid,2,$pdo,$first);
 	$insertparam = true;

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -363,19 +363,21 @@ if(strcmp($opt,"GETVARIANTANSWER")==0){
 	$first = $temp[0];
 	$second = $temp[1];
 	$thrid = $temp[2];
+	$variant = $temp[3];
 
-	$query = $pdo->prepare("SELECT variant.variantanswer,useranswer,feedback FROM variant,userAnswer WHERE userAnswer.quiz = variant.quizID and userAnswer.uid = :uid and userAnswer.cid = :cid and userAnswer.vers = :vers");
 	
+	$query = $pdo->prepare("SELECT variant.variantanswer,useranswer,feedback FROM variant,userAnswer WHERE userAnswer.quiz = variant.quizID and userAnswer.uid = :uid and userAnswer.cid = :cid and userAnswer.vers = :vers and variant.vid = :vid");
 	$query->bindParam(':uid', $userid);
 	$query->bindParam(':cid', $first);
 	$query->bindParam(':vers', $second);
+	$query->bindParam(':vid', $variant);
 	$result = $query->execute();
 	
 	$setanswer="";
 	
 	foreach($query->fetchAll() as $row) {
-		$setanswer.=$row['variantanswer'].",";
-		$savedanswer.=$row['useranswer'].",";
+		$setanswer=$row['variantanswer'];
+		$savedanswer=$row['useranswer'];
 	}
 	
 	makeLogEntry($userid,2,$pdo,$first);

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -132,7 +132,7 @@ var answer ="";
 	}
 idunique = 0;
 		// Duggastr includes only the local information, duggasys adds the dugga number and the rest of the information.
-		savequizResult(answer);
+		savequizResult(answer, variant);
 }
 
 //----------------------------------------------------------------------------------

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -164,7 +164,7 @@ var answeredSplit = allanswers.split(",");
 		}
 	}
 
-	var yoloswag = "Answered: " + theanswers;
+	var yoloswag = "Correct answers: " + theanswers;
 $("#output").html(checkifcorrect+"</br>"+yoloswag);
 }
 function closeFacit(){

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -19,6 +19,7 @@ Example seed
 -------------==============######## Documentation End ###########==============-------------
 */
 var idunique = 0;
+var variant = "UNK";
 function quiz(parameters) {
 	if(parameters != undefined) {
 		console.log("pram:" + parameters);
@@ -84,6 +85,7 @@ function setup()
 
 function returnedDugga(data)
 {	
+	variant = data['variant'];
 	if(querystring['highscoremode'] == 1) {
 		Timer.startTimer();
 	} else if (querystring['highscoremode'] == 2) {

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -144,11 +144,10 @@ function showFacit(param, uanswer, danswer)
 {
 	AJAXService("GETVARIANTANSWER",{ setanswer:uanswer},"VARIANTPDUGGA");
 	var splited = uanswer.split(" ");
-	allanswers =  splited[3];
+	allanswers =  splited[4];
 }
 
 function returnedanswersDugga(data){
-
 theanswers= data['param'];
 var checkifcorrect ="Answered: ";
 
@@ -159,9 +158,9 @@ var answeredSplit = allanswers.split(",");
 	for(var i = 0;i < answeredSplit.length;i++){
 		if(theanswerSplit[i] == answeredSplit[i]){
 	
-			checkifcorrect += "<span style ='color:green'>"+answeredSplit[i] + ',</span>';
+			checkifcorrect += "<span style ='color:green'>"+answeredSplit[i] + ' </span>';
 		}else{
-			checkifcorrect +=  "<span style ='color:red'>"+answeredSplit[i] + ',</span>';
+			checkifcorrect +=  "<span style ='color:red'>"+answeredSplit[i] + ' </span>';
 		}
 	}
 

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -152,7 +152,7 @@ theanswers= data['param'];
 var checkifcorrect ="Answered: ";
 
 
-var theanswerSplit = theanswers.split(",");
+var theanswerSplit = theanswers.split(" ");
 var answeredSplit = allanswers.split(",");
 
 	for(var i = 0;i < answeredSplit.length;i++){

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -602,8 +602,9 @@ function saveDuggaResult(citstr)
 // savequizResult: Saves the result of a quiz
 //----------------------------------------------------------------------------------
 
-function savequizResult(citstr)
+function savequizResult(citstr, variant)
 {
+	citstr= variant+" "+citstr;
 	citstr=querystring['moment']+" "+citstr;
 	citstr=querystring['coursevers']+" "+citstr;
 	citstr=querystring['cid']+" "+citstr;


### PR DESCRIPTION
Solves #9516.

User answers and correct answers for the specific dugga variant the user was assigned to should now be displayed properly. Works for both single-question variants as well as variants with several questions. See screenshots.

Screenshot one. Example of submission from a variant with one question with a correct answer.
![image](https://user-images.githubusercontent.com/49141758/82427060-e10a4d80-9a88-11ea-8b96-89af8027e26c.png)

Screenshot two. Example of submission from a variant with two questions with one correct answer and one incorrect answer.
![image](https://user-images.githubusercontent.com/49141758/82426949-c33ce880-9a88-11ea-9eb1-04a97d8f319f.png)

Screenshot three. Example of how a dugga with more than one question looks. Not necessarily related to the solved issue but I'll include it just to show that the process works all the way from opening the Frågedugga to submitting and opening the submission in the Result Editor.
![image](https://user-images.githubusercontent.com/49141758/82427233-1747cd00-9a89-11ea-8b26-d2383c600443.png)

