### PR TITLE
Change the title of assignments #10629

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -2007,7 +2007,15 @@ function displayDuggaStatus(answer,grade,submitted,marked){
 			marked=new Date(tt[0], tt[1]-1, tt[2], tt[3], tt[4], tt[5]);
 		}
 
-		str+="<div class='StopLight WhiteLight' style='margin:4px;'></div></div><div>Dugga</div>";
+		//If duggaTitle variable have a value set. 
+		if(duggaTitle) {	
+			str+="<div class='StopLight WhiteLight' style='margin:4px;'></div></div><div>"+duggaTitle+"</div>";
+		}
+		//If there is no name of the dugga.
+		if(duggaTitle == undefined || duggaTitle == "UNK" || duggaTitle == "null" || duggaTitle == ""){	
+			str+="<div class='StopLight WhiteLight' style='margin:4px;'></div></div><div>Untitled dugga</div>";
+		}
+
 		str+="</div>";
 		$("#duggaStatus").remove();
 		$("<td id='duggaStatus' align='center'>"+str+"</td>").insertAfter("#menuHook");


### PR DESCRIPTION
To test:

- Make sure every Dugga have their corresponding title once entering the dugga.
- Force the variable duggaTitle to have a faulty value, for example: _duggaTitle = "";_ or _duggaTitle = 0;_ in dugga.js, row 2009. The dugga title should then be "untitled Dugga".