### PR TITLE
G1-2020-W22-ISSUE#9619

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -1080,7 +1080,8 @@ function loadUserInformation(){
 						updateState(users);	
 					}
 				}
-            });
+			});
+			updateState(users);	
 		});
 	}
 


### PR DESCRIPTION
The table headings and the dropdown should now still be visible. Test by removing logs and then look at the page.
![bild](https://user-images.githubusercontent.com/49142342/82798077-55256680-9e78-11ea-96c2-70854141de69.png)
Closes #9619 
