### PR TITLE
The announcement icon in the navbar disappears when the width of the …

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5085,7 +5085,7 @@ only screen and (max-device-width: 860px) {
   
   #versionCog, #versionPlus, #editStudent,
   #testsBTN, #editFiles, #courseIMG,
-  #editCourse, #announcement{
+  #editCourse{
     display: none;
   }
 }


### PR DESCRIPTION
…viewport is less than 861px

@a18danli 

Announcement Icon is no longer  hiden!