### PR TITLE
"Fixed" Make options side panel extend to the top

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -58,7 +58,7 @@
 
 #options-pane {
     position: fixed;
-    top: 130px;
+    top: 0px;
     width: 280px;
     bottom: 120px;
     z-index: 5000;


### PR DESCRIPTION
fixed by replace top 130px to 0 px, could not remove top attribute at all because it affects the height of the panel