### PR TITLE
Fix: Correct name on new elements - #9889

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -334,11 +334,7 @@ function setMouseMode(mode = 0)
 {
     mouseMode = mode;
 }
-/*var defaults = {
-    defaultERtentity: { kind: "EREntity", fill: "White", Stroke: "Black", width: 200, height: 50 },
-    defaultERrelation: { kind: "ERRelation", fill: "White", Stroke: "Black", width: 60, height: 60 },
-    defaultERattr: { kind: "ERAttr", fill: "White", Stroke: "Black", width: 90, height: 45 }
-}*/
+
 function getEntityType()
 {
     var entityObj = [

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -240,12 +240,12 @@ function mup(event)
                 var entityType = getEntityType()
 
                 data.push({
-                    name: 'Entity',
-                    x: mp.x - (entityType.width * 0.5),
-                    y: mp.y - (entityType.height * 0.5),
-                    width: entityType.width,
-                    height: entityType.height,
-                    kind: entityType.kind,
+                    name: entityType.name,
+                    x: mp.x - (entityType.data.width * 0.5),
+                    y: mp.y - (entityType.data.height * 0.5),
+                    width: entityType.data.width,
+                    height: entityType.data.height,
+                    kind: entityType.data.kind,
                     id: makeRandomID()
                 });
                 showdata()
@@ -334,14 +334,24 @@ function setMouseMode(mode = 0)
 {
     mouseMode = mode;
 }
-
+/*var defaults = {
+    defaultERtentity: { kind: "EREntity", fill: "White", Stroke: "Black", width: 200, height: 50 },
+    defaultERrelation: { kind: "ERRelation", fill: "White", Stroke: "Black", width: 60, height: 60 },
+    defaultERattr: { kind: "ERAttr", fill: "White", Stroke: "Black", width: 90, height: 45 }
+}*/
 function getEntityType()
 {
+    var entityObj = [
+        {data: defaults.defaultERtentity, name: "Entity"},
+        {data: defaults.defaultERrelation, name: "Relation"},
+        {data: defaults.defaultERattr, name: "Attribute"}
+    ]
+  
     switch (mouseMode)
     {
-        case 1: return defaults.defaultERtentity;
-        case 2: return defaults.defaultERrelation;
-        case 3: return defaults.defaultERattr;
+        case 1: return entityObj[0];
+        case 2: return entityObj[1];
+        case 3: return entityObj[2];
     }
 }
 


### PR DESCRIPTION
Fixed an issue where new elements had the same name. Each element is now created with the correct name respectively.
fixes #9889