### PR TITLE
Fixes #9667 - Guidelines can be created by dragging from the rulers

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6393,17 +6393,23 @@ function initRulers() {
         diagramCanvasContainer.removeEventListener("mouseover", mouseOverHandler);
     }
 
+    function mouseUpHandler() {
+        mouseDownRulerX = false;
+        mouseDownRulerY = false;
+        document.removeEventListener("mouseup", mouseUpHandler);
+    }
+
     rulerX.addEventListener("mousedown", () => {
         mouseDownRulerX = true;
         diagramCanvasContainer.addEventListener("mouseover", mouseOverHandler);
+        document.addEventListener("mouseup", mouseUpHandler);
     });
-    rulerX.addEventListener("mouseup", () => mouseDownRulerX = false);
 
     rulerY.addEventListener("mousedown", () => {
         mouseDownRulerY = true;
         diagramCanvasContainer.addEventListener("mouseover", mouseOverHandler);
+        document.addEventListener("mouseup", mouseUpHandler);
     });
-    rulerY.addEventListener("mouseup", () => mouseDownRulerY = false);
 }
 
 let guidelines = [];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6375,12 +6375,14 @@ function initRulers() {
         toggleRulers();
     }
 
+    //Code below here makes it possible to drag out new guidelines from a ruler
     const rulerX = document.getElementById("ruler-x");
     const rulerY = document.getElementById("ruler-y");
     const diagramCanvasContainer = document.getElementById("diagram-canvas-container");
     let mouseDownRulerX = false;
     let mouseDownRulerY = false;
 
