### PR TITLE
Fixed "deselect all" functionality

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -767,11 +767,12 @@ document.addEventListener('keydown', function (e)
         if (e.key == keybinds.ZOOM_OUT.key && e.ctrlKey == keybinds.ZOOM_OUT.ctrl) zoomout(); // Works but interferes with browser zoom
         if (e.key == keybinds.ESCAPE.key && escPressed != true) {
             escPressed = true;
-            clearContext();
-            setMouseMode(mouseModes.POINTER);
-            clearContextLine();
-            movingObject = false;
-
+            if(context.length > 0 || contextLine.length > 0) {
+                clearContext();
+                clearContextLine();
+            } else {
+                setMouseMode(mouseModes.POINTER);
+            }
             if (movingContainer) {
                 scrollx = sscrollx;
                 scrolly = sscrolly;
@@ -781,7 +782,7 @@ document.addEventListener('keydown', function (e)
             pointerState = pointerStates.DEFAULT;
             showdata();
         }
-
+        
         if (e.key == "Backspace" && (context.length > 0 || contextLine.length > 0) && !propFieldState) {
             if (contextLine.length > 0) removeLines(contextLine);
             if (context.length > 0) removeElements(context);


### PR DESCRIPTION
The "Escape" key now detects if anything is selected and deselects  it/them, then returns to the mouseMode it is currently in. If "Escape" is pressed again with nothing selected we return to the default mouse mode.