### PR TITLE
Added all pages to page information dropdown - G1-2020-W22-ISSUE#9305

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -646,23 +646,22 @@ function loadPageInformation() {
 	
 	var firstLoad = true;
  
-    var selectPage = $("<select></select>")
-        .append('<option value="showDugga" selected>showDugga</option>')
-		.append('<option value="codeviewer">codeviewer</option>')
-		.append('<option value="sectioned">sectioned</option>')
-		.append('<option value="courseed">courseed</option>')
-		.append('<option value="fileed">fileed</option>')
-		.append('<option value="resulted">resulted</option>')
+	var selectPage = $("<select></select>")
+		.append('<option value="accessed">accessed</option>') 
 		.append('<option value="analytic">analytic</option>')
+		.append('<option value="codeviewer">codeviewer</option>')
+		.append('<option value="courseed">courseed</option>')
 		.append('<option value="contribution">contribution</option>')
 		.append('<option value="duggaed">duggaed</option>')
-		.append('<option value="accessed">accessed</option>') 
+		.append('<option value="fileed">fileed</option>')
 		.append('<option value="profile">profile</option>')
+		.append('<option value="resulted">resulted</option>')
+        .append('<option value="showDugga" selected>showDugga</option>')
+		.append('<option value="sectioned">sectioned</option>')
         .appendTo($('#analytic-info'));
    
     function updatePageHitInformation(pages, page){
         loadAnalytics("pageInformation", function(data) {
-			console.log(data);
 
 			var tableData = [["Page", "Hits"]];
 			for(var i = 0; i < pages.length; i++){
@@ -693,7 +692,6 @@ function loadPageInformation() {
 		var tablePercentage = [["Courseid", "Percentage", "Coursename"]];
 
         for (var i = 0; i < data['percentage'][page].length; i++) {
-			console.log(data['percentage'][page][i]);
 			numberOfCourses = parseInt(data['percentage'][page].length);
 			courseID.push([
                 data['percentage'][page][i].courseid

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -653,6 +653,7 @@ function loadPageInformation() {
 		.append('<option value="courseed">courseed</option>')
 		.append('<option value="contribution">contribution</option>')
 		.append('<option value="duggaed">duggaed</option>')
+		.append('<option value="diagram">diagram</option>')
 		.append('<option value="fileed">fileed</option>')
 		.append('<option value="profile">profile</option>')
 		.append('<option value="resulted">resulted</option>')
@@ -753,7 +754,7 @@ function loadPageInformation() {
  
     function updateState(){
 		// Add additonal pages here
-		var pages = ["dugga", "codeviewer", "sectioned", "courseed", "fileed", "resulted", "analytic", "contribution", "duggaed", "accessed", "profile"];
+		var pages = ["dugga", "codeviewer", "sectioned", "courseed", "fileed", "resulted", "analytic", "contribution", "duggaed", "accessed", "profile", "diagram"];
 
 		if(firstLoad === true){
 			updatePageHitInformation(pages, pages[0]);
@@ -793,6 +794,9 @@ function loadPageInformation() {
 					break;
 				case "profile":
 					updatePageHitInformation(pages, pages[10]);
+					break;
+				case "diagram":
+					updatePageHitInformation(pages, pages[11]);
 					break;
 				
             }

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -651,10 +651,18 @@ function loadPageInformation() {
 		.append('<option value="codeviewer">codeviewer</option>')
 		.append('<option value="sectioned">sectioned</option>')
 		.append('<option value="courseed">courseed</option>')
+		.append('<option value="fileed">fileed</option>')
+		.append('<option value="resulted">resulted</option>')
+		.append('<option value="analytic">analytic</option>')
+		.append('<option value="contribution">contribution</option>')
+		.append('<option value="duggaed">duggaed</option>')
+		.append('<option value="accessed">accessed</option>') 
+		.append('<option value="profile">profile</option>')
         .appendTo($('#analytic-info'));
    
     function updatePageHitInformation(pages, page){
         loadAnalytics("pageInformation", function(data) {
+			console.log(data);
 
 			var tableData = [["Page", "Hits"]];
 			for(var i = 0; i < pages.length; i++){
@@ -766,7 +774,29 @@ function loadPageInformation() {
 					break;
 				case "courseed":
 					updatePageHitInformation(pages, pages[3]);
+					break; 
+				case "fileed":
+					updatePageHitInformation(pages, pages[4]);
 					break;
+				case "resulted":
+					updatePageHitInformation(pages, pages[5]);
+					break;
+				case "analytic":
+					updatePageHitInformation(pages, pages[6]);
+					break;
+				case "contribution":
+					updatePageHitInformation(pages, pages[7]);
+					break;
+				case "duggaed":
+					updatePageHitInformation(pages, pages[8]);
+					break;
+				case "accessed":
+					updatePageHitInformation(pages, pages[9]);
+					break;
+				case "profile":
+					updatePageHitInformation(pages, pages[10]);
+					break;
+				
             }
         });
     }

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -1023,6 +1023,16 @@ function pageInformation(){
 		refer LIKE "%profile%"
 	')->fetchAll(PDO::FETCH_ASSOC);
 
+	$diagram = $GLOBALS['log_db']->query('
+	SELECT
+		refer,
+		COUNT(*) AS pageLoads
+	FROM 
+		userHistory
+	WHERE 
+		refer LIKE "%diagram%"
+	')->fetchAll(PDO::FETCH_ASSOC);
+
 	$result = [];
 	$result['hits']['dugga'] = $dugga[0];
 	$result['hits']['codeviewer'] = $codeviewer[0];
@@ -1034,7 +1044,8 @@ function pageInformation(){
 	$result['hits']['contribution'] = $contribution[0];
 	$result['hits']['duggaed'] = $duggaed[0];   
 	$result['hits']['accessed'] = $accessed[0];
-	$result['hits']['profile'] = $profile[0];   
+	$result['hits']['profile'] = $profile[0];
+	$result['hits']['diagram'] = $diagram[0];   
 
 
 	$result['percentage']['dugga'] = $dugga;
@@ -1048,6 +1059,7 @@ function pageInformation(){
 	$result['percentage']['duggaed'] = $duggaed;
 	$result['percentage']['accessed'] = $accessed;
 	$result['percentage']['profile'] = $profile;
+	$result['percentage']['diagram'] = $diagram;
 
 	echo json_encode($result);
 }

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -946,11 +946,21 @@ function pageInformation(){
 	$resulted = $GLOBALS['log_db']->query('
 		SELECT
 			refer,
+			substr(
+				refer, 
+				INSTR(refer, "courseid=")+9, 
+				INSTR(refer, "&coursevers=")-18 - INSTR(refer, "courseid=")+9
+			) courseid,
+			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM userHistory WHERE refer LIKE "%resulted%") AS percentage,
 			COUNT(*) AS pageLoads
 		FROM 
 			userHistory
 		WHERE 
 			refer LIKE "%resulted%"
+		GROUP BY 
+			courseid;
+		ORDER BY 
+			percentage DESC;
 	')->fetchAll(PDO::FETCH_ASSOC);
 
 	$analytic = $GLOBALS['log_db']->query('
@@ -974,13 +984,23 @@ function pageInformation(){
 	')->fetchAll(PDO::FETCH_ASSOC);
 
 	$duggaed = $GLOBALS['log_db']->query('
-	SELECT
-		refer,
-		COUNT(*) AS pageLoads
-	FROM 
-		userHistory
-	WHERE 
-		refer LIKE "%duggaed%"
+		SELECT
+			refer,
+			substr(
+				refer, 
+				INSTR(refer, "courseid=")+9, 
+				INSTR(refer, "&coursevers=")-18 - INSTR(refer, "courseid=")+9
+			) courseid,
+			COUNT(*) * 100.0 / (SELECT COUNT(*) FROM userHistory WHERE refer LIKE "%duggaed%") AS percentage,
+			COUNT(*) AS pageLoads
+		FROM 
+			userHistory
+		WHERE 
+			refer LIKE "%duggaed%"
+		GROUP BY 
+			courseid;
+		ORDER BY 
+			percentage DESC;
 	')->fetchAll(PDO::FETCH_ASSOC);
 
 	$accessed = $GLOBALS['log_db']->query('
@@ -1021,6 +1041,13 @@ function pageInformation(){
 	$result['percentage']['codeviewer'] = $codeviewer;
 	$result['percentage']['sectioned'] = $sectioned;
 	$result['percentage']['courseed'] = $courseed;
+	$result['percentage']['fileed'] = $fileed;
+	$result['percentage']['resulted'] = $resulted;
+	$result['percentage']['analytic'] = $analytic;
+	$result['percentage']['contribution'] = $contribution;
+	$result['percentage']['duggaed'] = $duggaed;
+	$result['percentage']['accessed'] = $accessed;
+	$result['percentage']['profile'] = $profile;
 
 	echo json_encode($result);
 }


### PR DESCRIPTION
All pages now appear in page information dropdown, they are all connected to their respective log db query in analyticService.php. The queries needs to be modified to show useful information for each page, this needs to be set done in another issue. 

![Screenshot 2020-05-20 at 15 17 48](https://user-images.githubusercontent.com/62876614/82451491-59cfd080-9aae-11ea-8747-d914d0ccb057.png)
