### PR TITLE
Fixed layout in Random clipping dugga. #9522

### DIFF
--- a/DuggaSys/templates/clipping_masking_dugga.html
+++ b/DuggaSys/templates/clipping_masking_dugga.html
@@ -23,7 +23,7 @@
             
     </div>
 
-    <div style="margin:0 4px 0 4px;">
+    <div id="drawingArea">
       
           <div class='loginBoxheader'>
                 <h3>Rityta</h3>

--- a/DuggaSys/templates/clipping_masking_dugga.html
+++ b/DuggaSys/templates/clipping_masking_dugga.html
@@ -24,19 +24,13 @@
     </div>
 
     <div id="drawingArea">
-      
-          <div class='loginBoxheader'>
-                <h3>Rityta</h3>
-          </div>
+          <div class='loginBoxheader'><h3>Rityta</h3></div>
           <canvas id='a'></canvas>
-            
     </div>
 
     <div id="toolbox" >
       <div style="flex-grow: 1">
-        <div class='loginBoxheader'>
-            <h3>Ritverktyg</h3>
-        </div>
+        <div class='loginBoxheader'><h3>Ritverktyg</h3></div>
      	  <div style="display:flex;justify-content:center;">
             <select id="ops" name="function" >
               <optgroup label="Misc.">    
@@ -67,21 +61,22 @@
               </optgroup>
             </select>			
             
-            <input id="addOpButton" class='submit-button' type='button' value='Add Op.' onclick="newbutton();" />
-        </div>
+                <input id="addOpButton" class='submit-button' type='button' value='Add Op.' onclick="newbutton();" />
+            </div>
     		<div id="opTableContainer" style="min-height:300px;background-color:#FFF; overflow-y:scroll;">
-            <table id="opTable" style="width:100%;">
-                <caption>Operations</caption>
-                <thead>
-                    <tr><th>Op#</th>
-                        <th>Operation</th>
-                        <th colspan="3">Modify</th>
-                    </tr>
-                </thead>
-                <tbody id="operationList" ></tbody>
-            </table>			
+                <table id="opTable" style="width:100%;">
+                    <caption>Operations</caption>
+                    <thead>
+                        <tr>
+                            <th>Op#</th>
+                            <th>Operation</th>
+                            <th colspan="3">Modify</th>
+                        </tr>
+                    </thead>
+                    <tbody id="operationList" ></tbody>
+                </table>			
     		</div>
-    </div>
+        </div>
     </div>
 </div>
 

--- a/DuggaSys/templates/clipping_masking_dugga.html
+++ b/DuggaSys/templates/clipping_masking_dugga.html
@@ -32,7 +32,7 @@
             
     </div>
 
-    <div id="toolbox" style="min-width:340px;width:340px;margin:0 4px 0 4px;display: flex;flex-direction: column;justify-content: flex-start;">
+    <div id="toolbox" >
       <div style="flex-grow: 1">
         <div class='loginBoxheader'>
             <h3>Ritverktyg</h3>

--- a/DuggaSys/templates/clipping_masking_dugga.html
+++ b/DuggaSys/templates/clipping_masking_dugga.html
@@ -28,7 +28,7 @@
           <div class='loginBoxheader'>
                 <h3>Rityta</h3>
           </div>
-          <canvas id='a' style='background-color:#FFFFFF; border:2px solid black; display:block;'></canvas>
+          <canvas id='a'></canvas>
             
     </div>
 

--- a/DuggaSys/templates/clipping_masking_dugga.html
+++ b/DuggaSys/templates/clipping_masking_dugga.html
@@ -15,9 +15,7 @@
 <div class="clippingLayout">
     <div id='clippingInfoBox2'>
       
-          <div class='loginBoxheader'>
-                <h3>Målbild</h3>
-          </div>
+          <div class='loginBoxheader'><h3>Målbild</h3></div>
                 <p style="margin-left: 4px;">Rita följande:</p>
           <img id="target-img" src="" style="width:100%;">
             
@@ -25,6 +23,7 @@
 
     <div id="drawingArea">
           <div class='loginBoxheader'><h3>Rityta</h3></div>
