### PR TITLE
Removed pointer event from toolTipText to fix the hover.

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -262,10 +262,6 @@
     visibility: visible;
 }
 
-.diagramIcons:not(:hover) .toolTipText{
-    visibility: hidden;
-}
-
 .tooltip{
     position: absolute;
     z-index: 1;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -252,8 +252,7 @@
     text-align: center;
     border-radius: 5px;
     padding: 5px 0;
-    
-
+    pointer-events: none;
     position: absolute;
     z-index: 2;
 }


### PR DESCRIPTION
Removed pointer event from toolTipText to fix the hover and removed an not hover styling in css because it is not needed due to if not hover the element will go back to default styling.