### PR TITLE
Change back name of element at escape pressed

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1122,6 +1122,14 @@ document.addEventListener('keyup', function (e)
                 displayMessage(messageTypes.SUCCESS, `Clipboard cleared.`)
             }
         }
+    } else {
+        if(document.activeElement.id == 'elementProperty_name' && isKeybindValid(e, keybinds.ESCAPE)){
+            if(context.length == 1){
+                document.activeElement.value = context[0].name;
+                document.activeElement.blur();
+                fab_action();
+            }
+        }   
     }
 });
 


### PR DESCRIPTION
Change back the name of a element at escape pressed, if you have not saved the value