### PR TITLE
G2 2020 w22 #9566 Quiz/Frågedugga now uses saveDuggaResult instead of it's own saveQuizResult

### DIFF
--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -564,6 +564,7 @@ $array = array(
 		"files" => $files,
 		"userfeedback" => $userfeedback,
 		"feedbackquestion" => $feedbackquestion,
+		"variant" => $savedvariant,
 	);
 if (strcmp($opt, "GRPDUGGA")==0) $array["group"] = $group;
 

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -366,19 +366,16 @@ if(strcmp($opt,"GETVARIANTANSWER")==0){
 	$variant = $temp[3];
 
 	
-	$query = $pdo->prepare("SELECT variant.variantanswer,useranswer,feedback FROM variant,userAnswer WHERE userAnswer.quiz = variant.quizID and userAnswer.uid = :uid and userAnswer.cid = :cid and userAnswer.vers = :vers and variant.vid = :vid");
-	$query->bindParam(':uid', $userid);
+	$query = $pdo->prepare("SELECT variant.variantanswer,useranswer,feedback FROM variant,userAnswer WHERE userAnswer.quiz = variant.quizID and userAnswer.cid = :cid and userAnswer.vers = :vers and variant.vid = :vid");
 	$query->bindParam(':cid', $first);
 	$query->bindParam(':vers', $second);
 	$query->bindParam(':vid', $variant);
-	$result = $query->execute();
+	$query->execute();
+	$result = $query->fetch();
 	
 	$setanswer="";
 	
-	foreach($query->fetchAll() as $row) {
-		$setanswer=$row['variantanswer'];
-		$savedanswer=$row['useranswer'];
-	}
+	$setanswer=$result['variantanswer'];
 	
 	makeLogEntry($userid,2,$pdo,$first);
 	$insertparam = true;

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -363,19 +363,21 @@ if(strcmp($opt,"GETVARIANTANSWER")==0){
 	$first = $temp[0];
 	$second = $temp[1];
 	$thrid = $temp[2];
+	$variant = $temp[3];
 
-	$query = $pdo->prepare("SELECT variant.variantanswer,useranswer,feedback FROM variant,userAnswer WHERE userAnswer.quiz = variant.quizID and userAnswer.uid = :uid and userAnswer.cid = :cid and userAnswer.vers = :vers");
 	
+	$query = $pdo->prepare("SELECT variant.variantanswer,useranswer,feedback FROM variant,userAnswer WHERE userAnswer.quiz = variant.quizID and userAnswer.uid = :uid and userAnswer.cid = :cid and userAnswer.vers = :vers and variant.vid = :vid");
 	$query->bindParam(':uid', $userid);
 	$query->bindParam(':cid', $first);
 	$query->bindParam(':vers', $second);
+	$query->bindParam(':vid', $variant);
 	$result = $query->execute();
 	
 	$setanswer="";
 	
 	foreach($query->fetchAll() as $row) {
-		$setanswer.=$row['variantanswer'].",";
-		$savedanswer.=$row['useranswer'].",";
+		$setanswer=$row['variantanswer'];
+		$savedanswer=$row['useranswer'];
 	}
 	
 	makeLogEntry($userid,2,$pdo,$first);

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -132,7 +132,7 @@ var answer ="";
 	}
 idunique = 0;
 		// Duggastr includes only the local information, duggasys adds the dugga number and the rest of the information.
-		savequizResult(answer);
+		savequizResult(answer, variant);
 }
 
 //----------------------------------------------------------------------------------

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -132,7 +132,8 @@ var answer ="";
 	}
 idunique = 0;
 		// Duggastr includes only the local information, duggasys adds the dugga number and the rest of the information.
-		savequizResult(answer, variant);
+		answer = variant + " " + answer;
+		saveDuggaResult(answer);
 }
 
 //----------------------------------------------------------------------------------

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -164,7 +164,7 @@ var answeredSplit = allanswers.split(",");
 		}
 	}
 
