### PR TITLE
Solution for branch G1-2020-W19-ISSUE#9546

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6167,6 +6167,15 @@ only screen and (max-device-width: 320px) {
   .fileView{
     width: 75%;
   }
+
+    
+}
+@media only screen and (max-height: 600px) {
+        .markText{
+        height: 60% !important;
+    }
+
+    
 }
 
 @media only screen and (max-width: 441px) {


### PR DESCRIPTION
The boxes now doenst move out of the windows when resizing
result: 
![7205ac3cbf1f34952a27fb7abde543f7](https://user-images.githubusercontent.com/49142553/82657644-fb2d6280-9c25-11ea-9e16-5d7e35ff9ae2.gif)
