### PR TITLE
"fixed" "Snap To Grid" button needs a keybinding

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -504,6 +504,7 @@ const keybinds = {
         ZOOM_OUT: {key: "-", ctrl: true},
         TOGGLE_GRID: {key: "g", ctrl: false},
         TOGGLE_RULER: {key: "t", ctrl: false},
+        TOGGLE_SNAPGRID: {key: "s", ctrl: false},
         OPTIONS: {key: "o", ctrl: false},
         ENTER: {key: "Enter", ctrl: false},
         COPY: {key: "c", ctrl: true},
@@ -848,6 +849,9 @@ document.addEventListener('keyup', function (e)
         }
         if (pressedKey == keybinds.TOGGLE_RULER.key && e.ctrlKey == keybinds.TOGGLE_RULER.ctrl) {
             toggleRuler();
+        }
+        if (pressedKey == keybinds.TOGGLE_SNAPGRID.key && e.ctrlKey == keybinds.TOGGLE_SNAPGRID.ctrl) {
+            toggleSnapToGrid();
         }
         if (pressedKey == keybinds.OPTIONS.key && e.ctrlKey == keybinds.OPTIONS.ctrl) {
             fab_action();

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -108,7 +108,7 @@
                 <img src="../Shared/icons/diagram_gridmagnet.svg"/>
                 <span class="toolTipText"><b>Toggle Snap To Grid</b><br>
                     <p>Enable/disable the Snap To Grid</p><br>
-                    <p id="tooltip-TOGGLE_RULER" class="key_tooltip">Keybinding:</p>
+                    <p id="tooltip-TOGGLE_SNAPGRID" class="key_tooltip">Keybinding:</p>
                 </snap>
         </fieldset>
     </div>


### PR DESCRIPTION
fixed by creating keybinding to the key s. Now works on W18 version