### PR TITLE
Added media query for smaller plattforms.

### DIFF
--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -7,31 +7,31 @@
 <div id="container">
     <table id="htmlCssTable" style="width:100%; border-collapse:separate; border-spacing: 10px;">
         <tr>
-            <td id="target-col" class="dugga-col" style="max-width:400px;min-width:350px;vertical-align:top; background-color:#FFF;box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:scroll;">
+            <td id="target-col" class="dugga-col" >
                 <div>
-                    <div><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Webbplatsutseende som skall skapas</h2><p style="margin:10px;"><strong>Extrakrav: </strong><span id="target-text"></span></p></div>
-                    <div id="target-window" style="min-width:200px;min-height:400px;max-width:600px;overflow:scroll;"><img style="margin:5px; box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);" id="target-window-img" src="" /></div>
+                    <div><h2 class='loginBoxheader' >Webbplatsutseende som skall skapas</h2><p style="margin:10px;"><strong>Extrakrav: </strong><span id="target-text"></span></p></div>
+                    <div id="target-window" ><img id="target-window-img" src="" /></div>
                 </div>
             </td>
-            <td id="input-col" class="dugga-col" style="min-width:400px;vertical-align:top; background-color:#FFF;vertical-align:top; box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:hidden;">
+            <td id="input-col" class="dugga-col">
                 <div style="width:100%; height:100%; position:relative;">
-                    <div><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Skriv/klistra in kod</h2></div>
-                    <div style="position:absolute;top:45px;left:15px;right:15px;bottom:100px;"><textarea id="content-window" onkeyup="processpreview();" style="resize: none;display:block;width:100%;height:100%;box-sizing:border-box; "></textarea></div>
-                    <div style="position:absolute; bottom:1px; left:1px; right:1px; min-height:75px; margin: 15px;"><label>Adress (URL) till din publicerad version:</label><br><input style="border:1px solid black;width:100%;box-sizing:border-box;" id="url-input" type="text" name="url" placeholder="http://wwwlab.iit.his.se/<ditt login>/<sökvägen till din dugga>"><a id="url-button" class="submit-button" style="display:hidden" target="_blank" href="#">Visa externt</a><span class="submit-button" onclick="refreshdUrl()">Uppdatera URL</span></div>
+                    <div><h2 class='loginBoxheader'>Skriv/klistra in kod</h2></div>
+                    <div id="input-col-content"><textarea id="content-window" onkeyup="processpreview();"></textarea></div>
+                    <div id="input-col-URL"><label>Adress (URL) till din publicerad version:</label><br><input id="url-input" type="text" name="url" placeholder="http://wwwlab.iit.his.se/<ditt login>/<sökvägen till din dugga>"><a id="url-button" class="submit-button" style="display:hidden" target="_blank" href="#">Visa externt</a><span class="submit-button" onclick="refreshdUrl()">Uppdatera URL</span></div>
                 </div>
             </td>
-            <td id="preview-col" class="dugga-col" style="width:400px;vertical-align:top; background-color:#FFF;vertical-align:top; box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:hidden;">
+            <td id="preview-col" class="dugga-col">
                 <div>
-                    <div id="code-preview-label"><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; margin-bottom:10px; color:#FFF;overflow:hidden; text-align:center;">Förhandsgranskning av inklistrad programkod</h2></div>
-                    <div  id="code-preview-window-wrapper" style="width:400px;height:265px;"><iframe id="code-preview-window" style="transform:scale(0.5); transform-origin:0 0; box-sizing:border-box; border:2px solid #614875;overflow:hidden;margin:1px; width:796px; min-height:530px; box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);"></iframe></div>
-                    <div id="url-preview-label"><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Förhandsgranskning av publicerad kod</h2><p style="margin:10px;">Skall se identisk ut med ovan ovanstående.</p></div>
-                    <div style="width:400px;height:265px;"><div id="url-preview-window" style="transform:scale(1); transform-origin:0 0; box-sizing:border-box;overflow:hidden; width:400px; min-height:520px; box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);"></div></div>
+                    <div id="code-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av inklistrad programkod</h2></div>
+                    <div  id="code-preview-window-wrapper"><iframe id="code-preview-window"></iframe></div>
+                    <div id="url-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av publicerad kod</h2><p style="margin:10px;">Skall se identisk ut med ovan ovanstående.</p></div>
+                    <div id="url-preview-window-wrapper"><div id="url-preview-window"></div></div>
                 </div>
             </td>
