### PR TITLE
fix issue#9684 red outline glitch

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2335,6 +2335,7 @@ function updateGraphics() {
     diagram.updateQuadrants();
     drawGrid();
     drawOrigoLine();
+    drawVirtualPaper();
     if(developerModeActive) drawOrigo();
 
     // Mark the last freedraw point on mobiles
@@ -2345,7 +2346,6 @@ function updateGraphics() {
     diagram.updateQuadrants();
     diagram.draw();
     points.drawPoints();
-    drawVirtualPaper();
     if(developerModeActive) drawCrosshair();
 }
 


### PR DESCRIPTION
Before fix the objects that were positioned on the virtual paper's line were inconsitent. Sometimes they would get a red outline, sometimes they wouldn't. Also objects that weren't positioned on the virtual paper's line would sometimes get a red outline. This was especially noticeable when zooming. 

After fix this shoud not be a problem anymore. The red outline on objects should only appear when they are positioned on the virtual paper's line. 

**Test this:** Enable Display Virtual paper, create a couple of objects and place some of them on the papers line and some of them next to the line. Only the objects that are placed on the line should have a red outline. Try to zoom in and out and make sure the colors stay correct and consistent with the positioning of the objects. 

**Link to test:** http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%239684/DuggaSys/diagram.php

**Before:**

![1770046b45582655c2af5d76d64d1397](https://user-images.githubusercontent.com/49142301/82906005-e70a9d80-9f64-11ea-9c73-d98f7b3f9872.gif)


**After:**

![de7494b5387e9604d3ccf3e6177e2e91](https://user-images.githubusercontent.com/49142301/82906086-05709900-9f65-11ea-96da-d4949cb044cb.gif)
