### PR TITLE
Corrected the timestamp displayed for files in File Information tab - G1-2020-W22-ISSUE#9682

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -598,15 +598,17 @@ function loadFileInformation() {
  
                     if (!files.hasOwnProperty(file)) {
                         files[file] = [["Username", "Action", "Version", "File", "Timestamp"]];
-                    }
-                    const splits = row.timestamp.split(' ', 2)
+					}
+					
+					const splits = row.timestamp.split(' ', 2)
+					timestamp = new Date(row.timestamp.replace(' ', 'T') + "Z").toLocaleString();
                     if(splits[0] >=  inputDateFrom.val() && splits[0] <= inputDateTo.val()){
                         files[file].push([
                         row.userName,
                         action,
                         version,
                         file,
-                        row.timestamp
+                        timestamp
                     ]);     
                     }
                 });


### PR DESCRIPTION
Now files edited or created shows the correct timestamp. 

Before:
![Screenshot 2020-05-26 at 11 43 27](https://user-images.githubusercontent.com/62876614/82886621-14e0e980-9f47-11ea-93f9-5ae670748a8b.png)

After:
![Screenshot 2020-05-26 at 11 44 04](https://user-images.githubusercontent.com/62876614/82886633-18747080-9f47-11ea-8131-583e93baae26.png)
