### PR TITLE
Fixed error with stepForward() targetting an non existing state

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -469,9 +469,8 @@ class StateMachine
         displayMessage(messageTypes.SUCCESS, "Changes reverted!")
     }
     stepForward(){
-        // If there is no history => return
-        // If the current index is last index
-        if (this.currentHistoryIndex == -1 && this.historyLog.length -1 == this.currentHistoryIndex) return;
+        // If there is not anything to restore => return
+        if (this.historyLog.length == 0 || this.currentHistoryIndex == (this.historyLog.length -1)) return;
 
         // Increase the currentHistoryIndex by one
         this.currentHistoryIndex++;


### PR DESCRIPTION
Fixed error with stepForward() targetting an non existing state by changeing the return statement.