### PR TITLE
Arrow on moments in sectioned now always shows Issue#10191

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -963,7 +963,7 @@ function returnedSection(data) {
           str += `<span class='ellipsis listentries-span'>${item['entryname']} ${strz} </span>`;
           str += `<img src='../Shared/icons/desc_complement.svg' id='arrowComp${item['lid']}'
           class='arrowComp' style='display:inline-block;'>`;
-          str += `<img src='../Shared/icons/right_complement.svg'" + "id='arrowRight${item['lid']}'
+          str += `<img src='../Shared/icons/right_complement.svg' id='arrowRight${item['lid']}'
           class='arrowRight' style='display:none;'>`;
           str += "</div>";
         } else if (itemKind == 2) {


### PR DESCRIPTION
Fixed wierd string that broke arrow functionality.

Co-Authored-By: @b18phika