### PR TITLE
Grid is now enabled by default

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2041,6 +2041,7 @@ function getData()
     container = document.getElementById("container");
     showdata();
     drawRulerBars();
+    enableGrid();
 }
 
 function data_returned(ret)


### PR DESCRIPTION
By calling enable grid in the onload function, the grid is now being drawn as default.