### PR TITLE
Fixes #3744 - Added timeline for diagram states and animation support

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6373,14 +6373,27 @@ function updateTimeline() {
         const part = document.createElement("div");
         part.classList.add("diagram-timeline-part");
         if(i <= diagramChanges.indexes.current) {
-            part.classList.add("done");    
+            part.classList.add("included");    
         }
         timelineElement.appendChild(part);
     }
 }
 
-function timelineHover(e) {
-    const elementIndex = getElementIndexInParent(e.target);
+function timelineMouseOver(e) {
+    const hoveredPartIndex = getElementIndexInParent(e.target);
+    const timelineParts = document.querySelectorAll(".diagram-timeline-part");
+
+    timelineParts.forEach((part, i) => {
+        part.classList.remove("plus", "minus");
+
+        //When hovered part is after current iteration part and current iteration part is not already a shown state, current iteration part should be marked green
+        //When hovered part is before current iteration part and current iteration part is a shown state, current iteration part should be marked red
+        if(hoveredPartIndex >= i && !part.classList.contains("included")) {
+            part.classList.add("plus");
+        } else if(hoveredPartIndex < i && part.classList.contains("included")) {
+            part.classList.add("minus");
+        }
+    });
 }
 
 function getElementIndexInParent(element) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6379,6 +6379,14 @@ function updateTimeline() {
     }
 }
 
