### PR TITLE
Added page load counter to user information pages

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -814,6 +814,7 @@ function loadPageInformation() {
 
 var hasCounter;
 var rowCount;
+var nameCount;
 
 function loadUserInformation(){
 	localStorage.setItem('analyticsPage', 'userInformation');
@@ -1099,6 +1100,9 @@ function loadUserInformation(){
             if (users.hasOwnProperty(user)) {
 				if(localStorage.getItem('analyticsLastUser') == user) {
 					userSelect.append('<option value="' + user + '" selected>' + user + '</option>');
+					if(hasCounter = true){
+						nameCount = user;
+					}
 				} else {
 					userSelect.append('<option value="' + user + '">' + user + '</option>');
 				}
@@ -1415,14 +1419,14 @@ function renderTable(data) {
 	}
 	str += "</tbody></table>";
 	if(hasCounter == true){
-		updateCounter(rowCount);
+		updateCounter(rowCount, nameCount);
 	}
 	return str;
 }
 
-function updateCounter(count)
+function updateCounter(count, user)
 {
-	$('#analytic-info').append("<p> This page has been loaded " + count + " times by this user!");
+	$('#analytic-info').append("<p> This page has been loaded " + count + " times by " + user + "! </p>");
 	hasCounter = false;
 }
 

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -816,6 +816,7 @@ var hasCounter;
 var rowCount;
 var nameCount;
 var pageCount;
+var counterFirstLoad = true;
 
 function loadUserInformation(){
 	localStorage.setItem('analyticsPage', 'userInformation');
@@ -1421,9 +1422,10 @@ function renderTable(data) {
 		});
 	}
 	str += "</tbody></table>";
-	if(hasCounter == true){
+	if(hasCounter == true && counterFirstLoad == false){
 		updateCounter(rowCount, nameCount, pageCount);
 	}
+	counterFirstLoad = false;
 	return str;
 }
 

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -812,6 +812,9 @@ function loadPageInformation() {
     updateState();
 }
 
+var hasCounter;
+var rowCount;
+
 function loadUserInformation(){
 	localStorage.setItem('analyticsPage', 'userInformation');
 	resetAnalyticsChart();
@@ -833,6 +836,7 @@ function loadUserInformation(){
  
  
     function updateSectionedInformation(){
+		hasCounter = true;
         loadAnalytics("sectionedInformation", function(data) {
             var users = {};
             $.each(data, function(i, row) {
@@ -890,6 +894,7 @@ function loadUserInformation(){
 	}
 	
 	function updateCourseedInformation(){
+		hasCounter = true;
         loadAnalytics("courseedInformation", function(data) {
 			var users = {};
             $.each(data, function(i, row) {
@@ -925,6 +930,7 @@ function loadUserInformation(){
     }
  
     function updateCodeviewerInformation(){
+		hasCounter = true;
 		var users = {};
         loadAnalytics("codeviewerInformation", function(data) {
             $.each(data, function(i, row) {
@@ -950,6 +956,7 @@ function loadUserInformation(){
 	
 
     function updateDuggaInformation(){
+		hasCounter = true;
 		var users = {};
         loadAnalytics("duggaInformation", function(data) {
             $.each(data, function(i, row) {
@@ -1383,6 +1390,7 @@ function drawPieChart(data, title = null, multirow = false) {
 }
 
 function renderTable(data) {
+	rowCount = 0;
 	if (!$.isArray(data)) return;
 
 	var str = '<table class="list rows">';
@@ -1401,11 +1409,21 @@ function renderTable(data) {
 			$.each(row, function(j, col) {
 				str += "<td>" + col + "</td>";
 			});
-			str += "</tr>"
+			str += "</tr>";
+			rowCount++;
 		});
 	}
 	str += "</tbody></table>";
+	if(hasCounter == true){
+		updateCounter(rowCount);
+	}
 	return str;
+}
+
+function updateCounter(count)
+{
+	$('#analytic-info').append("<p> This page has been loaded " + count + " times by this user!");
+	hasCounter = false;
 }
 
 function drawLineChart(data) {

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -815,6 +815,7 @@ function loadPageInformation() {
 var hasCounter;
 var rowCount;
 var nameCount;
+var pageCount;
 
 function loadUserInformation(){
 	localStorage.setItem('analyticsPage', 'userInformation');
@@ -1100,9 +1101,7 @@ function loadUserInformation(){
             if (users.hasOwnProperty(user)) {
 				if(localStorage.getItem('analyticsLastUser') == user) {
 					userSelect.append('<option value="' + user + '" selected>' + user + '</option>');
-					if(hasCounter = true){
-						nameCount = user;
-					}
+					nameCount = user;
 				} else {
 					userSelect.append('<option value="' + user + '">' + user + '</option>');
 				}
@@ -1156,16 +1155,20 @@ function loadUserInformation(){
         selectPage.change(function(){
             switch(selectPage.val()){
                 case "sectioned":
-                    updateSectionedInformation();
+					updateSectionedInformation();
+					pageCount = "sectioned.php";
                     break;
                 case "courseed":
-                    updateCourseedInformation();
+					updateCourseedInformation();
+					pageCount = "courseed.php";
 					break;
 				case "showDugga":
 					updateDuggaInformation();
+					pageCount = "showdugga.php";
 					break;
 				case "codeviewer":
 					updateCodeviewerInformation();
+					pageCount = "codeviewer.php";
 					break;
 				case "events":
 					updateUserLogInformation();
@@ -1419,14 +1422,14 @@ function renderTable(data) {
 	}
 	str += "</tbody></table>";
 	if(hasCounter == true){
-		updateCounter(rowCount, nameCount);
+		updateCounter(rowCount, nameCount, pageCount);
 	}
 	return str;
 }
 
-function updateCounter(count, user)
+function updateCounter(count, user, page)
 {
-	$('#analytic-info').append("<p> This page has been loaded " + count + " times by " + user + "! </p>");
+	$('#analytic-info').append("<p>" + page + " has been loaded " + count + " times by " + user + "! </p>");
 	hasCounter = false;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49142833/82803299-9457b580-9e80-11ea-97cf-3e86e458ccb2.png)


A counter has been added on top of the tables contaning user page loads. The counter contains the current selected user, page and the amount of times said user has loaded that page. 

There's an issue with the counter which appears when the selected user is changed, which causes the counter to break. This is fixed by changing the selected file aswell. This bug may become a future issue.