### PR TITLE
Swimlanes now hide after clicking the arrow once. Issue#10185

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -791,6 +791,9 @@ p {
 }
 
  #sectionList_arrowStatisticsClosed{
+  display: inline;
+}
+#sectionList_arrowStatisticsOpen{
   display: none;
 }
 #sectionList_arrowStatisticsOpen,


### PR DESCRIPTION
Updated style.css so that the correct open/close-button for the swimlanes in the course-view is showing by default.