### PR TITLE
Checks if usergroups has the value null instead of "none" Issue#9752

### DIFF
--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -257,7 +257,7 @@ if(checklogin() && (hasAccess($_SESSION['uid'], $cid, 'w') || isSuperUser($_SESS
 			$users = $query->fetchAll(PDO::FETCH_ASSOC);
 			
 			//if it is a group assignment and the user being graded is NOT in the "None" group, make database insert/updates for all group members
-			if($groupdugga == 1 && !strpos($usergroups, 'None')){
+			if($groupdugga == 1 && $usergroups){
 				foreach($users as $user){
 					$luid = current($user);
 					if($ukind=="U"){


### PR DESCRIPTION
Made small change to the if statement on line 260.  The if-statement now checks if usergroups has the value null instead of "none".

Co-author: @a18willi 