### PR TITLE
Fixed removing elements when holding down ALT with box selection

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1558,13 +1558,20 @@ function boxSelect_Update(mouseX, mouseY)
 
         if (ctrlPressed) {
             var markedEntities = getElementsInsideCoordinateBox(rect);
-
             // Remove entity from previous context is the element is marked
             previousContext = previousContext.filter(entity => !markedEntities.includes(entity));
 
             context = [];
             context = context.concat(markedEntities);
             context = context.concat(previousContext);
+        }else if (altPressed) {
+            markedEntities = getElementsInsideCoordinateBox(rect);
+            // Remove entity from previous context is the element is marked
+            previousContext = previousContext.filter(entity => !markedEntities.includes(entity));
+
+            context = [];
+            context = previousContext;
+
         }else {
             context = getElementsInsideCoordinateBox(rect);
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1565,7 +1565,7 @@ function boxSelect_Update(mouseX, mouseY)
             context = context.concat(markedEntities);
             context = context.concat(previousContext);
         }else if (altPressed) {
-            markedEntities = getElementsInsideCoordinateBox(rect);
+            var markedEntities = getElementsInsideCoordinateBox(rect);
             // Remove entity from previous context is the element is marked
             previousContext = previousContext.filter(entity => !markedEntities.includes(entity));
 


### PR DESCRIPTION
When using the box selection you can now de-select by holding down alt and selecting multiple elements. 