### PR TITLE
fix issue#9620 Free draw point size change with zoom

### DIFF
--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -3068,12 +3068,12 @@ function Path() {
                 var segb = points[this.segments[i].pb];
                 if(this.targeted) {
                     ctx.beginPath();
-                    ctx.arc(pixelsToCanvas(seg.x).x, pixelsToCanvas(0, seg.y).y, 5,0,2*Math.PI,false);
+                    ctx.arc(pixelsToCanvas(seg.x).x, pixelsToCanvas(0, seg.y).y, 5*zoomValue,0,2*Math.PI,false);
                     ctx.fillStyle = '#F82';
                     ctx.fill();
 
                     ctx.beginPath();
-                    ctx.arc(pixelsToCanvas(segb.x).x, pixelsToCanvas(0, segb.y).y, 5,0,2*Math.PI,false);
+                    ctx.arc(pixelsToCanvas(segb.x).x, pixelsToCanvas(0, segb.y).y, 5*zoomValue,0,2*Math.PI,false);
                     ctx.fillStyle = '#F82';
                     ctx.fill();
                 }


### PR DESCRIPTION
Before fix the points for free drawn objects were too small when zoomed in and too big when zoomed out. 

The size of the points should now change dynamically with the zoom value of the diagram like the points for all the other objects. 

**Test this:** Create a free drawn objects. Zoom in and out and make sure the size of the points is neither too small when zoomed in or too big when zoomed out. Create another kind of object to compare the point sizes. They should be the same.  

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%239620/DuggaSys/diagram.php

**Before:** 

![Screenshot_54](https://user-images.githubusercontent.com/49142301/82808691-c2da8e00-9e8a-11ea-8ac5-5aaf4f0f4bfc.png)

![44bdcb26448dbf8c78fdc9bc5b18f426](https://user-images.githubusercontent.com/49142301/82808708-ca019c00-9e8a-11ea-912a-ef79e392843f.gif)

**After:** 

![Screenshot_56](https://user-images.githubusercontent.com/49142301/82808760-e7cf0100-9e8a-11ea-80e3-60d0995c090b.png)

![9604ab338900a394f28777a346447712](https://user-images.githubusercontent.com/49142301/82808833-0e8d3780-9e8b-11ea-9958-c71f5e0c7b86.gif)
