### PR TITLE
Fix fab button overflow in mobile landscape issue#10179

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6251,6 +6251,13 @@ only screen and (max-device-width: 320px) {
   padding-top: 8px;
 }
 
+@media screen and (max-height: 600px) {
+  .fab-btn-list {
+    transform-origin: bottom left;
+    transform: rotate(270deg);
+  }
+}
+
 /* FAB scaling transition */
 
 .scale-transition {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6256,6 +6256,12 @@ only screen and (max-device-width: 320px) {
     transform-origin: bottom left;
     transform: rotate(270deg);
   }
+  .fab-btn-sm {
+    transform: rotate(135deg);
+  }
+  [data-tooltip]:before {
+    bottom: 85%;
+  }
 }
 
 /* FAB scaling transition */


### PR DESCRIPTION
Make fab button items horizontal in mobile landscape mode, to prevent overflow.

Co-author: @a18willi 