### PR TITLE
Fix bug where ghostelement got removed when pressing esc

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -958,6 +958,7 @@ document.addEventListener('keydown', function (e)
                 clearContext();
                 clearContextLine();
             } else {
+                ghostElement = null;
                 setMouseMode(mouseModes.POINTER);
             }
             if (movingContainer) {
@@ -965,7 +966,6 @@ document.addEventListener('keydown', function (e)
                 scrolly = sscrolly;
             }
             ghostLine = null;
-            ghostElement = null;
             pointerState = pointerStates.DEFAULT;
             showdata();
         }


### PR DESCRIPTION
Moved the assignment of null to ghostelement variable to only trigger if there is nothing in the context or contextLine array.