### PR TITLE
Escape key returns to pointer state

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -704,6 +704,7 @@ document.addEventListener('keydown', function (e)
         if (e.key == keybinds.ESCAPE.key && escPressed != true) {
             escPressed = true;
             clearContext();
+            setMouseMode(mouseModes.POINTER);
             movingObject = false;
 
             if (movingContainer) {


### PR DESCRIPTION
Now when pressing escape from any other mode we always return to the "pointer" mode.