### PR TITLE
Holding ctrl while clicking background fixed

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1345,10 +1345,14 @@ function updateSelectedLine(selectedLine)
             contextLine.push(selectedLine);
         } else
         {
-            contextLine = [];
+            if(mouseMode != mouseModes.POINTER)
+            {
+                contextLine = [];
+            }
             contextLine.push(selectedLine);
         }
-    } else
+
+    } else if (!altPressed && !ctrlPressed)
     {
         contextLine = [];
     }


### PR DESCRIPTION
The selected lines no longer deselects while holding down ctrl and clicking on the background.