### PR TITLE
G2 2020 w22 #9533 removed Check Answers-button 

### DIFF
--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -55,8 +55,6 @@ function quiz(parameters) {
 				}
 			}
 		}
-
-		app += "<button class='submit' style='margin:15px;' onclick='checkQuizAnswer();'>Check answers</button>";
 		
 		$("#output").html(app);
 	}
@@ -115,11 +113,6 @@ function getCheckedBoxes(){
 		});
 		return answers; // returnerar de värden på de checkboxes som är i-bockade.
 
-	}
-	function checkQuizAnswer(){
-		for(var t = 1;t <= idunique; t++){
-			alert("question "+t+ ": "+$("input[type='radio'][name='answers"+t+"']:checked").attr('id'));
-		}
 	}
 
 function saveClick()


### PR DESCRIPTION
Solves #9533.

The Check Answers-button was obsolete and has been removed. checkQuizAnswer-function was also removed. Below is a screenshot showing what the "new" Frågedugga looks like (without the Check Answers-button).

![image](https://user-images.githubusercontent.com/49141758/82430408-917a5080-9a8d-11ea-8aa2-0200d70f1646.png)
