### PR TITLE
Fixed incorrect naming of variable to retrieve username - G1-2020-W22-ISSUE#9676

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -602,7 +602,7 @@ function loadFileInformation() {
                     const splits = row.timestamp.split(' ', 2)
                     if(splits[0] >=  inputDateFrom.val() && splits[0] <= inputDateTo.val()){
                         files[file].push([
-                        row.userName,
+                        row.username,
                         action,
                         version,
                         file,


### PR DESCRIPTION
Unidentified username was caused by the variable for retrieving username being incorrectly spelled. 

Before:
![Screenshot 2020-05-26 at 10 43 27](https://user-images.githubusercontent.com/62876614/82879992-0fcb6c80-9f3e-11ea-94ac-d61afe17c25f.png)

After:
![Screenshot 2020-05-26 at 10 43 40](https://user-images.githubusercontent.com/62876614/82880003-13f78a00-9f3e-11ea-8a7b-c934039e8a00.png)
