### PR TITLE
Now possible to select lines #9975

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -486,9 +486,25 @@ function determineLineSelect(mouseX, mouseY)
     // This func is used when determining which line is clicked on.
 
     // TODO: Add functionality to make sure we are only getting LINES from svgbacklayer in the future !!!!!.
-    var allLines = document.getElementById("svgbacklayer").children;
 
+    var allLines = document.getElementById("svgbacklayer").children;
     var cMouse_XY = {x: mouseX, y: mouseY}; // Current mouse XY
+    var currentline = {};
+    var lineData = {};
+    var lineCoeffs = {};
+    var highestX;
+    var lowestX; 
+    var highestY;
+    var lowestY;
+    var lineWasHit = false; 
+
+    // Position and radius of the circle hitbox that is used when 
+    var circleHitBox = {
+        pos_x: cMouse_XY.x, // Mouse pos X.
+        pos_y: cMouse_XY.y, // Mouse pos Y.
+        radius: 10 // This will determine the error margin, "how far away from the line we can click and still select it". Higer val = higher margin.
+    }
+    
     for(var i = 0; i < allLines.length; i++)
     {
         // Get all X and Y -coords for current line in iteration.
@@ -499,40 +515,27 @@ function determineLineSelect(mouseX, mouseY)
             y2: allLines[i].getAttribute("y2")
         };
 
-        var a1 = currentline.x1;
-        var a2 = currentline.x2;
-        var b1 = currentline.y1;
-        var b2 = currentline.y2;
-
         // Used later to make sure the current mouse-position is in the span of a line.
-        var highestX = Math.max(a1, a2);
-        var lowestX = Math.min(a1, a2);
-        var highestY = Math.max(b1, b2);
-        var lowestY = Math.min(b1, b2);
-
-        var lineData = {
+        highestX = Math.max(currentline.x1, currentline.x2);
+        lowestX = Math.min(currentline.x1, currentline.x2);
+        highestY = Math.max(currentline.y1, currentline.y2);
+        lowestY = Math.min(currentline.y1, currentline.y2);
+        lineData = {
             hX: highestX,
             lX: lowestX,
             hY: highestY,
             lY: lowestY
         }
-
-        // Position and radius of the circle hitbox that is used when 
-        var circleHitBox = {
-            pos_x: cMouse_XY.x, // Mouse pos X.
-            pos_y: cMouse_XY.y, // Mouse pos Y.
-            radius: 10 // This will determine the error margin, "how far away from the line we can click and still select it". Higer val = higher margin.
-        }
         
         // Coefficients of the general equation of the current line.
-        var lineCoeffs = {
-            a: (b1 - b2),
-            b: (a2 - a1),
-            c: ((a1 - a2)*b1 + (b2-b1)*a1)
+        lineCoeffs = {
+            a: (currentline.y1 - currentline.y2),
+            b: (currentline.x2 - currentline.x1),
+            c: ((currentline.x1 - currentline.x2)*currentline.y1 + (currentline.y2-currentline.y1)*currentline.x1)
         }
         
         // Determines if a line was clicked
-        var lineWasHit = didClickLine(lineCoeffs.a, lineCoeffs.b, lineCoeffs.c, circleHitBox.pos_x, circleHitBox.pos_y, circleHitBox.radius, lineData);
+        lineWasHit = didClickLine(lineCoeffs.a, lineCoeffs.b, lineCoeffs.c, circleHitBox.pos_x, circleHitBox.pos_y, circleHitBox.radius, lineData);
         
         // --- Used when debugging ---
         // Creates a circle with the same position and radius as the hitbox of the circle being sampled with.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -330,6 +330,10 @@ function mdown(event)
         startX = event.clientX;
         startY = event.clientY;
     }
+    // Used when clicking on a line between two elements.
+    var clickedLine = determineLineSelect(event.clientX, event.clientY);
+    if(clickedLine != null) clickedLine.setAttribute('stroke', 'rgb(0,0,255)');
+
 }
 
 function ddown(event)
