### PR TITLE
Removing access category and group assignment from access editor

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -781,7 +781,7 @@ function returnedAccess(data) {
 			modified: "Last Modified",
 			/*examiner: "Examiner",*/
 			/*vers: "Version",*/
-			access: "Access",
+			/*access: "Access",*/
 			/*groups: "Group(s)",*/
 			requestedpasswordchange: "Password"
 		},
@@ -789,7 +789,7 @@ function returnedAccess(data) {
 		tblfoot: {}
 	}
 	//myTable = undefined;
-	var colOrder = ["username",/* "ssn",*/ "firstname", "lastname", /*"class",*/ "modified", /*"examiner",*/ /*"vers",*/ "access", /*"groups",*/ "requestedpasswordchange"]
+	var colOrder = ["username",/* "ssn",*/ "firstname", "lastname", /*"class",*/ "modified", /*"examiner", "vers", "access", "groups",*/ "requestedpasswordchange"]
 	if (typeof myTable === "undefined") { // only create a table if none exists
 		myTable = new SortableTable({
 			data: tabledata,

--- a/DuggaSys/accessed_removedColumn.txt
+++ b/DuggaSys/accessed_removedColumn.txt
@@ -1,0 +1,7 @@
+The following columns aren't used anymore by the accessed.js file:
+SSN
+Class
+Examiner
+Vers
+Access
+Groups


### PR DESCRIPTION
Commented out the access column in the function returnedAccess in the accessed.js file. Created a text file called accessed_removedColumn.txt which describes what columns aren't used anymore by the accessed.js file. 