### PR TITLE
Fix: Only the diagram is magnified when zooming

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -894,8 +894,14 @@ document.addEventListener('keydown', function (e)
             showdata();
         }
 
-        if (isKeybindValid(e, keybinds.ZOOM_IN)) zoomin();
-        if (isKeybindValid(e, keybinds.ZOOM_OUT)) zoomout();
+        if (isKeybindValid(e, keybinds.ZOOM_IN)){
+            e.preventDefault();
+            zoomin();
+        } 
+        if (isKeybindValid(e, keybinds.ZOOM_OUT)){
+            e.preventDefault();
+            zoomout();
+        } 
 
         if (isKeybindValid(e, keybinds.SELECT_ALL)){
             e.preventDefault();
@@ -992,6 +998,7 @@ window.onfocus = function()
  */
 function mwheel(event)
 {
+    event.preventDefault();
     if(event.deltaY < 0) {
         zoomin(event);
     } else {


### PR DESCRIPTION
Added preventdefault() to stop the webpage from getting magnified when zooming in the diagram.
Fixed so this both works when zooming with ctrl+mwheel as well as with ctrl+"+" and ctrl+"-" on the numpad.