-	var yoloswag = "Answered: " + theanswers;
+	var yoloswag = "Correct answers: " + theanswers;
 $("#output").html(checkifcorrect+"</br>"+yoloswag);
 }
 function closeFacit(){

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -19,6 +19,7 @@ Example seed
 -------------==============######## Documentation End ###########==============-------------
 */
 var idunique = 0;
+var variant = "UNK";
 function quiz(parameters) {
 	if(parameters != undefined) {
 		console.log("pram:" + parameters);
@@ -84,6 +85,7 @@ function setup()
 
 function returnedDugga(data)
 {	
+	variant = data['variant'];
 	if(querystring['highscoremode'] == 1) {
 		Timer.startTimer();
 	} else if (querystring['highscoremode'] == 2) {

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -144,11 +144,10 @@ function showFacit(param, uanswer, danswer)
 {
 	AJAXService("GETVARIANTANSWER",{ setanswer:uanswer},"VARIANTPDUGGA");
 	var splited = uanswer.split(" ");
-	allanswers =  splited[3];
+	allanswers =  splited[4];
 }
 
 function returnedanswersDugga(data){
-
 theanswers= data['param'];
 var checkifcorrect ="Answered: ";
 
@@ -159,9 +158,9 @@ var answeredSplit = allanswers.split(",");
 	for(var i = 0;i < answeredSplit.length;i++){
 		if(theanswerSplit[i] == answeredSplit[i]){
 	
-			checkifcorrect += "<span style ='color:green'>"+answeredSplit[i] + ',</span>';
+			checkifcorrect += "<span style ='color:green'>"+answeredSplit[i] + ' </span>';
 		}else{
-			checkifcorrect +=  "<span style ='color:red'>"+answeredSplit[i] + ',</span>';
+			checkifcorrect +=  "<span style ='color:red'>"+answeredSplit[i] + ' </span>';
 		}
 	}
 

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -152,7 +152,7 @@ theanswers= data['param'];
 var checkifcorrect ="Answered: ";
 
 
-var theanswerSplit = theanswers.split(",");
+var theanswerSplit = theanswers.split(" ");
 var answeredSplit = allanswers.split(",");
 
 	for(var i = 0;i < answeredSplit.length;i++){

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -126,6 +126,17 @@ function getCheckedBoxes(){
 
 function saveClick()
 {
+	Timer.stopTimer();
+
+	timeUsed = Timer.score;
+	stepsUsed = ClickCounter.score;
+
+	if (querystring['highscoremode'] == 1) {	
+		score = Timer.score;
+	} else if (querystring['highscoremode'] == 2) {
+		score = ClickCounter.score;
+	}
+
 var answer ="";
 	for(var t = 1;t <= idunique; t++){
 	answer+= ($("input[type='radio'][name='answers"+t+"']:checked").attr('id')) + ",";

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -599,21 +599,6 @@ function saveDuggaResult(citstr)
 }
 
 //----------------------------------------------------------------------------------
-// savequizResult: Saves the result of a quiz
-//----------------------------------------------------------------------------------
-
-function savequizResult(citstr, variant)
-{
-	citstr= variant+" "+citstr;
-	citstr=querystring['moment']+" "+citstr;
-	citstr=querystring['coursevers']+" "+citstr;
-	citstr=querystring['cid']+" "+citstr;
-	AJAXService("SAVDU",{answer:citstr},"PDUGGA");
-	alert('inlämnat');
-}
-
-
-//----------------------------------------------------------------------------------
 // changeURL: Patch-in for changeURL from project 2014 code
 //----------------------------------------------------------------------------------
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -602,8 +602,9 @@ function saveDuggaResult(citstr)
 // savequizResult: Saves the result of a quiz
 //----------------------------------------------------------------------------------
 
-function savequizResult(citstr)
+function savequizResult(citstr, variant)
 {
+	citstr= variant+" "+citstr;
 	citstr=querystring['moment']+" "+citstr;
 	citstr=querystring['coursevers']+" "+citstr;
 	citstr=querystring['cid']+" "+citstr;


### PR DESCRIPTION
Solves #9566.

**Note: This is branched from https://github.com/HGustavs/LenaSYS/tree/G2-2020-W22-%239516 since it relies on the changes made there to work.**

Removed saveResultQuiz and replaced it with saveDuggaResult, which the other duggas use.

As the linked issue describes this adds a few things "for free", such as this window upon saving:

![image](https://user-images.githubusercontent.com/49141758/82646940-b4d00780-9c15-11ea-9955-75e9f9e88bff.png)

Before no window would be shown, the only visual feedback given to the user/student was the navheader being updated (the stoplight and timestamp for submission would update). As with the other duggas the Feedback-area of the window would only be show if feedback is enabled for this dugga. Opening feedback from the Section/Course Editor works exactly the same as for all the other duggas.