-            <td id="validation-col" class="dugga-col" style="width:400px;vertical-align:top;display:none; background-color:#FFF;vertical-align:top;box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:hidden;">
+            <td id="validation-col" class="dugga-col">
                 <div>
-                    <div id="validation-label"><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Validering</h2></div>
-                    <div id="validation-content" style="width:400px;height:265px;">
+                    <div id="validation-label"><h2 class='loginBoxheader'>Validering</h2></div>
+                    <div id="validation-content">
                         <div id="url-validation-window"></div>
                 </div>
             </td>

--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -27,7 +27,7 @@
                 <div>
                     <div id="code-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av inklistrad programkod</h2></div>
                     <div  id="code-preview-window-wrapper"><iframe id="code-preview-window"></iframe></div>
-                    <div id="url-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av publicerad kod</h2><p style="margin:10px;">Skall se identisk ut med ovan ovanstående.</p></div>
+                    <div id="url-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av publicerad kod</h2><p>Skall se identisk ut med ovan ovanstående.</p></div>
                     <div id="url-preview-window-wrapper"><div id="url-preview-window"></div></div>
                 </div>
             </div> 

--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -17,7 +17,10 @@
                 <div style="width:100%; height:100%; position:relative;">
                     <div><h2 class='loginBoxheader'>Skriv/klistra in kod</h2></div>
                     <div id="input-col-content"><textarea id="content-window" onkeyup="processpreview();"></textarea></div>
-                    <div id="input-col-URL"><label>Adress (URL) till din publicerad version:</label><br><input id="url-input" type="text" name="url" placeholder="http://wwwlab.iit.his.se/<ditt login>/<sökvägen till din dugga>"><a id="url-button" class="submit-button" style="display:hidden" target="_blank" href="#">Visa externt</a><span class="submit-button" onclick="refreshdUrl()">Uppdatera URL</span></div>
+                    <div id="input-col-URL"><label>Adress (URL) till din publicerad version:</label><br>
+                        <input id="url-input" type="text" name="url" placeholder="http://wwwlab.iit.his.se/<ditt login>/<sökvägen till din dugga>">
+                        <a id="url-button" style="display:hidden" target="_blank" href="#">Visa externt</a>
+                        <span  id="url-button"onclick="refreshdUrl()">Uppdatera URL</span></div>
                 </div>
             </div> 
             <div id="preview-col" class="dugga-col">

--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -5,38 +5,38 @@
 		</div>
 </div>
 <div id="container">
-    <table id="htmlCssTable" style="width:100%; border-collapse:separate; border-spacing: 10px;">
-        <tr>
-            <td id="target-col" class="dugga-col" >
+    <div id="htmlCssTable" style="width:100%; border-collapse:separate; border-spacing: 10px;">
+         
+            <div id="target-col" class="dugga-col" >
                 <div>
                     <div><h2 class='loginBoxheader' >Webbplatsutseende som skall skapas</h2><p style="margin:10px;"><strong>Extrakrav: </strong><span id="target-text"></span></p></div>
                     <div id="target-window" ><img id="target-window-img" src="" /></div>
                 </div>
-            </td>
-            <td id="input-col" class="dugga-col">
+            </div> 
+            <div id="input-col" class="dugga-col">
                 <div style="width:100%; height:100%; position:relative;">
                     <div><h2 class='loginBoxheader'>Skriv/klistra in kod</h2></div>
                     <div id="input-col-content"><textarea id="content-window" onkeyup="processpreview();"></textarea></div>
                     <div id="input-col-URL"><label>Adress (URL) till din publicerad version:</label><br><input id="url-input" type="text" name="url" placeholder="http://wwwlab.iit.his.se/<ditt login>/<sökvägen till din dugga>"><a id="url-button" class="submit-button" style="display:hidden" target="_blank" href="#">Visa externt</a><span class="submit-button" onclick="refreshdUrl()">Uppdatera URL</span></div>
                 </div>
