### PR TITLE
Analytic: User information - Resulted and fileed information shown in user information 

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -831,6 +831,7 @@ function loadUserInformation(){
     .append('<option value="sectioned" selected>sectioned</option>')
 		.append('<option value="courseed">courseed</option>')
         .append('<option value="fileed">fileed</option>')
+        .append('<option value="resulted">resulted</option>')
 		.append('<option value="showDugga" selected>showDugga</option>')
 		.append('<option value="codeviewer">codeviewer</option>')
 		.append('<option value="events">events</option>')
@@ -1175,6 +1176,45 @@ function loadUserInformation(){
             updateState(users);
         });
     }
+ 
+//------------------------------------------------------------------------------------------------
+// Retrieves the data and makes the table for resulted
+//------------------------------------------------------------------------------------------------
+ 	function updateResultedInformation(){
+		hasCounter = true;
+        loadAnalytics("resultedInformation", function(data) {
+			var users = {};
+            $.each(data, function(i, row) {
+				var user = row.username;
+				var pageParts;
+				var pageLoad;
+
+				//Retrives the page 
+				if(row.refer.includes("/DuggaSys/")){
+					pageParts = row.refer.split("/DuggaSys/");
+					pageLoad = pageParts[1];
+
+					if(pageLoad.includes("?")){
+						pageParts = pageParts[1].split("?");
+						pageLoad = pageParts[0];
+					}
+				}
+
+                if (!users.hasOwnProperty(user)) {
+                    users[user] = [["Userid", "Username", "Event", "Timestamp"]];
+				}
+				if(pageLoad != undefined) {
+					users[user].push([
+						row.uid,
+						row.username,
+						pageLoad,
+						row.timestamp
+					]);
+				}
+            });
+            updateState(users);
+        });
+    }
 
    
     function updateState(users){
@@ -1237,10 +1277,10 @@ function loadUserInformation(){
 		} 
         selectPage.change(function(){
             switch(selectPage.val()){
-                /*case "resulted":
-					updateCourseedInformation();
+                case "resulted":
+					updateResultedInformation();
 					pageCount = "resulted.php";
-					break;*/
+					break;
                 case "sectioned":
 					updateSectionedInformation();
 					pageCount = "sectioned.php";

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -830,6 +830,7 @@ function loadUserInformation(){
 	var selectPage = $("<select></select>")
     .append('<option value="sectioned" selected>sectioned</option>')
 		.append('<option value="courseed">courseed</option>')
+        .append('<option value="fileed">fileed</option>')
 		.append('<option value="showDugga" selected>showDugga</option>')
 		.append('<option value="codeviewer">codeviewer</option>')
 		.append('<option value="events">events</option>')
@@ -1135,6 +1136,45 @@ function loadUserInformation(){
 			updateState(users);	
 		});
 	}
+ 
+//------------------------------------------------------------------------------------------------
+// Retrieves the data and makes the table for fileed
+//------------------------------------------------------------------------------------------------
+ 	function updateFileedInformation(){
+		hasCounter = true;
+        loadAnalytics("fileedInformation", function(data) {
+			var users = {};
+            $.each(data, function(i, row) {
+				var user = row.username;
+				var pageParts;
+				var pageLoad;
+
+				//Retrives the page 
+				if(row.refer.includes("/DuggaSys/")){
+					pageParts = row.refer.split("/DuggaSys/");
+					pageLoad = pageParts[1];
+
+					if(pageLoad.includes("?")){
+						pageParts = pageParts[1].split("?");
+						pageLoad = pageParts[0];
+					}
+				}
+
+                if (!users.hasOwnProperty(user)) {
+                    users[user] = [["Userid", "Username", "Event", "Timestamp"]];
+				}
+				if(pageLoad != undefined) {
+					users[user].push([
+						row.uid,
+						row.username,
+						pageLoad,
+						row.timestamp
+					]);
+				}
+            });
+            updateState(users);
+        });
+    }
 
    
     function updateState(users){
@@ -1197,6 +1237,10 @@ function loadUserInformation(){
 		} 
         selectPage.change(function(){
             switch(selectPage.val()){
+                /*case "resulted":
+					updateCourseedInformation();
+					pageCount = "resulted.php";
+					break;*/
                 case "sectioned":
 					updateSectionedInformation();
 					pageCount = "sectioned.php";
@@ -1204,6 +1248,10 @@ function loadUserInformation(){
                 case "courseed":
 					updateCourseedInformation();
 					pageCount = "courseed.php";
+					break;
+                case "fileed":
+					updateFileedInformation();
+					pageCount = "fileed.php";
 					break;
 				case "showDugga":
 					updateDuggaInformation();
@@ -1219,10 +1267,10 @@ function loadUserInformation(){
 				case "fileEvents":
 					updatefileEvents();
 					break;
-        case "course":
-          updateCourseInformation();
-          break;
-        case "loginFail":
+                case "course":
+                    updateCourseInformation();
+                    break;
+                case "loginFail":
 					updateloginFail();
 					break;
             }

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -84,6 +84,9 @@ if (isset($_SESSION['uid']) && checklogin() && isSuperUser($_SESSION['uid'])) {
             case 'fileedInformation':
                 fileedInformation($pdo);
                 break;
+            case 'resultedInformation':
+                resultedInformation($pdo);
+                break;
 		}
 	} else {
 		echo 'N/A';
@@ -848,7 +851,6 @@ function courseedInformation($pdo){
 //------------------------------------------------------------------------------------------------
 // Retrieves fileed log information      
 //------------------------------------------------------------------------------------------------
- 
 function fileedInformation($pdo){
 	$query = $pdo->prepare("SELECT username, uid FROM user");
 	if(!$query->execute()) {
@@ -873,6 +875,46 @@ function fileedInformation($pdo){
 		   timestamp 
 	   FROM userHistory
 	   WHERE refer LIKE "%fileed%"
+	   ORDER BY timestamp;
+   ')->fetchAll(PDO::FETCH_ASSOC);
+
+	foreach($result as $value) {
+		$key = array_search($value['uid'], array_column($users, 'uid'));
+		if($key === TRUE) { 
+			unset($users[$key]);
+		} 
+	}
+
+    echo json_encode(array_merge($users,$result));
+}
+
+//------------------------------------------------------------------------------------------------
+// Retrieves resulted log information      
+//------------------------------------------------------------------------------------------------
+function resultedInformation($pdo){
+	$query = $pdo->prepare("SELECT username, uid FROM user");
+	if(!$query->execute()) {
+	} else {
+		$rows = $query->fetchAll(PDO::FETCH_ASSOC);
+		$users = [];
+		foreach($rows as $key => $value) {
+			$users[$key] =  [	
+								"uid" 			=>	$value['uid'],
+								"username"		=>	$value['username'],								
+								"refer"		=>	"",
+								"timestamp"	=>	""
+							];
+		}
+	}
+
+    $result = $GLOBALS['log_db']->query('
+       SELECT
+		   userid AS uid,
+		   username,
+		   refer,
+		   timestamp 
+	   FROM userHistory
+	   WHERE refer LIKE "%resulted%"
 	   ORDER BY timestamp;
    ')->fetchAll(PDO::FETCH_ASSOC);
 

--- a/DuggaSys/analyticService.php
+++ b/DuggaSys/analyticService.php
@@ -81,6 +81,9 @@ if (isset($_SESSION['uid']) && checklogin() && isSuperUser($_SESSION['uid'])) {
 			case 'courseInformation':
                 courseInformation($pdo);
                 break;
+            case 'fileedInformation':
+                fileedInformation($pdo);
+                break;
 		}
 	} else {
 		echo 'N/A';
@@ -829,6 +832,47 @@ function courseedInformation($pdo){
 		   timestamp 
 	   FROM userHistory
 	   WHERE refer LIKE "%courseed%"
+	   ORDER BY timestamp;
+   ')->fetchAll(PDO::FETCH_ASSOC);
+
+	foreach($result as $value) {
+		$key = array_search($value['uid'], array_column($users, 'uid'));
+		if($key === TRUE) { 
+			unset($users[$key]);
+		} 
+	}
+
+    echo json_encode(array_merge($users,$result));
+}
+
+//------------------------------------------------------------------------------------------------
+// Retrieves fileed log information      
+//------------------------------------------------------------------------------------------------
+ 
+function fileedInformation($pdo){
+	$query = $pdo->prepare("SELECT username, uid FROM user");
+	if(!$query->execute()) {
+	} else {
+		$rows = $query->fetchAll(PDO::FETCH_ASSOC);
+		$users = [];
+		foreach($rows as $key => $value) {
+			$users[$key] =  [	
+								"uid" 			=>	$value['uid'],
+								"username"		=>	$value['username'],								
+								"refer"		=>	"",
+								"timestamp"	=>	""
+							];
+		}
+	}
+
+    $result = $GLOBALS['log_db']->query('
+       SELECT
+		   userid AS uid,
+		   username,
+		   refer,
+		   timestamp 
+	   FROM userHistory
+	   WHERE refer LIKE "%fileed%"
 	   ORDER BY timestamp;
    ')->fetchAll(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
Information from resulted.php and fileed.php  with number of hits, userId, username and timestamp is now shown on the "user information" page. 

Maybe there is more information to show, but for now its like this.

resulted:
![image](https://user-images.githubusercontent.com/49142935/82884464-0ba24d80-9f44-11ea-978c-b90c80acff96.png)

fileed:
![image](https://user-images.githubusercontent.com/49142935/82884501-1826a600-9f44-11ea-99b4-586d2c6e89e9.png)
