### PR TITLE
G2 2020 w22 #9735 

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -478,7 +478,7 @@ function renderCell(col, celldata, cellid) {
 		if (parseFloat(obj.recent) < 1440) {
 			str = "<div class='submit-button' style='display:block;margin:auto;float:none;'";
 		} else {
-			str = "<div class='submit-button' id='reset-pw' style='display:block;margin:auto;float:none;'";
+			str = "<div class='submit-button reset-pw' style='display:block;margin:auto;float:none;'";
 		}
 		str += " onclick='if(confirm(\"Reset password for " + obj.username + "?\")) ";
 		str += "resetPw(\"" + obj.uid + "\",\"" + obj.username + "\"); return false;'>";

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -476,7 +476,7 @@ function renderCell(col, celldata, cellid) {
 	} else if (col == "requestedpasswordchange") {
 		
 		if (parseFloat(obj.recent) < 1440) {
-			str = "<div class='submit-button new-user' style='display:block;margin:auto;float:none;'";
+			str = "<div class='submit-button reset-pw new-user' style='display:block;margin:auto;float:none;'";
 		} else {
 			str = "<div class='submit-button reset-pw' style='display:block;margin:auto;float:none;'";
 		}

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -476,7 +476,7 @@ function renderCell(col, celldata, cellid) {
 	} else if (col == "requestedpasswordchange") {
 		
 		if (parseFloat(obj.recent) < 1440) {
-			str = "<div class='submit-button' style='display:block;margin:auto;float:none;'";
+			str = "<div class='submit-button new-user' style='display:block;margin:auto;float:none;'";
 		} else {
 			str = "<div class='submit-button reset-pw' style='display:block;margin:auto;float:none;'";
 		}

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3116,13 +3116,13 @@ padding: 10px;
 .access-dropdown-selected {
   background-color:var(--color-accent);
 }
-#reset-pw{
+div.reset-pw{
   width:70%; 
   margin-left:20px;
   background-color: var(--color-accent);
   color: var(--color-text-primary);
 }
-#reset-pw:hover{
+div.reset-pw:hover{
   background-color: var(--color-accent-hover);
   transition: 0.2s;
   filter: brightness(1.05);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2225,14 +2225,14 @@ input.submit-button.resetpw-button {
   margin: auto;
   display: block;
 }
-input.submit-button.new-user {
+div.submit-button.new-user {
   background-color: var(--color-new-user);
   color: var(--color-primary);
   float: none;
   margin: auto;
   display: block;
 }
-input.submit-button.new-user:hover {
+div.submit-button.new-user:hover {
     background-color: var(--color-new-user-hover);
 }
 


### PR DESCRIPTION
Solves #9735. 

reset-pw is now a class instead of an id.

new-user class should now be applied to new users (but it's a bit unclear how to create/add new users at the moment, something seems to have broken at some point). The styling is applied properly, at least (can be tested by manually adding the class new-user to one of the buttons in Developer Tools).