### PR TITLE
G1 2021 w19 #10720

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1535,6 +1535,7 @@ function setupLoginLogoutButton(isLoggedIn){
 function showLoadDuggaPopup()
 {
 	$("#loadDuggaBox").css("display","flex");
+	localStorage.setItem("ls-redirect-last-url", document.URL);
 }
 
 function hideLoadDuggaPopup()
@@ -1590,7 +1591,7 @@ function copyHashtoCB() {
 
 function hideHashBox(){
     $("#hashBox").css("display","none");
-	history.back(); //Takes us back to the dugga when pressing X on the popup.
+	window.location.href = localStorage.getItem("ls-redirect-last-url"); //Takes us to previous visited dugga
 }
 
 function checkHashPassword(){

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1590,6 +1590,7 @@ function copyHashtoCB() {
 
 function hideHashBox(){
     $("#hashBox").css("display","none");
+	history.back(); //Takes us back to the dugga when pressing X on the popup.
 }
 
 function checkHashPassword(){


### PR DESCRIPTION
Since assignments are only going to be accessed through canvas in the future and not through direct urls, there should be no issues for the fix we did, in that it stores the url in local storage when you open the assignment and redirects to it if you cannot enter the correct hash or wish not to (e.g. closing the popup window).

To test this, either access a dugga through your local installation of lenasys or through the following link: http://canvas.webug.his.se/courses/1/assignments/5 and use the admin account.

If you're having issues loading the iframes, simply open up the HTML editor inside canvas and change the address to where you have your lenasys installation folder.

Co-Authored-By: b18jacha 62884577+b18jacha@users.noreply.github.com

