### PR TITLE
You can now change line properties in the options panel #10305

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1947,6 +1947,7 @@ function updateSelectedLine(selectedLine)
     } else if (!altPressed && !ctrlPressed) {
         contextLine = [];
     }
+    generateContextProperties();
 }
 
 function updateSelection(ctxelement)
@@ -2145,21 +2146,18 @@ function generateContextProperties()
         str += '</select>'; 
         str+=`<br><br><input type="submit" value="Save" onclick="changeState();saveProperties()">`;
 
-    } else if (context.length > 1) {
-        str += "<p>Pick only ONE element!</p>";
-    }
+    } 
 
-    // Update selected line
+    // Creates drop down for changing the kind attribute on the selected line.
     if (contextLine.length == 1 && context.length == 0) {
         str = "<legend>Properties</legend>";
-        var line = contextLine[0];
         
         var value;
         var selected = contextLine[0].kind;
         if(selected == undefined) selected = normal;
         
         value = Object.values(lineKind);
-
+        
         str += '<select id="propertySelect">';
         for(var i = 0; i < value.length; i++){
             if(selected == value[i]){
@@ -2170,6 +2168,10 @@ function generateContextProperties()
         }
         str += '</select>';
         str+=`<br><br><input type="submit" value="Save" onclick="changeLineKind();">`;
+    }
+
+    if ((context.length > 1 || contextLine.length > 1) || (context.length == 1 && contextLine.length == 1)) {
+        str += "<p>Pick only ONE element!</p>";
     }
 
     propSet.innerHTML = str;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -645,6 +645,11 @@ const relationState = {
     WEAK: "weak",
 };
 
+const lineKind = {
+    NORMAL: "Normal",
+    DOUBLE: "Double"
+};
+
 // Demo data - read / write from service later on
 var data = [
     { name: "Person", x: 100, y: 100, width: 200, height: 50, kind: "EREntity", id: PersonID },
@@ -2081,6 +2086,14 @@ function changeState()
     element.state = property;
 }
 
+function changeLineKind()
+{
+    var property = document.getElementById("propertySelect").value;
+    var line = contextLine[0];
+    line.kind = property;
+    showdata();
+}
+
 function propFieldSelected(isSelected)
 {
     propFieldState = isSelected;
@@ -2141,8 +2154,22 @@ function generateContextProperties()
         str = "<legend>Properties</legend>";
         var line = contextLine[0];
         
+        var value;
+        var selected = contextLine[0].kind;
+        if(selected == undefined) selected = normal;
+        
+        value = Object.values(lineKind);
 
-        //propSet.innerHTML = str;
+        str += '<select id="propertySelect">';
+        for(var i = 0; i < value.length; i++){
+            if(selected == value[i]){
+                str += `<option selected="selected" value='${value[i]}'>${value[i]}</option>`;
+            }else {
+                str += `<option value='${value[i]}'> ${value[i]}</option>`;   
+            }
+        }
+        str += '</select>';
+        str+=`<br><br><input type="submit" value="Save" onclick="changeLineKind();">`;
     }
 
     propSet.innerHTML = str;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2093,7 +2093,7 @@ function generateContextProperties()
 
     //more than one element selected
 
-    if (context.length == 1) {
+    if (context.length == 1 && contextLine.length == 0) {
         var element = context[0];
         
         //ID MUST START WITH "elementProperty_"!!!!!1111!!!!!1111 
@@ -2134,6 +2134,15 @@ function generateContextProperties()
 
     } else if (context.length > 1) {
         str += "<p>Pick only ONE element!</p>";
+    }
+
+    // Update selected line
+    if (contextLine.length == 1 && context.length == 0) {
+        str = "<legend>Properties</legend>";
+        var line = contextLine[0];
+        
+
+        //propSet.innerHTML = str;
     }
 
     propSet.innerHTML = str;


### PR DESCRIPTION
It's now possible to change the line from Normal to Double or vice versa in the options panel after selecting a line.

Side note: 
Warning text when selecting more than one element doesn't work correctly on mouse-down when switching from selecting an entity to a line. Further investigation required. 