+function timelineHover(e) {
+    const elementIndex = getElementIndexInParent(e.target);
+}
+
+function getElementIndexInParent(element) {
+    return [...element.parentNode.childNodes].indexOf(element);
+}
+
 function getOrigoOffsetX() {
     return origoOffsetX;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6451,7 +6451,7 @@ function playTimeline(playButton) {
     const srcName = srcSplitted[srcSplitted.length - 1];
 
     if(srcName === "Play.svg") {
-        img.src = "../Shared/icons/Pause.svg";
+        img.src = "../Shared/icons/pause.svg";
         timelineAnimation = setInterval(() => {
             if(diagramChanges.indexes.current === diagramChanges.indexes.stack.length - 1) {
                 diagramChanges.indexes.current = -1;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2637,6 +2637,9 @@ function gridToSVG(width, height) {
 //------------------------------------------------------------------------------
 
 function clearCanvas() {
+    if(!confirm(`The diagram contains ${diagramChanges.indexes.stack.length} state(s).\nDo you really want to clear the diagram?`)) {
+        return;
+    }
     while (diagram.length > 0) {
         diagram[diagram.length - 1].erase();
         diagram.pop();
@@ -2646,7 +2649,6 @@ function clearCanvas() {
     }
     resetSerialNumbers();
     updateGraphics();
-    SaveState();
 }
 
 //--------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6361,6 +6361,24 @@ function setIsRulersActiveOnRefresh() {
     }
 }
 
+//------------------------------------------------
+// Diagram timeline functions
+//------------------------------------------------
+
+function updateTimeline() {
+    const timelineElement = document.getElementById("diagram-timeline");
+
+    timelineElement.innerHTML = "";
+    for(let i = 0; i < diagramChanges.indexes.stack.length; i++) {
+        const part = document.createElement("div");
+        part.classList.add("diagram-timeline-part");
+        if(i <= diagramChanges.indexes.current) {
+            part.classList.add("done");    
+        }
+        timelineElement.appendChild(part);
+    }
+}
+
 function getOrigoOffsetX() {
     return origoOffsetX;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6401,6 +6401,13 @@ function timelineMouseLeave() {
     timelineParts.forEach(part => part.classList.remove("plus", "minus"));
 }
 
+function timelineClick(e) {
+    const clickedPartIndex = getElementIndexInParent(e.target);
+    diagramChanges.indexes.current = clickedPartIndex;
+    saveDiagramChangesToLocalStorage();
+    Load();
+}
+
 function getElementIndexInParent(element) {
     return [...element.parentNode.childNodes].indexOf(element);
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6174,7 +6174,6 @@ function fixExampleLayer(){
         diagram[i].properties.setLayer = writeToLayer;
     }
     updateGraphics();
-    //SaveState(); // This save breaks the undo functionality right now
 }
 //A check if line should connect to a object when loose line is released inside a object
 function canConnectLine(startObj, endObj){
@@ -6370,6 +6369,11 @@ function setIsRulersActiveOnRefresh() {
 // Diagram timeline functions
 //------------------------------------------------
 
+//-----------------------------------------------------------------------------------------------------------
+// initTimeline: Initializes the timeline. Adds eventlisteners to timeline element.
+//               Loads active status from local storage to decide if they should be active or not on refresh.
+//-----------------------------------------------------------------------------------------------------------
+
 function initTimeline() {
     const timelineElement = document.getElementById("diagram-timeline");
     const tempIsTimelineActive = localStorage.getItem("isTimelineActive");
@@ -6384,6 +6388,10 @@ function initTimeline() {
     timelineElement.addEventListener("click", timelineClick);
 }
 
+//-------------------------------------------------------------------------------------------------
+// updateTimeline: Empties the timeline and regenerates parts based on current diagram state index.
+//-------------------------------------------------------------------------------------------------
+
 function updateTimeline() {
     const timelineElement = document.getElementById("diagram-timeline");
 
@@ -6397,6 +6405,11 @@ function updateTimeline() {
         timelineElement.appendChild(part);
     }
 }
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+// timelineMouseOver: Executes when moving the mouse over the timeline element.
+//                    Gets the index of the hovered part in the timeline to show correct styling on parts before and after hovered part.
+//--------------------------------------------------------------------------------------------------------------------------------------
 
 function timelineMouseOver(e) {
     const hoveredPartIndex = getElementIndexInParent(e.target);
@@ -6415,10 +6428,18 @@ function timelineMouseOver(e) {
     });
 }
 
+//----------------------------------------------------------------------------------------------------------------------------------
+// timelineMouseLeave: Executes when mouse leaves the timeline element. Removes special classes from all parts to restore to normal.
+//----------------------------------------------------------------------------------------------------------------------------------
+
 function timelineMouseLeave() {
     const timelineParts = document.querySelectorAll(".diagram-timeline-part");
     timelineParts.forEach(part => part.classList.remove("plus", "minus"));
 }
+
+//------------------------------------------------------------------------------------------------------------------
+// timelineClick: Executes when clicking on the timeline element. Loads state based on clicked timeline parts index.
+//------------------------------------------------------------------------------------------------------------------
 
 function timelineClick(e) {
     const clickedPartIndex = getElementIndexInParent(e.target);
@@ -6426,6 +6447,10 @@ function timelineClick(e) {
     saveDiagramChangesToLocalStorage();
     Load();
 }
+
+//----------------------------------------------------------------------------------------------------------
+// toggleTimeline: Toggles the timeline element. Sets the correct value in local storage and menu-item tick.
+//----------------------------------------------------------------------------------------------------------
 
 function toggleTimeline() {
     const diagramPageWrapper = document.getElementById("diagram-page-wrapper");
@@ -6444,6 +6469,13 @@ function toggleTimeline() {
     localStorage.setItem("isTimelineActive", isTimelineActive);
     canvasSize();
 }
+
+//----------------------------------------------------------------------------------------------------------------------------------
+// playTimeline: Executes when clicking on the timeline play/pause button or when changing speed in the speed slider.
+//               Sets or clears animation interval depending on play/pause. Resets timeline if current index is the last available.
+//               Passed boolean is only true when function is called from changing value in speed slider. 
+//               This is used to only update speed text when speed was changed and never toggle play/pause icon when changing speed.
+//----------------------------------------------------------------------------------------------------------------------------------
 
 function playTimeline(isSpeedChanged = false) {
     const playButton = document.getElementById("diagram-timeline-play-button");
@@ -6477,11 +6509,19 @@ function playTimeline(isSpeedChanged = false) {
     }
 }
 
+//-------------------------------------------------------------------------------------------------------------
+// resetTimeline: Resets the timeline and diagram state to show an empty diagram and no colored timeline parts.
+//-------------------------------------------------------------------------------------------------------------
+
 function resetTimeline() {
     diagramChanges.indexes.current = -1;
     saveDiagramChangesToLocalStorage();
     Load();
 }
+
+//------------------------------------------------------------------------------------------------------------------------------
+// toggleTimelineControls: Toggles the extra timeline controls with an animation. Toggles the icon for the clicked button (+/-).
+//------------------------------------------------------------------------------------------------------------------------------
 
 function toggleTimelineControls() {
     const plusButton = document.getElementById("diagram-timline-plus-button")
@@ -6498,6 +6538,10 @@ function toggleTimelineControls() {
         width: "toggle"
     }, 300);
 }
+
+//---------------------------------------------------------------------------------------------------------------------------------------------
+// getElementIndexInParent: Returns the index the the passed element has in parent element. Used to get index of clicked/hovered timeline part.
+//---------------------------------------------------------------------------------------------------------------------------------------------
 
 function getElementIndexInParent(element) {
     return [...element.parentNode.childNodes].indexOf(element);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6396,6 +6396,11 @@ function timelineMouseOver(e) {
     });
 }
 
+function timelineMouseLeave() {
+    const timelineParts = document.querySelectorAll(".diagram-timeline-part");
+    timelineParts.forEach(part => part.classList.remove("plus", "minus"));
+}
+
 function getElementIndexInParent(element) {
     return [...element.parentNode.childNodes].indexOf(element);
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -124,6 +124,7 @@ var fullscreen = false;             // Used to toggle fullscreen
 var toolbarDisplayed = false;       // Show/hide toolbar in fullscreen
 var isRulersActive = false;         //Show/hide rulers
 var isTimelineActive = true;        //Show/hide timeline
+var timelineAnimation = null;       //Used to set and clear interval auto animating diagram states
 var movobj = -1;                    // Moving object ID
 var lastSelectedObject = -1;        // The last selected object
 var uimode = "normal";              // User interface mode e.g. normal or create class currently
@@ -6440,6 +6441,25 @@ function toggleTimeline() {
     setCheckbox($(".drop-down-option:contains('Timeline')"), isTimelineActive);
     localStorage.setItem("isTimelineActive", isTimelineActive);
     canvasSize();
+}
+
+function playTimeline(playButton) {
+    const img = playButton.querySelector("img");
+    const srcSplitted = img.src.split("/");
+    const srcName = srcSplitted[srcSplitted.length - 1];
+
+    if(srcName === "Play.svg") {
+        img.src = "../Shared/icons/Pause.svg";
+        timelineAnimation = setInterval(() => {
+            if(diagramChanges.indexes.current === diagramChanges.indexes.stack.length - 1) {
+                diagramChanges.indexes.current = -1;
+            }
+            redoDiagram();
+        }, 1000);
+    } else {
+        img.src = "../Shared/icons/Play.svg";
+        clearInterval(timelineAnimation);
+    }
 }
 
 function getElementIndexInParent(element) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -123,6 +123,7 @@ var lineStartObj = -1;
 var fullscreen = false;             // Used to toggle fullscreen 
 var toolbarDisplayed = false;       // Show/hide toolbar in fullscreen
 var isRulersActive = false;         //Show/hide rulers
+var isTimelineActive = true;        //Show/hide timeline
 var movobj = -1;                    // Moving object ID
 var lastSelectedObject = -1;        // The last selected object
 var uimode = "normal";              // User interface mode e.g. normal or create class currently
@@ -6368,6 +6369,12 @@ function setIsRulersActiveOnRefresh() {
 
 function initTimeline() {
     const timelineElement = document.getElementById("diagram-timeline");
+    const tempIsTimelineActive = localStorage.getItem("isTimelineActive");
+
+    if(tempIsTimelineActive !== null) {
+        isTimelineActive = !(tempIsTimelineActive === "true");
+        toggleTimeline();
+    }
 
     timelineElement.addEventListener("mouseover", timelineMouseOver);
     timelineElement.addEventListener("mouseleave", timelineMouseLeave);
@@ -6415,6 +6422,24 @@ function timelineClick(e) {
     diagramChanges.indexes.current = clickedPartIndex;
     saveDiagramChangesToLocalStorage();
     Load();
+}
+
+function toggleTimeline() {
+    const diagramPageWrapper = document.getElementById("diagram-page-wrapper");
+    const timelineContainer = document.getElementById("diagram-timeline-container");
+
+    isTimelineActive = !isTimelineActive;
+
+    if(isTimelineActive) {
+        diagramPageWrapper.classList.add("timeline-active");
+        timelineContainer.classList.remove("hidden");
+    } else {
+        diagramPageWrapper.classList.remove("timeline-active");
+        timelineContainer.classList.add("hidden");
+    }
+    setCheckbox($(".drop-down-option:contains('Timeline')"), isTimelineActive);
+    localStorage.setItem("isTimelineActive", isTimelineActive);
+    canvasSize();
 }
 
 function getElementIndexInParent(element) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -493,6 +493,7 @@ function init() {
     setIsFullscreenActiveOnRefresh();
     setHideCommentOnRefresh();
     initAppearanceForm();
+    initTimeline();
     setPaperSize(event, paperSize);
     updateGraphics(); 
 }
@@ -6364,6 +6365,14 @@ function setIsRulersActiveOnRefresh() {
 //------------------------------------------------
 // Diagram timeline functions
 //------------------------------------------------
+
+function initTimeline() {
+    const timelineElement = document.getElementById("diagram-timeline");
+
+    timelineElement.addEventListener("mouseover", timelineMouseOver);
+    timelineElement.addEventListener("mouseleave", timelineMouseLeave);
+    timelineElement.addEventListener("click", timelineClick);
+}
 
 function updateTimeline() {
     const timelineElement = document.getElementById("diagram-timeline");

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -296,6 +296,9 @@
                     <div class="drop-down-item" tabindex="0">
                         <span class="drop-down-option" onclick="toggleRulers();">Rulers</span>        
                     </div>
+                    <div class="drop-down-item" tabindex="0">
+                        <span class="drop-down-option" onclick="toggleTimeline();">Timeline</span>        
+                    </div>
                 </div>
             </div>
             <div class="menu-drop-down" tabindex="0">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -502,7 +502,17 @@
                 </div>
             </div>
             <div id="diagram-timeline-container">
-
+                <div class="diagram-timeline-controls">
+                    <button class="diagram-tools-button diagram-tools-button-small">
+                        <img src="../Shared/icons/SkipB.svg">
+                    </button>
+                    <button class="diagram-tools-button diagram-tools-button-small">
+                        <img src="../Shared/icons/Play.svg">
+                    </button>
+                    <button class="diagram-tools-button diagram-tools-button-small">
+                        <img src="../Shared/icons/SkipF.svg">
+                    </button>
+                </div>
             </div>
         </div>
     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -501,7 +501,7 @@
                     <span id="zoomV"></span>
                 </div>
             </div>
-            <div id="diagram-timeline-container">
+            <div id="diagram-timeline-container" style="border-right:1px solid #000000;">
                 <div class="diagram-timeline-controls">
                     <button class="diagram-tools-button diagram-tools-button-small">
                         <img src="../Shared/icons/SkipB.svg">
@@ -513,8 +513,8 @@
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>
-                <div id="diagram-timeline"></div>
-                <div class="diagram-timeline-controls">
+                <div id="diagram-timeline" onmouseover='timelineHover(event);' onclick='timelineClick(event);'></div>
+                <div class="diagram-timeline-controls" style="border-left:1px solid #000000;">
                     <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                         <img src="../Shared/icons/fullscreen.svg">
                     </button>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -501,15 +501,15 @@
                     <span id="zoomV"></span>
                 </div>
             </div>
-            <div id="diagram-timeline-container" style="border-right:1px solid #000000;">
-                <div class="diagram-timeline-controls">
-                    <button class="diagram-tools-button diagram-tools-button-small">
+            <div id="diagram-timeline-container">
+                <div class="diagram-timeline-controls" style="border-right:1px solid #000000;">
+                    <button class="diagram-tools-button diagram-tools-button-small" onclick="undoDiagram();">
                         <img src="../Shared/icons/SkipB.svg">
                     </button>
                     <button class="diagram-tools-button diagram-tools-button-small">
                         <img src="../Shared/icons/Play.svg">
                     </button>
-                    <button class="diagram-tools-button diagram-tools-button-small">
+                    <button class="diagram-tools-button diagram-tools-button-small" onclick="redoDiagram();">
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -513,9 +513,13 @@
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>
-                <div id="diagram-timeline"></div>
+                <div id="diagram-timeline">
+                    <div class="diagram-timeline-part"></div>
+                    <div class="diagram-timeline-part"></div>
+                    <div class="diagram-timeline-part"></div>
+                </div>
                 <div class="diagram-timeline-controls">
-                    <button class="diagram-tools-button diagram-tools-button-small">
+                    <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                         <img src="../Shared/icons/fullscreen.svg">
                     </button>
                 </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -513,7 +513,7 @@
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>
-                <div id="diagram-timeline" onmouseover='timelineMouseOver(event);' onclick='timelineClick(event);'></div>
+                <div id="diagram-timeline" onmouseover='timelineMouseOver(event);' onmouseleave='timelineMouseLeave();' onclick='timelineClick(event);'></div>
                 <div class="diagram-timeline-controls" style="border-left:1px solid #000000;">
                     <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                         <img src="../Shared/icons/fullscreen.svg">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -513,7 +513,7 @@
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>
-                <div id="diagram-timeline" onmouseover='timelineMouseOver(event);' onmouseleave='timelineMouseLeave();' onclick='timelineClick(event);'></div>
+                <div id="diagram-timeline" onmouseover="timelineMouseOver(event);" onmouseleave="timelineMouseLeave();" onclick="timelineClick(event);"></div>
                 <div class="diagram-timeline-controls" style="border-left:1px solid #000000;">
                     <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                         <img src="../Shared/icons/fullscreen.svg">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -509,7 +509,7 @@
                     <button class="diagram-tools-button diagram-tools-button-small" onclick="undoDiagram();">
                         <img src="../Shared/icons/SkipB.svg">
                     </button>
-                    <button class="diagram-tools-button diagram-tools-button-small">
+                    <button class="diagram-tools-button diagram-tools-button-small" onclick="playTimeline(this);">
                         <img src="../Shared/icons/Play.svg">
                     </button>
                     <button class="diagram-tools-button diagram-tools-button-small" onclick="redoDiagram();">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -513,7 +513,7 @@
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>
-                <div id="diagram-timeline" onmouseover="timelineMouseOver(event);" onmouseleave="timelineMouseLeave();" onclick="timelineClick(event);"></div>
+                <div id="diagram-timeline"></div>
                 <div class="diagram-timeline-controls" style="border-left:1px solid #000000;">
                     <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                         <img src="../Shared/icons/fullscreen.svg">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -514,6 +514,11 @@
                     </button>
                 </div>
                 <div id="diagram-timeline">
+                    <div class="diagram-timeline-part done"></div>
+                    <div class="diagram-timeline-part done"></div>
+                    <div class="diagram-timeline-part done"></div>
+                    <div class="diagram-timeline-part done"></div>
+                    <div class="diagram-timeline-part"></div>
                     <div class="diagram-timeline-part"></div>
                     <div class="diagram-timeline-part"></div>
                     <div class="diagram-timeline-part"></div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -79,7 +79,7 @@
         $exampleDiagramFilePaths = glob('templates/example-diagram/*.txt');
     ?>
 
-    <div id="diagram-page-wrapper">
+    <div id="diagram-page-wrapper" class="timeline-active">
     <div id="diagram-header">
         <div id=diagram-toolbar-switcher>DEV: All</div>
         <div id="diagram-toolbar-container">
@@ -500,6 +500,9 @@
                     </span>
                     <span id="zoomV"></span>
                 </div>
+            </div>
+            <div id="diagram-timeline-container">
+
             </div>
         </div>
     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -513,7 +513,7 @@
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>
-                <div id="diagram-timeline" onmouseover='timelineHover(event);' onclick='timelineClick(event);'></div>
+                <div id="diagram-timeline" onmouseover='timelineMouseOver(event);' onclick='timelineClick(event);'></div>
                 <div class="diagram-timeline-controls" style="border-left:1px solid #000000;">
                     <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                         <img src="../Shared/icons/fullscreen.svg">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -513,6 +513,12 @@
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>
+                <div id="diagram-timeline"></div>
+                <div class="diagram-timeline-controls">
+                    <button class="diagram-tools-button diagram-tools-button-small">
+                        <img src="../Shared/icons/fullscreen.svg">
+                    </button>
+                </div>
             </div>
         </div>
     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -513,16 +513,7 @@
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
                 </div>
-                <div id="diagram-timeline">
-                    <div class="diagram-timeline-part done"></div>
-                    <div class="diagram-timeline-part done"></div>
-                    <div class="diagram-timeline-part done"></div>
-                    <div class="diagram-timeline-part done"></div>
-                    <div class="diagram-timeline-part"></div>
-                    <div class="diagram-timeline-part"></div>
-                    <div class="diagram-timeline-part"></div>
-                    <div class="diagram-timeline-part"></div>
-                </div>
+                <div id="diagram-timeline"></div>
                 <div class="diagram-timeline-controls">
                     <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                         <img src="../Shared/icons/fullscreen.svg">

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -139,6 +139,7 @@ function SaveState() {
         diagramChanges.indexes.push();
     }
 
+    updateTimeline();
     saveDiagramChangesToLocalStorage();
     localStorage.setItem("Settings", JSON.stringify(settings));
     console.log("State is saved");
@@ -224,6 +225,7 @@ function loadDiagram() {
             overwritePoints(built.points);
         }
     }
+    updateTimeline();
     deselectObjects();
     updateGraphics();
 }
@@ -307,6 +309,7 @@ function Load() {
     diagramChanges.indexes = new UndoRedoStack(diagramChanges.indexes.stack, diagramChanges.indexes.current);
     overwriteDiagram(built.diagram);
     overwritePoints(built.points);
+    updateTimeline();
 
     console.log("State is loaded");
     updateGraphics();

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -122,6 +122,7 @@ function SaveState() {
         const positionFromLast = diagramChanges.indexes.getCurrentPositionsFromLast();
         if(positionFromLast > 0) {
             if(!confirm(`You are ${positionFromLast} state(s) behind the latest save.\nDo you really want to invalidate them and continue working from here?`)) {
+                Load();
                 return;
             }
             //Remove everything from index to end of changes array if not at last position and push will happen

--- a/DuggaSys/diagram_IOHandler.js
+++ b/DuggaSys/diagram_IOHandler.js
@@ -171,11 +171,12 @@ function saveDiagramChangesToLocalStorage(value = JSON.stringify(diagramChanges)
 //-----------------------------------------------------------------------------------------
 
 function resetDiagramChanges() {
-    saveDiagramChangesToLocalStorage("null");
     diagramChanges = {
         indexes: new UndoRedoStack([], -1),
         changes: []
     };
+    saveDiagramChangesToLocalStorage();
+    updateTimeline();
 }
 
 //---------------------------------------------

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5452,7 +5452,7 @@ only screen and (max-device-width: 320px) {
   --ruler-size: 38px;
   --diagram-sidebar-width: 60px;
   --canvas-margin: 8px;
-  --timeline-height: 24px;
+  --timeline-height: 28px;
 }
 
 #diagram-header {
@@ -5853,7 +5853,15 @@ only screen and (max-device-width: 320px) {
 #diagram-timeline-container {
   height: var(--timeline-height);
   width: calc(100% - var(--canvas-margin));
-  background-color: green;
+  border-right: 1px solid #000000;
+  border-bottom: 1px solid #000000;
+  border-left: 1px solid #000000;
+}
+
+.diagram-timeline-controls {
+  display: flex;
+  align-items: center;
+  height: 100%;
 }
 
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5870,10 +5870,20 @@ only screen and (max-device-width: 320px) {
 }
 
 #diagram-timeline {
+  display: flex;
   flex-grow: 1;
   border-right: 1px solid #000000;
   border-left: 1px solid #000000;
 }
+
+.diagram-timeline-part {
+  background-color: aquamarine;
+  width: 50px;
+  height: 100%;
+  flex-grow: 1;
+}
+
+
 
 
 /* --------------================################================-------------- *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5638,6 +5638,15 @@ only screen and (max-device-width: 320px) {
   height: calc(100vh - var(--header-height) - var(--diagram-header-height) - var(--ruler-size) - var(--canvas-margin));
 }
 
+#diagram-page-wrapper.timeline-active #diagram-canvas-container {
+  height: calc(100vh - var(--header-height) - var(--diagram-header-height) - var(--timeline-height) - var(--canvas-margin));
+  margin-bottom: 0;
+}
+
+#diagram-page-wrapper.rulers-active.timeline-active #diagram-canvas-container {
+  height: calc(100vh - var(--header-height) - var(--diagram-header-height) - var(--timeline-height) - var(--ruler-size) - var(--canvas-margin));
+}
+
 #diagram-page-wrapper.fullscreen #diagram-canvas-container {
   position: absolute;
   top: 0;
@@ -5839,7 +5848,7 @@ only screen and (max-device-width: 320px) {
 
 #diagram-timeline-container {
   height: var(--timeline-height);
-  width: 100%;
+  width: calc(100% - var(--canvas-margin));
   background-color: green;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5653,13 +5653,17 @@ only screen and (max-device-width: 320px) {
   right: 0;
   bottom: 0;
   left: 0;
-  height: unset;
+  height: unset !important;
   margin: 0;
 }
 
 #diagram-page-wrapper.fullscreen.rulers-active #diagram-canvas-container {
   top: var(--ruler-size);
   left: var(--ruler-size);
+}
+
+#diagram-page-wrapper.fullscreen.timeline-active #diagram-canvas-container {
+  bottom: var(--timeline-height);
 }
 
 #diagram-canvas {
@@ -5736,6 +5740,10 @@ only screen and (max-device-width: 320px) {
 
 #diagram-page-wrapper.timeline-active #ruler-y {
   height: calc(100% - var(--ruler-size) - var(--timeline-height) - var(--canvas-margin));
+}
+
+#diagram-page-wrapper.fullscreen.timeline-active #ruler-y {
+  height: calc(100% - var(--ruler-size) - var(--timeline-height));
 }
 
 .ruler-lines {
@@ -5858,6 +5866,22 @@ only screen and (max-device-width: 320px) {
   border-right: 1px solid #000000;
   border-bottom: 1px solid #000000;
   border-left: 1px solid #000000;
+  background-color: #ffffff;
+}
+
+#diagram-page-wrapper.fullscreen #diagram-timeline-container{
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  border: 1px solid #000000;
+  width: 100%;
+}
+
+#diagram-page-wrapper.fullscreen.rulers-active #diagram-timeline-container{
+  width: calc(100% - var(--ruler-size));
+  left: var(--ruler-size);
 }
 
 .diagram-timeline-controls {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5452,6 +5452,7 @@ only screen and (max-device-width: 320px) {
   --ruler-size: 38px;
   --diagram-sidebar-width: 60px;
   --canvas-margin: 8px;
+  --timeline-height: 24px;
 }
 
 #diagram-header {
@@ -5683,6 +5684,7 @@ only screen and (max-device-width: 320px) {
   border-left: 1px solid #000000;
   position: relative;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 #diagram-page-wrapper.fullscreen .ruler {
@@ -5819,7 +5821,6 @@ only screen and (max-device-width: 320px) {
   right: 0;
 }
 
-
 #ruler-x .ruler-extra-lines .mouse-line {
   width: 4px;
 }
@@ -5835,6 +5836,13 @@ only screen and (max-device-width: 320px) {
 #ruler-y .ruler-extra-lines .point-line {
   height: 3px;
 }
+
+#diagram-timeline-container {
+  height: var(--timeline-height);
+  width: 100%;
+  background-color: green;
+}
+
 
 /* --------------================################================-------------- *
  *                            FAB Button (SectionED)                            *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5877,13 +5877,28 @@ only screen and (max-device-width: 320px) {
 }
 
 .diagram-timeline-part {
-  background-color: aquamarine;
+  background-color: #ffffff;
   width: 50px;
   height: 100%;
   flex-grow: 1;
+  cursor: pointer;
 }
 
+#diagram-timeline:hover .diagram-timeline-part {
+  background-color: var(--color-primary);
+}
 
+.diagram-timeline-part:hover ~ .diagram-timeline-part {
+  background-color: #ffffff !important;
+}
+
+.diagram-timeline-part.done {
+  background-color: var(--color-primary);
+}
+
+.diagram-timeline-part:not(:last-child) {
+  border-right: 2px solid var(--color-primary-light);
+}
 
 
 /* --------------================################================-------------- *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5872,8 +5872,6 @@ only screen and (max-device-width: 320px) {
 #diagram-timeline {
   display: flex;
   flex-grow: 1;
-  border-right: 2px solid #000000;
-  border-left: 2px solid #000000;
 }
 
 .diagram-timeline-part {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5886,11 +5886,11 @@ only screen and (max-device-width: 320px) {
 }
 
 .diagram-timeline-part.plus {
-  background-color: green;
+  background-color: #4ca64c;
 }
 
 .diagram-timeline-part.minus {
-  background-color: red;
+  background-color: #ff4c4c;
 }
 
 .diagram-timeline-part:not(:last-child) {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5881,20 +5881,20 @@ only screen and (max-device-width: 320px) {
   cursor: pointer;
 }
 
-#diagram-timeline:hover .diagram-timeline-part {
+.diagram-timeline-part.included {
   background-color: var(--color-primary);
 }
 
-.diagram-timeline-part:hover ~ .diagram-timeline-part {
-  background-color: #ffffff !important;
+.diagram-timeline-part.plus {
+  background-color: green;
 }
 
-.diagram-timeline-part.done {
-  background-color: var(--color-primary);
+.diagram-timeline-part.minus {
+  background-color: red;
 }
 
 .diagram-timeline-part:not(:last-child) {
-  border-right: 2px solid var(--color-primary-light);
+  border-right: 1px solid var(--color-primary-light);
 }
 
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5733,6 +5733,10 @@ only screen and (max-device-width: 320px) {
   margin-top: var(--ruler-size);
 }
 
+#diagram-page-wrapper.timeline-active #ruler-y {
+  height: calc(100% - var(--ruler-size) - var(--timeline-height) - var(--canvas-margin));
+}
+
 .ruler-lines {
   display: flex;
   align-items: flex-end;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5708,7 +5708,8 @@ only screen and (max-device-width: 320px) {
   border: 1px solid #000000;
 }
 
-.ruler.hidden {
+.ruler.hidden,
+#diagram-timeline-container.hidden {
   display: none;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5872,13 +5872,12 @@ only screen and (max-device-width: 320px) {
 #diagram-timeline {
   display: flex;
   flex-grow: 1;
-  border-right: 1px solid #000000;
-  border-left: 1px solid #000000;
+  border-right: 2px solid #000000;
+  border-left: 2px solid #000000;
 }
 
 .diagram-timeline-part {
   background-color: #ffffff;
-  width: 50px;
   height: 100%;
   flex-grow: 1;
   cursor: pointer;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5851,6 +5851,7 @@ only screen and (max-device-width: 320px) {
 }
 
 #diagram-timeline-container {
+  display: flex;
   height: var(--timeline-height);
   width: calc(100% - var(--canvas-margin));
   border-right: 1px solid #000000;
@@ -5859,9 +5860,19 @@ only screen and (max-device-width: 320px) {
 }
 
 .diagram-timeline-controls {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   height: 100%;
+}
+
+.diagram-timeline-controls > .diagram-tools-button {
+  margin: 0 2px;
+}
+
+#diagram-timeline {
+  flex-grow: 1;
+  border-right: 1px solid #000000;
+  border-left: 1px solid #000000;
 }
 
 

--- a/Shared/icons/fullscreen.svg
+++ b/Shared/icons/fullscreen.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+	<polygon fill="#FFFFFF" points="4.402,1 1,1 1,4.369 1,9.42 4.402,9.42 4.402,4.369 9.504,4.369 9.504,1"/>
+	<polygon fill="#FFFFFF" points="19.6,1 14.497,1 14.497,4.402 19.6,4.402 19.6,9.504 23.001,9.504 23.001,4.402 23.001,1"/>
+	<polygon fill="#FFFFFF" points="19.599,14.496 19.599,19.598 14.497,19.598 14.497,23 19.599,23 23,23 23,19.598 23,14.496"/>
+	<polygon fill="#FFFFFF" points="4.402,19.599 4.402,14.496 1,14.496 1,19.599 1,23 4.402,23 9.504,23 9.504,19.599"/>
+</svg>


### PR DESCRIPTION
You can test by loading any example diagram (Help -> Generate example diagrams) or by creating your own diagrams. Or do both.

The original issue #3744 was about adding animation support for the diagram. I took it one step further, also creating a timeline making it possible to manually go to any available diagram state. In my opinion this is even more useful. I made sure the timeline works in all scenarios; when rulers are active, when full screen is active, when rulers and full screen mode are active at the same time. **Test** all of these scenarios.

The timeline gives good response for which states that were included, will no longer be included after clicking a hovered part on the timeline and which states that were not included, but will be included after clicking a part. **Test** so this works. Also **test** click on a part and see so the right state is loaded.

**Test** to click the play button to animate the diagram creation. Every second, the next part of the timeline should be loaded and when reaching the end of the timeline, the animation will start from zero again. **Test** to pause it.

**Test** to click the "+" button, an element with a few extra buttons should animate to show. Test to use the step backwards/forwards buttons. **Test** the full screen mode button that is in the end of the timeline. **Test** the reset button, the timeline should have no colored steps and the diagram should be empty. **Test** the speed slider (0,1s - 3s is possible right now) so the correct speed is applied to the animating diagram. It should be possible to change speed while animating and it should be directly applied to the animation. It should also be possible to reset the diagram while animating without any problems.

When attempting to change the diagram (add, move, change property) when not in the latest state, a confirm dialog should appear giving information about how many states will be invalidated. When cancelling this, the correct state should be loaded again, preventing new actions to show (I added this in previous pull request, but the actions were shown but not saved, now they are never shown as well). **Test** this. Also **test** to accept this confirmation, all states after current one should be invalidated, removed from the timeline and one new state added for the new action.
![image](https://user-images.githubusercontent.com/49121839/82752502-ce608300-9dbe-11ea-85cd-be4484c5f5f0.png)

A similar dialog should now appear when attempting to clear the diagram (File -> Clear diagram). **Test** to clear the diagram to see so the timeline clears as well and attempt to start creating a new diagram, the timeline should fill up again.

Link: http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%233744/DuggaSys/diagram.php