### PR TITLE
Now hides swimlanes if there is a noaccess-message. Issue#10403

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1164,6 +1164,7 @@ function returnedSection(data) {
       // But disable sorting if there is a #noAccessMessage
       if( $("#noAccessMessage").length) {
         $("#Sectionlistc").sortable("disable");
+        $("#statisticsSwimlanes").hide();
       }
     }
   } else {


### PR DESCRIPTION
"StatisticsSwimalanes" is hidden if a noaccess-message is displayed.

Co-author: @b18phika 