### PR TITLE
Receiptbox - Remove the receipt numbers when saving a dugga #10592

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -279,7 +279,7 @@ if($hash!='UNK'){
 					</div>
 			</div>
 			<div id='receiptInfo'></div>
-    		<!--<textarea id="receipt" autofocus readonly style="resize: none;"></textarea>-->
+
     		<div id='emailPopup' style="display:block">
 				<div id='urlAndPwd'>
 					<div class="testasd"><p class="bold">URL</p><p id='url'></p></div>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -234,7 +234,7 @@ if($hash!='UNK'){
 	<!-- LoginBox (receipt&Feedback-box ) Start! -->
 	<div id='receiptBox' class="loginBoxContainer" style="display:none">
 	  <div class="receiptBox loginBox" style="max-width:400px; overflow-y:visible;">
-			<div class='loginBoxheader'><h3>Kvittoo och feedback - Duggasvar</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
+			<div class='loginBoxheader'><h3>Kvitto och feedback - Duggasvar</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
 			<div id='feedbackbox'>
 				<span id='feedbackquestion'></span>
 					<div id="ratingbox">
@@ -279,7 +279,6 @@ if($hash!='UNK'){
 					</div>
 			</div>
 			<div id='receiptInfo'></div>
-    		<textarea id="receipt" autofocus readonly style="resize: none;"></textarea>
  
     		<div id='emailPopup' style="display:block">
 				<div id='urlAndPwd'>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -234,7 +234,7 @@ if($hash!='UNK'){
 	<!-- LoginBox (receipt&Feedback-box ) Start! -->
 	<div id='receiptBox' class="loginBoxContainer" style="display:none">
 	  <div class="receiptBox loginBox" style="max-width:400px; overflow-y:visible;">
-			<div class='loginBoxheader'><h3>Kvitto och feedback - Duggasvar</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
+			<div class='loginBoxheader'><h3>Kvittoo och feedback - Duggasvar</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
 			<div id='feedbackbox'>
 				<span id='feedbackquestion'></span>
 					<div id="ratingbox">

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -279,7 +279,7 @@ if($hash!='UNK'){
 					</div>
 			</div>
 			<div id='receiptInfo'></div>
- 
+    		<!--<textarea id="receipt" autofocus readonly style="resize: none;"></textarea>-->
     		<div id='emailPopup' style="display:block">
 				<div id='urlAndPwd'>
 					<div class="testasd"><p class="bold">URL</p><p id='url'></p></div>

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -696,11 +696,12 @@ function saveDuggaResult(citstr)
 			citstr+= "##!!##" + timeUsed;
 			citstr+= "##!!##" + stepsUsed;
 			//citstr+= "##!!##" + score;
-			hexstr="";
+			//Old way of generating a receipt. Not used anymore.
+			/*hexstr="";
 			for(i=0;i<citstr.length;i++){
 					hexstr+=citstr.charCodeAt(i).toString(16)+" ";
 			}
-			
+			*/
 			AJAXService("SAVDU",{answer:citstr},"PDUGGA");
 
 			document.getElementById('receipt').value = hexstr;

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -704,7 +704,7 @@ function saveDuggaResult(citstr)
 			*/
 			AJAXService("SAVDU",{answer:citstr},"PDUGGA");
 
-			document.getElementById('receipt').value = hexstr;
+			//document.getElementById('receipt').value = hexstr;
 
 			var dateTime = new Date(); // Get the current date and time
 
@@ -712,12 +712,12 @@ function saveDuggaResult(citstr)
 
 			var deadline = querystring['deadline']; //Get deadlinedate from URL
 
-
+			
 			Number.prototype.padLeft = function(base,chr){
 				var  len = (String(base || 10).length - String(this).length)+1;
 				return len > 0? new Array(len).join(chr || '0')+this : this;
 			}
-
+			
 			dateTimeFormat = [dateTime.getFullYear(),(dateTime.getMonth()+1).padLeft(),dateTime.getDate().padLeft()].join('-') +' ' +[dateTime.getHours().padLeft(),dateTime.getMinutes().padLeft(),dateTime.getSeconds().padLeft()].join(':');
 
 			if(deadline > dateTimeFormat){	//Check if deadline has past

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -696,15 +696,7 @@ function saveDuggaResult(citstr)
 			citstr+= "##!!##" + timeUsed;
 			citstr+= "##!!##" + stepsUsed;
 			//citstr+= "##!!##" + score;
-			//Old way of generating a receipt. Not used anymore.
-			/*hexstr="";
-			for(i=0;i<citstr.length;i++){
-					hexstr+=citstr.charCodeAt(i).toString(16)+" ";
-			}
-			*/
 			AJAXService("SAVDU",{answer:citstr},"PDUGGA");
-
-			//document.getElementById('receipt').value = hexstr;
 
 			var dateTime = new Date(); // Get the current date and time
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -714,16 +714,16 @@ function saveDuggaResult(citstr)
 
 			if(deadline > dateTimeFormat){	//Check if deadline has past
 
-				document.getElementById('receiptInfo').innerHTML = "<p>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.\n\n</p>";
+				document.getElementById('receiptInfo').innerHTML = "<p>Hash and password can be used to return to the dugga in the future. Make sure to store it on a secure place.\n\n</p>";
 
 			}
 			else{ //Check if deadline has past
 
 				if(comment == "UNK" || comment == "undefined" || comment == "null"){
-					document.getElementById('receiptInfo').innerHTML = "<p style='margin:15px 5px;'>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.</p><img style='width:40px;float:left;margin-right:10px;' title='Warning' src='../Shared/icons/warningTriangle.svg'/><p>OBS! Denna inlämning har gjorts efter att deadline har passerat. Läraren kommer att rätta duggan vid nästa ordinarie rättningstillfälle ELLER i mån av tid.</p>";
+					document.getElementById('receiptInfo').innerHTML = "<p style='margin:15px 5px;'>Hash and password can be used to return to the dugga in the future. Make sure to store it on a secure place.</p><img style='width:40px;float:left;margin-right:10px;' title='Warning' src='../Shared/icons/warningTriangle.svg'/><p>OBS! This assignment has passed its deadline. The teacher will grade this assignment during the next ordinary grading occation OR when time allows.</p>";
 				}
 				else{
-					document.getElementById('receiptInfo').innerHTML = "<p>Teckensträngen är ditt kvitto på att duggan har lämnats in. Spara kvittot på en säker plats.</p><img style='width:40px;float:left;margin-right:10px;' title='Warning' src='../Shared/icons/warningTriangle.svg'/><p>"+comment+"</p>";
+					document.getElementById('receiptInfo').innerHTML = "<p>Hash and password can be used to return to the dugga in the future. Make sure to store it on a secure place.</p><img style='width:40px;float:left;margin-right:10px;' title='Warning' src='../Shared/icons/warningTriangle.svg'/><p>"+comment+"</p>";
 				}
 
 			}


### PR DESCRIPTION
To test this change:

- Make sure the receipt dialog popup appears whenever you try to save a dugga/submission.
- Also check if it works when you use a URL with hash & password access.