### PR TITLE
markdown preview textfield does not break

### DIFF
--- a/Shared/css/markdown.css
+++ b/Shared/css/markdown.css
@@ -10,6 +10,8 @@
 	overflow-y: scroll;
 	background-color: #fff;
 	padding:10px;
+    width: 83vw;
+    overflow-x: scroll;
 }
 
 .descbox pre {


### PR DESCRIPTION
preview textfield now wrap
![image](https://user-images.githubusercontent.com/49142935/82796422-d16a7a80-9e75-11ea-8d90-87b9cb75a11a.png)

Together with pull request https://github.com/HGustavs/LenaSYS/pull/9529 a scrollbar will appear on the "mdtarget" element instead of "fieldset" element. 
![image](https://user-images.githubusercontent.com/49142935/82796645-24dcc880-9e76-11ea-9403-01a7bd5789ac.png)

