### PR TITLE
Gave studentteacher access to see hidden items || issue #9461

### DIFF
--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -425,7 +425,7 @@ if($gradesys=="UNK") $gradesys=0;
 
 		$cvisibility=false;
 		if ($row = $query->fetch(PDO::FETCH_ASSOC)) {
-				if($isSuperUserVar||$row['visibility']==1||($row['visibility']==2&&($hasread||$haswrite))||($row['visibility']==0&&$haswrite)) $cvisibility=true;
+				if($isSuperUserVar||$row['visibility']==1||($row['visibility']==2&&($hasread||$haswrite))||($row['visibility']==0&&($haswrite==true||$studentTeacher==true))) $cvisibility=true;
 		}
 
 		$ha = (checklogin() && ($haswrite || $isSuperUserVar));
@@ -555,7 +555,7 @@ if($gradesys=="UNK") $gradesys=0;
 			}
 
 			foreach($query->fetchAll() as $row) {
-				if($isSuperUserVar||$row['visible']==1||($row['visible']==2&&($hasread||$haswrite))||($row['visible']==0&&$haswrite==true)){
+				if($isSuperUserVar||$row['visible']==1||($row['visible']==2&&($hasread||$haswrite))||($row['visible']==0&&($haswrite==true||$studentTeacher==true))){
 						array_push(
 							$entries,
 							array(


### PR DESCRIPTION
Users with studentteacher and supervisor access can now see hidden items(duggas, headings, codes).

test with:
Studentteacher: Got 'ST' access for all courses.
mofre

Supervisor: Got SV access for all courses.
ryrey

Password is ‘password’.