### PR TITLE
You can now choose weak key attribute

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -209,6 +209,10 @@
     text-underline-offset: 0.15em;
     text-decoration: underline;
 }
+.weakAttribute{
+    text-underline-offset: 0.15em;
+    text-decoration: underline dotted;
+}
 
 .saveButton {
     background-color: #614875;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -209,6 +209,7 @@
     text-underline-offset: 0.15em;
     text-decoration: underline;
 }
+
 .weakAttribute{
     text-underline-offset: 0.15em;
     text-decoration: underline dotted;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -210,11 +210,6 @@
     text-decoration: underline;
 }
 
-.weakAttribute{
-    text-underline-offset: 0.15em;
-    text-decoration: underline dotted 2px;
-}
-
 .saveButton {
     background-color: #614875;
     border: 0px;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -212,7 +212,7 @@
 
 .weakAttribute{
     text-underline-offset: 0.15em;
-    text-decoration: underline dotted;
+    text-decoration: underline dotted 2px;
 }
 
 .saveButton {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -626,6 +626,7 @@ const messageTypes = {
  */
 const attrState = {
     NORMAL: "normal",
+    WEAK: "weak",
     MULTIPLE: "multiple",
     KEY: "key",
     COMPUTED: "computed",
@@ -3436,6 +3437,7 @@ function drawElement(element, ghosted = false)
         if (element.state == "computed") {
             dash = "stroke-dasharray='4 4'";
         }
+       
         if (element.state == "multiple") {
             multi = `
                     <path d="M${linew * multioffs},${hboxh} 
@@ -3456,6 +3458,12 @@ function drawElement(element, ghosted = false)
                     ${multi}
 
                     <text x='${xAnchor}' y='${hboxh}' `;
+
+        if(element.state == "weak") {
+            str += `class='weakAttribute'`;
+        }
+        str += `dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>
+            `;
 
         if(element.state == "key") {
             str += `class='underline'`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3466,7 +3466,10 @@ function drawElement(element, ghosted = false)
         `;
             
         if(element.state == "weakKey") {
-            str += `<line x1="${xAnchor - textWidth / 2}" y1="${hboxh + texth * 0.5 + 1}" x2="${xAnchor + textWidth / 2}" y2="${hboxh + texth * 0.5 + 1}" stroke="black" stroke-dasharray="5" stroke-width='2'/>`;
+            // Calculates how far to the left X starts
+            var diff = xAnchor - textWidth / 2;
+            diff = diff < 0 ? 0 - diff + 10 : 0;
+            str += `<line x1="${xAnchor - textWidth / 2 + diff}" y1="${hboxh + texth * 0.5 + 1}" x2="${xAnchor + textWidth / 2 + diff}" y2="${hboxh + texth * 0.5 + 1}" stroke="black" stroke-dasharray="5" stroke-width='2'/>`;
         }
         
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3446,7 +3446,7 @@ function drawElement(element, ghosted = false)
                     Q${boxw - (linew * multioffs)},${boxh - (linew * multioffs)} ${hboxw},${boxh - (linew * multioffs)} 
                     Q${linew * multioffs},${boxh - (linew * multioffs)} ${linew * multioffs},${hboxh}" 
                     stroke='black' fill='#ffccdc' stroke-width='${linew}' />`;
-        }
+        }    
 
         str += `<path d="M${linew},${hboxh} 
                            Q${linew},${linew} ${hboxw},${linew} 
@@ -3458,17 +3458,17 @@ function drawElement(element, ghosted = false)
                     ${multi}
 
                     <text x='${xAnchor}' y='${hboxh}' `;
-                    
-        if(element.state == "weakKey") {
-            str += `class='weakAttribute'`;
-        }
-
+        
         if(element.state == "key") {
             str += `class='underline'`;
-        }    
-            str += `dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>
-            `;
-    
+        }             
+        str += `dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>
+        `;
+            
+        if(element.state == "weakKey") {
+            str += `<line x1="${xAnchor - textWidth / 2}" y1="${hboxh + texth * 0.5 + 1}" x2="${xAnchor + textWidth / 2}" y2="${hboxh + texth * 0.5 + 1}" stroke="black" stroke-dasharray="5" stroke-width='2'/>`;
+        }
+        
     }
     else if (element.kind == "ERRelation") {
         var weak = "";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3458,18 +3458,17 @@ function drawElement(element, ghosted = false)
                     ${multi}
 
                     <text x='${xAnchor}' y='${hboxh}' `;
-
+                    
         if(element.state == "weak") {
             str += `class='weakAttribute'`;
         }
-        str += `dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>
-            `;
 
         if(element.state == "key") {
             str += `class='underline'`;
         }    
             str += `dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>
             `;
+    
     }
     else if (element.kind == "ERRelation") {
         var weak = "";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -626,7 +626,7 @@ const messageTypes = {
  */
 const attrState = {
     NORMAL: "normal",
-    WEAK: "weak",
+    WEAK: "weakKey",
     MULTIPLE: "multiple",
     KEY: "key",
     COMPUTED: "computed",
@@ -3459,7 +3459,7 @@ function drawElement(element, ghosted = false)
 
                     <text x='${xAnchor}' y='${hboxh}' `;
                     
-        if(element.state == "weak") {
+        if(element.state == "weakKey") {
             str += `class='weakAttribute'`;
         }
 


### PR DESCRIPTION
Added a weak key choice to the attribute elements, a small issue in chrome is that the underline cannot be dotted. Works in firefox.

Maybe someone knows a quick fix to this, but the option is there anyway.