### PR TITLE
Group3 2021 #9829 - Fixed Proper Cursor Type

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -78,7 +78,11 @@
         .hide {
             display: none;
         }	
-			
+		
+        .zoomButtons:hover {
+            cursor:pointer;
+        }
+
 			.element {
           font-size: small;
 					box-sizing: border-box;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -30,6 +30,7 @@
             border-radius: 40px;
             background-color: #eb4;
             box-shadow: 6px 6px 10px #888;
+        user-select: none;
         }
 
         #options-pane {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -45,13 +45,15 @@
             box-shadow: 0px 6px 10px #888;
             padding: 10px;
             transition: right .3s ease-in-out;
+        user-select: none;
         }
 
         #options-pane-button {
             display: inline-block;
             vertical-align: top;
 						transform-origin: top left;            
-						transform: translate(20px,0px) rotate(90deg);					
+						transform: translate(20px,0px) rotate(90deg);	
+            cursor:pointer;				
         }
 
         #options-pane-content {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -464,8 +464,8 @@
             <div>
                 <fieldset>
                     <legend>Zoom</legend>
-                    <input type="button" value="Zoom in" style="cursor:pointer" onclick='zoomin();' />
-                    <input type="button" value="Zoom out" style="cursor:pointer" onclick='zoomout();' />									
+                    <input class="zoomButtons" type="button" value="Zoom in" onclick='zoomin();' />
+                    <input class="zoomButtons" type="button" value="Zoom out" onclick='zoomout();' />									
                 </fieldset>
             </div>
         </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -464,8 +464,8 @@
             <div>
                 <fieldset>
                     <legend>Zoom</legend>
-                    <input type="button" value="Zoom in" onclick='zoomin();' />
-                    <input type="button" value="Zoom out" onclick='zoomout();' />									
+                    <input type="button" value="Zoom in" style="cursor:pointer" onclick='zoomin();' />
+                    <input type="button" value="Zoom out" style="cursor:pointer" onclick='zoomout();' />									
                 </fieldset>
             </div>
         </div>


### PR DESCRIPTION
Fixed a proper cursor type for Zoom in/out buttons in the options panel and a pointer cursor when hovering "Options".

Also disabled user-select for the "Zoom" title in the box.