### PR TITLE
G2 2020 w22 #9673 added new "None"-option for group dropdowns

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -484,6 +484,7 @@ function renderCell(col, celldata, cellid) {
         }
 		str = "<div class='multiselect-group'><div class='group-select-box' onclick='showCheckboxes(this)'>";
 		str += "<div><div class='access-dropdown'><span>" + optstr + "</span><img class='sortingArrow' src='../Shared/icons/desc_black.svg'/></div></div><div class='overSelect'></div></div><div class='checkboxes' id='grp" + obj.uid + "' >";
+		str += "<label><input type='radio' name='groupradio"+obj.uid+"' checked id='g" + obj.uid + "' value='' />None</label>";
 		for (var i = 0; i < filez['groups'].length; i++) {
 			var group = filez['groups'][i];
 			if (tgroups.indexOf((group.groupkind + "_" + group.groupval)) > -1) {

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -767,6 +767,7 @@ function updateAndCloseGroupDropdown(checkboxes){
 			readStr += checkboxes.childNodes[i].childNodes[0].value.substr(3);
 		}
 	}
+	shouldReRender = true;
 	if (str != "") changeProperty(checkboxes.id.substr(3), "group", str);
 	// if user unpresses all checkboxes it the student will now belong to no group
 	else changeProperty(checkboxes.id.substr(3), "group", "None");

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -745,8 +745,8 @@ function updateAndCloseGroupDropdown(checkboxes){
 	var str = "", readStr = "<span>";
 	for (i = 0; i < checkboxes.childNodes.length; i++) {
 		if (checkboxes.childNodes[i].childNodes[0].checked) {
-			str += checkboxes.childNodes[i].childNodes[0].value + " ";
-			readStr += checkboxes.childNodes[i].childNodes[0].value.substr(3) + " ";
+			str += checkboxes.childNodes[i].childNodes[0].value;
+			readStr += checkboxes.childNodes[i].childNodes[0].value.substr(3);
 		}
 	}
 	if (str != "") changeProperty(checkboxes.id.substr(3), "group", str);


### PR DESCRIPTION
Solves #9673.

Added a new "None"-option for each group dropdown. Made a few small modifications to the updateAndCloseGroupDropdowns so it would handle the new option properly. The changes do not affect anything in a negative manner as they were originally implemented to handle multiple group assignments (this is no longer possible, a user can only belong to 1 or 0 groups at once) so they were obsolete anyway.

![image](https://user-images.githubusercontent.com/49141758/82877357-5ae38080-9f3a-11ea-8366-7637e8788307.png)
