### PR TITLE
Updated counter and page load behaviour on user change. Issue #9688

### DIFF
--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -1219,7 +1219,7 @@ function loadUserInformation(){
         });
     }
 
-   
+	var currentPage;
     function updateState(users){
         $('#analytic-info > select.file-select').remove();
         var userSelect = $('<select class="file-select"></select>');
@@ -1269,7 +1269,9 @@ function loadUserInformation(){
 				localStorage.setItem('analyticsLastUser', $(this).val());
 			} catch(err) { }
 
-			selectPage.change();
+			if(currentPage != "events" && currentPage != "fileEvents"){
+				selectPage.change();	
+			}
 		});
         $('#analytic-info').append(userSelect);
 		userSelect.change();
@@ -1281,6 +1283,7 @@ function loadUserInformation(){
 			firstLoad = false;
 		} 
         selectPage.change(function(){
+			currentPage = selectPage.val();
             switch(selectPage.val()){
                 case "resulted":
 					updateResultedInformation();
@@ -1318,7 +1321,7 @@ function loadUserInformation(){
                 case "loginFail":
 					updateloginFail();
 					break;
-            }
+			}
         });
     }
  

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -1237,7 +1237,7 @@ function loadUserInformation(){
         userSelect.change(function() {
 			deleteTable();
 			$('#analytic-info').append(selectPage);
-			
+
 			var events = [];
 			if(users[$(this).val()][0][5] == "EventDescription") {
 				for(var i = 1; i < users[$(this).val()].length; i++) {
@@ -1268,6 +1268,7 @@ function loadUserInformation(){
 				localStorage.setItem('analyticsLastUser', $(this).val());
 			} catch(err) { }
 
+			selectPage.change();
 		});
         $('#analytic-info').append(userSelect);
 		userSelect.change();

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -1235,6 +1235,7 @@ function loadUserInformation(){
         }
 		
         userSelect.change(function() {
+			$('#counter').remove();
 			deleteTable();
 			$('#analytic-info').append(selectPage);
 
@@ -1568,7 +1569,7 @@ function renderTable(data) {
 
 function updateCounter(count, user, page)
 {
-	$('#analytic-info').append("<p>" + page + " has been loaded " + count + " times by " + user + "! </p>");
+	$('#analytic-info').append("<p id ='counter'>" + page + " has been loaded " + count + " times by " + user + "! </p>");
 	hasCounter = false;
 }
 

--- a/DuggaSys/analytic.js
+++ b/DuggaSys/analytic.js
@@ -1269,7 +1269,7 @@ function loadUserInformation(){
 				localStorage.setItem('analyticsLastUser', $(this).val());
 			} catch(err) { }
 
-			if(currentPage != "events" && currentPage != "fileEvents"){
+			if(currentPage != "events" && currentPage != "fileEvents" && currentPage != "loginFail"){
 				selectPage.change();	
 			}
 		});


### PR DESCRIPTION
![ezgif-7-40e080997c31](https://user-images.githubusercontent.com/49142833/82907005-59c84880-9f66-11ea-99ec-a9e6ca9a211c.gif)

The information table now always updates on user change.

The counter is now removed on user change and reappears after the table update has been made (displayed in the gif above). This prevents those weird positioning issues with the dropdown lists for users and pages. 

Test by changing user while having selected a page (such as courseed) in the User Information section of Analytic.