### PR TITLE
Time is now correct in courseed section of User Information

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -929,7 +929,7 @@ function loadUserInformation(){
 						row.uid,
 						row.username,
 						pageLoad,
-						row.timestamp
+						new Date(row.timestamp.replace(' ', 'T') + "Z").toLocaleString()
 					]);
 				}
             });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49142833/82899341-17e5d500-9f5b-11ea-8794-96ad3e9cba6a.png)

The timestamps are no longer off by 2 hours.