### PR TITLE
G2 2021 w18 issue#10558 -> changed lightbulb icons

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -851,7 +851,7 @@ function returnedSection(data) {
             str += "<div ><img alt='pen icon dugga' src='../Shared/icons/PenT.svg'></div>";
           } else if (itemKind === 4) {
             str += "<td class='LightBoxFilled" + hideState + "'>";
-            str += "<div ><img alt='pen icon dugga' src='../Shared/icons/PenV.svg'></div>";
+            str += "<div ><img alt='pen icon dugga' src='../Shared/icons/list_docfiles.svg'></div>";
           }
           str += "</td>";
         }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -848,10 +848,11 @@ function returnedSection(data) {
 
           if (itemKind === 3) {
             str += "<td class='LightBox" + hideState + "'>";
+            str += "<div ><img alt='pen icon dugga' src='../Shared/icons/PenT.svg'></div>";
           } else if (itemKind === 4) {
             str += "<td class='LightBoxFilled" + hideState + "'>";
+            str += "<div ><img alt='pen icon dugga' src='../Shared/icons/PenV.svg'></div>";
           }
-          str += "<div class='StopLight WhiteLight'></div>";
           str += "</td>";
         }
 


### PR DESCRIPTION
We were tasked with changing the lightbulb icons, there are multiple different icons that could  be used, look in the comments for alternatives and make a change request for the best looking one (unless the current one is best).

1 (current)
![Skärmklipp](https://user-images.githubusercontent.com/81560923/116869405-f8e2cf00-ac10-11eb-9ced-a596e46a5127.PNG)

2
![option1](https://user-images.githubusercontent.com/81560923/116869438-0d26cc00-ac11-11eb-826f-b6cde5e50806.PNG)

3
![option2](https://user-images.githubusercontent.com/81560923/116869509-2596e680-ac11-11eb-9ef8-e1f53f76381c.PNG)

4
![option4](https://user-images.githubusercontent.com/81560923/116869568-3e070100-ac11-11eb-9657-50861a9d9d21.PNG)

