### PR TITLE
G1-2020-W22-ISSUE#9508

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -698,7 +698,7 @@ function loadPageInformation() {
 					for (var i = 0; i < courseName.length; i++){
 						tablePercentage.push([
 							courseID[i],
-							coursePercentage[i],
+							Number(coursePercentage[i]).toFixed(2),
 							courseName[i]
 						]);
 					}


### PR DESCRIPTION
The percentage values in the table will now always have 2 decimals.
![bild](https://user-images.githubusercontent.com/49142342/82439356-cb9e1f00-9a9a-11ea-93d7-f783f8a47353.png)
Controll by looking at the column containing the percentage values in the table.
closes #9508 