### PR TITLE
Fixed styling

### DIFF
--- a/DuggaSys/templates/clipping_masking_dugga.html
+++ b/DuggaSys/templates/clipping_masking_dugga.html
@@ -62,7 +62,7 @@
             
                 <input id="addOpButton" class='submit-button' type='button' value='Add Op.' onclick="newbutton();" />
             </div>
-    		<div id="opTableContainer" style="min-height:300px;background-color:#FFF; overflow-y:scroll;">
+    		<div id="opTableContainer">
                 <table id="opTable" style="width:100%;">
                     <caption>Operations</caption>
                     <thead>

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -707,6 +707,14 @@ svg text {
 	flex-wrap: wrap; 
 	justify-content: center;
 }
+#toolbox, #drawingarea, #clippingInfoBox2{
+	height: 462px;
+}
+#opTableContainer{
+	height:390px;
+	background-color:#FFF; 
+	overflow-y:scroll;
+}
 #clippingInfoBox {
 	min-width:170px;
 	width:395px;


### PR DESCRIPTION
Fixed styling on #toolbox, #drawingarea, #clippingInfoBox2 and moved inline styling to dugga.css.

<img width="1280" alt="Screenshot 2020-05-27 at 09 21 25" src="https://user-images.githubusercontent.com/49142649/82989752-7498cc80-9ffb-11ea-9c16-599e6785cead.png">