-            </td>
-            <td id="preview-col" class="dugga-col">
+            </div> 
+            <div id="preview-col" class="dugga-col">
                 <div>
                     <div id="code-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av inklistrad programkod</h2></div>
                     <div  id="code-preview-window-wrapper"><iframe id="code-preview-window"></iframe></div>
                     <div id="url-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av publicerad kod</h2><p style="margin:10px;">Skall se identisk ut med ovan ovanstående.</p></div>
                     <div id="url-preview-window-wrapper"><div id="url-preview-window"></div></div>
                 </div>
-            </td>
-            <td id="validation-col" class="dugga-col">
+            </div> 
+            <div id="validation-col" class="dugga-col">
                 <div>
                     <div id="validation-label"><h2 class='loginBoxheader'>Validering</h2></div>
                     <div id="validation-content">
                         <div id="url-validation-window"></div>
                 </div>
-            </td>
-       </tr>
-   </table>
+            </div> 
+        
+    </div>
 </div>
 
 <div id='duggaInfoBox' class="loginBoxContainer" style="display:none">
@@ -47,17 +47,17 @@
     </div>
     <div class="table-wrap">
         <table>
-            <tr>
-                <td>
+             
+                <div> 
                     <p id="duggaInstructions" style="margin-left: 4px;"></p>
                     <p style="margin-left: 4px;">Lycka till!</p>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                </div> 
+             
+             
+                <div> 
                     <input type='button' class='submit-button' style="float: right;" onclick="hideDuggaInfoPopup();" value='Stäng'>
-                </td>
-            </tr>
+                </div> 
+             
         </table>
     </div>
 </div>

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -643,11 +643,17 @@ svg text {
     overflow:hidden; 
     text-align:center;
 }
- @media only screen and (max-width: 800px) {
-	#htmlCssTable > tbody,
-	#htmlCssTable > tbody > tr, 
-	#htmlCssTable > tbody > tr > td {
-		display: block;
+ @media screen and (min-width:200px){
+	#htmlCssTable{
+		display: flex; 
+		flex-wrap: wrap; 
+		justify-content: center;
+	}
+	#target-col, #input-col, #preview-col, #validation-col{
+		margin: 5px;
+	}
+	#input-col{
+		width: 200px;
 	}
  }
 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -586,6 +586,7 @@ svg text {
     overflow:hidden;
 }
 #preview-col p{
+	text-align: left;
 	margin:10px;
 	color: #000;
 }

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -643,6 +643,26 @@ svg text {
     overflow:hidden; 
     text-align:center;
 }
