### PR TITLE
Only clear contextLine if ctrl is not pressed when clicking the container

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1029,11 +1029,10 @@ function mup(event)
                 if (!deltaExceeded) {
                     if (mouseMode == mouseModes.EDGE_CREATION) {
                         clearContext();
-                        clearContextLine();
                     } else if (mouseMode == mouseModes.POINTER) {
                         updateSelection(null);
-                        clearContextLine();
                     }
+                    if (!ctrlPressed) clearContextLine();
                 }
             }
             break;


### PR DESCRIPTION
Added if-statement to check if ctrl is pressed before clearing contextLine