### PR TITLE
Removed CID from "Add user"-form. Issue#10093

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -429,34 +429,6 @@ function tooltipTerm()
 	}
 }
 
-//---------------------------------------------------------------------------------------------------
-// validateCIDcid)
-// Returns null if there are NO errors, otherwise a descripitve error message as string.
-//---------------------------------------------------------------------------------------------------
-
-function validateCID(cid)
-{
-	const length = cid.length;
-	if(length > 5)	return 'CID is too long\nMaximum FIVE characters';	// Too long
-	if(cid.match(/^\d{1,5}$/gm) == null ) return 'The CID can not contain any letters'; // checks if there are non numerical
-
-	return null;
-}
-function tooltipCID()
-{
-	var error = validateCID(document.getElementById('addCid').value);
-	var cidInputBox = document.getElementById('addCid');
-
-	if(error && document.getElementById('addCid').value.length > 0) {	// Error, fade in tooltip
-		document.getElementById('tooltipCID').innerHTML = error;
-		$('#tooltipCID').fadeIn();
-		cidInputBox.style.backgroundColor = '#f57';
-	} else {															// No error, fade out tooltip
-		$('#tooltipCID').fadeOut();
-		cidInputBox.style.backgroundColor = '#fff';
-	}
-}
-
 var inputVerified;
 
 function addClass() {

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -105,11 +105,6 @@
 					<input placeholder="Gregersson" class='textinput' type='text' id='addLastname' onchange="tooltipLast()" onkeyup="tooltipLast()"/>
 				</div>
 				<div class='flexwrapper'>
-					<span>CID:</span>
-					<div class="tooltipDugga"><span id="tooltipCID" style="display: none;" class="tooltipDuggatext">  </span></div>
-					<input placeholder="91001" class='textinput' id='addCid' onchange="tooltipCID()" onkeyup="tooltipCID()" />
-				</div>
-				<div class='flexwrapper'>
 					<span>PID:</span>
 					<div class="tooltipDugga"><span id="tooltipPID" style="display: none;" class="tooltipDuggatext">  </span></div>
 					<input placeholder="WEBUG" class='textinput' id='addPid' onchange="tooltipPID()" onkeyup="tooltipPID()"/>


### PR DESCRIPTION
We've looked into the purpose of the CID and Term field in the "Add-user"-form. The Ny-field seemed to have already been removed in issue #9753. CID didn't seem to have a purpose so we've removed it along with it's validation and tooltip function. The Term-field as it currently stands is saved in the class-column in the User-table in the database. We have not modified the Term-field.