### PR TITLE
Fixes #9613 - speed slider and reset button to diagram timeline

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6445,22 +6445,34 @@ function toggleTimeline() {
     canvasSize();
 }
 
-function playTimeline(playButton) {
+function playTimeline(isSpeedChanged = false) {
+    const playButton = document.getElementById("diagram-timeline-play-button");
+    const speedRange = document.getElementById("diagram-timeline-speed-range")
+    const speed = parseFloat(speedRange.value) || 1.0;
     const img = playButton.querySelector("img");
-    const srcSplitted = img.src.split("/");
-    const srcName = srcSplitted[srcSplitted.length - 1];
 
-    if(srcName === "Play.svg") {
-        img.src = "../Shared/icons/pause.svg";
+    if(isSpeedChanged) {
+        const speedTextElement = document.getElementById("diagram-timeline-speed");
+        speedTextElement.innerHTML = `<b>Speed:</b> ${speed}s`;
+        clearInterval(timelineAnimation);
+    } else {
+        playButton.classList.toggle("paused");
+        if(playButton.classList.contains("paused")) {
+            img.src = "../Shared/icons/Play.svg";
+        } else {
+            img.src = "../Shared/icons/pause.svg";
+        }
+    }
+
+    if(!playButton.classList.contains("paused")) {
         timelineAnimation = setInterval(() => {
             if(diagramChanges.indexes.current === diagramChanges.indexes.stack.length - 1) {
                 resetTimeline();
             } else {
                 redoDiagram();
             }
-        }, 1000);
+        }, speed * 1000);
     } else {
-        img.src = "../Shared/icons/Play.svg";
         clearInterval(timelineAnimation);
     }
 }
@@ -6471,15 +6483,15 @@ function resetTimeline() {
     Load();
 }
 