+          <p style="margin-left: 4px;">Mitt verk:</p>
           <canvas id='a'></canvas>
     </div>
 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -554,6 +554,7 @@ svg text {
 #clippingInfoBox {
 	min-width:170px;
 	width:395px;
+	height: 459px;
 	margin:0 4px 0 4px;
 	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
@@ -565,7 +566,7 @@ svg text {
 }
 #toolbox{
 	min-width:340px;
-	width:340px;
+	width:395px;
 	margin:0 4px 0 4px;
 	display: flex;
 	flex-direction: column;
@@ -579,6 +580,7 @@ svg text {
 #drawingArea #a{
 	background-color:#FFFFFF; 
 	display:block;
+	width: 395px;
 }
  @media only screen and (max-width: 1360px) {
 	#clippingInfoBox {

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -555,11 +555,13 @@ svg text {
 	min-width:170px;
 	width:395px;
 	margin:0 4px 0 4px;
+	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
 #clippingInfoBox2 {
 	min-width:120px;
 	width:400px;
 	margin:0 4px 0 4px;
+	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
 #toolbox{
 	min-width:340px;
@@ -568,6 +570,11 @@ svg text {
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-start;
+	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
+}
+#drawingArea{
+	margin:0 4px 0 4px;
+	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
  @media only screen and (max-width: 1360px) {
 	#clippingInfoBox {

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -547,7 +547,6 @@ svg text {
  *                      	     Clipping Masking Dugga				       							 *
  * --------------================################================-------------- */
  .clippingLayout{
-	margin:0 4px 0 4px;
 	display: flex; 
 	flex-wrap: wrap; 
 	justify-content: center;
@@ -600,14 +599,6 @@ svg text {
 	}
 	#toolbox{
 		width:320px;
-	}
-}
-@media screen and (min-width: 1361px){
-	.clippingLayout{
-		justify-content: space-evenly;
-		margin:0 4px 0 4px;
-		display: flex; 
-		flex-wrap: wrap;
 	}
 }
 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -553,13 +553,21 @@ svg text {
 }
 #clippingInfoBox {
 	min-width:170px;
-	width:300px;
+	width:395px;
 	margin:0 4px 0 4px;
 }
 #clippingInfoBox2 {
 	min-width:120px;
 	width:400px;
 	margin:0 4px 0 4px;
+}
+#toolbox{
+	min-width:340px;
+	width:340px;
+	margin:0 4px 0 4px;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
 }
  @media only screen and (max-width: 1360px) {
 	#clippingInfoBox {

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -561,20 +561,20 @@ svg text {
 #clippingInfoBox2 {
 	min-width:120px;
 	width:400px;
-	margin:0 4px 0 4px;
+	margin:0 4px 5px 4px;
 	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
 #toolbox{
-	min-width:340px;
 	width:395px;
-	margin:0 4px 0 4px;
+	margin:0 4px 5px 4px;
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-start;
 	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
 #drawingArea{
-	margin:0 4px 0 4px;
+	min-width:120px;
+	margin:0 4px 5px 4px;
 	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
 #drawingArea #a{
@@ -588,6 +588,17 @@ svg text {
 	}
 	.clippingContainer {
 		flex-wrap: wrap;
+	}
+}
+@media screen and (max-width: 394px){
+	#drawingArea #a{
+		width: 320px;
+	}
+	#clippingInfoBox2 {
+		width:320px;	
+	}
+	#toolbox{
+		width:320px;
 	}
 }
 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -547,6 +547,7 @@ svg text {
  *                      	     Clipping Masking Dugga				       							 *
  * --------------================################================-------------- */
  .clippingLayout{
+	margin:0 4px 0 4px;
 	display: flex; 
 	flex-wrap: wrap; 
 	justify-content: center;
@@ -599,6 +600,14 @@ svg text {
 	}
 	#toolbox{
 		width:320px;
+	}
+}
+@media screen and (min-width: 1361px){
+	.clippingLayout{
+		justify-content: space-evenly;
+		margin:0 4px 0 4px;
+		display: flex; 
+		flex-wrap: wrap;
 	}
 }
 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -576,6 +576,10 @@ svg text {
 	margin:0 4px 0 4px;
 	box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
 }
+#drawingArea #a{
+	background-color:#FFFFFF; 
+	display:block;
+}
  @media only screen and (max-width: 1360px) {
 	#clippingInfoBox {
 		width:100%;


### PR DESCRIPTION
- Moved some inline styling. 
- Added shadows to make a card feeling.
- Cleaned up some code.
- Added a paragraph to the "Rityta ".
- Added a media query to make it more mobile-friendly. 

<img width="1280" alt="Screenshot 2020-05-20 at 12 53 11" src="https://user-images.githubusercontent.com/49142649/82438250-0737e980-9a99-11ea-8d14-6a45aa4b136e.png">
<img width="189" alt="Screenshot 2020-05-20 at 12 54 16" src="https://user-images.githubusercontent.com/49142649/82438268-0c953400-9a99-11ea-9986-8dfcbfb67826.png">

