### PR TITLE
#9518 Solved bug from #9014.

### DIFF
--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -207,8 +207,15 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 			// Success, log and return results as JSON.
 			// get all rows with fields indexed only by the same names as
 			// they were addressed by in the query
+
 			$resultRows = $statement->fetchAll(PDO::FETCH_ASSOC);
-			echo json_encode($resultRows);
+
+			if (empty($resultRows) && $getType !== "ONLYDATE") {
+				echo $resultRows;
+			} else {
+				echo $resultRows;
+			}
+			
 			// log success and exit
 			$info = $opt . ' ' . $cid . ' ' . $coursevers . ' completed successfully';
 			logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "resultedservice.php", $userid, $info);

--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -208,14 +208,20 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 			// get all rows with fields indexed only by the same names as
 			// they were addressed by in the query
 
-			$resultRows = $statement->fetchAll(PDO::FETCH_ASSOC);
+			$resultRows = $statement->fetchAll();
+			$resultRows = json_encode($resultRows);
 
-			if (empty($resultRows) && $getType !== "ONLYDATE") {
+			// Check if the returned array has anything in it.
+			// If it does, then constinue as usual and forward the data to the next step.
+			// If it doesn't and the SELECT is not only asking for date,
+			// then forward the data anyway.
+			// Otherwise, don't forward any data.
+			if ($resultRows !== "[]") {
 				echo $resultRows;
-			} else {
+			} else if ($resultRows === "[]" && $getType !== "ONLYDATE") {
 				echo $resultRows;
 			}
-			
+
 			// log success and exit
 			$info = $opt . ' ' . $cid . ' ' . $coursevers . ' completed successfully';
 			logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "resultedservice.php", $userid, $info);


### PR DESCRIPTION
Solved the bug where the no unexported popup would appear when opening the ResultEd page.

The only problem found when testing on localhost is that the export date in the popup takes a long time to popup if you export a lot of grades when only exporting unexported grades. This might mean that something in the code needs to be refined so it runs faster. But that's a future issue in that case.

Co-authored-by: a18eripi <a18eripi@users.noreply.github.com>