### PR TITLE
G1 2021 W17 #10466

### DIFF
--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -242,7 +242,8 @@ if($demo){
 	$query->execute();
 	$variantsize = $query->fetchColumn();
 
-
+	//If the variant value is unknown (E.G: UNK) then we retrieve the variant from the variant set in useranswer 
+	//where there exists a corresponding hash, and set the resulting useranswer.variant into $variantvalue
 	if($variantvalue == "UNK") {
 		$query = $pdo->prepare("SELECT useranswer.variant FROM useranswer WHERE hash=:hash");
 		$query->bindParam(':hash', $hash);

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -331,7 +331,7 @@ if(checklogin()){
 				$query->bindParam(':coursevers', $coursevers);
 				$query->bindParam(':did', $duggaid);
 				$query->bindParam(':moment', $moment);
-				$query->bindParam(':variant', $savedvariant);
+				$query->bindParam(':variant', $variantvalue);
 				$query->bindParam(':hash', $hash);
 				$query->bindParam(':password', $password);
 				if(!$query->execute()) {

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -41,6 +41,7 @@ $password=getOP('password');
 $AUtoken=getOP('AUtoken');
 //$localStorageVariant= getOP('variant');
 $variantvalue= getOP('variant');
+$hashvariant;
 
 $showall="true";
 $param = "UNK";
@@ -244,6 +245,8 @@ if($demo){
 
 	//If the variant value is unknown (E.G: UNK) then we retrieve the variant from the variant set in useranswer 
 	//where there exists a corresponding hash, and set the resulting useranswer.variant into $variantvalue
+	
+	error_log("!=UNK".$variantvalue);
 	if($variantvalue == "UNK") {
 		$query = $pdo->prepare("SELECT useranswer.variant FROM useranswer WHERE hash=:hash");
 		$query->bindParam(':hash', $hash);
@@ -251,7 +254,9 @@ if($demo){
 		$result = $query->fetch();
 		if($param != null) {
 			$variantvalue = $result['variant'];
+			$hashvariant = $result['variant'];
 		}
+		error_log("==UNK".$result['variant']);
 	}
 
 	//Makes sure that the variantvalue is set before retrieving data from database
@@ -261,6 +266,7 @@ if($demo){
 		$query->execute();
 		$result = $query->fetch();
 		$param=html_entity_decode($result['param']);
+		error_log("!=UNK".$variantvalue);
 	}
 } else if ($hr){
 	//Finds the highest variant.quizID, which is then used to compare against the duggaid to make sure that the dugga is within the scope of listed duggas in the database
@@ -617,6 +623,7 @@ $array = array(
 		"variantsize" => $variantsize,
 		"variantvalue" => $variantvalue,
 		"password" => $password,
+		"hashvariant" => $hashvariant,
 	);
 if (strcmp($opt, "GRPDUGGA")==0) $array["group"] = $group;
 

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -242,14 +242,24 @@ if($demo){
 	$query->execute();
 	$variantsize = $query->fetchColumn();
 
-	//Makes sure that the localstorage variant is set before retrieving data from database
-	if(isset($variantvalue)) {
+
+	if($variantvalue == "UNK") {
+		$query = $pdo->prepare("SELECT useranswer.variant FROM useranswer WHERE hash=:hash");
+		$query->bindParam(':hash', $hash);
+		$query->execute();
+		$result = $query->fetch();
+		if($param != null) {
+			$variantvalue = $result['variant'];
+		}
+	}
+
+	//Makes sure that the variantvalue is set before retrieving data from database
+	if(isset($variantvalue) && ($variantvalue != "UNK")) {
 		$query = $pdo->prepare("SELECT param FROM variant WHERE vid=:vid");
 		$query->bindParam(':vid', $variantvalue);
 		$query->execute();
 		$result = $query->fetch();
 		$param=html_entity_decode($result['param']);
-		error_log("result param: ".$param);
 	}
 } else if ($hr){
 	//Finds the highest variant.quizID, which is then used to compare against the duggaid to make sure that the dugga is within the scope of listed duggas in the database

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1035,7 +1035,7 @@ function AJAXService(opt,apara,kind)
 			datatype: "json",
 			success: function(data){
 				getVariantValue(data);					//Get variant.
-				console.log("real variantvalue: "+variantvalue);
+				
 				$.ajax({ 								//We need to have this Ajax call inside of the outer Ajax call, otherwise variantValue cant be retrieved.
 					url: "showDuggaservice.php",
 					type: "POST",

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -27,6 +27,8 @@ var passwordReload = false; // Bool turns true when reloading in combination wit
 var isGroupDugga = true; // Set to false if you hate the popup
 var variantvalue;
 
+var tempvar;
+
 
 $(function () {  // Used to set the position of the FAB above the cookie message
 	if(localStorage.getItem("cookieMessage")!="off"){
@@ -1035,7 +1037,6 @@ function AJAXService(opt,apara,kind)
 			datatype: "json",
 			success: function(data){
 				getVariantValue(data);					//Get variant.
-				
 				$.ajax({ 								//We need to have this Ajax call inside of the outer Ajax call, otherwise variantValue cant be retrieved.
 					url: "showDuggaservice.php",
 					type: "POST",
@@ -1161,6 +1162,7 @@ function handleHash(hashdata){
 function handleLocalStorage(storagedata){
 	// Check localstorage variants.
 	var newvariant = storagedata['variantvalue'];
+	console.log(storagedata);
 
 	if(localStorage.getItem(querystring['did']) == null){
 		localStorage.setItem(querystring['did'], newvariant);
@@ -1170,14 +1172,16 @@ function handleLocalStorage(storagedata){
 	getExpireTime(querystring['did']);
 	var variantsize = storagedata['variantsize'];
 	localStorage.setItem("variantSize", variantsize);
-						
 }
 
 function getVariantValue(ajaxdata){
+	console.log(ajaxdata);
 	//Checks if the variantSize variant is set in localstorage. When its not, its set.
 	if(localStorage.getItem("variantSize") == null) {
 		localStorage.setItem("variantSize", 100);
 	}
+	tempvar = JSON.parse(ajaxdata);
+	console.log("tempvar: "+tempvar.variantvalue);
 	//Converts the localstorage variant from string to int
 	var newInt = +localStorage.getItem('variantSize');
 	//Checks if the dugga id is within scope (Not bigger than the largest dugga variant)
@@ -1185,9 +1189,15 @@ function getVariantValue(ajaxdata){
 		if(localStorage.getItem(querystring['did']) == null){
 			returndata = JSON.parse(ajaxdata);
 			variantvalue = returndata.variant;
+			console.log("variantvalue1: "+variantvalue);
 		} else {
 			var test = JSON.parse(localStorage.getItem(querystring['did']));
 			variantvalue = test.value;
+			console.log("variantvalue2: "+variantvalue);
+		}
+		if(tempvar.hashvariant != null) {
+			variantvalue = tempvar.hashvariant;
+			setExpireTime(querystring['did'], tempvar.hashvariant, 2592000000);
 		}
 	}
 }


### PR DESCRIPTION
The corresponding variant to the hash URL should now load correctly, when "visiting" a hash, and the saved answer should display correctly. To check this compare the saved answer to the useranswer in the userAnswer inserts, after loading the URL address with the hashes. You could also reset the local storage and save a dugga yourself, and then use the hash and password that is generated to test this issue.