### PR TITLE
Fixes #9733 - Global appearance menu structure

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5372,7 +5372,7 @@ function createCollapsible(formGroups, types, index, subCollapsibleGroups = [], 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 
 function loadGlobalAppearanceForm() {
-    showFormGroups([-1]);
+    showFormGroups([-1], true);
     globalappearanceMenuOpen = true;
     toggleApperanceElement(true);
     document.getElementById("lineThicknessGlobal").value = settings.properties.lineWidth;
@@ -5563,7 +5563,7 @@ function setErCardinalityElementDisplayStatus(object) {
 // showFormGroups: Resets the form to the state before previous creation to remove old collapsibles. Shows all form groups having the type in the passed array and groups them into new collapsibles.
 //---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-function showFormGroups(typesToShow) {
+function showFormGroups(typesToShow, isGlobal = false) {
     const form = document.getElementById("appearanceForm");
 
     //Replace appearance form with original to keep structure after collapsible addition changes it
@@ -5575,7 +5575,12 @@ function showFormGroups(typesToShow) {
     allformGroups.forEach(group => group.style.display = "none");
     formGroupsToShow.forEach(group => group.style.display = "block");
 
-    const collapsibleStructure = getCollapsibleStructure(formGroupsToShow, typesToShow);
+    const collapsibleStructure = null;
+    if(isGlobal) {
+        collapsibleStructure =  getCollapsibleStructure(formGroupsToShow, [0,1,2,3,4,5,6,7], "subtypes");
+    } else {
+        collapsibleStructure = getCollapsibleStructure(formGroupsToShow, typesToShow);
+    }
 
     initAppearanceForm();
 
@@ -5599,9 +5604,9 @@ function showFormGroups(typesToShow) {
 // getCollapsibleStructure: Generates an array of objects where each object represents a collapsible. Each object have information about which form-groups should be in the collapsible and which object types will be affected by the collapsible's content.
 //-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-function getCollapsibleStructure(formGroups, typesToShow) {
+function getCollapsibleStructure(formGroups, typesToShow, dataAttribute = "types") {
     return formGroups.reduce((result, group) => {
-        const groupTypes = group.dataset.types.split(",");
+        const groupTypes = group.dataset[dataAttribute].split(",");
         const types = groupTypes.filter(type => typesToShow.includes(parseInt(type)));
         const duplicateTypesIndex = result.findIndex(item => sameMembers(item.types, types));
         if(duplicateTypesIndex === -1) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5575,12 +5575,9 @@ function showFormGroups(typesToShow, isGlobal = false) {
     allformGroups.forEach(group => group.style.display = "none");
     formGroupsToShow.forEach(group => group.style.display = "block");
 
-    const collapsibleStructure = null;
-    if(isGlobal) {
-        collapsibleStructure =  getCollapsibleStructure(formGroupsToShow, [0,1,2,3,4,5,6,7], "subtypes");
-    } else {
-        collapsibleStructure = getCollapsibleStructure(formGroupsToShow, typesToShow);
-    }
+    const collapsibleStructure = (isGlobal) 
+                                    ? getCollapsibleStructure(formGroupsToShow, [0,1,2,3,4,5,6,7], "subtypes")
+                                    : getCollapsibleStructure(formGroupsToShow, typesToShow);
 
     initAppearanceForm();
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5242,8 +5242,7 @@ function toggleApperanceElement(show = false) {
         appearanceElement.style.display = "none";
 
         if(globalappearanceMenuOpen) {
-            //const diagram = localStorage.getItem("diagram" + diagramNumber);
-            //if (diagram != null) LoadImport(diagram);
+            Load();
         }
 
         appearanceMenuOpen = false;
@@ -5674,8 +5673,7 @@ function setGlobalSelections() {
 // setGlobalProperties: Used when the global appearance menu is submitted to set the global properties to the newly selected properties. Also updates each existing object in the diagram to the new properties.
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-function setGlobalProperties() {
-    const groups = getGroupsByTypes([-1]);
+function setGlobalProperties(groups) {
     groups.forEach(group => {
         const element = group.querySelector("select, input:not([type='submit'])");
         if(element !== null) {
@@ -5807,9 +5805,9 @@ function initAppearanceForm() {
         elements.forEach(element => {
             if(element.id.includes("Global")) {
                 if(element.tagName === "SELECT") {
-                    element.addEventListener("change", setGlobalProperties);
+                    element.addEventListener("change", () => setGlobalProperties([group]));
                 } else if(element.tagName === "INPUT") {
-                    element.addEventListener("input", setGlobalProperties);
+                    element.addEventListener("input", () => setGlobalProperties([group]));
                 }
             } else if(element.tagName === "INPUT" || element.tagName === "TEXTAREA") {
                 element.addEventListener("input", () => setSelectedObjectsProperties(element));
@@ -5850,7 +5848,7 @@ function getGroupsByTypes(typesToShow) {
 //----------------------------------------------------------------------------------------
 function submitAppearanceForm() {
     if(globalappearanceMenuOpen) {
-        setGlobalProperties();
+        setGlobalProperties(getGroupsByTypes([-1]));
     }
     SaveState();
     toggleApperanceElement();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5242,7 +5242,9 @@ function toggleApperanceElement(show = false) {
         appearanceElement.style.display = "none";
 
         if(globalappearanceMenuOpen) {
+            //Restore to previous state. Will revert if changes were made in global appearance but form not submitted (enter/button click)
             Load();
+            settings = JSON.parse(localStorage.getItem("Settings"));
         }
 
         appearanceMenuOpen = false;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5443,6 +5443,7 @@ function loadAppearanceForm() {
             document.getElementById("figureOpacity").value = object.opacity * 100;
             document.getElementById("fillColor").focus();
         }
+        document.getElementById("lineThickness").value = object.properties.lineWidth;
         setSelections(object);
     });
 }
@@ -5734,7 +5735,7 @@ function setSelectedObjectsProperties(element) {
                     object[access[0]] = getTextareaArray(element, textareaIndex);
                 }
                 textareaIndex++;
-            } else if(element.type === "range") {
+            } else if(element.id === "opacity") {
                 object[access[0]] = element.value / 100;
             } else if(access[0] === "cardinality") {
                 object[access[0]][access[1]] = element.value;

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -686,6 +686,10 @@
                         <label for="figureOpacity">Opacity:</label>
                         <input type="range" id="figureOpacity" data-access="opacity">
                     </div>
+                    <div class="form-group" data-types="0,1,2,3,4,5,7" data-advanced>
+                        <label for="lineThickness">Line thickness:</label>
+                        <input type="range" id="lineThickness" min="1" max="4" value="2" data-access="properties.lineWidth">
+                    </div>	
                     <div class="form-group" data-types="-1">
                         <label for="backgroundColorGlobal">Background color:</label>
                         <select id="backgroundColorGlobal" data-access="properties.fillColor"><?=$colors;?></select>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -690,27 +690,27 @@
                         <label for="lineThickness">Line thickness:</label>
                         <input type="range" id="lineThickness" min="1" max="4" value="2" data-access="properties.lineWidth">
                     </div>	
-                    <div class="form-group" data-types="-1">
+                    <div class="form-group" data-types="-1" data-subtypes="1,2,3,5">
                         <label for="backgroundColorGlobal">Background color:</label>
                         <select id="backgroundColorGlobal" data-access="properties.fillColor"><?=$colors;?></select>
                     </div>
-                    <div class="form-group" data-types="-1">
+                    <div class="form-group" data-types="-1" data-subtypes="1,2,3,5,6">
                         <label for="fontFamilyGlobal">Font family:</label>
                         <select id="fontFamilyGlobal" data-access="properties.font"><?=$fonts?></select>
                     </div>
-                    <div class="form-group" data-types="-1">
+                    <div class="form-group" data-types="-1" data-subtypes="1,2,3,5,6">
                         <label for="fontColorGlobal">Font color:</label>
                         <select id="fontColorGlobal" data-access="properties.fontColor"><?=$colors;?></select>
                     </div>
-                    <div class="form-group" data-types="-1">
+                    <div class="form-group" data-types="-1" data-subtypes="1,2,3,5,6">
                     <label for="textSizeGlobal">Text size:</label>
                     <select id="textSizeGlobal" data-access="properties.sizeOftext"><?=$textSizes;?></select>
                     </div>
-                    <div class="form-group" data-types="-1">
+                    <div class="form-group" data-types="-1" data-subtypes="0,1,2,3,4,5,7">
                         <label for="lineColorGlobal">Line color:</label>
                         <select id="lineColorGlobal" data-access="properties.strokeColor"><?=$colors;?></select>
                     </div>
-                    <div class="form-group" data-types="-1">
+                    <div class="form-group" data-types="-1" data-subtypes="0,1,2,3,4,5,7">
                         <label for="lineThicknessGlobal">Line thickness:</label>
                         <input type="range" id="lineThicknessGlobal" min="1" max="4" value="2" data-access="properties.lineWidth">
                     </div>	

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -610,7 +610,7 @@
                             <option value="Composition">Composition</option>
                         </select>
                     </div>
-                    <div class="form-group" data-types="2,3,5" data-advanced>
+                    <div class="form-group" data-types="1,2,3,5" data-advanced>
                         <label for="backgroundColor">Background color:</label>
                         <select id="backgroundColor" data-access="properties.fillColor"><?=$colors;?></select>
                     </div>
@@ -622,19 +622,19 @@
                         <label for="freeText">Text:</label>
                         <textarea id="freeText" data-access="textLines"></textarea>
                     </div>
-                    <div class="form-group" data-types="2,3,5,6" data-advanced>
+                    <div class="form-group" data-types="1,2,3,5,6" data-advanced>
                         <label for="fontFamily">Font family:</label>
                         <select id="fontFamily" data-access="properties.font"><?=$fonts?></select>
                     </div>
-                    <div class="form-group" data-types="2,3,5,6" data-advanced>
+                    <div class="form-group" data-types="1,2,3,5,6" data-advanced>
                         <label for="fontColor">Font color:</label>
                         <select id="fontColor" data-access="properties.fontColor"><?=$colors;?></select>
                     </div>
-                    <div class="form-group" data-types="2,3,5,6" data-advanced>
+                    <div class="form-group" data-types="1,2,3,5,6" data-advanced>
                         <label for="textSize">Text size:</label>
                         <select id="textSize" data-access="properties.sizeOftext"><?=$textSizes;?></select>
                     </div>
-                    <div class="form-group" data-types="2,3,5,0" data-advanced>
+                    <div class="form-group" data-types="1,2,3,4,5,7,0" data-advanced>
                         <label for="lineColor">Line color:</label>
                         <select id="lineColor" data-access="properties.strokeColor"><?=$colors;?></select>
                     </div>

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1411,13 +1411,10 @@ function Symbol(kindOfSymbol) {
     //---------------------------------------------------------------
     this.drawUML = function(x1, y1, x2, y2) {
         var midy = pixelsToCanvas(0, points[this.middleDivider].y).y;
-        this.properties['strokeColor'] = '#000000';
-        this.properties['fontColor'] = '#000000';
-        this.properties['lineWidth'] = 2;
         ctx.font = "bold " + parseInt(this.properties['textSize']) + "px Arial";
 
         // Clear Class Box
-        ctx.fillStyle = '#ffffff';
+        ctx.fillStyle = this.properties['fillColor'];
 		ctx.lineWidth = this.properties['lineWidth'] * diagram.getZoomValue();
 		
 		// Set border to redish if crossing line

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1411,7 +1411,7 @@ function Symbol(kindOfSymbol) {
     //---------------------------------------------------------------
     this.drawUML = function(x1, y1, x2, y2) {
         var midy = pixelsToCanvas(0, points[this.middleDivider].y).y;
-        ctx.font = "bold " + parseInt(this.properties['textSize']) + "px Arial";
+        ctx.font = `bold ${parseInt(this.properties['textSize'])}px ${this.properties['font']}`;
 
         // Clear Class Box
         ctx.fillStyle = this.properties['fillColor'];
@@ -1460,7 +1460,7 @@ function Symbol(kindOfSymbol) {
         // Change Alignment and Font
         ctx.textAlign = "start";
         ctx.textBaseline = "top";
-        ctx.font = parseInt(this.properties['textSize']) + "px Arial";
+        ctx.font = `${parseInt(this.properties['textSize'])}px ${this.properties['font']}`;
 
         for (var i = 0; i < this.attributes.length; i++) {
             ctx.fillText(this.attributes[i].text, x1 + (this.properties['textSize'] * 0.3), y1 + (this.properties['textSize'] * 1.7) + (this.properties['textSize'] * i));

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1456,15 +1456,7 @@ function Symbol(kindOfSymbol) {
         }else {
             ctx.fillText(this.name, x1 + ((x2 - x1) * 0.5), y1 + (0.85 * this.properties['textSize']));
         }
-        if (this.properties['key_type'] == 'Primary key') {
-            var linelength = ctx.measureText(this.name).width;
-            ctx.beginPath(1);
-            ctx.moveTo(x1 + ((x2 - x1) * 0.5), y1 + (0.85 * this.properties['textSize']));
-            ctx.lineTo(x1 + ((x2 - x1) * 0.5), y1 + (0.85 * this.properties['textSize']));
-            ctx.lineTo(x1 + ((x2 - x1) * 0.5) + linelength, y1 + (0.85 * this.properties['textSize']) + 10);
-            ctx.strokeStyle = this.properties['strokeColor'];
-            ctx.stroke();
-        }
+
         // Change Alignment and Font
         ctx.textAlign = "start";
         ctx.textBaseline = "top";

--- a/DuggaSys/diagram_objects.js
+++ b/DuggaSys/diagram_objects.js
@@ -1314,6 +1314,12 @@ function Symbol(kindOfSymbol) {
         this.isLayerLocked = false;
         ctx.lineWidth = this.properties['lineWidth'] * 2 * diagram.getZoomValue();
         this.properties['textSize'] = this.getFontsize();
+
+        // Makes sure that the stroke color can not be white
+        if (this.properties['strokeColor'] == '#ffffff') {
+            this.properties['strokeColor'] = '#000000';
+        }
+
         ctx.strokeStyle = (this.targeted || this.isHovered) ? "#F82" : this.properties['strokeColor'];
 
         var x1 = pixelsToCanvas(points[this.topLeft].x).x;
@@ -1336,6 +1342,17 @@ function Symbol(kindOfSymbol) {
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.font = "bold " + parseInt(this.properties['textSize']) + "px " + this.properties['font'];
+
+        // Make sure that the font color is always able to be seen.
+        // Symbol and Font color should therefore not be the same
+        if (this.properties['fontColor'] === this.properties['fillColor']) {
+            if (this.properties['fillColor'] === '#000000') {
+                this.properties['fontColor'] = '#ffffff';
+            } else {
+                this.properties['fontColor'] = '#000000';
+            }
+        }
+
 
         if (this.symbolkind == symbolKind.uml) {
             this.drawUML(x1, y1, x2, y2);
@@ -1415,14 +1432,12 @@ function Symbol(kindOfSymbol) {
 
         // Clear Class Box
         ctx.fillStyle = this.properties['fillColor'];
-		ctx.lineWidth = this.properties['lineWidth'] * diagram.getZoomValue();
-		
-		// Set border to redish if crossing line
-		if(!checkSamePage(x1,y1,x2,y2)){
-			ctx.strokeStyle = '#DC143C';
-		}else{
-			ctx.strokeStyle = this.properties['strokeColor'];
-		}
+        ctx.lineWidth = this.properties['lineWidth'] * diagram.getZoomValue();
+        
+        // Set border to redish if crossing line
+        if(!checkSamePage(x1,y1,x2,y2)){
+            ctx.strokeStyle = '#DC143C';
+        }
 
         // Box
         ctx.beginPath();
@@ -1472,12 +1487,10 @@ function Symbol(kindOfSymbol) {
     }
 
     this.drawERAttribute = function(x1, y1, x2, y2) {
-		//if on two or more pages turn redish
+        // Set border to redish if crossing line
         if(!checkSamePage(x1,y1,x2,y2)){
-			ctx.strokeStyle = '#DC143C';
-		}else{
-			ctx.strokeStyle = this.properties['strokeColor'];
-		}
+            ctx.strokeStyle = '#DC143C';
+        }
 
         ctx.fillStyle = this.properties['fillColor'];
         // Drawing a multivalue attribute
@@ -1485,32 +1498,11 @@ function Symbol(kindOfSymbol) {
             drawOval(x1 - 7 * diagram.getZoomValue(), y1 - 7 * diagram.getZoomValue(), x2 + 7 * diagram.getZoomValue(), y2 + 7 * diagram.getZoomValue());
             ctx.stroke();
             drawOval(x1, y1, x2, y2);
-            // Makes sure that the stroke color can not be white
-            if (this.properties['strokeColor'] == '#ffffff') {
-                this.properties['strokeColor'] = '#000000';
-            }
-            // Make sure that the font color is always able to be seen.
-            // Symbol and Font color should therefore not be the same
-            if (this.properties['fontColor'] == this.properties['fillColor']) {
-                if (this.properties['fillColor'] == '#000000') {
-                    this.properties['fontColor'] = '#ffffff';
-                } else {
-                    this.properties['fontColor'] = '#000000';
-                }
-            }
+
         // Drawing a normal attribute
         } else {
             drawOval(x1, y1, x2, y2);
             ctx.fill();
-            // Make sure that the font color is always able to be seen.
-            // Symbol and Font color should therefore not be the same
-            if (this.properties['fontColor'] == this.properties['fillColor']) {
-                if (this.properties['fillColor'] == '#000000') {
-                    this.properties['fontColor'] = '#ffffff';
-                } else {
-                    this.properties['fontColor'] = '#000000';
-                }
-            }
         }
         ctx.clip();
 
@@ -1738,13 +1730,6 @@ function Symbol(kindOfSymbol) {
         ctx.closePath();
         ctx.lineWidth = (this.properties['lineWidth'] * 1.5) * diagram.getZoomValue();
         ctx.stroke();
-
-        // Makes sure that the stroke color can not be white
-        if (this.properties['strokeColor'] == '#ffffff') {
-            this.properties['strokeColor'] = '#000000';
-        }
-        
-        
     }
 
     this.drawEntity = function(x1, y1, x2, y2) {
@@ -1755,13 +1740,11 @@ function Symbol(kindOfSymbol) {
             setLinesConnectedToRelationsToForced(x1, y1, x2, y2);
         } else {
             removeForcedAttributeFromLinesIfEntityIsNotWeak(x1, y1, x2, y2);
-		}
-
-		if(!checkSamePage(x1,y1,x2,y2)){
-			ctx.strokeStyle = '#DC143C';
-		}else{
-			ctx.strokeStyle = this.properties['strokeColor'];
-		}
+        }
+        
+        if(!checkSamePage(x1,y1,x2,y2)){
+            ctx.strokeStyle = '#DC143C';
+        }
 
         ctx.beginPath();
         ctx.moveTo(x1, y1);
@@ -1772,18 +1755,9 @@ function Symbol(kindOfSymbol) {
 		ctx.closePath();	
 		ctx.fill();
 
-		// Make sure that the font color is always able to be seen.
-        // Symbol and Font color should therefore not be the same
-        if (this.properties['fontColor'] == this.properties['fillColor']) {
-            if (this.properties['fillColor'] == '#000000') {
-                this.properties['fontColor'] = '#ffffff';
-            } else {
-                this.properties['fontColor'] = '#000000';
-            }
-		}
-
         ctx.clip();
         ctx.stroke();
+        
 		if(!checkSamePage(x1,y1,x2,y2)){
 			ctx.fillStyle = '#DC143C';
 		}else{
@@ -1840,10 +1814,6 @@ function Symbol(kindOfSymbol) {
     // drawUMLLine: Draws uml line between uml objects
     //---------------------------------------------------------------
     this.drawUMLLine = function(x1, y1, x2, y2) {
-
-        this.properties['strokeColor'] = '#000000';
-        this.properties['lineWidth'] = 2;
-
         //Checks if there is cardinality set on either first or second side of line
         if((this.cardinality.value != "" && this.cardinality.value != null) || (this.cardinality.valueUML != "" && this.cardinality.valueUML != null)) {
             ctx.fillStyle = '#000';
@@ -2239,32 +2209,16 @@ function Symbol(kindOfSymbol) {
       ctx.closePath();
       ctx.lineWidth = (this.properties['lineWidth'] * 1.5) * diagram.getZoomValue();
       ctx.stroke();
-
-      // Makes sure that the stroke color can not be white
-      if (this.properties['strokeColor'] == '#ffffff') {
-          this.properties['strokeColor'] = '#000000';
-      }
-      // Make sure that the font color is always able to be seen.
-      //Symbol and Font color should therefore not be the same
-      if (this.properties['fontColor'] == this.properties['fillColor']) {
-          if (this.properties['fillColor'] == '#000000') {
-              this.properties['fontColor'] = '#ffffff';
-          } else {
-              this.properties['fontColor'] = '#000000';
-          }
-      }
     }
 
     this.drawRelation = function(x1, y1, x2, y2, midx, midy) {
         var midx = pixelsToCanvas(points[this.centerPoint].x).x;
         var midy = pixelsToCanvas(0, points[this.centerPoint].y).y;
-		
-		// Set border to redish if crossing line
-		if(!checkSamePage(x1,y1,x2,y2)){
-			ctx.strokeStyle = '#DC143C';
-		}else{
-			ctx.strokeStyle = this.properties['strokeColor'];
-		}
+        
+        // Set border to redish if crossing line
+        if(!checkSamePage(x1,y1,x2,y2)){
+            ctx.strokeStyle = '#DC143C';
+        }
 
         if (this.properties['key_type'] == 'Weak') {
           this.drawWeakRelation(x1, y1, x2, y2, midx, midy);
@@ -2279,15 +2233,6 @@ function Symbol(kindOfSymbol) {
         ctx.lineTo(midx, y1);
         ctx.closePath();
         ctx.fill();
-        // Make sure that the font color is always able to be seen.
-        // Symbol and Font color should therefore not be the same
-        if (this.properties['fontColor'] == this.properties['fillColor']) {
-            if (this.properties['fillColor'] == '#000000') {
-                this.properties['fontColor'] = '#ffffff';
-            } else {
-                this.properties['fontColor'] = '#000000';
-            }
-        }
         ctx.clip();
 		ctx.stroke();
 		

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5367,7 +5367,7 @@ only screen and (max-device-width: 320px) {
   display: block;
 }
 
-#figureOpacity, #lineThicknessGlobal {
+#figureOpacity, #lineThickness, #lineThicknessGlobal {
   width: 100%;
   border: 0;
   margin: 0;


### PR DESCRIPTION
Global appearance menu is now structured in collapsibles so it is clear what objects will be affected by the change. I also made UML and lines be affected by the global appearance menu changes. Almost nothing in global appearance menu affected UML before, now everything does. I also added the advanced properties that are available in the global appearance menu to the local appearance menus so it is possible to style these things on individual objects as well. I also added back the line color change on hover which did not happen anymore after the issue to change line color for when an object is over the paper lines was implemented.

Link: http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%239733/DuggaSys/diagram.php