+#url-button{
+	display: inline-block;
+	background-color: var(--color-primary);
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	color: #fff;
+	cursor: pointer;
+	margin: 8px 2px 4px 2px;
+	font-size: 14px;
+	transition: 0.1s background-color;
+	-webkit-appearance: none;
+	border-radius: 4px;
+	line-height: 30px;
+	padding-left: 5px;
+	padding-right: 5px;
+	text-decoration: none;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+}
+#url-button:hover {
+    background-color: var(--color-primary-hover);
+}
  @media screen and (min-width:200px){
 	#htmlCssTable{
 		display: flex; 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -515,7 +515,134 @@ svg text {
  /* --------------================################================-------------- *
  *                      	         HTML-CSS Dugga				       								   *
  * --------------================################================-------------- */
-
+ #target-col{
+    max-width:400px;
+    min-width:350px;
+    vertical-align:top;
+    background-color:#FFF;
+    box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
+    overflow:scroll;
+}
+.dugga-col .loginBoxheader{
+    padding:5px;
+    padding-bottom:10px;
+    margin-top:0; 
+    color:#FFF;
+    overflow:hidden; 
+    text-align:center;
+}
+.dugga-col #target-window {
+    min-width:200px;
+    min-height:400px;
+    max-width:600px;
+    overflow:scroll;
+}
+#target-window img{
+    margin:5px; 
+    box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);
+}
+#input-col{
+    min-width:400px;
+    vertical-align:top; 
+    background-color:#FFF;
+    vertical-align:top; 
+    box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
+    overflow:hidden;
+}
+#input-col-content{
+    position:absolute;
+    top:45px;left:15px;
+    right:15px;
+    bottom:100px;
+}
+#content-window{
+    resize: none;
+    display:block;
+    width:100%;
+    height:100%;
+    box-sizing:border-box;
+}
+#input-col-URL {
+    position:absolute; 
+    bottom:1px; 
+    left:1px; 
+    right:1px; 
+    min-height:75px; 
+    margin: 15px;
+}
+#url-input{
+    border:1px solid black;
+    width:100%;
+    box-sizing:border-box;
+}
+#preview-col{
+    width:400px;
+    vertical-align:top; 
+    background-color:#FFF;
+    vertical-align:top; 
+    box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
+    overflow:hidden;
+}
+#code-preview-label{
+    padding:5px; 
+    padding-bottom:10px; 
+    margin-top:0; 
+    margin-bottom:10px; 
+    color:#FFF;
+    overflow:hidden; 
+    text-align:center;
+}
+#code-preview-window-wrapper, 
+#url-preview-window-wrapper,
+#validation-content{
+    width:400px;
+    height:265px;
+}
+#preview-col #code-preview-window {
+    transform:scale(0.5); 
+    transform-origin:0 0; 
+    box-sizing:border-box; 
+    border:2px solid #614875;
+    overflow:hidden;
+    margin:1px; 
+    width:796px; 
+    min-height:530px; 
+    box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);
+}
+#url-preview-label{
+    padding:5px; 
+    padding-bottom:10px; 
+    margin-top:0; 
+    color:#FFF;
+    overflow:hidden; 
+    text-align:center;
+}
+#url-preview-window{
+    transform:scale(1); 
+    transform-origin:0 0; 
+    box-sizing:border-box;
+    overflow:hidden; 
+    width:400px; 
+    min-height:520px; 
+    box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);
+}
+#validation-col{
+    width:400px;
+    vertical-align:top;
+    display:none; 
+    background-color:#FFF;
+    vertical-align:top;
+    box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
+    overflow:hidden;
+}
+#validation-label{
+    padding:5px; 
+    padding-bottom:10px; 
+    margin-top:0; 
+    color:#FFF;
+    overflow:hidden; 
+    text-align:center;
+}
  @media only screen and (max-width: 800px) {
 	#htmlCssTable > tbody,
 	#htmlCssTable > tbody > tr, 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -558,9 +558,11 @@ svg text {
 #content-window{
     resize: none;
     display:block;
-    width:100%;
+	width:398px;
+	margin-left: -14px;
     height:100%;
-    box-sizing:border-box;
+	box-sizing:border-box;
+	border:1px solid #614875;
 }
 #input-col-URL {
     position:absolute; 
@@ -583,11 +585,12 @@ svg text {
     box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
     overflow:hidden;
 }
+#preview-col p{
+	margin:10px;
+	color: #000;
+}
 #code-preview-label{
-    padding:5px; 
-    padding-bottom:10px; 
     margin-top:0; 
-    margin-bottom:10px; 
     color:#FFF;
     overflow:hidden; 
     text-align:center;
@@ -610,8 +613,6 @@ svg text {
     box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);
 }
 #url-preview-label{
-    padding:5px; 
-    padding-bottom:10px; 
     margin-top:0; 
     color:#FFF;
     overflow:hidden; 
@@ -623,7 +624,8 @@ svg text {
     box-sizing:border-box;
     overflow:hidden; 
     width:400px; 
-    min-height:520px; 
+	min-height:520px; 
+	border:1px solid #614875;
     box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);
 }
 #validation-col{


### PR DESCRIPTION
- Moved inline styling to dugga.css. 
- Added media query for smaller plattforms. 
- Removed all tables, tr and td for the content and added div to them. 
- Fixed styling on buttons in #input-col. See img 1 & 2
- Fixed some styling on the preview-col. 
<img width="1280" alt="Screenshot 2020-05-26 at 08 30 16" src="https://user-images.githubusercontent.com/49142649/82867512-4b107000-9f2b-11ea-8dc2-5eaad0b7f6b6.png">
img 1 - After

<img width="1280" alt="Screenshot 2020-05-26 at 08 31 12" src="https://user-images.githubusercontent.com/49142649/82867513-4c419d00-9f2b-11ea-96df-2552cdf7cdc2.png"> 
img 2 - Before
