### PR TITLE
G2 2020 w22 #9575 Group assignment grading should now update table properly

### DIFF
--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -249,10 +249,10 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 			$usergroups = current(current($usergroups));
 			$usergroups = rtrim($usergroups);
 			
-			$query = $pdo->prepare("SELECT user_course.uid FROM user_course WHERE user_course.groups LIKE :group and user_course.cid = :cid");
-			$usergroups = "%{$usergroups}%";
+			$query = $pdo->prepare("SELECT user_course.uid FROM user_course, userAnswer WHERE user_course.groups = :group and user_course.cid = :cid and userAnswer.quiz = :quizId and user_course.uid = userAnswer.uid");
 			$query->bindParam(':group', $usergroups);
 			$query->bindParam(':cid', $cid);
+			$query->bindParam(':quizId', $quizId);
 			$query->execute();
 			$users = $query->fetchAll(PDO::FETCH_ASSOC);
 			


### PR DESCRIPTION
Solves #9575.

Issue was caused by a select query which would select too many students (all students in a specific group, regardless of whether they had made a submission or not). Updated this to only select students who have made submissions and are in the same group as the student you're trying to grade (this only applies to group assignments, no "normal" duggas are affected).

Before this fix it would still update the database correctly, because it wouldn't be able to update/grade students who haven't made a submission, but the GUI was still updated as if they were graded. Hence why a refresh would show a correct table.

Since it would select way too many students it would take a long time to update. After this fix it updates a lot quicker (with small groups, if a group has 20+ members all with submissions it will be quite slow still).

**To test this please follow the instructions described here https://github.com/HGustavs/LenaSYS/pull/8497.**