+    //Event handler for when the mouse reaches over the canvas container after mouse down on ruler
     function mouseOverHandler() {
         document.body.classList.add("noselect");
         if(mouseDownRulerX) {
@@ -6394,6 +6396,7 @@ function initRulers() {
         diagramCanvasContainer.removeEventListener("mouseover", mouseOverHandler);
     }
 
+    //Event handler for mouse up anywhere on the screen after mouse down on ruler
     function mouseUpHandler() {
         mouseDownRulerX = false;
         mouseDownRulerY = false;
@@ -6414,8 +6417,11 @@ function initRulers() {
     });
 }
 
-let guidelines = [];
-let isGuidelinesLocked = false;
+let guidelines = []; //Stores all active guideline objects
+
+//-------------------------------------------------------------------------------------------------------------------------------------------
+// initGuidelines: Gets all guideline objects from local storage and creates instances of the Guideline class based on values in each object.
+//-------------------------------------------------------------------------------------------------------------------------------------------
 
 function initGuidelines() {
     let tempGuidelines = localStorage.getItem("guidelines");
@@ -6428,6 +6434,10 @@ function initGuidelines() {
     }
 }
 
+//-----------------------------------------------------------------------------------------------------------------------------------------------------
+// saveGuidelinesToLocalStorage: Gets all required properties from each guideline object, stringifies the whole new array and saves it in localstorage. 
+//-----------------------------------------------------------------------------------------------------------------------------------------------------
+
 function saveGuidelinesToLocalStorage() {
     const localStorageGuidelines = guidelines.reduce((result, guideline) => {
         return [...result, guideline.exportToLocalStorage()];
@@ -6436,17 +6446,29 @@ function saveGuidelinesToLocalStorage() {
     localStorage.setItem("guidelines", JSON.stringify(localStorageGuidelines));
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------------------
+// addGuideline: Adds passed guideline instance to the array of guideline objects, saves guidelines to local storage and returns the guideline instance.
+//------------------------------------------------------------------------------------------------------------------------------------------------------
+
 function addGuideline(guideline) {
     guidelines.push(guideline);
     saveGuidelinesToLocalStorage();
     return guideline;
 }
 
+//-----------------------------------------------------------------------------------------------------------------------------------------------
+// deleteGuidelines: Deletes all guideline HTML-elements and empties the array of guideline objects and saves the emptied array to local storage.
+//-----------------------------------------------------------------------------------------------------------------------------------------------
+
 function deleteGuidelines() {
     guidelines.forEach(guideline => guideline.element.remove());
     guidelines.splice(0, guidelines.length);
     saveGuidelinesToLocalStorage();
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+// lockOrUnlockGuidelines: Locks all active guidelines if passing true. Unlocks all active guidelines if passing false.
+//---------------------------------------------------------------------------------------------------------------------
 
 function lockOrUnlockGuidelines(isLocked = true) {
     guidelines.forEach(guideline => {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -491,7 +491,7 @@ function init() {
     setModeOnRefresh(); 
     refreshVirtualPaper();
     setPaperSizeOnRefresh();
-    setIsRulersActiveOnRefresh();
+    initRulers();
     setIsFullscreenActiveOnRefresh();
     setHideCommentOnRefresh();
     initAppearanceForm();
@@ -6364,15 +6364,43 @@ function toggleRulers() {
 }
 
 //------------------------------------------------------------------------------------------------------------------------
-// setIsRulersActiveOnRefresh: Gets the isActiveRulers value from localStorage to decide if rulers should be shown or not.
+// initRulers Gets the isActiveRulers value from localStorage to decide if rulers should be shown or not.
 //------------------------------------------------------------------------------------------------------------------------
 
-function setIsRulersActiveOnRefresh() {
+function initRulers() {
     const tempIsRulerActive = localStorage.getItem("isRulersActive");
     if(tempIsRulerActive !== null) {
         isRulersActive = !(tempIsRulerActive === "true");
         toggleRulers();
     }
+
+    const rulerX = document.getElementById("ruler-x");
+    const rulerY = document.getElementById("ruler-y");
+    const diagramCanvasContainer = document.getElementById("diagram-canvas-container");
+    let mouseDownRulerX = false;
+    let mouseDownRulerY = false;
+
+    function mouseUpHandler() {
+        if(mouseDownRulerX) {
+            addGuideline(new Guideline('x', 0, false));
+        }
+        if(mouseDownRulerY) {
+            addGuideline(new Guideline('y', 0, false));
+        }
+        diagramCanvasContainer.removeEventListener("mouseup", mouseUpHandler);
+    }
+
+    rulerX.addEventListener("mousedown", () => {
+        mouseDownRulerX = true;
+        diagramCanvasContainer.addEventListener("mouseup", mouseUpHandler);
+    });
+    rulerX.addEventListener("mouseup", () => mouseDownRulerX = false);
+
+    rulerY.addEventListener("mousedown", () => {
+        mouseDownRulerY = true;
+        diagramCanvasContainer.addEventListener("mouseup", mouseUpHandler);
+    });
+    rulerY.addEventListener("mouseup", () => mouseDownRulerY = false);
 }
 
 let guidelines = [];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6363,9 +6363,10 @@ function toggleRulers() {
     canvasSize();
 }
 
-//------------------------------------------------------------------------------------------------------------------------
-// initRulers Gets the isActiveRulers value from localStorage to decide if rulers should be shown or not.
-//------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------------------
+// initRulers: Gets the isActiveRulers value from localStorage to decide if rulers should be shown or not.
+//             Also adds eventlistners to rulers making it possible to create guidelines by dragging from them.
+//-------------------------------------------------------------------------------------------------------------
 
 function initRulers() {
     const tempIsRulerActive = localStorage.getItem("isRulersActive");
@@ -6380,25 +6381,27 @@ function initRulers() {
     let mouseDownRulerX = false;
     let mouseDownRulerY = false;
 
-    function mouseUpHandler() {
+    function mouseOverHandler() {      
         if(mouseDownRulerX) {
-            addGuideline(new Guideline('x', 0, false));
-        }
+            const guideline = addGuideline(new Guideline('x', 0, false));
+            guideline.mouseDownHandler({clientX: 0});
+        } 
         if(mouseDownRulerY) {
-            addGuideline(new Guideline('y', 0, false));
+            const guideline = addGuideline(new Guideline('y', 0, false));
+            guideline.mouseDownHandler({clientY: 0});
         }
-        diagramCanvasContainer.removeEventListener("mouseup", mouseUpHandler);
+        diagramCanvasContainer.removeEventListener("mouseover", mouseOverHandler);
     }
 
     rulerX.addEventListener("mousedown", () => {
         mouseDownRulerX = true;
-        diagramCanvasContainer.addEventListener("mouseup", mouseUpHandler);
+        diagramCanvasContainer.addEventListener("mouseover", mouseOverHandler);
     });
     rulerX.addEventListener("mouseup", () => mouseDownRulerX = false);
 
     rulerY.addEventListener("mousedown", () => {
         mouseDownRulerY = true;
-        diagramCanvasContainer.addEventListener("mouseup", mouseUpHandler);
+        diagramCanvasContainer.addEventListener("mouseover", mouseOverHandler);
     });
     rulerY.addEventListener("mouseup", () => mouseDownRulerY = false);
 }
@@ -6428,6 +6431,7 @@ function saveGuidelinesToLocalStorage() {
 function addGuideline(guideline) {
     guidelines.push(guideline);
     saveGuidelinesToLocalStorage();
+    return guideline;
 }
 
 function deleteGuidelines() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6381,7 +6381,8 @@ function initRulers() {
     let mouseDownRulerX = false;
     let mouseDownRulerY = false;
 
-    function mouseOverHandler() {      
+    function mouseOverHandler() {
+        document.body.classList.add("noselect");
         if(mouseDownRulerX) {
             const guideline = addGuideline(new Guideline('x', 0, false));
             guideline.mouseDownHandler({clientX: 0});
@@ -6396,6 +6397,7 @@ function initRulers() {
     function mouseUpHandler() {
         mouseDownRulerX = false;
         mouseDownRulerY = false;
+        document.body.classList.add("noselect");
         document.removeEventListener("mouseup", mouseUpHandler);
     }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5824,6 +5824,7 @@ only screen and (max-device-width: 320px) {
 .ruler-extra-lines .mouse-line,
 .ruler-extra-lines .point-line {
   position: absolute;
+  pointer-events: none;
 }
 
 .ruler-extra-lines .mouse-line {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5724,6 +5724,7 @@ only screen and (max-device-width: 320px) {
   height: var(--ruler-size);
   margin-right: var(--canvas-margin);
   border-right: 1px solid #000000;
+  cursor: row-resize;
 }
 
 #diagram-page-wrapper.fullscreen #ruler-x {
@@ -5735,6 +5736,7 @@ only screen and (max-device-width: 320px) {
   margin-top: var(--ruler-size);
   margin-bottom: var(--canvas-margin);
   border-bottom: 1px solid #000000;
+  cursor: col-resize;
 }
 
 #diagram-page-wrapper.fullscreen #ruler-y {


### PR DESCRIPTION
Guidelines can now be created by dragging from the rulers. Before guidelines could only be created by menu-items.