### PR TITLE
Fixes #9315 - Implements ruler guidelines

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6412,6 +6412,7 @@ class Guideline {
     constructor(axis, position) {
         this.axis = axis;
         this.position = position;
+        this.moveStartPosition = 0;
         this.isLocked = false;
         this.container = document.getElementById("diagram-guideline-container");
         this.element = null;
@@ -6422,14 +6423,18 @@ class Guideline {
         this.element = document.createElement("div");
         this.element.classList.add("guideline");
 
-        const position = this.position.toString().includes("%") ? this.position : `${this.position}px`;
-
         if(this.axis === 'x') {
             this.element.classList.add("guideline-x");
-            this.element.style.top = position;
+            if(this.position === undefined) {
+                this.position = this.container.clientHeight / 2;
+            }
+            this.element.style.top = `${this.position}px`;
         } else if(this.axis === 'y') {
             this.element.classList.add("guideline-y");
-            this.element.style.left = position;
+            if(this.position === undefined) {
+                this.position = this.container.clientWidth / 2;
+            }
+            this.element.style.left = `${this.position}px`;
         }
 
         this.container.appendChild(this.element);
@@ -6455,10 +6460,10 @@ class Guideline {
         this.container.parentElement.parentElement.classList.add("noselect")
 
         if(this.axis === 'x') {
-            this.position = e.clientY;
+            this.moveStartPosition = e.clientY;
             this.container.style.cursor = "row-resize";
         } else if(this.axis === 'y') {
-            this.position = e.clientX;
+            this.moveStartPosition = e.clientX;
             this.container.style.cursor = "col-resize";
         }
 
@@ -6469,13 +6474,15 @@ class Guideline {
     mouseMove(e) {
         if(this.element.classList.contains("moving")) {
             if(this.axis === 'x') {
-                const movePosition = this.position - e.clientY;
-                this.position = e.clientY;
-                this.element.style.top = `${this.element.offsetTop - movePosition}px`;
+                const movePosition = this.moveStartPosition - e.clientY;
+                this.moveStartPosition = e.clientY;
+                this.position = this.element.offsetTop - movePosition;
+                this.element.style.top = `${this.position}px`;
             } else if(this.axis === 'y') {
-                const movePosition = this.position - e.clientX;
-                this.position = e.clientX;
-                this.element.style.left = `${this.element.offsetLeft - movePosition}px`;
+                const movePosition = this.moveStartPosition - e.clientX;
+                this.moveStartPosition = e.clientX;
+                this.position = this.element.offsetLeft - movePosition;
+                this.element.style.left = `${this.position}px`;
             }
         }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2359,6 +2359,7 @@ function resetViewToOrigin(event){
     origoOffsetY = 0;
     updateGraphics();
     SaveState();
+    createRulers();
 }
 
 //---------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6371,7 +6371,7 @@ function setIsRulersActiveOnRefresh() {
 }
 
 function createGuideline(axis = 'x', position = 0) {
-    const container = document.getElementById("diagram-guidelines-container")
+    const container = document.getElementById("diagram-guidelines-container");
     const guideline = document.createElement("div");
     let startPosition = 0;
 
@@ -6438,6 +6438,11 @@ function createGuideline(axis = 'x', position = 0) {
     guideline.addEventListener("mousedown", mouseDownHandler);
 
     container.appendChild(guideline);
+}
+
+function deleteGuidelines() {
+    const guidelines = document.querySelectorAll(".guideline");
+    guidelines.forEach(guideline => guideline.remove());
 }
 
 //------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6370,26 +6370,30 @@ function setIsRulersActiveOnRefresh() {
     }
 }
 
-function createGuideline(axis = 'x', isFromRuler = false) {
+function createGuideline(axis = 'x', position = 0) {
     const container = document.getElementById("diagram-guidelines-container")
     const guideline = document.createElement("div");
 
     guideline.classList.add("guideline");
     if(axis === 'x') {
         guideline.classList.add("guideline-x");
-        if(!isFromRuler) {
-            guideline.style.top = "50%";
-        }
+        guideline.style.top = position;
     } else if(axis === 'y') {
         guideline.classList.add("guideline-y");
-        if(!isFromRuler) {
-            guideline.style.left = "50%";
-        }
+        guideline.style.left = position;
     }
 
+    let startPosition = 0;
+    let movePosition = 0;
+
     function mouseDownHandler(e) {
-        e.preventDefault();
         guideline.classList.add("moving");
+
+        if(axis === 'x') {
+            startPosition = e.clientY;
+        } else if(axis === 'y') {
+            startPosition = e.clientX;
+        }
 
         document.addEventListener("mousemove", mouseMoveHandler);
         document.addEventListener("mouseup", mouseUpHandler);
@@ -6397,7 +6401,17 @@ function createGuideline(axis = 'x', isFromRuler = false) {
 
     function mouseMoveHandler(e) {
         if(guideline.classList.contains("moving")) {
-
+            if(axis === 'x') {
+                movePosition = startPosition - e.clientY;
+                startPosition = e.clientY;
+                guideline.style.top = `${guideline.offsetTop - movePosition}px`;
+                container.style.cursor = "row-resize";
+            } else if(axis === 'y') {
+                movePosition = startPosition - e.clientX;
+                startPosition = e.clientX;
+                guideline.style.left = `${guideline.offsetLeft - movePosition}px`;
+                container.style.cursor = "column-resize";
+            }
         }
     }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6370,15 +6370,21 @@ function setIsRulersActiveOnRefresh() {
     }
 }
 
-function createGuideline(axis = 'x') {
+function createGuideline(axis = 'x', isFromRuler = false) {
     const container = document.getElementById("diagram-guidelines-container")
     const guideline = document.createElement("div");
 
     guideline.classList.add("guideline");
     if(axis === 'x') {
         guideline.classList.add("guideline-x");
+        if(!isFromRuler) {
+            guideline.style.top = "50%";
+        }
     } else if(axis === 'y') {
         guideline.classList.add("guideline-y");
+        if(!isFromRuler) {
+            guideline.style.left = "50%";
+        }
     }
 
     function mouseDownHandler(e) {
@@ -6390,7 +6396,9 @@ function createGuideline(axis = 'x') {
     }
 
     function mouseMoveHandler(e) {
-        
+        if(guideline.classList.contains("moving")) {
+
+        }
     }
 
     function mouseUpHandler(e) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6345,15 +6345,19 @@ function getSelectedObjectsPoints() {
 function toggleRulers() {
     const diagramPageWrapper = document.getElementById("diagram-page-wrapper");
     const rulers = document.querySelectorAll(".ruler");
+    const guidelineContainer = document.getElementById("diagram-guideline-container");
+
+    isRulersActive = !isRulersActive;
 
     if(isRulersActive) {
-        diagramPageWrapper.classList.remove("rulers-active");
-        rulers.forEach(ruler => ruler.classList.add("hidden"));
-    } else {
         diagramPageWrapper.classList.add("rulers-active");
         rulers.forEach(ruler => ruler.classList.remove("hidden"));
+        guidelineContainer.classList.remove("hidden");
+    } else {
+        diagramPageWrapper.classList.remove("rulers-active");
+        rulers.forEach(ruler => ruler.classList.add("hidden"));
+        guidelineContainer.classList.add("hidden");
     }
-    isRulersActive = !isRulersActive;
     setCheckbox($(".drop-down-option:contains('Rulers')"), isRulersActive);
     localStorage.setItem("isRulersActive", isRulersActive);
     canvasSize();
@@ -6385,7 +6389,7 @@ function initGuidelines() {
     }
 }
 
-function saveGuidelinesLocalStorage() {
+function saveGuidelinesToLocalStorage() {
     const localStorageGuidelines = guidelines.reduce((result, guideline) => {
         return [...result, guideline.exportToLocalStorage()];
     }, []);
@@ -6395,13 +6399,13 @@ function saveGuidelinesLocalStorage() {
 
 function addGuideline(guideline) {
     guidelines.push(guideline);
-    saveGuidelinesLocalStorage();
+    saveGuidelinesToLocalStorage();
 }
 
 function deleteGuidelines() {
     guidelines.forEach(guideline => guideline.element.remove());
     guidelines.splice(0, guidelines.length);
-    saveGuidelinesLocalStorage();
+    saveGuidelinesToLocalStorage();
 }
 
 class Guideline {
@@ -6495,7 +6499,7 @@ class Guideline {
         document.removeEventListener("mousemove", this.mouseMove);
         document.removeEventListener("mouseup", this.mouseUp);
 
-        saveGuidelinesLocalStorage();
+        saveGuidelinesToLocalStorage();
     }
 
     remove() {
@@ -6504,7 +6508,7 @@ class Guideline {
         const index = guidelines.findIndex(guideline => Object.is(this, guideline));
         guidelines.splice(index, 1);
 
-        saveGuidelinesLocalStorage();
+        saveGuidelinesToLocalStorage();
     }
 
     exportToLocalStorage() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6370,79 +6370,102 @@ function setIsRulersActiveOnRefresh() {
     }
 }
 
-function createGuideline(axis = 'x', position = 0) {
-    const container = document.getElementById("diagram-guidelines-container");
-    const guideline = document.createElement("div");
-    let startPosition = 0;
+let guidelines = [];
 
-    guideline.classList.add("guideline");
-    if(axis === 'x') {
-        guideline.classList.add("guideline-x");
-        guideline.style.top = position;
-    } else if(axis === 'y') {
-        guideline.classList.add("guideline-y");
-        guideline.style.left = position;
-    }
-
-    function mouseDownHandler(e) {
-        guideline.classList.add("moving");
-        container.style.pointerEvents = "all";
-        container.parentElement.parentElement.classList.add("noselect")
-
-        if(axis === 'x') {
-            startPosition = e.clientY;
-            container.style.cursor = "row-resize";
-        } else if(axis === 'y') {
-            startPosition = e.clientX;
-            container.style.cursor = "col-resize";
-        }
-
-        document.addEventListener("mousemove", mouseMoveHandler);
-        document.addEventListener("mouseup", mouseUpHandler);
-    }
-
-    function mouseMoveHandler(e) {
-        if(guideline.classList.contains("moving")) {
-            if(axis === 'x') {
-                const movePosition = startPosition - e.clientY;
-                startPosition = e.clientY;
-                guideline.style.top = `${guideline.offsetTop - movePosition}px`;
-            } else if(axis === 'y') {
-                const movePosition = startPosition - e.clientX;
-                startPosition = e.clientX;
-                guideline.style.left = `${guideline.offsetLeft - movePosition}px`;
-            }
-        }
-    }
-
-    function mouseUpHandler() {
-        guideline.classList.remove("moving");
-        container.style.pointerEvents = "none";
-        container.style.cursor = "default";
-        container.parentElement.parentElement.classList.remove("noselect");
-
-        if(axis === 'x') {
-            if(guideline.offsetTop < 0 || guideline.offsetTop > container.offsetHeight) {
-                guideline.remove();
-            }
-        } else if(axis === 'y') {
-            if(guideline.offsetLeft < 0 || guideline.offsetLeft > container.offsetWidth) {
-                guideline.remove();
-            }
-        }
-
-        document.removeEventListener("mousemove", mouseMoveHandler);
-        document.removeEventListener("mouseup", mouseUpHandler);
-    }
-
-    guideline.addEventListener("mousedown", mouseDownHandler);
-
-    container.appendChild(guideline);
+function addGuideline(guideline) {
+    guidelines.push(guideline);
 }
 
 function deleteGuidelines() {
-    const guidelines = document.querySelectorAll(".guideline");
-    guidelines.forEach(guideline => guideline.remove());
+    guidelines.forEach(guideline => {
+        guideline.element.remove();
+    });
+    guidelines.splice(0, guidelines.length);
+}
+
+class Guideline {
+    constructor(axis, position) {
+        this.axis = axis;
+        this.position = position;
+        this.container = document.getElementById("diagram-guideline-container");
+        this.element = null;
+        this.createGuideline();
+    }
+
+    createGuideline() {
+        this.element = document.createElement("div");
+        this.element.classList.add("guideline");
+
+        if(this.axis === 'x') {
+            this.element.classList.add("guideline-x");
+            this.element.style.top = this.position;
+        } else if(this.axis === 'y') {
+            this.element.classList.add("guideline-y");
+            this.element.style.left = this.position;
+        }
+
+        this.container.appendChild(this.element);
+
+        this.element.addEventListener("mousedown", e => this.mouseDown(e));
+    }
+
+    mouseDown(e) {
+        this.element.classList.add("moving");
+        this.container.style.pointerEvents = "all";
+        this.container.parentElement.parentElement.classList.add("noselect")
+
+        if(this.axis === 'x') {
+            this.position = e.clientY;
+            this.container.style.cursor = "row-resize";
+        } else if(this.axis === 'y') {
+            this.position = e.clientX;
+            this.container.style.cursor = "col-resize";
+        }
+
+        document.addEventListener("mousemove", e => this.mouseMove(e));
+        document.addEventListener("mouseup", () => this.mouseUp());
+    }
+
+    mouseMove(e) {
+        if(this.element.classList.contains("moving")) {
+            if(this.axis === 'x') {
+                const movePosition = this.position - e.clientY;
+                this.position = e.clientY;
+                this.element.style.top = `${this.element.offsetTop - movePosition}px`;
+            } else if(this.axis === 'y') {
+                const movePosition = this.position - e.clientX;
+                this.position = e.clientX;
+                this.element.style.left = `${this.element.offsetLeft - movePosition}px`;
+            }
+        }
+    }
+
+    mouseUp() {
+        this.element.classList.remove("moving");
+        this.container.style.pointerEvents = "none";
+        this.container.style.cursor = "default";
+        this.container.parentElement.parentElement.classList.remove("noselect");
+
+        if(this.axis === 'x') {
+            if(this.element.offsetTop < 0 || this.element.offsetTop > this.container.offsetHeight) {
+                this.remove();
+            }
+        } else if(this.axis === 'y') {
+            if(this.element.offsetLeft < 0 || this.element.offsetLeft > this.container.offsetWidth) {
+                this.remove();
+            }
+        }
+
+        document.removeEventListener("mousemove", this.mouseMove);
+        document.removeEventListener("mouseup", this.mouseUp);
+    }
+
+    remove() {
+        this.element.remove();
+
+        const index = guidelines.findIndex(guideline => Object.is(this, guideline));
+        guidelines.splice(index, 1);
+    }
 }
 
 //------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6369,6 +6369,18 @@ function setIsRulersActiveOnRefresh() {
     }
 }
 
+function createGuideline(axis = 'x') {
+    const container = document.getElementById("diagram-guidelines-container")
+    const guideline = document.createElement("div");
+    guideline.classList.add("guideline");
+    if(axis === 'x') {
+        guideline.classList.add("guideline-x");
+    } else if(axis === 'y') {
+        guideline.classList.add("guideline-y");
+    }
+    container.appendChild(guideline);
+}
+
 //------------------------------------------------
 // Diagram timeline functions
 //------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6373,15 +6373,23 @@ function setIsRulersActiveOnRefresh() {
 let guidelines = [];
 let isGuidelinesLocked = false;
 
+function saveGuidelinesLocalStorage() {
+    const localStorageGuidelines = guidelines.reduce((result, guideline) => {
+        return [...result, guideline.exportToLocalStorage()];
+    }, []);
+
+    localStorage.setItem("guidelines", JSON.stringify(localStorageGuidelines));
+}
+
 function addGuideline(guideline) {
     guidelines.push(guideline);
+    saveGuidelinesLocalStorage();
 }
 
 function deleteGuidelines() {
-    guidelines.forEach(guideline => {
-        guideline.element.remove();
-    });
+    guidelines.forEach(guideline => guideline.element.remove());
     guidelines.splice(0, guidelines.length);
+    saveGuidelinesLocalStorage();
 }
 
 class Guideline {
@@ -6472,6 +6480,8 @@ class Guideline {
 
         document.removeEventListener("mousemove", this.mouseMove);
         document.removeEventListener("mouseup", this.mouseUp);
+
+        saveGuidelinesLocalStorage();
     }
 
     remove() {
@@ -6479,6 +6489,15 @@ class Guideline {
 
         const index = guidelines.findIndex(guideline => Object.is(this, guideline));
         guidelines.splice(index, 1);
+
+        saveGuidelinesLocalStorage();
+    }
+
+    exportToLocalStorage() {
+        return {
+            axis: this.axis,
+            position: this.position
+        };
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6373,6 +6373,7 @@ function setIsRulersActiveOnRefresh() {
 function createGuideline(axis = 'x', position = 0) {
     const container = document.getElementById("diagram-guidelines-container")
     const guideline = document.createElement("div");
+    let startPosition = 0;
 
     guideline.classList.add("guideline");
     if(axis === 'x') {
@@ -6382,9 +6383,6 @@ function createGuideline(axis = 'x', position = 0) {
         guideline.classList.add("guideline-y");
         guideline.style.left = position;
     }
-
-    let startPosition = 0;
-    let movePosition = 0;
 
     function mouseDownHandler(e) {
         guideline.classList.add("moving");
@@ -6405,11 +6403,11 @@ function createGuideline(axis = 'x', position = 0) {
     function mouseMoveHandler(e) {
         if(guideline.classList.contains("moving")) {
             if(axis === 'x') {
-                movePosition = startPosition - e.clientY;
+                const movePosition = startPosition - e.clientY;
                 startPosition = e.clientY;
                 guideline.style.top = `${guideline.offsetTop - movePosition}px`;
             } else if(axis === 'y') {
-                movePosition = startPosition - e.clientX;
+                const movePosition = startPosition - e.clientX;
                 startPosition = e.clientX;
                 guideline.style.left = `${guideline.offsetLeft - movePosition}px`;
             }
@@ -6420,6 +6418,16 @@ function createGuideline(axis = 'x', position = 0) {
         guideline.classList.remove("moving");
         container.style.pointerEvents = "none";
         container.style.cursor = "default";
+
+        if(axis === 'x') {
+            if(guideline.offsetTop < 0 || guideline.offsetTop > container.offsetHeight) {
+                guideline.remove();
+            }
+        } else if(axis === 'y') {
+            if(guideline.offsetLeft < 0 || guideline.offsetLeft > container.offsetWidth) {
+                guideline.remove();
+            }
+        }
 
         document.removeEventListener("mousemove", mouseMoveHandler);
         document.removeEventListener("mouseup", mouseUpHandler);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6387,6 +6387,7 @@ function createGuideline(axis = 'x', position = 0) {
     function mouseDownHandler(e) {
         guideline.classList.add("moving");
         container.style.pointerEvents = "all";
+        container.parentElement.parentElement.classList.add("noselect")
 
         if(axis === 'x') {
             startPosition = e.clientY;
@@ -6418,6 +6419,7 @@ function createGuideline(axis = 'x', position = 0) {
         guideline.classList.remove("moving");
         container.style.pointerEvents = "none";
         container.style.cursor = "default";
+        container.parentElement.parentElement.classList.remove("noselect");
 
         if(axis === 'x') {
             if(guideline.offsetTop < 0 || guideline.offsetTop > container.offsetHeight) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6372,12 +6372,34 @@ function setIsRulersActiveOnRefresh() {
 function createGuideline(axis = 'x') {
     const container = document.getElementById("diagram-guidelines-container")
     const guideline = document.createElement("div");
+
     guideline.classList.add("guideline");
     if(axis === 'x') {
         guideline.classList.add("guideline-x");
     } else if(axis === 'y') {
         guideline.classList.add("guideline-y");
     }
+
+    function mouseDownHandler(e) {
+        e.preventDefault();
+        guideline.classList.add("moving");
+
+        document.addEventListener("mousemove", mouseMoveHandler);
+        document.addEventListener("mouseup", mouseUpHandler);
+    }
+
+    function mouseMoveHandler(e) {
+        
+    }
+
+    function mouseUpHandler(e) {
+        guideline.classList.remove("moving");
+        document.removeEventListener("mousemove", mouseMoveHandler);
+        document.removeEventListener("mouseup", mouseUpHandler);
+    }
+
+    guideline.addEventListener("mousedown", mouseDownHandler);
+
     container.appendChild(guideline);
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6598,7 +6598,6 @@ class Guideline {
 
     mouseLeave() {
         this.unlock();
-        document.body.classList.remove("noselect");
     }
 
     //-------------------------------------------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6457,15 +6457,24 @@ class Guideline {
         this.container.appendChild(this.element);
 
         this.element.addEventListener("mouseover", () => this.mouseOver());
+        this.element.addEventListener("mouseleave", () => this.mouseLeave());
         this.element.addEventListener("mousedown", e => this.mouseDown(e));
     }
 
     mouseOver() {
+        if(md !== mouseState.empty) {
+            this.container.parentElement.parentElement.classList.add("noselect");
+            return;
+        }
         if(this.axis === 'x') {
             this.element.style.cursor = "row-resize";
         } else if(this.axis === 'y') {
             this.element.style.cursor = "col-resize";
         }
+    }
+
+    mouseLeave() {
+        this.container.parentElement.parentElement.classList.remove("noselect");
     }
 
     mouseDown(e) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -496,6 +496,7 @@ function init() {
     setHideCommentOnRefresh();
     initAppearanceForm();
     initTimeline();
+    initGuidelines();
     setPaperSize(event, paperSize);
     updateGraphics(); 
 }
@@ -6373,6 +6374,17 @@ function setIsRulersActiveOnRefresh() {
 let guidelines = [];
 let isGuidelinesLocked = false;
 
+function initGuidelines() {
+    let tempGuidelines = localStorage.getItem("guidelines");
+
+    if(tempGuidelines !== null) {
+        tempGuidelines = JSON.parse(tempGuidelines);
+        for(let i = 0; i < tempGuidelines.length; i++) {
+            guidelines[i] = new Guideline(tempGuidelines[i].axis, tempGuidelines[i].position);
+        }
+    }
+}
+
 function saveGuidelinesLocalStorage() {
     const localStorageGuidelines = guidelines.reduce((result, guideline) => {
         return [...result, guideline.exportToLocalStorage()];
@@ -6406,12 +6418,14 @@ class Guideline {
         this.element = document.createElement("div");
         this.element.classList.add("guideline");
 
+        const position = this.position.toString().includes("%") ? this.position : `${this.position}px`;
+
         if(this.axis === 'x') {
             this.element.classList.add("guideline-x");
-            this.element.style.top = this.position;
+            this.element.style.top = position;
         } else if(this.axis === 'y') {
             this.element.classList.add("guideline-y");
-            this.element.style.left = this.position;
+            this.element.style.left = position;
         }
 
         this.container.appendChild(this.element);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6352,7 +6352,7 @@ function toggleRulers() {
         rulers.forEach(ruler => ruler.classList.remove("hidden"));
     }
     isRulersActive = !isRulersActive;
-    setCheckbox($(".drop-down-option:contains('Rulers')"), isRulersActive);
+    setCheckbox($(".drop-down-option:contains('Toggle rulers')"), isRulersActive);
     localStorage.setItem("isRulersActive", isRulersActive);
     canvasSize();
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6427,6 +6427,14 @@ class Guideline {
         this.isLocked = isLocked;
         this.container = document.getElementById("diagram-guideline-container");
         this.element = null;
+
+        //Used to be able to access same reference to class functions
+        this.mouseOverHandler = e => this.mouseOver(e);
+        this.mouseLeaveHandler = e => this.mouseLeave(e);
+        this.mouseDownHandler = e => this.mouseDown(e);
+        this.mouseMoveHandler = e => this.mouseMove(e);
+        this.mouseUpHandler = e => this.mouseUp(e);
+
         this.createGuideline();
     }
 
@@ -6456,16 +6464,20 @@ class Guideline {
 
         this.container.appendChild(this.element);
 
-        this.element.addEventListener("mouseover", () => this.mouseOver());
-        this.element.addEventListener("mouseleave", () => this.mouseLeave());
-        this.element.addEventListener("mousedown", e => this.mouseDown(e));
+        this.element.addEventListener("mouseover", this.mouseOverHandler);
+        this.element.addEventListener("mouseleave", this.mouseLeaveHandler);
+        this.element.addEventListener("mousedown", this.mouseDownHandler);
     }
 
     mouseOver() {
+        this.element.style.cursor = "default";
+
         if(md !== mouseState.empty) {
+            this.lock();
             this.container.parentElement.parentElement.classList.add("noselect");
             return;
         }
+        
         if(this.axis === 'x') {
             this.element.style.cursor = "row-resize";
         } else if(this.axis === 'y') {
@@ -6474,6 +6486,7 @@ class Guideline {
     }
 
     mouseLeave() {
+        this.unlock();
         this.container.parentElement.parentElement.classList.remove("noselect");
     }
 
@@ -6490,8 +6503,8 @@ class Guideline {
             this.container.style.cursor = "col-resize";
         }
 
-        document.addEventListener("mousemove", e => this.mouseMove(e));
-        document.addEventListener("mouseup", () => this.mouseUp());
+        document.addEventListener("mousemove", this.mouseMoveHandler);
+        document.addEventListener("mouseup", this.mouseUpHandler);
     }
 
     mouseMove(e) {
@@ -6526,8 +6539,8 @@ class Guideline {
             }
         }
 
-        document.removeEventListener("mousemove", this.mouseMove);
-        document.removeEventListener("mouseup", this.mouseUp);
+        document.removeEventListener("mousemove", this.mouseMoveHandler);
+        document.removeEventListener("mouseup", this.mouseUpHandler);
 
         saveGuidelinesToLocalStorage();
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6388,11 +6388,14 @@ function createGuideline(axis = 'x', position = 0) {
 
     function mouseDownHandler(e) {
         guideline.classList.add("moving");
+        container.style.pointerEvents = "all";
 
         if(axis === 'x') {
             startPosition = e.clientY;
+            container.style.cursor = "row-resize";
         } else if(axis === 'y') {
             startPosition = e.clientX;
+            container.style.cursor = "col-resize";
         }
 
         document.addEventListener("mousemove", mouseMoveHandler);
@@ -6405,18 +6408,19 @@ function createGuideline(axis = 'x', position = 0) {
                 movePosition = startPosition - e.clientY;
                 startPosition = e.clientY;
                 guideline.style.top = `${guideline.offsetTop - movePosition}px`;
-                container.style.cursor = "row-resize";
             } else if(axis === 'y') {
                 movePosition = startPosition - e.clientX;
                 startPosition = e.clientX;
                 guideline.style.left = `${guideline.offsetLeft - movePosition}px`;
-                container.style.cursor = "column-resize";
             }
         }
     }
 
-    function mouseUpHandler(e) {
+    function mouseUpHandler() {
         guideline.classList.remove("moving");
+        container.style.pointerEvents = "none";
+        container.style.cursor = "default";
+
         document.removeEventListener("mousemove", mouseMoveHandler);
         document.removeEventListener("mouseup", mouseUpHandler);
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6384,7 +6384,7 @@ function initGuidelines() {
     if(tempGuidelines !== null) {
         tempGuidelines = JSON.parse(tempGuidelines);
         for(let i = 0; i < tempGuidelines.length; i++) {
-            guidelines[i] = new Guideline(tempGuidelines[i].axis, tempGuidelines[i].position);
+            guidelines[i] = new Guideline(tempGuidelines[i].axis, tempGuidelines[i].position, tempGuidelines[i].isLocked);
         }
     }
 }
@@ -6408,12 +6408,23 @@ function deleteGuidelines() {
     saveGuidelinesToLocalStorage();
 }
 
+function lockOrUnlockGuidelines(isLocked = true) {
+    guidelines.forEach(guideline => {
+        if(isLocked) {
+            guideline.lock();
+        } else {
+            guideline.unlock();
+        }
+    });
+    saveGuidelinesToLocalStorage();
+}
+
 class Guideline {
-    constructor(axis, position) {
+    constructor(axis, position, isLocked = false) {
         this.axis = axis;
         this.position = position;
         this.moveStartPosition = 0;
-        this.isLocked = false;
+        this.isLocked = isLocked;
         this.container = document.getElementById("diagram-guideline-container");
         this.element = null;
         this.createGuideline();
@@ -6437,6 +6448,12 @@ class Guideline {
             this.element.style.left = `${this.position}px`;
         }
 
+        if(this.isLocked) {
+            this.lock();
+        } else {
+            this.unlock();
+        }
+
         this.container.appendChild(this.element);
 
         this.element.addEventListener("mouseover", () => this.mouseOver());
@@ -6444,7 +6461,6 @@ class Guideline {
     }
 
     mouseOver() {
-        if(this.isLocked) return;
         if(this.axis === 'x') {
             this.element.style.cursor = "row-resize";
         } else if(this.axis === 'y') {
@@ -6453,8 +6469,6 @@ class Guideline {
     }
 
     mouseDown(e) {
-        if(this.isLocked) return;
-
         this.element.classList.add("moving");
         this.container.style.pointerEvents = "all";
         this.container.parentElement.parentElement.classList.add("noselect")
@@ -6518,10 +6532,21 @@ class Guideline {
         saveGuidelinesToLocalStorage();
     }
 
+    lock() {
+        this.isLocked = true;
+        this.element.style.pointerEvents = "none";
+    }
+
+    unlock() {
+        this.isLocked = false;
+        this.element.style.pointerEvents = "all";
+    }
+
     exportToLocalStorage() {
         return {
             axis: this.axis,
-            position: this.position
+            position: this.position,
+            isLocked: this.isLocked
         };
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6352,7 +6352,7 @@ function toggleRulers() {
         rulers.forEach(ruler => ruler.classList.remove("hidden"));
     }
     isRulersActive = !isRulersActive;
-    setCheckbox($(".drop-down-option:contains('Toggle rulers')"), isRulersActive);
+    setCheckbox($(".drop-down-option:contains('Rulers')"), isRulersActive);
     localStorage.setItem("isRulersActive", isRulersActive);
     canvasSize();
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6371,6 +6371,7 @@ function setIsRulersActiveOnRefresh() {
 }
 
 let guidelines = [];
+let isGuidelinesLocked = false;
 
 function addGuideline(guideline) {
     guidelines.push(guideline);
@@ -6387,6 +6388,7 @@ class Guideline {
     constructor(axis, position) {
         this.axis = axis;
         this.position = position;
+        this.isLocked = false;
         this.container = document.getElementById("diagram-guideline-container");
         this.element = null;
         this.createGuideline();
@@ -6406,10 +6408,22 @@ class Guideline {
 
         this.container.appendChild(this.element);
 
+        this.element.addEventListener("mouseover", () => this.mouseOver());
         this.element.addEventListener("mousedown", e => this.mouseDown(e));
     }
 
+    mouseOver() {
+        if(this.isLocked) return;
+        if(this.axis === 'x') {
+            this.element.style.cursor = "row-resize";
+        } else if(this.axis === 'y') {
+            this.element.style.cursor = "col-resize";
+        }
+    }
+
     mouseDown(e) {
+        if(this.isLocked) return;
+
         this.element.classList.add("moving");
         this.container.style.pointerEvents = "all";
         this.container.parentElement.parentElement.classList.add("noselect")

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -295,10 +295,10 @@
                         <span class="drop-down-option">Guidelines</span>
                         <div class="side-drop-down">
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="createGuideline('x');">Create horizontal guideline</span>
+                                <span class="drop-down-option" onclick="createGuideline('x', '50%');">Create horizontal guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="createGuideline('y');">Create vertical guideline</span>
+                                <span class="drop-down-option" onclick="createGuideline('y', '50%');">Create vertical guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
                                 <span class="drop-down-option" onclick="">Lock guidelines</span>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -295,10 +295,10 @@
                         <span class="drop-down-option">Guidelines</span>
                         <div class="side-drop-down">
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="">Create horizontal guideline</span>
+                                <span class="drop-down-option" onclick="createGuideline('x');">Create horizontal guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="">Create vertical guideline</span>
+                                <span class="drop-down-option" onclick="createGuideline('y');">Create vertical guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
                                 <span class="drop-down-option" onclick="">Lock guidelines</span>
@@ -521,10 +521,7 @@
                     </span>
                     <span id="zoomV"></span>
                 </div>
-                <div id="diagram-guidelines">
-                    <div class="guideline guideline-y"></div>
-                    <div class="guideline guideline-x"></div>
-                </div>
+                <div id="diagram-guidelines-container"></div>
             </div>
             <div id="diagram-timeline-container">
                 <div class="diagram-timeline-controls" style="border-right:1px solid #000000;">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -521,6 +521,10 @@
                     </span>
                     <span id="zoomV"></span>
                 </div>
+                <div id="diagram-guidelines">
+                    <div class="guideline guideline-y"></div>
+                    <div class="guideline guideline-x"></div>
+                </div>
             </div>
             <div id="diagram-timeline-container">
                 <div class="diagram-timeline-controls" style="border-right:1px solid #000000;">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -287,15 +287,22 @@
                     <div class="drop-down-item" tabindex="0">
                         <span class="drop-down-option" onclick='toggleComments(event);'>Hide Comments</span>                       
                     </div>
-                    <div class="drop-down-divider">
+                    <div class="drop-down-divider"></div>
+                    <div class="drop-down-item" tabindex="0">
+                        <span class="drop-down-option">Rulers</span>
+                        <div class="side-drop-down">
+                            <div class="drop-down-item" tabindex="0">
+                                <span class="drop-down-option" onclick="toggleRulers();">Toggle rulers</span>
+                            </div>
+
+                        </div>
                     </div>
+                    <div class="drop-down-divider"></div>
                     <div class="drop-down-item" tabindex="0">
                         <span class="drop-down-option" onclick="toggleFullscreen();">Fullscreen</span>
                         <i class="hot-key hot-key-tick">Shift + F11</i>           
                     </div>
-                    <div class="drop-down-item" tabindex="0">
-                        <span class="drop-down-option" onclick="toggleRulers();">Rulers</span>        
-                    </div>
+                    <div class="drop-down-divider"></div>
                     <div class="drop-down-item" tabindex="0">
                         <span class="drop-down-option" onclick="toggleTimeline();">Timeline</span>        
                     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -295,10 +295,10 @@
                         <span class="drop-down-option">Guidelines</span>
                         <div class="side-drop-down">
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="addGuideline(new Guideline('x', '50%'));">Create horizontal guideline</span>
+                                <span class="drop-down-option" onclick="addGuideline(new Guideline('x'));">Create horizontal guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="addGuideline(new Guideline('y', '50%'));">Create vertical guideline</span>
+                                <span class="drop-down-option" onclick="addGuideline(new Guideline('y'));">Create vertical guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
                                 <span class="drop-down-option" onclick="">Lock guidelines</span>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -289,11 +289,11 @@
                     </div>
                     <div class="drop-down-divider"></div>
                     <div class="drop-down-item" tabindex="0">
-                        <span class="drop-down-option">Rulers</span>
+                        <span class="drop-down-option" onclick="toggleRulers();">Rulers active</span>
+                    </div>
+                    <div class="drop-down-item" tabindex="0">
+                        <span class="drop-down-option">Guidelines</span>
                         <div class="side-drop-down">
-                            <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="toggleRulers();">Toggle rulers</span>
-                            </div>
                             <div class="drop-down-item" tabindex="0">
                                 <span class="drop-down-option" onclick="">Create horizontal guideline</span>
                             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -295,10 +295,10 @@
                         <span class="drop-down-option">Guidelines</span>
                         <div class="side-drop-down">
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="createGuideline('x', '50%');">Create horizontal guideline</span>
+                                <span class="drop-down-option" onclick="addGuideline(new Guideline('x', '50%'));">Create horizontal guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="createGuideline('y', '50%');">Create vertical guideline</span>
+                                <span class="drop-down-option" onclick="addGuideline(new Guideline('y', '50%'));">Create vertical guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
                                 <span class="drop-down-option" onclick="">Lock guidelines</span>
@@ -521,7 +521,7 @@
                     </span>
                     <span id="zoomV"></span>
                 </div>
-                <div id="diagram-guidelines-container"></div>
+                <div id="diagram-guideline-container"></div>
             </div>
             <div id="diagram-timeline-container">
                 <div class="diagram-timeline-controls" style="border-right:1px solid #000000;">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -294,7 +294,18 @@
                             <div class="drop-down-item" tabindex="0">
                                 <span class="drop-down-option" onclick="toggleRulers();">Toggle rulers</span>
                             </div>
-
+                            <div class="drop-down-item" tabindex="0">
+                                <span class="drop-down-option" onclick="">Create horizontal guideline</span>
+                            </div>
+                            <div class="drop-down-item" tabindex="0">
+                                <span class="drop-down-option" onclick="">Create vertical guideline</span>
+                            </div>
+                            <div class="drop-down-item" tabindex="0">
+                                <span class="drop-down-option" onclick="">Lock guidelines</span>
+                            </div>
+                            <div class="drop-down-item" tabindex="0">
+                                <span class="drop-down-option" onclick="">Delete guidelines</span>
+                            </div>
                         </div>
                     </div>
                     <div class="drop-down-divider"></div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -304,7 +304,7 @@
                                 <span class="drop-down-option" onclick="">Lock guidelines</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="">Delete guidelines</span>
+                                <span class="drop-down-option" onclick="deleteGuidelines();">Delete guidelines</span>
                             </div>
                         </div>
                     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -301,7 +301,10 @@
                                 <span class="drop-down-option" onclick="addGuideline(new Guideline('y'));">Create vertical guideline</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
-                                <span class="drop-down-option" onclick="">Lock guidelines</span>
+                                <span class="drop-down-option" onclick="lockOrUnlockGuidelines(true);">Lock guidelines</span>
+                            </div>
+                            <div class="drop-down-item" tabindex="0">
+                                <span class="drop-down-option" onclick="lockOrUnlockGuidelines(false);">Unlock guidelines</span>
                             </div>
                             <div class="drop-down-item" tabindex="0">
                                 <span class="drop-down-option" onclick="deleteGuidelines();">Delete guidelines</span>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5943,10 +5943,10 @@ only screen and (max-device-width: 320px) {
 
 #diagram-guidelines-container {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  left: 1px;
   pointer-events: none;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5962,13 +5962,11 @@ only screen and (max-device-width: 320px) {
 .guideline-x {
   height: 3px;
   width: 100%;
-  cursor: row-resize;
 }
 
 .guideline-y {
   height: 100%;
   width: 3px;
-  cursor: col-resize;
 }
 
 /* --------------================################================-------------- *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5957,14 +5957,14 @@ only screen and (max-device-width: 320px) {
 }
 
 .guideline-x {
-  height: 2px;
+  height: 3px;
   width: 100%;
   cursor: row-resize;
 }
 
 .guideline-y {
   height: 100%;
-  width: 2px;
+  width: 3px;
   cursor: col-resize;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5941,7 +5941,7 @@ only screen and (max-device-width: 320px) {
   white-space: nowrap;
 }
 
-#diagram-guidelines {
+#diagram-guidelines-container {
   position: absolute;
   top: 0;
   right: 0;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5715,7 +5715,8 @@ only screen and (max-device-width: 320px) {
 }
 
 .ruler.hidden,
-#diagram-timeline-container.hidden {
+#diagram-timeline-container.hidden,
+#diagram-guideline-container.hidden {
   display: none;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5950,6 +5950,7 @@ only screen and (max-device-width: 320px) {
   bottom: 1px;
   left: 1px;
   pointer-events: none;
+  overflow: hidden;
 }
 
 .guideline {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5034,6 +5034,7 @@ only screen and (max-device-width: 320px) {
   height: 30px;
   position: absolute;
   bottom: 4px;
+  z-index: 2;
   -webkit-box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
   -moz-box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
   box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
@@ -5239,6 +5240,7 @@ only screen and (max-device-width: 320px) {
   font-size: 14px;
   bottom: 4px;
   right: 4px;
+  z-index: 2;
   position: absolute;
   cursor: default;
   /* Removes the possibility to copy the text in this element */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5943,7 +5943,7 @@ only screen and (max-device-width: 320px) {
   white-space: nowrap;
 }
 
-#diagram-guidelines-container {
+#diagram-guideline-container {
   position: absolute;
   top: 1px;
   right: 1px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5941,6 +5941,33 @@ only screen and (max-device-width: 320px) {
   white-space: nowrap;
 }
 
+#diagram-guidelines {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.guideline {
+  position: absolute;
+  pointer-events: all;
+  background-color: cyan;
+}
+
+.guideline-x {
+  height: 2px;
+  width: 100%;
+  cursor: row-resize;
+}
+
+.guideline-y {
+  height: 100%;
+  width: 2px;
+  cursor: col-resize;
+}
+
 /* --------------================################================-------------- *
  *                            FAB Button (SectionED)                            *
  * --------------================################================-------------- */


### PR DESCRIPTION
It is now possible to create guidelines. There is a new Guidelines menu-item that is a side-dropdown with everything related to guidelines. It is possible to create horizontal and vertical guidelines here. Guidelines can also be created by dragging it out from one of the rulers. These menu-items will always create the guideline in the middle of the canvas to begin with, they can then be moved around. The guidelines should always follow the ruler value they were positioned at, when zooming, when moving the camera and after refreshing the page. They should only be visible when the rulers are activated. It is possible to delete one guideline at a time by dragging it outside of the canvas container area. All guidelines can be deleted at once by the menu-item in the side-dropdown for guidelines. All guidelines can also be locked and unlocked at the same time by two different menu-items. Test all of these situations.

Link: http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%239315/DuggaSys/diagram.php