### PR TITLE
Previously selected items cleared when switching to line creation mode

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -578,6 +578,7 @@ document.addEventListener('keyup', function (e)
         }
         if (e.key == keybinds.EDGE_CREATION) {
             setMouseMode(mouseModes.EDGE_CREATION);
+            clearContext();
         }
         if (e.key == keybinds.PLACE_ENTITY) {
             setElementPlacementType(elementTypes.ENTITY);
@@ -2460,4 +2461,10 @@ function data_returned(ret)
     } else {
         alert("Error receiveing data!");
     }
+}
+
+function clearContext()
+{
+    context = [];
+    showdata();
 }

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -63,7 +63,7 @@
                     <p id="tooltip-PLACE_ATTRIBUTE" class="key_tooltip">Keybinding:</p>
                     </span>
                 </div>
-                <div id="mouseMode3" class="diagramIcons toolbarMode" onclick='setMouseMode(3);'>
+                <div id="mouseMode3" class="diagramIcons toolbarMode" onclick='setMouseMode(3); clearContext();'>
                     <img src="../Shared/icons/diagram_line.svg"/>
                     <span class="toolTipText"><b>Line</b><br>
                     <p>Make a line between objects</p><br>


### PR DESCRIPTION
The context is now cleared when switching to line creation mode.