### PR TITLE
Fixes #7645 - Global appearance menu is mode specific

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5580,10 +5580,7 @@ function showFormGroups(typesToShow, isGlobal = false) {
 
     let collapsibleStructure = null;
     if(isGlobal) {
-        formGroupsToShow = formGroupsToShow.filter(group => {
-            const subtypes = group.dataset.subtypes.split(",").map(Number);
-            return subtypes.some(subtype => toolbarStateTypes[toolbarState].includes(subtype));
-        });
+        formGroupsToShow = filterGlobalFormGroups(formGroupsToShow);
         collapsibleStructure = getCollapsibleStructure(formGroupsToShow, toolbarStateTypes[toolbarState], "subtypes");
     } else {
         collapsibleStructure = getCollapsibleStructure(formGroupsToShow, typesToShow);
@@ -5692,6 +5689,7 @@ function setGlobalSelections() {
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 function setGlobalProperties(groups) {
+    
     groups.forEach(group => {
         const element = group.querySelector("select, input:not([type='submit'])");
         if(element !== null) {
@@ -5858,6 +5856,17 @@ function getGroupsByTypes(typesToShow) {
     return [...formGroups].filter(group => {
         const types = group.dataset.types.split(",");
         return typesToShow.some(type => types.includes(type.toString()));
+    });
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------
+// filterGlobalFormGroups: Filters global form groups by active toolbarState to only return form groups that affects tools in toolbar.
+//------------------------------------------------------------------------------------------------------------------------------------
+
+function filterGlobalFormGroups(formGroupsToShow) {
+    return formGroupsToShow.filter(group => {
+        const subtypes = group.dataset.subtypes.split(",").map(Number);
+        return subtypes.some(subtype => toolbarStateTypes[toolbarState].includes(subtype));
     });
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5674,7 +5674,7 @@ function getTextareaArray(element, index) {
 //------------------------------------------------------------------------------------------------------------------------------------------------
 
 function setGlobalSelections() {
-    const groups = getGroupsByTypes([-1]);
+    const groups = filterGlobalFormGroups(getGroupsByTypes([-1]));
     groups.forEach(group => {
         const select = group.querySelector("select");
         if(select !== null) {
@@ -5688,14 +5688,17 @@ function setGlobalSelections() {
 // setGlobalProperties: Used when the global appearance menu is submitted to set the global properties to the newly selected properties. Also updates each existing object in the diagram to the new properties.
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-function setGlobalProperties(groups) {
-    
+function setGlobalProperties(globalGroups) {
+    const groups = filterGlobalFormGroups(globalGroups);
     groups.forEach(group => {
         const element = group.querySelector("select, input:not([type='submit'])");
         if(element !== null) {
             const access = element.dataset.access.split(".");
             settings[access[0]][access[1]] = element.value;
-            diagram.forEach(object => object[access[0]][access[1]] = element.value);
+
+            diagram.getObjectsByTypes(toolbarStateTypes[toolbarState]).forEach(object => {
+                object[access[0]][access[1]] = element.value;
+            });
         }
     });
     updateGraphics();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5575,9 +5575,17 @@ function showFormGroups(typesToShow, isGlobal = false) {
     allformGroups.forEach(group => group.style.display = "none");
     formGroupsToShow.forEach(group => group.style.display = "block");
 
-    const collapsibleStructure = (isGlobal) 
-                                    ? getCollapsibleStructure(formGroupsToShow, [0,1,2,3,4,5,6,7], "subtypes")
-                                    : getCollapsibleStructure(formGroupsToShow, typesToShow);
+    let collapsibleStructure = null;
+    if(isGlobal) {
+        const toolbarStateTypes = {
+            [currentMode.er]: [0,2,3,4,5,6],
+            [currentMode.uml]: [1,6,7],
+            [currentMode.dev]: [0,1,2,3,4,5,6,7]
+        };
+        collapsibleStructure = getCollapsibleStructure(formGroupsToShow, toolbarStateTypes[toolbarState], "subtypes");
+    } else {
+        collapsibleStructure = getCollapsibleStructure(formGroupsToShow, typesToShow);
+    }
 
     initAppearanceForm();
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -197,6 +197,12 @@ var spacebarKeyPressed = false;         // True when entering MoveAround mode by
 var toolbarState = currentMode.er;      // Set default toolbar state to ER.
 var hideComment = false;				//Used to se if the comment marked text should be hidden(true) or shown(false)
 
+const toolbarStateTypes = {
+    [currentMode.er]: [0,2,3,4,5,6],
+    [currentMode.uml]: [1,6,7],
+    [currentMode.dev]: [0,1,2,3,4,5,6,7]
+};
+
 // Default keyboard keys
 const defaultBackspaceKey = 8;
 const defaultEnterKey = 13;
@@ -5570,22 +5576,21 @@ function showFormGroups(typesToShow, isGlobal = false) {
     form.parentNode.replaceChild(originalAppearanceForm, form);
 
     const allformGroups = document.querySelectorAll("#appearanceForm .form-group");
-    const formGroupsToShow = getGroupsByTypes(typesToShow);
-
-    allformGroups.forEach(group => group.style.display = "none");
-    formGroupsToShow.forEach(group => group.style.display = "block");
+    let formGroupsToShow = getGroupsByTypes(typesToShow);
 
     let collapsibleStructure = null;
     if(isGlobal) {
-        const toolbarStateTypes = {
-            [currentMode.er]: [0,2,3,4,5,6],
-            [currentMode.uml]: [1,6,7],
-            [currentMode.dev]: [0,1,2,3,4,5,6,7]
-        };
+        formGroupsToShow = formGroupsToShow.filter(group => {
+            const subtypes = group.dataset.subtypes.split(",").map(Number);
+            return subtypes.some(subtype => toolbarStateTypes[toolbarState].includes(subtype));
+        });
         collapsibleStructure = getCollapsibleStructure(formGroupsToShow, toolbarStateTypes[toolbarState], "subtypes");
     } else {
         collapsibleStructure = getCollapsibleStructure(formGroupsToShow, typesToShow);
     }
+
+    allformGroups.forEach(group => group.style.display = "none");
+    formGroupsToShow.forEach(group => group.style.display = "block");
 
     initAppearanceForm();
 


### PR DESCRIPTION
Global appearance menu is now mode specific. Create objects of all types. Switch to ER toolbar mode. Open the global appearance menu. Only the objects in the ER toolbar should be mentioned in the collapsibles. When changing some input only the objects available in the ER toolbar should be changed. Test the same when being in UML toolbar mode and when being in Dev display all tools.

Link: http://group4.webug.his.se:20001/G4-2020-W22-ISSUE%237645/DuggaSys/diagram.php

There is just one problem that could possibly be fixed next year; all objects use the same base settings when being created. So when changing global appearance settings in UML mode, only objects active in the toolbar will be changed. But when creating a new object that is not in the UML toolbar, they will still have the new settings that were set for UML. Or when opening the global appearance menu for a new mode, the settings that were set while in UML mode will be used as presets.