### PR TITLE
Fix - zoom with mousewheel and ctrl-keys, issue #9932

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -138,6 +138,8 @@ document.addEventListener('keydown', function (e)
     if (e.key == "Alt" && altPressed !== true) altPressed = true;
     if (e.key == "Delete" && context.length > 0)  removeElements(context);
     if (e.key == "Meta" && ctrlPressed != true) ctrlPressed = true;
+    if (e.key == "-" && ctrlPressed) zoomin(); // Works but interferes with browser zoom
+    if (e.key == "+" && ctrlPressed) zoomout(); // Works but interferes with browser zoom
 });
 
 document.addEventListener('keyup', function (e)
@@ -146,6 +148,7 @@ document.addEventListener('keyup', function (e)
     if (e.key == "Alt") altPressed = false;
     if (e.key == "Meta") ctrlPressed = false;
 });
+
 
 //                              Coordinate-Screen Position Conversion
 //------------------------------------=======############==========----------------------------------------
@@ -193,6 +196,16 @@ function diagramToScreenPosition(coordX, coordY)
 //------------------------------------=======############==========----------------------------------------
 //                                           Mouse events
 //------------------------------------=======############==========----------------------------------------
+function mwheel(event){
+    if(event.deltaY < 0)
+    {
+        zoomin();
+    }
+    else
+    {
+        zoomout();
+    }
+}
 
 function mdown(event)
 {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -453,7 +453,7 @@
     </div>
 
     <!-- Diagram drawing system canvas. -->
-    <div id="container" onmousedown='mdown(event)' onmouseup='mup(event)' onmousemove='mmoving(event)'></div> <!-- Contains all elements (items) -->
+    <div id="container" onmousedown='mdown(event)' onmouseup='mup(event)' onmousemove='mmoving(event)' onwheel='mwheel(event)'></div> <!-- Contains all elements (items) -->
     <svg id="svgoverlay"  preserveAspectRatio="none">
    </svg>
 	<canvas id='canvasOverlay'></canvas>


### PR DESCRIPTION
Fixed so it's now possible to zoom in the diagram with the mouse-wheel and with ctrl+ or ctrl-.
Ctrl+ and ctrl- however interferes with the browser functionality with the same commands. I included it anyway since it was specifically asked to be implemented. A bigger function for handling all zoom-events have not been added as requested, since we already have two functions that handle this (zoomin and zoomout) and changing it could cause unnecessary problems.