### PR TITLE
G3 2020#9464 Search bar in mobile-view looks better

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -50,6 +50,13 @@ $codeLinkQuery->execute();
 	<!-- content START -->
     <div id="content">
         <div id='searchBarMobile' style='margin-bottom:15px;'>
+        <div id='tooltip-mobile' class="tooltip-searchbar">
+					<div class="tooltip-searchbar-box">
+                            <b>Keywords:</b> File name, File type <br> 
+                            <b>Ex:</b> html, example1
+					</div>
+					<span>?</span>
+				</div>
             <input id='searchinputMobile' type='text' name='search' placeholder='Search..' onkeyup='searchterm=document.getElementById("searchinputMobile").value;searchKeyUp(event);fileLink.reRender();document.getElementById("searchinput").value=document.getElementById("searchinputMobile").value;'/>
 
             <button id='searchbuttonMobile' class='switchContent' onclick='searchterm=document.getElementById("searchinputMobile").value;searchKeyUp(event);fileLink.reRender();' type='button'>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4860,41 +4860,43 @@ only screen and (max-device-width: 530px) {
     display: none;
   }
 
-  /*
+  
 
   #searchBarMobile,
   #searchbuttonMobile {
     width: 24px;
-    height: 22px;
+    height: 26px;
     margin-top: 10px;
   }
 
   #searchBarMobile {
     padding-left: 5px;
     display: inline-flex;
-    height: 22px;
+    height: 26px;
     border-radius: 5px;
     float: left;
   }
 
   #searchinputMobile {
-    border: 1px solid var(--color-border);
     border-radius: 0;
-    font-size: 14px;
+    border: 2px solid var(--color-border-2);
+    font-size: 16px;
+    padding-left: 5px;
   }
 
   #searchbuttonMobile {
     margin: 0;
   }
 
-  */
+  
 
   #tooltip-mobile {
-    border: 1px solid var(--color-border);
+    border: 2px solid var(--color-border-2);
     font-size: 17px;
     padding: 0px 5px;
     border-right-width: 0px;
     width: 100px;
+    border-radius: 4px 0px 0px 4px;
   }
 
 /*


### PR DESCRIPTION
The issues existed in accessed, fileed and duggaed and now the search-bar should look like this in mobile view:
![image](https://user-images.githubusercontent.com/49142669/82659662-557bf280-9c29-11ea-91bc-0368112814ad.png)
Also added the tooltip box (the one with the "?") to fileed.