### PR TITLE
G3 2020 #9645 | StudentTeacher/Supervisor delete items

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1017,7 +1017,7 @@ function returnedSection(data) {
         }
 
         // trashcan
-        if (data['writeaccess']) {
+        if (data['writeaccess'] || data['studentteacher']) {
           str += "<td style='width:32px;' class='" + makeTextArray(itemKind, ["header", "section", "code", "test", "moment", "link", "group", "message"]) + " " + hideState + "'>";
           str += "<img id='dorf' title='Delete item' class='' src='../Shared/icons/Trashcan.svg' onclick='confirmBox(\"openConfirmBox\", this);'>";
           str += "</td>";


### PR DESCRIPTION
Now StudentTeacher/Supervisor users can see the trashcan icon on items in sectioned and delete the items.

test with:
Studentteacher: Got 'ST' access for all courses.
mofre

Supervisor: Got SV access for all courses.
ryrey

Password is ‘password’.