### PR TITLE
Fixes #9593 - Rulers now work in fullscreen mode

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3520,8 +3520,6 @@ function scrollZoom(event) {
 function toggleFullscreen(){
     const header = document.querySelector("header");
     const diagramPageWrapper = document.getElementById("diagram-page-wrapper");
-    var diagramHeader = document.getElementById("diagram-header");
-    var diagramContainer = document.getElementById("diagram-container")
 
     if(!fullscreen){
         diagramPageWrapper.classList.add("fullscreen");
@@ -6321,13 +6319,14 @@ function getSelectedObjectsPoints() {
 //------------------------------------------------------------------------------------------------
 
 function toggleRulers() {
-    const diagramContent = document.getElementById("diagram-content");
+    const diagramPageWrapper = document.getElementById("diagram-page-wrapper");
     const rulers = document.querySelectorAll(".ruler");
+    
     if(isRulersActive) {
-        diagramContent.classList.remove("rulers-active");
+        diagramPageWrapper.classList.remove("rulers-active");
         rulers.forEach(ruler => ruler.classList.add("hidden"));
     } else {
-        diagramContent.classList.add("rulers-active");
+        diagramPageWrapper.classList.add("rulers-active");
         rulers.forEach(ruler => ruler.classList.remove("hidden"));
     }
     isRulersActive = !isRulersActive;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3518,18 +3518,17 @@ function scrollZoom(event) {
 //-----------------------
 
 function toggleFullscreen(){
-    var header = document.querySelector("header");
+    const header = document.querySelector("header");
+    const diagramPageWrapper = document.getElementById("diagram-page-wrapper");
     var diagramHeader = document.getElementById("diagram-header");
     var diagramContainer = document.getElementById("diagram-container")
 
     if(!fullscreen){
-        diagramHeader.classList.add("fullscreen");
-        diagramContainer.classList.add("fullscreen");
+        diagramPageWrapper.classList.add("fullscreen");
         header.style.display = "none";
         $("#fullscreenDialog").css("display", "flex");
     } else {
-        diagramHeader.classList.remove("fullscreen", "toolbar");
-        diagramContainer.classList.remove("fullscreen", "toolbar");
+        diagramPageWrapper.classList.remove("fullscreen", "toolbar");
         header.style.display = "inline-block";
         toolbarDisplayed = false;
     }
@@ -3551,16 +3550,13 @@ function closeFullscreenDialog(){
 //-----------------------
 
 function toggleToolbar(){
-    var diagramHeader = document.getElementById("diagram-header");
-    var diagramContainer = document.getElementById("diagram-container");
+    const diagramPageWrapper = document.getElementById("diagram-page-wrapper");
 
     if(!toolbarDisplayed){
-        diagramHeader.classList.add("toolbar");
-        diagramContainer.classList.add("toolbar");
+        diagramPageWrapper.classList.add("toolbar");
         toolbarDisplayed = true;
     } else {
-        diagramHeader.classList.remove("toolbar");
-        diagramContainer.classList.remove("toolbar");
+        diagramPageWrapper.classList.remove("toolbar");
         toolbarDisplayed = false;
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -490,6 +490,7 @@ function init() {
     refreshVirtualPaper();
     setPaperSizeOnRefresh();
     setIsRulersActiveOnRefresh();
+    setIsFullscreenActiveOnRefresh();
     setHideCommentOnRefresh();
     initAppearanceForm();
     setPaperSize(event, paperSize);
@@ -3532,7 +3533,20 @@ function toggleFullscreen(){
     }
     fullscreen = !fullscreen;
     setCheckbox($(".drop-down-option:contains('Fullscreen')"), fullscreen);
+    localStorage.setItem("isFullscreenActive", fullscreen);
     canvasSize();        
+}
+
+//------------------------------------------------------------------------------------------------------------------------
+// setIsRulersActiveOnRefresh: Gets the isActiveRulers value from localStorage to decide if rulers should be shown or not.
+//------------------------------------------------------------------------------------------------------------------------
+
+function setIsFullscreenActiveOnRefresh() {
+    const tempIsFullscreenActive = localStorage.getItem("isFullscreenActive");
+    if(tempIsFullscreenActive !== null) {
+        fullscreen = !(tempIsFullscreenActive === "true");
+        toggleFullscreen();
+    }
 }
 
 //-----------------------
@@ -6321,7 +6335,7 @@ function getSelectedObjectsPoints() {
 function toggleRulers() {
     const diagramPageWrapper = document.getElementById("diagram-page-wrapper");
     const rulers = document.querySelectorAll(".ruler");
-    
+
     if(isRulersActive) {
         diagramPageWrapper.classList.remove("rulers-active");
         rulers.forEach(ruler => ruler.classList.add("hidden"));

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3537,9 +3537,9 @@ function toggleFullscreen(){
     canvasSize();        
 }
 
-//------------------------------------------------------------------------------------------------------------------------
-// setIsRulersActiveOnRefresh: Gets the isActiveRulers value from localStorage to decide if rulers should be shown or not.
-//------------------------------------------------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------------------------------------------------------------
+// setIsFullscreenActiveOnRefresh: Gets the fullscreen value from localStorage to decide if full screen mode should be active or not.
+//-----------------------------------------------------------------------------------------------------------------------------------
 
 function setIsFullscreenActiveOnRefresh() {
     const tempIsFullscreenActive = localStorage.getItem("isFullscreenActive");

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -79,6 +79,7 @@
         $exampleDiagramFilePaths = glob('templates/example-diagram/*.txt');
     ?>
 
+    <div id="diagram-page-wrapper">
     <div id="diagram-header">
         <div id=diagram-toolbar-switcher>DEV: All</div>
         <div id="diagram-toolbar-container">
@@ -501,6 +502,7 @@
                 </div>
             </div>
         </div>
+    </div>
     </div>
 
     <!-- The Appearance menu. Default state is display: none; -->

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5612,7 +5612,7 @@ only screen and (max-device-width: 320px) {
   overflow: hidden;
 }
 
-#diagram-content.rulers-active {
+#diagram-page-wrapper.rulers-active #diagram-content {
   width: calc(100vw - var(--diagram-sidebar-width) - var(--ruler-size));
 }
 
@@ -5623,7 +5623,7 @@ only screen and (max-device-width: 320px) {
   height: calc(100vh - var(--header-height) - var(--diagram-header-height) - var(--canvas-margin));
 }
 
-#diagram-content.rulers-active #diagram-canvas-container {
+#diagram-page-wrapper.rulers-active #diagram-canvas-container {
   height: calc(100vh - var(--header-height) - var(--diagram-header-height) - var(--ruler-size) - var(--canvas-margin));
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5446,7 +5446,7 @@ only screen and (max-device-width: 320px) {
 
 /* Diagram */
 
-#diagram-header, #diagram-container {
+#diagram-page-wrapper {
   --header-height: 50px;
   --diagram-header-height: 36px;
   --ruler-size: 38px;
@@ -5462,7 +5462,7 @@ only screen and (max-device-width: 320px) {
   font-size: 14px;
 }
 
-#diagram-header.fullscreen.toolbar {
+#diagram-page-wrapper.fullscreen.toolbar #diagram-header {
   margin-top: 0;
   position: relative;
   z-index: 2;
@@ -5500,7 +5500,7 @@ only screen and (max-device-width: 320px) {
   width: var(--diagram-sidebar-width);
 }
 
-#diagram-container.fullscreen.toolbar #diagram-tools-container {
+#diagram-page-wrapper.fullscreen.toolbar #diagram-tools-container {
   position: relative;
   z-index: 2;
   background-color: #ffffff;
@@ -5627,7 +5627,7 @@ only screen and (max-device-width: 320px) {
   height: calc(100vh - var(--header-height) - var(--diagram-header-height) - var(--ruler-size) - var(--canvas-margin));
 }
 
-#diagram-container.fullscreen #diagram-canvas-container {
+#diagram-page-wrapper.fullscreen #diagram-canvas-container {
   position: absolute;
   top: 0;
   right: 0;
@@ -5643,7 +5643,7 @@ only screen and (max-device-width: 320px) {
   height: 100%;
 }
 
-#diagram-container.fullscreen #diagram-canvas {
+#diagram-page-wrapper.fullscreen #diagram-canvas {
   border: none;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5472,6 +5472,11 @@ only screen and (max-device-width: 320px) {
   border-bottom: 1px solid #000000;
 }
 
+#diagram-page-wrapper.rulers-active #diagram-header {
+  top: var(--ruler-size);
+  left: var(--ruler-size);
+}
+
 #diagram-toolbar-switcher {
   font-size: 11px;
   color: #c0c0c0;
@@ -5506,6 +5511,11 @@ only screen and (max-device-width: 320px) {
   background-color: #ffffff;
   border-right: 1px solid #000000;
   border-bottom: 1px solid #000000;
+}
+
+#diagram-page-wrapper.rulers-active #diagram-tools-container {
+  top: var(--ruler-size);
+  left: var(--ruler-size);
 }
 
 .diagram-sidebar-section {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5670,6 +5670,18 @@ only screen and (max-device-width: 320px) {
   overflow: hidden;
 }
 
+#diagram-page-wrapper.fullscreen .ruler {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 10;
+  background-color: #ffffff;
+  margin: 0;
+  border: 1px solid #000000;
+}
+
 .ruler.hidden {
   display: none;
 }
@@ -5680,11 +5692,19 @@ only screen and (max-device-width: 320px) {
   border-right: 1px solid #000000;
 }
 
+#diagram-page-wrapper.fullscreen #ruler-x {
+  margin-left: var(--ruler-size);
+}
+
 #ruler-y {
   width: var(--ruler-size);
   margin-top: var(--ruler-size);
   margin-bottom: var(--canvas-margin);
   border-bottom: 1px solid #000000;
+}
+
+#diagram-page-wrapper.fullscreen #ruler-y {
+  margin-top: var(--ruler-size);
 }
 
 .ruler-lines {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5637,6 +5637,11 @@ only screen and (max-device-width: 320px) {
   margin: 0;
 }
 
+#diagram-page-wrapper.fullscreen.rulers-active #diagram-canvas-container {
+  top: var(--ruler-size);
+  left: var(--ruler-size);
+}
+
 #diagram-canvas {
   border: 1px solid #000000;
   width: 100%;


### PR DESCRIPTION
Rulers do now work in full screen mode. The full screen state is now also pushed to local storage so when refreshing in full screen mode, full screen mode will be active after refresh. The toolbars have been taken into consideration. The toolbars will be moved in full screen mode when the rulers are active.

- Test to activate full screen mode. Active rulers and see if they work in full screen mode and have the right values (easy way to check is if 0 is at the origo line).
- Test to activate the toolbar (t) while in full screen mode. Try to use the toolbar both when having rulers off and on. When rulers are on the toolbar should be positioned under and to the side of the rulers. When no rulers are active the toolbar should be aligned to the screen edges like before. 
- Test to refresh the page while in full screen mode. Full screen mode should be active after refresh.

Link: http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%239601/DuggaSys/diagram.php