### PR TITLE
Fixes #9668 - Guidelines now stays at the ruler value when moving and zooming

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6431,7 +6431,7 @@ function initGuidelines() {
     if(tempGuidelines !== null) {
         tempGuidelines = JSON.parse(tempGuidelines);
         for(let i = 0; i < tempGuidelines.length; i++) {
-            guidelines[i] = new Guideline(tempGuidelines[i].axis, tempGuidelines[i].position, tempGuidelines[i].isLocked);
+            guidelines[i] = new Guideline(tempGuidelines[i].axis, tempGuidelines[i].position, tempGuidelines[i].isLocked, true);
         }
     }
 }
@@ -6492,11 +6492,12 @@ function updateGuidelines() {
 }
 
 class Guideline {
-    constructor(axis, position, isLocked = false) {
+    constructor(axis, position, isLocked = false, isRecreated = false) {
         this.axis = axis;
         this.position = position;
         this.moveStartPosition = 0;
         this.isLocked = isLocked;
+        this.isRecreated = isRecreated;
         this.container = document.getElementById("diagram-guideline-container");
         this.element = null;
 
@@ -6516,16 +6517,20 @@ class Guideline {
 
         if(this.axis === 'x') {
             this.element.classList.add("guideline-x");
-            if(this.position === undefined) {
-                this.position = this.container.clientHeight / 2;
+            if(!this.isRecreated) {
+                if(this.position === undefined) {
+                    this.position = this.container.clientHeight / 2;
+                }
+                this.position = canvasToPixels(0, this.position).y;
             }
-            this.position = canvasToPixels(0, this.position).y;
         } else if(this.axis === 'y') {
             this.element.classList.add("guideline-y");
-            if(this.position === undefined) {
-                this.position = this.container.clientWidth / 2;
+            if(!this.isRecreated) {
+                if(this.position === undefined) {
+                    this.position = this.container.clientWidth / 2;
+                }
+                this.position = canvasToPixels(this.position, 0).x;
             }
-            this.position = canvasToPixels(this.position, 0).x;
         }
 
         if(this.isLocked) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6517,13 +6517,15 @@ class Guideline {
         if(this.axis === 'x') {
             this.element.classList.add("guideline-x");
             if(this.position === undefined) {
-                this.position = canvasToPixels(0, this.container.clientHeight / 2).y;
+                this.position = this.container.clientHeight / 2;
             }
+            this.position = canvasToPixels(0, this.position).y;
         } else if(this.axis === 'y') {
             this.element.classList.add("guideline-y");
             if(this.position === undefined) {
-                this.position = canvasToPixels(this.container.clientWidth / 2, 0).x;
+                this.position = this.container.clientWidth / 2;
             }
+            this.position = canvasToPixels(this.position, 0).x;
         }
 
         if(this.isLocked) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2649,6 +2649,7 @@ function clearCanvas() {
     for (var i = 0; i < points.length;) {
         points.pop();
     }
+    selected_objects = [];
     resetSerialNumbers();
     updateGraphics();
 }
@@ -6400,7 +6401,7 @@ function initRulers() {
     function mouseUpHandler() {
         mouseDownRulerX = false;
         mouseDownRulerY = false;
-        document.body.classList.add("noselect");
+        document.body.classList.remove("noselect");
         document.removeEventListener("mouseup", mouseUpHandler);
     }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6242,6 +6242,7 @@ function createRulers() {
     createRuler(document.querySelector("#ruler-x .ruler-lines"), canvas.width, origoOffsetX, "marginLeft");
     createRuler(document.querySelector("#ruler-y .ruler-lines"), canvas.height, origoOffsetY, "marginTop");
     createRulerLinesObjectPoints();
+    updateGuidelines();
 }
 
 //------------------------------------------------------------------------------
@@ -6482,6 +6483,14 @@ function lockOrUnlockGuidelines(isLocked = true) {
     saveGuidelinesToLocalStorage();
 }
 
+//----------------------------------------------------------
+// updateGuidelines: Updates the position of all guidelines.
+//----------------------------------------------------------
+
+function updateGuidelines() {
+    guidelines.forEach(guideline => guideline.update());
+}
+
 class Guideline {
     constructor(axis, position, isLocked = false) {
         this.axis = axis;
@@ -6530,6 +6539,16 @@ class Guideline {
         this.element.addEventListener("mouseover", this.mouseOverHandler);
         this.element.addEventListener("mouseleave", this.mouseLeaveHandler);
         this.element.addEventListener("mousedown", this.mouseDownHandler);
+    }
+
+    update() {
+        const position = pixelsToCanvas(this.position, this.position);
+
+        if(this.axis === 'x') {
+            this.element.style.top = `${position.y}px`;
+        } else if(this.axis === 'y') {
+            this.element.style.left = `${position.x}px`;
+        }
     }
 
     mouseOver() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6517,12 +6517,12 @@ class Guideline {
         if(this.axis === 'x') {
             this.element.classList.add("guideline-x");
             if(this.position === undefined) {
-                this.position = this.container.clientHeight / 2;
+                this.position = canvasToPixels(0, this.container.clientHeight / 2).y;
             }
         } else if(this.axis === 'y') {
             this.element.classList.add("guideline-y");
             if(this.position === undefined) {
-                this.position = this.container.clientWidth / 2;
+                this.position = canvasToPixels(this.container.clientWidth / 2, 0).x;
             }
         }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6519,13 +6519,11 @@ class Guideline {
             if(this.position === undefined) {
                 this.position = this.container.clientHeight / 2;
             }
-            this.element.style.top = `${this.position}px`;
         } else if(this.axis === 'y') {
             this.element.classList.add("guideline-y");
             if(this.position === undefined) {
                 this.position = this.container.clientWidth / 2;
             }
-            this.element.style.left = `${this.position}px`;
         }
 
         if(this.isLocked) {
@@ -6533,6 +6531,8 @@ class Guideline {
         } else {
             this.unlock();
         }
+
+        this.update();
 
         this.container.appendChild(this.element);
 
@@ -6592,15 +6592,15 @@ class Guideline {
     mouseMove(e) {
         if(this.element.classList.contains("moving")) {
             if(this.axis === 'x') {
-                const movePosition = this.moveStartPosition - e.clientY;
+                const movePosition = this.element.offsetTop - (this.moveStartPosition - e.clientY);
                 this.moveStartPosition = e.clientY;
-                this.position = this.element.offsetTop - movePosition;
-                this.element.style.top = `${this.position}px`;
+                this.element.style.top = `${movePosition}px`;
+                this.position = canvasToPixels(0, movePosition).y;
             } else if(this.axis === 'y') {
-                const movePosition = this.moveStartPosition - e.clientX;
+                const movePosition = this.element.offsetLeft - (this.moveStartPosition - e.clientX);
                 this.moveStartPosition = e.clientX;
-                this.position = this.element.offsetLeft - movePosition;
-                this.element.style.left = `${this.position}px`;
+                this.element.style.left = `${movePosition}px`;
+                this.position = canvasToPixels(movePosition, 0).x;
             }
         }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6563,7 +6563,7 @@ class Guideline {
 
         if(md !== mouseState.empty) {
             this.lock();
-            this.container.parentElement.parentElement.classList.add("noselect");
+            document.body.classList.add("noselect");
             return;
         }
         
@@ -6576,13 +6576,13 @@ class Guideline {
 
     mouseLeave() {
         this.unlock();
-        this.container.parentElement.parentElement.classList.remove("noselect");
+        document.body.classList.add("noselect");
     }
 
     mouseDown(e) {
         this.element.classList.add("moving");
         this.container.style.pointerEvents = "all";
-        this.container.parentElement.parentElement.classList.add("noselect")
+        document.body.classList.add("noselect");
 
         if(this.axis === 'x') {
             this.moveStartPosition = e.clientY;
@@ -6616,7 +6616,7 @@ class Guideline {
         this.element.classList.remove("moving");
         this.container.style.pointerEvents = "none";
         this.container.style.cursor = "default";
-        this.container.parentElement.parentElement.classList.remove("noselect");
+        document.body.classList.add("noselect");
 
         if(this.axis === 'x') {
             if(this.element.offsetTop < 0 || this.element.offsetTop > this.container.offsetHeight) {


### PR DESCRIPTION
The guidelines were always stuck at the same position before. Now they are moved together with the ruler value they were positioned at. This should work when zooming and moving the camera. It should also work to refresh the page and the guidelines should be correctly positioned.