### PR TITLE
G2 2020 w22 #9550 added stylesheet link (dugga.css) to duggaed.php

### DIFF
--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -15,6 +15,7 @@ pdoConnect();
 
 	<link type="text/css" href="../Shared/css/style.css" rel="stylesheet">
   <link type="text/css" href="../Shared/css/jquery-ui-1.10.4.min.css" rel="stylesheet">
+  <link type="text/css" href="../Shared/css/dugga.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<script src="../Shared/js/jquery-1.11.0.min.js"></script>
 	<script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>


### PR DESCRIPTION
Solves #9550.

Duggas/Variants should now be styled using the dugga.css file (as well as style.css, which was already linked before).

This fixes the styling for a few previews, like the Biträkningsdugga and Färgdugga but not for others (Quiz/Frågedugga & HTML CSS Testdugga/html_css_dugga, maybe more). The issues related to these duggas are caused by something else and separate issues should be opened for these.