### PR TITLE
G3 2020#9594 fixed error in fileed when using mobile search-bar.

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -57,9 +57,9 @@ $codeLinkQuery->execute();
 					</div>
 					<span>?</span>
 				</div>
-            <input id='searchinputMobile' type='text' name='search' placeholder='Search..' onkeyup='searchterm=document.getElementById("searchinputMobile").value;searchKeyUp(event);fileLink.reRender();document.getElementById("searchinput").value=document.getElementById("searchinputMobile").value;'/>
+            <input id='searchinputMobile' type='text' name='search' placeholder='Search..' onkeyup='searchterm=document.getElementById("searchinputMobile").value;searchKeyUp(event);myTable.reRender();document.getElementById("searchinput").value=document.getElementById("searchinputMobile").value;'/>
 
-            <button id='searchbuttonMobile' class='switchContent' onclick='searchterm=document.getElementById("searchinputMobile").value;searchKeyUp(event);fileLink.reRender();' type='button'>
+            <button id='searchbuttonMobile' class='switchContent' onclick='searchterm=document.getElementById("searchinputMobile").value;searchKeyUp(event);myTable.reRender();' type='button'>
                 <img id='lookingGlassSVG' style='height:18px;' src='../Shared/icons/LookingGlass.svg'/>
             </button>
         </div>


### PR DESCRIPTION
The search function didn't work as intened in fileed in mobile-view below 530px when using the mobile search-bar. We got this error:
![image](https://user-images.githubusercontent.com/49142617/82897165-7f018a80-9f57-11ea-815c-7517b30fbf4b.png)

This is now fixed and you no longer get an error and the search-function works correctly.