### PR TITLE
"Fixed" Remove specific lines with delete or backspace

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -180,7 +180,11 @@ document.addEventListener('keydown', function (e)
 
         if (e.key == "Control" && ctrlPressed !== true) ctrlPressed = true;
         if (e.key == "Alt" && altPressed !== true) altPressed = true;
-        if (e.key == "Delete" && context.length > 0)  removeElements(context);
+        if (e.key == "Delete" && (context.length > 0 || contextLine.length > 0)) 
+        {
+            removeElements(context); 
+            removeLines(contextLine);
+        }
         if (e.key == "Meta" && ctrlPressed != true) ctrlPressed = true;
         if (e.key == "-" && ctrlPressed) zoomin(); // Works but interferes with browser zoom
         if (e.key == "+" && ctrlPressed) zoomout(); // Works but interferes with browser zoom
@@ -194,7 +198,11 @@ document.addEventListener('keydown', function (e)
             pointerState = pointerStates.DEFAULT;
             showdata();
         }
-        if (e.key == "Backspace" && context.length > 0 && !propFieldState) removeElements(context);
+        if (e.key == "Backspace" && (context.length > 0 || contextLine.length > 0) && !propFieldState)
+        {
+            removeElements(context); 
+            removeLines(contextLine);
+        }
     }
 });
 
@@ -1901,6 +1909,19 @@ function removeElements(elementArray){
         });
     }
     context = [];
+    redrawArrows();
+    showdata();
+}
+//Function to remove selected lines
+function removeLines(linesArray){
+    for(var i = 0; i < linesArray.length; i++){
+
+        //Remove line
+        lines=lines.filter(function(line) {
+            return line.id != linesArray[i].id;
+        });
+    }
+    contextLine = [];
     redrawArrows();
     showdata();
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1913,7 +1913,8 @@ function removeElements(elementArray){
     showdata();
 }
 //Function to remove selected lines
-function removeLines(linesArray){
+function removeLines(linesArray)
+{
     for(var i = 0; i < linesArray.length; i++){
 
         //Remove line


### PR DESCRIPTION
Fixed by adding a function to only delete selected lines with delte key or backspace key
@a19matma 
#10125 