### PR TITLE
Autoscroll to relevant swimlane#10756

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1502,27 +1502,6 @@ function drawSwimlanes() {
   }
 
 
-  var minDistance;
-  var index = -1;
-  for(var i = 0; i < deadlineEntries.length;i++) {
-      if(deadlineEntries[i].deadline >= current) {
-        if(deadlineEntries[i].deadline - current < minDistance || minDistance == undefined) {
-
-          minDistance = deadlineEntries[i].deadline - current;
-          index = i;
-          console.log(index);
-          console.log(minDistance);
-        }
-      }
-    }
-  
-  console.log(deadlineEntries[index]);
-  var myElement = document.getElementsByName(deadlineEntries[index]);
-  var topPos = myElement.offsetTop;
-  document.getElementById('statisticsSwimlanes').scrollTop = topPos;
-
-
-
   str += `<line opacity='0.7' x1='${(daySinceStart * daywidth)}'
   y1='${(15 + weekheight)}' x2='${(daySinceStart * daywidth) }'
   y2='${(((1 + deadlineEntries.length) * weekheight) + 15)}' stroke-width='4' stroke='red' />`;
@@ -1530,6 +1509,22 @@ function drawSwimlanes() {
 
   document.getElementById("swimlaneSVG").innerHTML = str;
   document.getElementById("swimlaneSVG").setAttribute("viewBox", "0 0 800 " + svgHeight);
+
+
+  var minDistance;
+  var min_index = -1;
+  //Looks through all the deadline entries and finds the one with the shortest distance to current date
+  for(var i = 0; i < deadlineEntries.length;i++) {
+      if(deadlineEntries[i].deadline >= current) {
+        if(deadlineEntries[i].deadline - current < minDistance || minDistance == undefined) {
+          minDistance = deadlineEntries[i].deadline - current;
+          min_index = i;
+        }
+      }
+    }
+   //index * height = topPos
+  var topPos =  min_index * weekheight;  
+  document.getElementById('statisticsSwimlanes').scrollTop = topPos;
 
 }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -742,7 +742,7 @@ function returnedSection(data) {
     str += "<div id='Sectionlistc'>";
 
     str += "<div id='statisticsSwimlanes'>";
-		str += "<svg id='swimlaneSVG' xmlns='http://www.w3.org/2000/svg'></svg>";
+    str += "<svg id='swimlaneSVG' xmlns='http://www.w3.org/2000/svg'></svg>";
 		str += "</div>";
 
 
@@ -1352,7 +1352,7 @@ function drawSwimlanes() {
 
   var deadlineEntries = [];
   var momentEntries = {};
- // var current = new Date(2021, 01, 15);
+  //var current = new Date(2015, 02, 19);
   var current = new Date();
 
   var momentno = 0;
@@ -1489,7 +1489,6 @@ function drawSwimlanes() {
   var newCurrent;
   var daySinceStart;
 
-
   if(enddate.getFullYear() < current.getFullYear()) { // Guesstimate deadline for current year if course not updated
     var yearDifference = current.getFullYear() - enddate.getFullYear();
     var tempYear = new Date(current); 
@@ -1503,11 +1502,32 @@ function drawSwimlanes() {
   }
 
 
+  var minDistance;
+  var index = -1;
+  for(var i = 0; i < deadlineEntries.length;i++) {
+      if(deadlineEntries[i].deadline >= current) {
+        if(deadlineEntries[i].deadline - current < minDistance || minDistance == undefined) {
+
+          minDistance = deadlineEntries[i].deadline - current;
+          index = i;
+          console.log(index);
+          console.log(minDistance);
+        }
+      }
+    }
+  
+  console.log(deadlineEntries[index]);
+  var myElement = document.getElementsByName(deadlineEntries[index]);
+  var topPos = myElement.offsetTop;
+  document.getElementById('statisticsSwimlanes').scrollTop = topPos;
+
+
 
   str += `<line opacity='0.7' x1='${(daySinceStart * daywidth)}'
   y1='${(15 + weekheight)}' x2='${(daySinceStart * daywidth) }'
   y2='${(((1 + deadlineEntries.length) * weekheight) + 15)}' stroke-width='4' stroke='red' />`;
   let svgHeight = ((1 + deadlineEntries.length) * weekheight) + 15;
+
   document.getElementById("swimlaneSVG").innerHTML = str;
   document.getElementById("swimlaneSVG").setAttribute("viewBox", "0 0 800 " + svgHeight);
 


### PR DESCRIPTION
Please take into account that there is a bug that removes duggas from the swimlane and adds a new, empty line in the bottom.
But other than this, the autoscrolling takes you to the dugga with deadline closest to the current date. If several duggas has same deadline date you should get scrolled to the one highest up in the list.

Co-author: @a19kimgr 