### PR TITLE
Fixes #6888 - Sub-collapsible for styling

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5578,9 +5578,15 @@ function showFormGroups(typesToShow) {
     initAppearanceForm();
 
     collapsibleStructure.forEach((object, i) => {
-        const normalGroups = object.groups.filter(group => typeof group.dataset.advanced === "undefined");
         const advancedGroups = object.groups.filter(group => typeof group.dataset.advanced !== "undefined");
-        createCollapsible(normalGroups, object.types, i, advancedGroups);
+
+        //Create normal collapsible with no sub-collapsibles if there are only advanced properties or no advanced properties.
+        if(object.groups.length - advancedGroups.length === 0 || advancedGroups.length === 0) {
+            createCollapsible(object.groups, object.types, i);
+        } else {
+            const normalGroups = object.groups.filter(group => typeof group.dataset.advanced === "undefined");
+            createCollapsible(normalGroups, object.types, i, advancedGroups);
+        }
     });
 
     //Always put submit-button in the end of the form

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5317,14 +5317,15 @@ const symbolTypeMap = {
     "4": "ER line",
     "5": "Relation",
     "6": "Text",
-    "7": "UML line"
+    "7": "UML line",
+    "8": "Advanced"
 }
 
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 // createCollapsible: Creates a collapsible element containing the form-groups passed. Types is an array used to concatenate the title from. Index is used to to open the first created collapsible.
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-function createCollapsible(formGroups, types, index) {
+function createCollapsible(formGroups, types, index, subCollapsibleGroups = [], appendTo = document.getElementById("appearanceForm")) {
     const collapsibleElement = document.createElement("div");
     const objectTypesElement = document.createElement("div");
     const iconContainer = document.createElement("div");
@@ -5358,7 +5359,11 @@ function createCollapsible(formGroups, types, index) {
 
     formGroups.forEach(group => formGroupContainer.appendChild(group));
 
-    document.getElementById("appearanceForm").appendChild(collapsibleElement);
+    appendTo.appendChild(collapsibleElement);
+
+    if(subCollapsibleGroups.length > 0) {
+        createCollapsible(subCollapsibleGroups, [8], -1, [], collapsibleElement);
+    }
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -5571,7 +5576,12 @@ function showFormGroups(typesToShow) {
     const collapsibleStructure = getCollapsibleStructure(formGroupsToShow, typesToShow);
 
     initAppearanceForm();
-    collapsibleStructure.forEach((object, i) => createCollapsible(object.groups, object.types, i));
+
+    collapsibleStructure.forEach((object, i) => {
+        const normalGroups = object.groups.filter(group => typeof group.dataset.advanced === "undefined");
+        const advancedGroups = object.groups.filter(group => typeof group.dataset.advanced !== "undefined");
+        createCollapsible(normalGroups, object.types, i, advancedGroups);
+    });
 
     //Always put submit-button in the end of the form
     document.getElementById("appearanceForm").appendChild(document.getElementById("appearanceButtonContainer"));

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -642,7 +642,7 @@
                         <label for="objectLayer">Write to layer:</label>
                         <select id="objectLayer" data-access="properties.setLayer"></select>
                     </div>
-                    <div class="form-group" data-types="6" data-advanced>
+                    <div class="form-group" data-types="6">
                         <label for="textAlignment">Text alignment:</label>
                         <select id="textAlignment" data-access="properties.textAlign">
                             <option value="start">Left</option>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -610,7 +610,7 @@
                             <option value="Composition">Composition</option>
                         </select>
                     </div>
-                    <div class="form-group" data-types="2,3,5">
+                    <div class="form-group" data-types="2,3,5" data-advanced>
                         <label for="backgroundColor">Background color:</label>
                         <select id="backgroundColor" data-access="properties.fillColor"><?=$colors;?></select>
                     </div>
@@ -622,19 +622,19 @@
                         <label for="freeText">Text:</label>
                         <textarea id="freeText" data-access="textLines"></textarea>
                     </div>
-                    <div class="form-group" data-types="2,3,5,6">
+                    <div class="form-group" data-types="2,3,5,6" data-advanced>
                         <label for="fontFamily">Font family:</label>
                         <select id="fontFamily" data-access="properties.font"><?=$fonts?></select>
                     </div>
-                    <div class="form-group" data-types="2,3,5,6">
+                    <div class="form-group" data-types="2,3,5,6" data-advanced>
                         <label for="fontColor">Font color:</label>
                         <select id="fontColor" data-access="properties.fontColor"><?=$colors;?></select>
                     </div>
-                    <div class="form-group" data-types="2,3,5,6">
+                    <div class="form-group" data-types="2,3,5,6" data-advanced>
                         <label for="textSize">Text size:</label>
                         <select id="textSize" data-access="properties.sizeOftext"><?=$textSizes;?></select>
                     </div>
-                    <div class="form-group" data-types="2,3,5,0">
+                    <div class="form-group" data-types="2,3,5,0" data-advanced>
                         <label for="lineColor">Line color:</label>
                         <select id="lineColor" data-access="properties.strokeColor"><?=$colors;?></select>
                     </div>
@@ -642,7 +642,7 @@
                         <label for="objectLayer">Write to layer:</label>
                         <select id="objectLayer" data-access="properties.setLayer"></select>
                     </div>
-                    <div class="form-group" data-types="6">
+                    <div class="form-group" data-types="6" data-advanced>
                         <label for="textAlignment">Text alignment:</label>
                         <select id="textAlignment" data-access="properties.textAlign">
                             <option value="start">Left</option>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5416,7 +5416,7 @@ only screen and (max-device-width: 320px) {
   align-items: center;
 }
 
-.collapsible .object-types .square {
+.collapsible > .object-types > .square {
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -5428,21 +5428,23 @@ only screen and (max-device-width: 320px) {
   cursor: pointer;
 }
 
-.collapsible .object-types .square div {
+.collapsible > .object-types > .square div {
   width: 80%;
   height: 80%;
   content:url("../icons/Minus.svg");
 }
 
-.collapsible.closed .object-types .square div {
+.collapsible.closed > .object-types > .square div {
   content:url("../icons/Plus.svg");
 }
 
-.collapsible .form-groups {
+.collapsible > .form-groups,
+.collapsible > .collapsible {
   display: block;
 }
 
-.collapsible.closed .form-groups {
+.collapsible.closed > .form-groups,
+.collapsible.closed > .collapsible {
   display: none;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5426,6 +5426,7 @@ only screen and (max-device-width: 320px) {
   justify-content: center;
   align-items: center;
   cursor: pointer;
+  flex-shrink: 0;
 }
 
 .collapsible > .object-types > .square div {


### PR DESCRIPTION
According to issue #6888 local styling appearance should be removed from from double-clicking to not encourage random colors and styling on objects. 

I did not think it was a good idea to separate the styling options in the appearance menu from the double click appearance menu functionality. It would in my opinion require too many steps to select an item and navigate to the menu-item for advanced settings. I think everything should be accessible from the normal appearance menu.

To not encourage styling on the objects, sub collapsibles will now be generated for these advanced settings. The sub collapsible will only be created if the main collapsible will not only contain advanced properties (can happen when selecting many different objects at the same time as the form groups are divided to many different collapsibles). It would be unnecessary to have empty main collapsibles containing a sub-collapsible for the advanced properties, therefor this exception.

Right now, the 5 basic stylings can possibly appear in an advanced sub-collapsible. New form groups can easily get this functionality by adding the HTML-attribute data-advanced to the form group.

Test the appearance menu. Test to open the appearance menu for single objects and also for many objects at the same time. Test so the advanced collapsible works. It should only appear when a main collapsible is opened and there should not be an advanced collapsible if all form groups in the main collapsible are advanced.

Link: http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%236888/DuggaSys/diagram.php