### PR TITLE
Avoiding line crossing on most frequently used browsers. Issue  #10092

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2393,10 +2393,10 @@ function sortvectors(a, b, ends, elementid, axis)
         toElementB = data[findIndex(data, lineB.fromID)];
     }
 
-    if (navigator.userAgent.indexOf("Chrome") !== -1) {
-        sortval = 1;
-    } else {
+    if (navigator.userAgent.indexOf("Chrome") !== 1) {
         sortval = -1;
+    } else {
+        sortval = 1;
     }
 
     // If lines cross swap otherwise keep as is
@@ -2407,7 +2407,7 @@ function sortvectors(a, b, ends, elementid, axis)
         if (axis == 0) parentx = parent.x1
         else parentx = parent.x2;
 
-        if (linetest(toElementA.cx, toElementA.cy, parentx, ay, toElementB.cx, toElementB.cy, parentx, by) === false) return sortval
+        if (linetest(toElementA.cx, toElementA.cy, parentx, ay, toElementB.cx, toElementB.cy, parentx, by) === false) return -sortval
 
     } else if (axis == 2 || axis == 3) {
         // Top / Bottom side
@@ -2416,10 +2416,10 @@ function sortvectors(a, b, ends, elementid, axis)
         if (axis == 2) parenty = parent.y1
         else parenty = parent.y2;
 
-        if (linetest(toElementA.cx, toElementA.cy, ax, parenty, toElementB.cx, toElementB.cy, bx, parenty) === false) return sortval
+        if (linetest(toElementA.cx, toElementA.cy, ax, parenty, toElementB.cx, toElementB.cy, bx, parenty) === false) return -sortval
     }
 
-    return - sortval;
+    return sortval;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2381,16 +2381,22 @@ function sortvectors(a, b, ends, elementid, axis)
     var parent = data[findIndex(data, elementid)];
 
     // Retrieve opposite element - assume element center (for now)
-     if (lineA.fromID == elementid){
+     if (lineA.fromID == elementid) {
         toElementA = (lineA == ghostLine) ? ghostElement : data[findIndex(data, lineA.toID)];
     } else {
         toElementA = data[findIndex(data, lineA.fromID)];
     }
 
-    if (lineB.fromID == elementid){
+    if (lineB.fromID == elementid) {
         toElementB = (lineB == ghostLine) ? ghostElement : data[findIndex(data, lineB.toID)];
     } else {
         toElementB = data[findIndex(data, lineB.fromID)];
+    }
+
+    if (navigator.userAgent.indexOf("Chrome") !== -1) {
+        sortval = 1;
+    } else {
+        sortval = -1;
     }
 
     // If lines cross swap otherwise keep as is
@@ -2401,7 +2407,7 @@ function sortvectors(a, b, ends, elementid, axis)
         if (axis == 0) parentx = parent.x1
         else parentx = parent.x2;
 
-        if (linetest(toElementA.cx, toElementA.cy, parentx, ay, toElementB.cx, toElementB.cy, parentx, by) === false) return -1
+        if (linetest(toElementA.cx, toElementA.cy, parentx, ay, toElementB.cx, toElementB.cy, parentx, by) === false) return sortval
 
     } else if (axis == 2 || axis == 3) {
         // Top / Bottom side
@@ -2410,10 +2416,10 @@ function sortvectors(a, b, ends, elementid, axis)
         if (axis == 2) parenty = parent.y1
         else parenty = parent.y2;
 
-        if (linetest(toElementA.cx, toElementA.cy, ax, parenty, toElementB.cx, toElementB.cy, bx, parenty) === false) return -1
+        if (linetest(toElementA.cx, toElementA.cy, ax, parenty, toElementB.cx, toElementB.cy, bx, parenty) === false) return sortval
     }
 
-    return 1;
+    return - sortval;
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Now the lines between the objects and its attributes and relations will not be crossing each other, wich will make a more sleek look to the diagram.

Implemented the code from the solution of week 16 branch with the  branch of week 17 to be able to merge it with the week 17 main branch.

Issue #10092 
close #10092 