### PR TITLE
Fixed duplicate of files in file information dropdown - G1-2020-W22-ISSUE#9621

### DIFF
--- a/DuggaSys/filereceive.php
+++ b/DuggaSys/filereceive.php
@@ -198,7 +198,7 @@ if ($storefile) {
             } else if($fileLocation == "MFILE"){
                 $movname = $currcvd . "/courses/" . $cid . "/" . $fileText;
                 $description="CourseLocal"." ".$fileText;
-                logUserEvent($userid, $username, EventTypes::AddFile, "CourseLocal"." , ".$fileText);
+                logUserEvent($userid, $username, EventTypes::AddFile, $description);
                 $kindid = 3;
             } else if($fileLocation == "GFILE"){
                 $movname = $currcvd . "/courses/global/" . $fileText;
@@ -317,7 +317,7 @@ if ($storefile) {
                     
                     // Logging for course local files
                     $description="CourseLocal"." ".$fname;
-                    logUserEvent($userid, $username, EventTypes::AddFile, "CourseLocal"." , ".$fname);
+                    logUserEvent($userid, $username, EventTypes::AddFile, $description);
                 } else {
                     $movname = $currcvd . "/courses/global/" . $fname;
 


### PR DESCRIPTION
When logging editing or creation of course local files duplicates will appear in the file information dropdown, this is now solved.

Before:
![Screenshot 2020-05-25 at 13 32 27](https://user-images.githubusercontent.com/62876614/82809703-0504cf00-9e8d-11ea-9e34-68d291b2cb0d.png)

After:
![Screenshot 2020-05-25 at 13 35 59](https://user-images.githubusercontent.com/62876614/82810084-e226ea80-9e8d-11ea-9f78-34f4bcb94fa6.png)


How to test: 
Edit or create a course local file in fileed, now navigate file information and check whether there are two mentions of the same file. There should only be one now. 