### PR TITLE
No more error pop-window  #10695

### DIFF
--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -120,9 +120,9 @@ $query = $pdo->prepare("SELECT visibility FROM course WHERE cid=:cid");
 $query->bindParam(':cid', $courseid);
 $result = $query->execute();
 if($row = $query->fetch(PDO::FETCH_ASSOC)){
-		$cvisibility=$row['visibility'];
+	$cvisibility=$row['visibility'];
 }else{
-		$debug="Error reading course visibility";
+	error_log("Error reading course visibility", 0);
 }
 // Read visibility of dugga (listentry)
 $query = $pdo->prepare("SELECT visible FROM listentries WHERE cid=:cid and lid=:moment");
@@ -130,9 +130,9 @@ $query->bindParam(':cid', $courseid);
 $query->bindParam(':moment', $moment);
 $result = $query->execute();
 if($row = $query->fetch(PDO::FETCH_ASSOC)){
-		$dvisibility=$row['visible'];
-}else{
-		$debug="Error reading dugga visibility";
+	$dvisibility=$row['visible'];
+}else{	
+	error_log("Error reading course visibility", 0);
 }
 
 // Get type of dugga


### PR DESCRIPTION
Changed debug to error_log.

For testing:
Go to a saved Url when you are logged in as a teacher and if you don't receive an alert with the text "Error reading course visibility" it should work as we planned. :)