### PR TITLE
sh/index.php now redirects to 404 error page when no match is found #10779

### DIFF
--- a/sh/index.php
+++ b/sh/index.php
@@ -67,6 +67,8 @@ if ($course != "UNK") {
 		header("Location: {$serverRoot}/DuggaSys/sectioned.php?courseid={$cid}&coursevers={$activeversion}");
 		exit();
 	}
+} else {
+	header("Location: ../errorpages/404.php");
 }
 
 $q = queryToUrl($course, $assignment);

--- a/sh/index.php
+++ b/sh/index.php
@@ -41,7 +41,10 @@ function GetAssigment ($hash){
 if($assignment != "UNK"){
 	$assignmentURL = GetAssigment($assignment);
 	header("Location: {$assignmentURL}");
+} else {
+	header("Location: ../errorpages/404.php");
 }
+
 if ($course != "UNK") {
 	global $pdo;
 


### PR DESCRIPTION
Fixed so that you are redirected to 404 page when there is no match for assignment or course. So also if you try to go directly to inde.php file you should see the error page. 