-function toggleTimelineControls(plusButton) {
+function toggleTimelineControls() {
+    const plusButton = document.getElementById("diagram-timline-plus-button")
     const img = plusButton.querySelector("img");
-    const srcSplitted = img.src.split("/");
-    const srcName = srcSplitted[srcSplitted.length - 1];
 
-    if(srcName === "Plus.svg") {
-        img.src = "../Shared/icons/Minus.svg";
-    } else {
+    plusButton.classList.toggle("closed");
+    if(plusButton.classList.contains("closed")) {
         img.src = "../Shared/icons/Plus.svg";
+    } else {
+        img.src = "../Shared/icons/Minus.svg";
     }
 
     $("#diagram-timeline-controls-toggleable").animate({

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6471,6 +6471,12 @@ function resetTimeline() {
     Load();
 }
 
+function toggleTimelineControls() {
+    $("#diagram-timeline-controls-toggleable").animate({
+        width: "toggle"
+    }, 300);
+}
+
 function getElementIndexInParent(element) {
     return [...element.parentNode.childNodes].indexOf(element);
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6454,9 +6454,10 @@ function playTimeline(playButton) {
         img.src = "../Shared/icons/pause.svg";
         timelineAnimation = setInterval(() => {
             if(diagramChanges.indexes.current === diagramChanges.indexes.stack.length - 1) {
-                diagramChanges.indexes.current = -1;
+                resetTimeline();
+            } else {
+                redoDiagram();
             }
-            redoDiagram();
         }, 1000);
     } else {
         img.src = "../Shared/icons/Play.svg";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6464,6 +6464,12 @@ function playTimeline(playButton) {
     }
 }
 
+function resetTimeline() {
+    diagramChanges.indexes.current = -1;
+    saveDiagramChangesToLocalStorage();
+    Load();
+}
+
 function getElementIndexInParent(element) {
     return [...element.parentNode.childNodes].indexOf(element);
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6471,7 +6471,17 @@ function resetTimeline() {
     Load();
 }
 
-function toggleTimelineControls() {
+function toggleTimelineControls(plusButton) {
+    const img = plusButton.querySelector("img");
+    const srcSplitted = img.src.split("/");
+    const srcName = srcSplitted[srcSplitted.length - 1];
+
+    if(srcName === "Plus.svg") {
+        img.src = "../Shared/icons/Minus.svg";
+    } else {
+        img.src = "../Shared/icons/Plus.svg";
+    }
+
     $("#diagram-timeline-controls-toggleable").animate({
         width: "toggle"
     }, 300);

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -506,25 +506,28 @@
             </div>
             <div id="diagram-timeline-container">
                 <div class="diagram-timeline-controls" style="border-right:1px solid #000000;">
-                    <button class="diagram-tools-button diagram-tools-button-small" onclick="undoDiagram();">
-                        <img src="../Shared/icons/SkipB.svg">
-                    </button>
                     <button class="diagram-tools-button diagram-tools-button-small" onclick="playTimeline(this);">
                         <img src="../Shared/icons/Play.svg">
                     </button>
-                    <button class="diagram-tools-button diagram-tools-button-small" onclick="redoDiagram();">
-                        <img src="../Shared/icons/SkipF.svg">
+                    <button class="diagram-tools-button diagram-tools-button-small" onclick="toggleTimelineControls();">
+                        <img src="../Shared/icons/Plus.svg">
                     </button>
-                    <button class="diagram-tools-button diagram-tools-button-small" onclick="resetTimeline();">
-                        <img src="../Shared/icons/ResetButton.svg">
-                    </button>
+                    <div id="diagram-timeline-controls-toggleable" style="display:none;">
+                        <button class="diagram-tools-button diagram-tools-button-small" onclick="undoDiagram();">
+                            <img src="../Shared/icons/SkipB.svg">
+                        </button>
+                        <button class="diagram-tools-button diagram-tools-button-small" onclick="redoDiagram();">
+                            <img src="../Shared/icons/SkipF.svg">
+                        </button>
+                        <button class="diagram-tools-button diagram-tools-button-small" onclick="resetTimeline();">
+                            <img src="../Shared/icons/ResetButton.svg">
+                        </button>
+                        <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
+                            <img src="../Shared/icons/fullscreen.svg">
+                        </button>
+                    </div>
                 </div>
                 <div id="diagram-timeline"></div>
-                <div class="diagram-timeline-controls" style="border-left:1px solid #000000;">
-                    <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
-                        <img src="../Shared/icons/fullscreen.svg">
-                    </button>
-                </div>
             </div>
         </div>
     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -509,7 +509,7 @@
                     <button class="diagram-tools-button diagram-tools-button-small" onclick="playTimeline(this);">
                         <img src="../Shared/icons/Play.svg">
                     </button>
-                    <button class="diagram-tools-button diagram-tools-button-small" onclick="toggleTimelineControls();">
+                    <button class="diagram-tools-button diagram-tools-button-small" onclick="toggleTimelineControls(this);">
                         <img src="../Shared/icons/Plus.svg">
                     </button>
                     <div id="diagram-timeline-controls-toggleable" style="display:none;">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -515,6 +515,9 @@
                     <button class="diagram-tools-button diagram-tools-button-small" onclick="redoDiagram();">
                         <img src="../Shared/icons/SkipF.svg">
                     </button>
+                    <button class="diagram-tools-button diagram-tools-button-small" onclick="resetTimeline();">
+                        <img src="../Shared/icons/ResetButton.svg">
+                    </button>
                 </div>
                 <div id="diagram-timeline"></div>
                 <div class="diagram-timeline-controls" style="border-left:1px solid #000000;">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -525,6 +525,8 @@
                         <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                             <img src="../Shared/icons/fullscreen.svg">
                         </button>
+                        <input type="range" id="diagram-timeline-speed-range" class="zoomSlider" min="0.1" max="5" value="1" step="0.1">
+                        <div id="diagram-timeline-speed"><b>Speed:</b> 1s</div>
                     </div>
                 </div>
                 <div id="diagram-timeline"></div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -506,10 +506,10 @@
             </div>
             <div id="diagram-timeline-container">
                 <div class="diagram-timeline-controls" style="border-right:1px solid #000000;">
-                    <button class="diagram-tools-button diagram-tools-button-small" onclick="playTimeline(this);">
+                    <button id="diagram-timeline-play-button" class="diagram-tools-button diagram-tools-button-small paused" onclick="playTimeline();">
                         <img src="../Shared/icons/Play.svg">
                     </button>
-                    <button class="diagram-tools-button diagram-tools-button-small" onclick="toggleTimelineControls(this);">
+                    <button id="diagram-timline-plus-button" class="diagram-tools-button diagram-tools-button-small closed" onclick="toggleTimelineControls();">
                         <img src="../Shared/icons/Plus.svg">
                     </button>
                     <div id="diagram-timeline-controls-toggleable" style="display:none;">
@@ -525,7 +525,7 @@
                         <button class="diagram-tools-button diagram-tools-button-small" onclick='toggleFullscreen();'>
                             <img src="../Shared/icons/fullscreen.svg">
                         </button>
-                        <input type="range" id="diagram-timeline-speed-range" class="zoomSlider" min="0.1" max="5" value="1" step="0.1">
+                        <input type="range" id="diagram-timeline-speed-range" class="zoomSlider" min="0.1" max="3" value="1" step="0.1" oninput="playTimeline(true);">
                         <div id="diagram-timeline-speed"><b>Speed:</b> 1s</div>
                     </div>
                 </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5929,6 +5929,16 @@ only screen and (max-device-width: 320px) {
   border-left: 1px solid #000000;
 }
 
+#diagram-timeline-speed-range {
+  padding: 0;
+}
+
+#diagram-timeline-speed {
+  margin: 0 4px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
 /* --------------================################================-------------- *
  *                            FAB Button (SectionED)                            *
  * --------------================################================-------------- */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5934,6 +5934,8 @@ only screen and (max-device-width: 320px) {
 }
 
 #diagram-timeline-speed {
+  flex-shrink: 0;
+  width: 64px;
   margin: 0 4px;
   font-size: 12px;
   white-space: nowrap;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5890,7 +5890,7 @@ only screen and (max-device-width: 320px) {
   height: 100%;
 }
 
-.diagram-timeline-controls > .diagram-tools-button {
+.diagram-timeline-controls .diagram-tools-button {
   margin: 0 2px;
 }
 
@@ -5922,6 +5922,12 @@ only screen and (max-device-width: 320px) {
   border-right: 1px solid var(--color-primary-light);
 }
 
+#diagram-timeline-controls-toggleable {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  border-left: 1px solid #000000;
+}
 
 /* --------------================################================-------------- *
  *                            FAB Button (SectionED)                            *


### PR DESCRIPTION
A speed slider and a button to reset the diagram timeline has been implemented. All of the extra timeline controls are now under a "+" button which on click will animate the rest of the control buttons to show. This was a way to save space. When resetting the timeline, the timeline should have 0 colored steps and be empty. The speed slider can go from 0,1 meaning 0,1 seconds per state change to 3 seconds per state change right now and changes by 0,1 for each step. It should be possible to interact with all the controls without stopping the animation.
![e87f8fbdee9750ff985ebaace5ac7070](https://user-images.githubusercontent.com/49121839/82766473-ba00a280-9e1f-11ea-9be3-6e89a51fbc79.gif)