@@ -475,6 +479,98 @@ function mup(event)
     // Restore pointer state to normal
     pointerState = pointerStates.DEFAULT;
     deltaExceeded = false;
+}
+
+function determineLineSelect(mouseX, mouseY)
+{
+    // This func is used when determining which line is clicked on.
+
+    // TODO: Add functionality to make sure we are only getting LINES from svgbacklayer in the future !!!!!.
+    var allLines = document.getElementById("svgbacklayer").children;
+
+    var cMouse_XY = {x: mouseX, y: mouseY}; // Current mouse XY
+    for(var i = 0; i < allLines.length; i++)
+    {
+        // Get all X and Y -coords for current line in iteration.
+        currentline = {
+            x1: allLines[i].getAttribute("x1"),
+            x2: allLines[i].getAttribute("x2"),
+            y1: allLines[i].getAttribute("y1"),
+            y2: allLines[i].getAttribute("y2")
+        };
+
+        var a1 = currentline.x1;
+        var a2 = currentline.x2;
+        var b1 = currentline.y1;
+        var b2 = currentline.y2;
+
+        // Used later to make sure the current mouse-position is in the span of a line.
+        var highestX = Math.max(a1, a2);
+        var lowestX = Math.min(a1, a2);
+        var highestY = Math.max(b1, b2);
+        var lowestY = Math.min(b1, b2);
+
+        var lineData = {
+            hX: highestX,
+            lX: lowestX,
+            hY: highestY,
+            lY: lowestY
+        }
+
+        // Position and radius of the circle hitbox that is used when 
+        var circleHitBox = {
+            pos_x: cMouse_XY.x, // Mouse pos X.
+            pos_y: cMouse_XY.y, // Mouse pos Y.
+            radius: 10 // This will determine the error margin, "how far away from the line we can click and still select it". Higer val = higher margin.
+        }
+        
+        // Coefficients of the general equation of the current line.
+        var lineCoeffs = {
+            a: (b1 - b2),
+            b: (a2 - a1),
+            c: ((a1 - a2)*b1 + (b2-b1)*a1)
+        }
+        
+        // Determines if a line was clicked
+        var lineWasHit = didClickLine(lineCoeffs.a, lineCoeffs.b, lineCoeffs.c, circleHitBox.pos_x, circleHitBox.pos_y, circleHitBox.radius, lineData);
+        
+        // --- Used when debugging ---
+        // Creates a circle with the same position and radius as the hitbox of the circle being sampled with.
+        //document.getElementById("svgoverlay").innerHTML += '<circle cx="'+ circleHitBox.pos_x + '" cy="'+ circleHitBox.pos_y+ '" r="' + circleHitBox.radius + '" stroke="black" stroke-width="3" fill="red" /> '
+        // ---------------------------
+
+        if(lineWasHit == true)
+        {
+            return allLines[i]; // Return the current line that registered as a "hit".
+        }
+    }
+    return null;
+}
+
+function didClickLine(a, b, c, circle_x, circle_y, circle_radius, line_data)
+{
+    // Adding and subtracting with the circle radius to allow for bigger margin of error when clicking.
+    // Check if we are clicking withing the span.
+    if( (circle_x < (line_data.hX + circle_radius)) &&
+     (circle_x > (line_data.lX - circle_radius)) && 
+     (circle_y < (line_data.hY + circle_radius)) && 
+     (circle_y > (line_data.lY - circle_radius))
+    )
+    {
+        // Distance between line and circle center.
+        var distance = (Math.abs(a*circle_x + b*circle_y + c)) / Math.sqrt(a*a + b*b);
+    
+        // Check if circle radius >= distance. (If so is the case, the line is intersecting the circle)
+        if(circle_radius >= distance)
+        {
+            return true;
+        }
+    }
+    else
+    {
+        // console.log("NO LINE WAS SELECTED");
+        return false;
+    }
 }
 
 function mouseMode_onMouseMove(event)


### PR DESCRIPTION
Implemented functionality for clicking lines.
Note: Since the "double lines" are stored as two separate lines individually they are also treated as such when clicking on them. Future functionality could be added to make sure they share the same ID and thus treated as the "same" line.