### PR TITLE
Swimlanes now properly hides when there are no "duggor". Issue#10403

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -802,7 +802,7 @@ function returnedSection(data) {
         if (itemKind === 3 || itemKind === 4) {
           
           //If there exists atleast one test or moment swimlanes shall be hidden
-          var hasDuggs = true;
+          hasDuggs = true;
 
           // Styling for quiz row e.g. add a tab spacer
           if (itemKind === 3) str += `<td style='width:0px'><div class='spacerLeft'></div></td>
@@ -1146,7 +1146,7 @@ function returnedSection(data) {
       resave = false;
     }
 
-    if (!hasDuggs){
+    if (hasDuggs === false){
       $("#statisticsSwimlanes").hide();
     }
 
@@ -1691,7 +1691,6 @@ $(window).load(function () {
       'flex-direction': 'column'
     });
     $(".statisticsContentBottom").show();
-    console.log(hasDuggs);
     if (hasDuggs) {
       $("#swimlaneSVG").show();
       $("#statisticsSwimlanes").show(); 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -799,6 +799,9 @@ function returnedSection(data) {
         }
 
         if (itemKind === 3 || itemKind === 4) {
+          
+          //If there exists atleast one test or moment swimlanes shall be hidden
+          var hasDuggs = true;
 
           // Styling for quiz row e.g. add a tab spacer
           if (itemKind === 3) str += `<td style='width:0px'><div class='spacerLeft'></div></td>
@@ -1140,6 +1143,10 @@ function returnedSection(data) {
         order: str
       }, "SECTION");
       resave = false;
+    }
+
+    if (!hasDuggs){
+      $("#statisticsSwimlanes").hide();
     }
 
     if (data['writeaccess']) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1691,11 +1691,12 @@ $(window).load(function () {
       'flex-direction': 'column'
     });
     $(".statisticsContentBottom").show();
+    console.log(hasDuggs);
+    if (hasDuggs) {
+      $("#swimlaneSVG").show();
+      $("#statisticsSwimlanes").show(); 
+    }
   }); 
-  if (hasDuggs) {
-    $("#swimlaneSVG").show();
-    $("#statisticsSwimlanes").show(); 
-  }
   $("#sectionList_arrowStatisticsClosed").click(function () {
     $("#sectionList_arrowStatisticsOpen").show();
     $("#sectionList_arrowStatisticsClosed").hide();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1691,9 +1691,11 @@ $(window).load(function () {
       'flex-direction': 'column'
     });
     $(".statisticsContentBottom").show();
-	$("#swimlaneSVG").show();
-    $("#statisticsSwimlanes").show();  
-  });
+  }); 
+  if (hasDuggs) {
+    $("#swimlaneSVG").show();
+    $("#statisticsSwimlanes").show(); 
+  }
   $("#sectionList_arrowStatisticsClosed").click(function () {
     $("#sectionList_arrowStatisticsOpen").show();
     $("#sectionList_arrowStatisticsClosed").hide();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -15,6 +15,7 @@ var versnme = "UNKz";
 var versnr;
 var motd;
 var deleteItemList = [];
+var hasDuggs = false;
 
 // Stores everything that relates to collapsable menus and their state.
 var menuState = {


### PR DESCRIPTION
Swimlanes should now properly hide in all browsers when there are no tests or moments in a course. Swimlanes should now also stay hidden when clicking the close/open swimlanes button multiple times. 

Note: A new branch has been used after the merge. All changes in branch G2-2021-W17-ISSUE#10403 should therefore be disregarded.