### PR TITLE
Change element name and state with Enter

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -684,7 +684,7 @@ document.addEventListener('keydown', function (e)
 {
     // If the active element in DOM is not an "INPUT" "SELECT" "TEXTAREA"
     if( !/INPUT|SELECT|TEXTAREA/.test(document.activeElement.nodeName.toUpperCase())) {
-
+       
         if (e.key == keybinds.LEFT_CONTROL.key && ctrlPressed !== true) ctrlPressed = true;
         if (e.key == keybinds.ALT.key && altPressed !== true) altPressed = true;
         if (e.key == keybinds.DELETE.key && e.ctrlKey == keybinds.DELETE.ctrl) {
@@ -715,6 +715,14 @@ document.addEventListener('keydown', function (e)
             removeElements(context); 
             removeLines(contextLine);
             updateSelection();
+        }
+       
+    }
+    // If the active element in DOM is an "INPUT" "SELECT" "TEXTAREA"
+    if ( /INPUT|SELECT|TEXTAREA/.test(document.activeElement.nodeName.toUpperCase())) {
+        if (e.key == "Enter") {
+            changeState();
+            saveProperties();
         }
     }
 });

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -498,6 +498,7 @@ const keybinds = {
         GRID: {key: "g", ctrl: false},
         RULER: {key: "t", ctrl: false},
         OPTIONS: {key: "o", ctrl: false},
+        ENTER: {key: "Enter", ctrl: false},
 };
 
 // Zoom variables
@@ -720,7 +721,7 @@ document.addEventListener('keydown', function (e)
     }
     // If the active element in DOM is an "INPUT" "SELECT" "TEXTAREA"
     if ( /INPUT|SELECT|TEXTAREA/.test(document.activeElement.nodeName.toUpperCase())) {
-        if (e.key == "Enter") {
+        if (e.key == keybinds.ENTER.key) {
             changeState();
             saveProperties();
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -721,7 +721,7 @@ document.addEventListener('keydown', function (e)
     }
     // If the active element in DOM is an "INPUT" "SELECT" "TEXTAREA"
     if ( /INPUT|SELECT|TEXTAREA/.test(document.activeElement.nodeName.toUpperCase())) {
-        if (e.key == keybinds.ENTER.key) {
+        if (e.key == keybinds.ENTER.key && e.ctrlKey == keybinds.ENTER.ctrl) {
             changeState();
             saveProperties();
         }


### PR DESCRIPTION
When you select an element and re-name it or change the state you can now also save by clicking "Enter"