### PR TITLE
Fixed redirection to latest courseversion from short url. Issue#9806

### DIFF
--- a/sh/index.php
+++ b/sh/index.php
@@ -46,10 +46,11 @@ if ($course != "UNK") {
 	$courses = array();
 
 	foreach($pdo->query($sql) as $c) {
-		array_push($courses, $c["coursename"]);
+		array_push($courses, str_replace($c["coursename"], " ", "_"));
 	}
 
 	if (in_array($course, $courses)) {
+		$course = str_replace($course, "_", " ");
 		$sql = "SELECT activeversion, cid FROM course WHERE coursename='".$course."'";
 		foreach ($pdo->query($sql) as $row) {
 			$cid = $row["cid"];

--- a/sh/index.php
+++ b/sh/index.php
@@ -38,25 +38,6 @@ function GetAssigment ($hash){
 	return $URL;
 }
 
-
-
-/* if($assignment != "UNK"){
-	// Check if it's an URL shorthand for assignments
-	if($course == "UNK"){
-		$assignmentURL = GetAssigment($assignment);
-		header("Location: {$assignmentURL}");
-	}elseif(($course == "Databaskonstruktion" || $course == "dbk")){
-		if($assignment=="a1"){
-			header("Location: https://dugga.iit.his.se/DuggaSys/showdoc.php?cid=4&coursevers=82452&fname=minimikrav_m1a.md");
-			exit();		
-		}else{
-			header("Location: https://dugga.iit.his.se/DuggaSys/sectioned.php?courseid=4&coursevers=82452");
-			exit();		
-		}
-	}
-	return $array;
-} */
-
 if ($course != "UNK") {
 	global $pdo;
 
@@ -64,8 +45,8 @@ if ($course != "UNK") {
 	
 	$courses = array();
 
-	foreach($pdo->query($sql) as $course) {
-		array_push($courses, $course["coursename"]);
+	foreach($pdo->query($sql) as $c) {
+		array_push($courses, $c["coursename"]);
 	}
 
 	if (in_array($course, $courses)) {
@@ -75,11 +56,9 @@ if ($course != "UNK") {
 			$activeversion = $row["activeversion"];
 		}
 		$serverRoot = serverRoot();
-		echo $serverRoot;
 		header("Location: {$serverRoot}/DuggaSys/sectioned.php?courseid={$cid}&coursevers={$activeversion}");
 		exit();
 	}
-	return 5;
 }
 
 $q = queryToUrl($course, $assignment);

--- a/sh/index.php
+++ b/sh/index.php
@@ -40,7 +40,7 @@ function GetAssigment ($hash){
 
 
 
-if($assignment != "UNK"){
+/* if($assignment != "UNK"){
 	// Check if it's an URL shorthand for assignments
 	if($course == "UNK"){
 		$assignmentURL = GetAssigment($assignment);
@@ -55,6 +55,31 @@ if($assignment != "UNK"){
 		}
 	}
 	return $array;
+} */
+
+if ($course != "UNK") {
+	global $pdo;
+
+	$sql = "SELECT coursename FROM course";
+	
+	$courses = array();
+
+	foreach($pdo->query($sql) as $course) {
+		array_push($courses, $course["coursename"]);
+	}
+
+	if (in_array($course, $courses)) {
+		$sql = "SELECT activeversion, cid FROM course WHERE coursename='".$course."'";
+		foreach ($pdo->query($sql) as $row) {
+			$cid = $row["cid"];
+			$activeversion = $row["activeversion"];
+		}
+		$serverRoot = serverRoot();
+		echo $serverRoot;
+		header("Location: {$serverRoot}/DuggaSys/sectioned.php?courseid={$cid}&coursevers={$activeversion}");
+		exit();
+	}
+	return 5;
 }
 
 $q = queryToUrl($course, $assignment);


### PR DESCRIPTION
The url shortener now takes you to the latest version of a course by typing in sh/"coursename". Use underscore instead of blank spaces in coursenames.
For example to get to "Datorns grunder" put /sh/Datorns_grunder in the url. This will take you to the latest version of the course.