### PR TITLE
Disabled right click when in edge creation

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -971,6 +971,7 @@ function ddown(event)
             }
 
         case mouseModes.EDGE_CREATION:
+            if(event.button == 2) return;
             var element = data[findIndex(data, event.currentTarget.id)];
             if (element != null && !context.includes(element) || !ctrlPressed){
                 updateSelection(element);


### PR DESCRIPTION
You can no longer right click an element when in edge creation mode to create lines.