### PR TITLE
Allow teachers to switch between variants when not inside a submission #10651

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -85,7 +85,7 @@ function returned(data)
 	retData = data;
 
 	//Stores the data that was sent from Section, which contains the ordering of the examples.
-	sectionData = JSON.parse(localStorage.getItem("sectionData"));
+	sectionData = JSON.parse(localStorage.getItem("ls-section-data"));
 
 	//Creates a list of all the code examples sorted after the example ordering in Section.
 	for(i = 1; i < sectionData['entries'].length; i++){

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -651,7 +651,7 @@ function returnedSection(data) {
 
   //data variable is put in localStorage which is then used in Codeviewer
 	//to get the right order when going backward and forward in code examples
-	localStorage.setItem("sectionData", JSON.stringify(data));
+	localStorage.setItem("ls-section-data", JSON.stringify(data));
 
   var now = new Date();
   var startdate = new Date(retdata['startdate']);

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -334,7 +334,21 @@ if($hash!='UNK'){
 	</div>
 	<!-- Load Dugga Popup (Enter hash to get redirected to another dugga) End! -->
 
-
+	<!-- Load Variant Popup (Change variant locally to check if the variant is presented) -->
+	<div id='loadVariantBox' class="loginBoxContainer" style="display:none">
+	  <div class="loadDuggaBox loginBox" style="max-width:400px; overflow-y:visible;">
+			<div class='loginBoxheader'><h3>Hämta variant av dugga</h3><div class='cursorPointer' onclick="hideLoadVariantPopup()">x</div></div>
+			<div id='loadDuggaInfo'></div>
+    		<div id='loadDuggaPopup' style="display:block">
+				<div class='inputwrapper'><span>Variants:</span><br></div>
+				<div class="button-row">
+					<input type='button' class='submit-button' onclick="loadDugga();" value='Load variant'>
+					<input type='button' class='submit-button' onclick="hideLoadVariantPopup();" value='Close'>
+				</div>
+    		</div>
+      </div>
+	</div>
+	<!-- Load Variant Popup (Change variant locally to check if the variant is presented) End! -->
 
 
 <!---------------------=============####### Preview Popover #######=============--------------------->
@@ -342,7 +356,7 @@ if($hash!='UNK'){
 	<?php 
 	if(isSuperUser($userid)){
     	echo '<script type="text/javascript">',
-    	'displayDownloadIcon();', 'noUploadForTeacher();',
+    	'toggleLoadVariant(true);','displayDownloadIcon();', 'noUploadForTeacher();',
     	'</script>';
 	}?>
 	

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -334,25 +334,6 @@ if($hash!='UNK'){
 	</div>
 	<!-- Load Dugga Popup (Enter hash to get redirected to another dugga) End! -->
 
-	<!-- Load Variant Popup (Change variant locally to check if the variant is presented. Teachers only) -->
-	<div id='loadVariantBox' class="loginBoxContainer" style="display:none">
-	  <div class="loadDuggaBox loginBox" style="max-width:400px; overflow-y:visible;">
-			<div class='loginBoxheader'><h3>Get variant of dugga</h3><div class='cursorPointer' onclick="hideLoadVariantPopup()">x</div></div>
-			<div id='loadDuggaInfo'></div>
-    		<div id='loadDuggaPopup' style="display:block">
-				<div class='inputwrapper'><span>Next variant</span><br>
-					
-				</div>
-				<div class="button-row">
-					<input type='button' class='submit-button' onclick="changeVariant(2);" value='Next variant'>
-					<input type='button' class='submit-button' onclick="hideLoadVariantPopup();" value='Close'>
-				</div>
-    		</div>
-      </div>
-	</div>
-	<!-- Load Variant Popup (Change variant locally to check if the variant is presented) End! -->
-
-
 <!---------------------=============####### Preview Popover #######=============--------------------->
 
 	<?php 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -337,12 +337,14 @@ if($hash!='UNK'){
 	<!-- Load Variant Popup (Change variant locally to check if the variant is presented. Teachers only) -->
 	<div id='loadVariantBox' class="loginBoxContainer" style="display:none">
 	  <div class="loadDuggaBox loginBox" style="max-width:400px; overflow-y:visible;">
-			<div class='loginBoxheader'><h3>Hämta variant av dugga</h3><div class='cursorPointer' onclick="hideLoadVariantPopup()">x</div></div>
+			<div class='loginBoxheader'><h3>Get variant of dugga</h3><div class='cursorPointer' onclick="hideLoadVariantPopup()">x</div></div>
 			<div id='loadDuggaInfo'></div>
     		<div id='loadDuggaPopup' style="display:block">
-				<div class='inputwrapper'><span>Varianter:</span><br></div>
+				<div class='inputwrapper'><span>Next variant</span><br>
+					
+				</div>
 				<div class="button-row">
-					<input type='button' class='submit-button' onclick="loadDugga();" value='Load variant'>
+					<input type='button' class='submit-button' onclick="changeVariant(2);" value='Next variant'>
 					<input type='button' class='submit-button' onclick="hideLoadVariantPopup();" value='Close'>
 				</div>
     		</div>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -334,7 +334,7 @@ if($hash!='UNK'){
 	</div>
 	<!-- Load Dugga Popup (Enter hash to get redirected to another dugga) End! -->
 
-	<!-- Load Variant Popup (Change variant locally to check if the variant is presented) -->
+	<!-- Load Variant Popup (Change variant locally to check if the variant is presented. Teachers only) -->
 	<div id='loadVariantBox' class="loginBoxContainer" style="display:none">
 	  <div class="loadDuggaBox loginBox" style="max-width:400px; overflow-y:visible;">
 			<div class='loginBoxheader'><h3>Hämta variant av dugga</h3><div class='cursorPointer' onclick="hideLoadVariantPopup()">x</div></div>
@@ -355,7 +355,7 @@ if($hash!='UNK'){
 
 	<?php 
 	if(isSuperUser($userid)){
-		if($hash == "UNK"){
+		if($hash == "UNK"){		//A teacher should not be able to change the variant (local) if they are grading an assignment.
 			echo '<script type="text/javascript">toggleLoadVariant(true);</script>';
 		}
     	echo '<script type="text/javascript">',

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -340,7 +340,7 @@ if($hash!='UNK'){
 			<div class='loginBoxheader'><h3>Hämta variant av dugga</h3><div class='cursorPointer' onclick="hideLoadVariantPopup()">x</div></div>
 			<div id='loadDuggaInfo'></div>
     		<div id='loadDuggaPopup' style="display:block">
-				<div class='inputwrapper'><span>Variants:</span><br></div>
+				<div class='inputwrapper'><span>Varianter:</span><br></div>
 				<div class="button-row">
 					<input type='button' class='submit-button' onclick="loadDugga();" value='Load variant'>
 					<input type='button' class='submit-button' onclick="hideLoadVariantPopup();" value='Close'>
@@ -355,10 +355,14 @@ if($hash!='UNK'){
 
 	<?php 
 	if(isSuperUser($userid)){
+		if($hash == "UNK"){
+			echo '<script type="text/javascript">toggleLoadVariant(true);</script>';
+		}
     	echo '<script type="text/javascript">',
-    	'toggleLoadVariant(true);','displayDownloadIcon();', 'noUploadForTeacher();',
+    	'displayDownloadIcon();', 'noUploadForTeacher();',
     	'</script>';
-	}?>
+	}
+	?>
 	
 	<!-- Timer START -->
 	<div id='scoreElement'>	

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -224,6 +224,7 @@ if($demo || $hr){
 		// if none has been chosen and there is a first one take that one.
 		if($newvariant=="UNK" && $firstvariant!=-1) $newvariant=$firstvariant;
 	}else{
+	
 		// There is a variant already -- do nothing!	
 	}
 	

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -625,6 +625,7 @@ $array = array(
 		"variantvalue" => $variantvalue,
 		"password" => $password,
 		"hashvariant" => $hashvariant,
+		"variants" => $variants,
 	);
 if (strcmp($opt, "GRPDUGGA")==0) $array["group"] = $group;
 

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -28,7 +28,7 @@ function setup()
 
 function returnedDugga(data)
 {
-	toggleLoadVariant(false);
+	toggleLoadVariant(false);	//A submission doesn't have any variants. The Load Variant button should be disabled.
 	dataV = data;
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
 

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -28,7 +28,7 @@ function setup()
 
 function returnedDugga(data)
 {
-	toggleLoadVariant(false);	//A submission doesn't have any variants. The Load Variant button should be disabled.
+	toggleLoadVariant(false);	//A submission doesn't have any variants. The Toggle variant button should be disabled.
 	dataV = data;
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
 

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -28,7 +28,7 @@ function setup()
 
 function returnedDugga(data)
 {
-	toggleLoadVariant(false);	//A submission doesn't have any variants. The Toggle variant button should be disabled.
+	toggleLoadVariant(false);	//A submission doesn't have any variants. The Next variant button should be disabled.
 	dataV = data;
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
 

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -28,6 +28,7 @@ function setup()
 
 function returnedDugga(data)
 {
+	toggleLoadVariant(false);
 	dataV = data;
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -498,7 +498,7 @@ function setExpireTime(key, value, ttl, locallystoredhash){
 	//Item is an object which contains the original value
 	//as well as the time when its supposed to expire
 	const item = {
-		value: value,
+		value: value,	//Här
 		expiry: now.getTime() + ttl,
 		locallystoredhash: locallystoredhash,
 	}
@@ -531,6 +531,8 @@ function updateExpireTime(key, value, ttl, locallystoredhash){
 //Lazily expiring the item (Its only checked when retrieved from storage)
 function getExpireTime(key){
 	const itemString = localStorage.getItem(key)
+	console.log("key: "+itemString);
+;
 	
 	if(!itemString){
 		return null
@@ -1213,7 +1215,7 @@ function handleHash(){
 function handleLocalStorage(data){
 	varArr = [];
 	data['variants'].forEach(element => varArr.push(element.vid));
-	console.log(varArr[1]);
+	console.log(varArr);
 
 	// Check localstorage variants.
 	var newvariant = data['variantvalue'];

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -30,6 +30,9 @@ var clicks = 0;
 var locallystoredhash;
 var loadVariantFlag = false;	// Flag to decide if the 'Load Variant' button should be visable or not.
 var varArr;
+var latestKeyUsed;
+var latestTTLUsed;
+var latestLocalHash;
 
 
 $(function () {  // Used to set the position of the FAB above the cookie message
@@ -491,13 +494,11 @@ function setExpireCookieLogOut() {
     }
 }
 
-
-function changeVariant(){
-	//Call setExpireTime() but with a specific 'value' taken from varArr[].
-	//localStorage.remove(key);
-	//setExpireTime(key, "2", ttl, locallystoredhash);
+function changeVariant(intvalue){											//Call setExpireTime() but with a specific 'value' taken from varArr[].
+	const value = String(intvalue);											//Value can select from a span 1 to varArr.length, whereas each value is an existing variant of the active dugga.
+	setExpireTime(latestKeyUsed, value, latestTTLUsed, latestLocalHash);	//Sets new variant by only changing the 'value' attribute.
+	location.reload(); 														//Reloads the site to show correct new variant.
 }
-
 
 //Creates TTL for localstorage //TTL value is in milliseconds
 function setExpireTime(key, value, ttl, locallystoredhash){
@@ -537,15 +538,18 @@ function updateExpireTime(key, value, ttl, locallystoredhash){
 	}
 }
 //Lazily expiring the item (Its only checked when retrieved from storage)
+//Global variables 'latestKeyUsed', 'latestTTLUsed' and 'latestLocalHash' are written to keep track of the latest values of the local-storage attributes, which needs be re-used, with the same values, if teacher change variant locally (Load Variant button).
 function getExpireTime(key){
-	const itemString = localStorage.getItem(key)
-	console.log("key: "+itemString);
-;
+	latestKeyUsed = key;						
+	const itemString = localStorage.getItem(key);
 	
 	if(!itemString){
 		return null
 	}
 	const item = JSON.parse(itemString)
+	latestTTLUsed = item.expiry;				
+	latestLocalHash = item.locallystoredhash;	
+
 	const now = new Date()
 
 	if(now.getTime() > item.expiry){
@@ -2049,7 +2053,7 @@ function displayDuggaStatus(answer,grade,submitted,marked){
 		}
 
 		if(loadVariantFlag){	//If the 'Load Variant' button is set to be visable (Teachers only). 
-			str+="<div style='width:0px;'><input class='submit-button large-button' type='button' value='Load variant' onclick='showLoadVariantPopup();' /></div>";
+			str+="<div style='width:0px;'><input class='submit-button large-button' type='button' value='Load variant' onclick='showLoadVariantPopup();' /></div>"; //showLoadVariantPopup() changeVariant(2)
 		}
 
 		str+="</div>";

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -79,16 +79,16 @@ function setHash(h){
 		//From localstorage we load what we have into our locallystoredhash variable, that is then compared against. 
 		//On the first dugga load, it will be undefined, and thereafter a hash value will be generated.
 		//If a hash is already stored in localstorage, we will load that hash instead.
-		locallystoredhash = localStorage.getItem("locallystoredhash"+(querystring['did']));
+		locallystoredhash = localStorage.getItem("ls-hash-dg"+(querystring['did']));
 
 		if((locallystoredhash == null) || (locallystoredhash == undefined) || (!locallystoredhash)){
 			hash = generateHash();
 			//locallystoredhash has not been set at this point, but will be after this.
-			localStorage.setItem("locallystoredhash"+(querystring['did']), hash);
-			hash = localStorage.getItem("locallystoredhash"+(querystring['did']));
+			localStorage.setItem("ls-hash-dg"+(querystring['did']), hash);
+			hash = localStorage.getItem("ls-hash-dg"+(querystring['did']));
 		}
 		else{
-			hash = localStorage.getItem("locallystoredhash"+(querystring['did']));
+			hash = localStorage.getItem("ls-hash-dg"+(querystring['did']));
 		}
 
 		
@@ -106,7 +106,7 @@ function setPassword(p){
 
 //Set the localstorage item securitynotifaction to on or off
 function setSecurityNotifaction(param){
-    localStorage.setItem("securitynotification", param);
+    localStorage.setItem("ls-security-notification", param);
 }
 
 function resetLoginStatus(){
@@ -468,7 +468,7 @@ function removeYearFromDate(date){
 //----------------------------------------------------------------------------------
 
 function setExpireCookie(){
-    if(localStorage.getItem("securityquestion") == "set") {
+    if(localStorage.getItem("ls-security-question") == "set") {
 				var expireDate = new Date();
 				// A test date so you dont have to actually wait 1 hour and 45 minutes.
 				// Don't forget to change the one below (setExpireCookieLogOut()) too.
@@ -483,7 +483,7 @@ function setExpireCookie(){
 //----------------------------------------------------------------------------------
 
 function setExpireCookieLogOut() {
-    if (localStorage.getItem("securityquestion") == "set") {
+    if (localStorage.getItem("ls-security-question") == "set") {
 				var expireDate = new Date();
 				//expireDate.setMinutes(expireDate.getMinutes() + 2);	// For testing
 				expireDate.setMinutes(expireDate.getMinutes() + 120);	// For actual use
@@ -708,9 +708,9 @@ function saveDuggaResult(citstr)
 	document.getElementById('url').innerHTML = url;
 	document.getElementById('pwd').innerHTML = pwd;
 
-	var scores = JSON.parse(localStorage.getItem("scores"+querystring['did']) || '[]');
+	var scores = JSON.parse(localStorage.getItem("ls-highscore-dg"+querystring['did']) || '[]');
 	scores.push(score);
-	localStorage.setItem("scores"+querystring['did'], JSON.stringify(scores));
+	localStorage.setItem("ls-highscore-dg"+querystring['did'], JSON.stringify(scores));
 
 	var readonly;
 	$.ajax({
@@ -1088,7 +1088,7 @@ function AJAXService(opt,apara,kind)
 			datatype: "json",
 			success: function(data){
 				getVariantValue(data, opt, para);	//Get variant, set localstorage lifespan and set password.
-				if(!localStorage.getItem("locallystoredhash"+(querystring['did']))){ //If hash exists in local storage, don't create a new one
+				if(!localStorage.getItem("ls-hash-dg"+(querystring['did']))){ //If hash exists in local storage, don't create a new one
 					handleHash();	//Makes sure hash is unique.
 				}
 			}
@@ -1220,47 +1220,47 @@ function handleLocalStorage(data){
 	console.log("newVariant: " + newvariant);
 
 	
-	if(localStorage.getItem(querystring['did']) == null){
-		localStorage.setItem(querystring['did'], newvariant);
+	if(localStorage.getItem("ls-allocated-variant-dg"+querystring['did']) == null){
+		localStorage.setItem("ls-allocated-variant-dg"+querystring['did'], newvariant);
 		//The big number below represents 30 days in milliseconds
-		setExpireTime(querystring['did'], localStorage.getItem(querystring['did']), 2592000000, hash);
+		setExpireTime("ls-allocated-variant-dg"+querystring['did'], localStorage.getItem("ls-allocated-variant-dg"+querystring['did']), 2592000000, hash);
 	}
 	//If locallystoragehash doesn't exist, it will set it to correct hash.
-	var itemString = localStorage.getItem(querystring['did']);
+	var itemString = localStorage.getItem("ls-allocated-variant-dg"+querystring['did']);
 	var itemParse = JSON.parse(itemString);
-	localStorage.setItem("locallystoredhash"+(querystring['did']), itemParse.locallystoredhash);
+	localStorage.setItem("ls-hash-dg"+(querystring['did']), itemParse.locallystoredhash);
 
-	getExpireTime(querystring['did']);
+	getExpireTime("ls-allocated-variant-dg"+querystring['did']);
 	var variantsize = data['variantsize'];
-	localStorage.setItem("variantSize", variantsize);
+	localStorage.setItem("ls-highest-variant-quizid", variantsize);
 						
 }
 
 function getVariantValue(ajaxdata, opt, para){
 	
 	//Checks if the variantSize variant is set in localstorage. When its not, its set.
-	if(localStorage.getItem("variantSize") == null) {
-		localStorage.setItem("variantSize", 100);
+	if(localStorage.getItem("ls-highest-variant-quizid") == null) {
+		localStorage.setItem("ls-highest-variant-quizid", 100);
 	}
 	//Converts the localstorage variant from string to int
-	var newInt = +localStorage.getItem('variantSize');
+	var newInt = +localStorage.getItem('ls-highest-variant-quizid');
 	console.log("variantSize: " + newInt);
 	//Checks if the dugga id is within scope (Not bigger than the largest dugga variant)
 	if(querystring['did'] <= newInt) {
-		if(localStorage.getItem(querystring['did']) == null){
+		if(localStorage.getItem("ls-allocated-variant-dg"+querystring['did']) == null){
 			//If we don't have a variant in localstorage
 			returndata = JSON.parse(ajaxdata);
 			variantvalue = returndata.variant;
 		} else {
 			//If we have a variant in localstorage
-			var test = JSON.parse(localStorage.getItem(querystring['did']));
+			var test = JSON.parse(localStorage.getItem("ls-allocated-variant-dg"+querystring['did']));
 			variantvalue = test.value;
 		}
 		//Will overrule localstorage variant if we use hash url
 		var dbvariant = JSON.parse(ajaxdata);
 		if(dbvariant.hashvariant != null){
 			variantvalue = dbvariant.hashvariant;
-			updateExpireTime(querystring['did'], dbvariant.hashvariant, 2592000000, hash);
+			updateExpireTime("ls-allocated-variant-dg"+querystring['did'], dbvariant.hashvariant, 2592000000, hash);
 		}
 	}
 
@@ -1320,7 +1320,7 @@ function addSecurityQuestionProfile(username) {
 		success:function(data) {
 			var result = JSON.parse(data);
 			if(result['getname'] == "success") {
-				$("#challengeQuestion").html(result['securityquestion']);
+				$("#challengeQuestion").html(result['ls-security-question']);
 			}else{
 				if(typeof result.reason != "undefined") {
 					$("#changeChallengeQuestion #securityQuestionError").html("<div class='alert danger'>" + result.reason + "</div>");
@@ -1354,7 +1354,7 @@ function processResetPasswordCheckUsername() {
 			var result = JSON.parse(data);
 				//It is worth to note that getname should probably be named status/error since thats basically what it is
 			if(result['getname'] == "success") {
-				$("#showsecurityquestion #displaysecurityquestion").html(result['securityquestion']);
+				$("#showsecurityquestion #displaysecurityquestion").html(result['ls-security-question']);
 				status = 2;
 				toggleloginnewpass();
 			}else if(result['getname'] == "limit"){
@@ -1426,8 +1426,8 @@ function processLogin() {
 			hideLoginPopup();
 
           	// was commented out before which resulted in the session to never end
-			if(result['securityquestion'] != null) {
-				localStorage.setItem("securityquestion", "set");
+			  if(result['ls-security-question'] != null) {
+				localStorage.setItem("ls-security-question", "set");
 			} else {
 				setSecurityNotifaction("on");
 			}
@@ -1476,7 +1476,7 @@ function processLogout() {
 		type:"POST",
 		url: "../Shared/loginlogout.php",
 		success:function(data) {
-            localStorage.removeItem("securityquestion");
+            localStorage.removeItem("ls-security-question");
             localStorage.removeItem("securitynotification");
             location.replace("../DuggaSys/courseed.php");
 		},

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -28,7 +28,7 @@ var variantvalue;
 var tempclicks = 0;
 var clicks = 0;
 var locallystoredhash;
-var loadVariantFlag = false;	// Flag to decide if the 'Load Variant' button should be visable or not.
+var loadVariantFlag = false;	// Flag to decide if the 'Toggle variant' button should be visable or not.
 var varArr;
 var nbrOfVariants;
 var latestKeyUsed;
@@ -502,17 +502,19 @@ function changeVariant(intvalue){											//Call setExpireTime() but with a sp
 	location.reload(); 														//Reloads the site to show correct new variant.
 }
 
-function selectNextVariant(){	//Selects next variant available and calls 'changeVariant' method with it.
-	var nextVariant;
-	console.log(latestVariantSet);
-	if(nbrOfVariants == 1){
-		nextVariant = latestVariantSet;
+//Selects next variant available and calls 'changeVariant' method.
+function selectNextVariant(){
+	if(nbrOfVariants != undefined){	//If no variants are available for this dugga.
+		var nextVariant;
+		if(nbrOfVariants == 1){
+			nextVariant = latestVariantSet;
+		}
+		else{
+			var tempIndex = (varArr.indexOf(latestVariantSet) + 1) % nbrOfVariants;
+			nextVariant = varArr[tempIndex];
+			changeVariant(nextVariant);
+		} 
 	}
-	else{
-		nextVariant = (latestVariantSet + 1) % nbrOfVariants;
-		nextVariant = nextVariant + 1;
-		changeVariant(nextVariant);
-	} 
 }
 
 //Creates TTL for localstorage //TTL value is in milliseconds
@@ -553,7 +555,7 @@ function updateExpireTime(key, value, ttl, locallystoredhash){
 	}
 }
 //Lazily expiring the item (Its only checked when retrieved from storage)
-//Global variables 'latestKeyUsed', 'latestTTLUsed' and 'latestLocalHash' are written to keep track of the latest values of the local-storage attributes, which needs be re-used, with the same values, if teacher change variant locally (Load Variant button).
+//Global variables 'latestKeyUsed', 'latestTTLUsed' and 'latestLocalHash' are written to keep track of the latest values of the local-storage attributes, which needs be re-used, with the same values, if teacher change variant locally (Toggle variant button).
 function getExpireTime(key){
 	latestKeyUsed = key;						
 	const itemString = localStorage.getItem(key);
@@ -1569,17 +1571,9 @@ function setupLoginLogoutButton(isLoggedIn){
 	}
 }
 
-function toggleLoadVariant(setbool){	//setbool has a value of True or False. This decides if the Load Variant button should be visable or not.
+function toggleLoadVariant(setbool){	//setbool has a value of True or False. This decides if the Toggle variant button should be visable or not.
 	loadVariantFlag = setbool;
 	console.log("Value: " + setbool);
-}
-
-function showLoadVariantPopup(){		//If 'Load variant' is clicked.
-	$("#loadVariantBox").css("display","flex");
-}
-
-function hideLoadVariantPopup(){		//'Load variant' window exit.
-	$("#loadVariantBox").css("display","none");
 }
 
 function showLoadDuggaPopup()
@@ -2069,7 +2063,7 @@ function displayDuggaStatus(answer,grade,submitted,marked){
 			str+="<div class='StopLight WhiteLight' style='margin:4px;'></div></div><div>Untitled dugga</div>";
 		}
 
-		if(loadVariantFlag){	//If the 'Load Variant' button is set to be visable (Teachers only). 
+		if(loadVariantFlag){	//If the 'Toggle variant' button is set to be visable (Teachers only). 
 			str+="<div style='width:0px;'><input class='submit-button large-button' type='button' value='Toggle variant' onclick='selectNextVariant();' /></div>"; 
 		}
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -29,6 +29,7 @@ var tempclicks = 0;
 var clicks = 0;
 var locallystoredhash;
 var loadVariantFlag = false;	// Flag to decide if the 'Load Variant' button should be visable or not.
+var varArr;
 
 
 $(function () {  // Used to set the position of the FAB above the cookie message
@@ -1210,6 +1211,9 @@ function handleHash(){
 	});
 }
 function handleLocalStorage(data){
+	varArr = [];
+	data['variants'].forEach(element => varArr.push(element));
+	console.log(varArr);
 
 	// Check localstorage variants.
 	var newvariant = data['variantvalue'];
@@ -1233,6 +1237,7 @@ function handleLocalStorage(data){
 }
 
 function getVariantValue(ajaxdata, opt, para){
+	
 	//Checks if the variantSize variant is set in localstorage. When its not, its set.
 	if(localStorage.getItem("variantSize") == null) {
 		localStorage.setItem("variantSize", 100);

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -491,6 +491,14 @@ function setExpireCookieLogOut() {
     }
 }
 
+
+function changeVariant(){
+	//Call setExpireTime() but with a specific 'value' taken from varArr[].
+	//localStorage.remove(key);
+	//setExpireTime(key, "2", ttl, locallystoredhash);
+}
+
+
 //Creates TTL for localstorage //TTL value is in milliseconds
 function setExpireTime(key, value, ttl, locallystoredhash){
 	const now = new Date();

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -502,11 +502,17 @@ function changeVariant(intvalue){											//Call setExpireTime() but with a sp
 	location.reload(); 														//Reloads the site to show correct new variant.
 }
 
-function selectNextVariant(){
-	console.log("latest..."+latestVariantSet);
-	var nextVariant = (latestVariantSet + 1) % nbrOfVariants + 1;
-	console.log("next..."+nextVariant);
-	changeVariant(nextVariant);
+function selectNextVariant(){	//Selects next variant available and calls 'changeVariant' method with it.
+	var nextVariant;
+	console.log(latestVariantSet);
+	if(nbrOfVariants == 1){
+		nextVariant = latestVariantSet;
+	}
+	else{
+		nextVariant = (latestVariantSet + 1) % nbrOfVariants;
+		nextVariant = nextVariant + 1;
+		changeVariant(nextVariant);
+	} 
 }
 
 //Creates TTL for localstorage //TTL value is in milliseconds

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -28,7 +28,7 @@ var variantvalue;
 var tempclicks = 0;
 var clicks = 0;
 var locallystoredhash;
-var loadVariantFlag = false;
+var loadVariantFlag = false;	// Flag to decide if the 'Load Variant' button should be visable or not.
 
 
 $(function () {  // Used to set the position of the FAB above the cookie message
@@ -1531,16 +1531,16 @@ function setupLoginLogoutButton(isLoggedIn){
 	}
 }
 
-function toggleLoadVariant(setbool){
+function toggleLoadVariant(setbool){	//setbool has a value of True or False. This decides if the Load Variant button should be visable or not.
 	loadVariantFlag = setbool;
 	console.log("Value: " + setbool);
 }
 
-function showLoadVariantPopup(){
+function showLoadVariantPopup(){		//If 'Load variant' is clicked.
 	$("#loadVariantBox").css("display","flex");
 }
 
-function hideLoadVariantPopup(){
+function hideLoadVariantPopup(){		//'Load variant' window exit.
 	$("#loadVariantBox").css("display","none");
 }
 
@@ -2033,10 +2033,10 @@ function displayDuggaStatus(answer,grade,submitted,marked){
 			str+="<div class='StopLight WhiteLight' style='margin:4px;'></div></div><div>Untitled dugga</div>";
 		}
 
-		if(loadVariantFlag){
+		if(loadVariantFlag){	//If the 'Load Variant' button is set to be visable (Teachers only). 
 			str+="<div style='width:0px;'><input class='submit-button large-button' type='button' value='Load variant' onclick='showLoadVariantPopup();' /></div>";
 		}
-		
+
 		str+="</div>";
 		$("#duggaStatus").remove();
 		$("<td id='duggaStatus' align='center'>"+str+"</td>").insertAfter("#menuHook");

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -28,7 +28,7 @@ var variantvalue;
 var tempclicks = 0;
 var clicks = 0;
 var locallystoredhash;
-var loadVariantFlag = false;	// Flag to decide if the 'Toggle variant' button should be visable or not.
+var loadVariantFlag = false;	// Flag to decide if the 'Next variant' button should be visable or not.
 var varArr;
 var nbrOfVariants;
 var latestKeyUsed;
@@ -555,7 +555,7 @@ function updateExpireTime(key, value, ttl, locallystoredhash){
 	}
 }
 //Lazily expiring the item (Its only checked when retrieved from storage)
-//Global variables 'latestKeyUsed', 'latestTTLUsed' and 'latestLocalHash' are written to keep track of the latest values of the local-storage attributes, which needs be re-used, with the same values, if teacher change variant locally (Toggle variant button).
+//Global variables 'latestKeyUsed', 'latestTTLUsed' and 'latestLocalHash' are written to keep track of the latest values of the local-storage attributes, which needs be re-used, with the same values, if teacher change variant locally (Next variant button).
 function getExpireTime(key){
 	latestKeyUsed = key;						
 	const itemString = localStorage.getItem(key);
@@ -1246,6 +1246,10 @@ function handleLocalStorage(data){
 	varArr = [];		
 	data['variants'].forEach(element => varArr.push(element.vid));
 	nbrOfVariants = varArr.length;
+	if(nbrOfVariants == 1){
+		document.getElementById("nextVariantBtn").style.display="none";
+		console.log("test");
+	}
 
 	// Check localstorage variants.
 	var newvariant = data['variantvalue'];
@@ -1571,7 +1575,7 @@ function setupLoginLogoutButton(isLoggedIn){
 	}
 }
 
-function toggleLoadVariant(setbool){	//setbool has a value of True or False. This decides if the Toggle variant button should be visable or not.
+function toggleLoadVariant(setbool){	//setbool has a value of True or False. This decides if the Next variant button should be visable or not.
 	loadVariantFlag = setbool;
 	console.log("Value: " + setbool);
 }
@@ -2063,8 +2067,8 @@ function displayDuggaStatus(answer,grade,submitted,marked){
 			str+="<div class='StopLight WhiteLight' style='margin:4px;'></div></div><div>Untitled dugga</div>";
 		}
 
-		if(loadVariantFlag){	//If the 'Toggle variant' button is set to be visable (Teachers only). 
-			str+="<div style='width:0px;'><input class='submit-button large-button' type='button' value='Toggle variant' onclick='selectNextVariant();' /></div>"; 
+		if(loadVariantFlag){	//If the 'Next variant' button is set to be visable (Teachers only). 
+			str+="<div id='nextVariantBtn' style='width:0px;'><input class='submit-button large-button' type='button' value='Next Variant' onclick='selectNextVariant();' /></div>"; 
 		}
 
 		str+="</div>";

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1212,8 +1212,8 @@ function handleHash(){
 }
 function handleLocalStorage(data){
 	varArr = [];
-	data['variants'].forEach(element => varArr.push(element));
-	console.log(varArr);
+	data['variants'].forEach(element => varArr.push(element.vid));
+	console.log(varArr[1]);
 
 	// Check localstorage variants.
 	var newvariant = data['variantvalue'];

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1210,9 +1210,11 @@ function handleHash(){
 	});
 }
 function handleLocalStorage(data){
+
 	// Check localstorage variants.
 	var newvariant = data['variantvalue'];
 	console.log("newVariant: " + newvariant);
+
 	
 	if(localStorage.getItem(querystring['did']) == null){
 		localStorage.setItem(querystring['did'], newvariant);
@@ -1231,13 +1233,13 @@ function handleLocalStorage(data){
 }
 
 function getVariantValue(ajaxdata, opt, para){
-	
 	//Checks if the variantSize variant is set in localstorage. When its not, its set.
 	if(localStorage.getItem("variantSize") == null) {
 		localStorage.setItem("variantSize", 100);
 	}
 	//Converts the localstorage variant from string to int
 	var newInt = +localStorage.getItem('variantSize');
+	console.log("variantSize: " + newInt);
 	//Checks if the dugga id is within scope (Not bigger than the largest dugga variant)
 	if(querystring['did'] <= newInt) {
 		if(localStorage.getItem(querystring['did']) == null){
@@ -1586,8 +1588,6 @@ function checkScroll(obj) {
 		obj.style.height = (parseInt(obj.style.height)+1) + 'em';
 	}
 }
-
-
 
 //----------------------------------------------------------------------------------
 // copyURLtoCB: Copy the url to user clipboard

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -28,6 +28,7 @@ var variantvalue;
 var tempclicks = 0;
 var clicks = 0;
 var locallystoredhash;
+var loadVariantFlag = false;
 
 
 $(function () {  // Used to set the position of the FAB above the cookie message
@@ -1530,6 +1531,19 @@ function setupLoginLogoutButton(isLoggedIn){
 	}
 }
 
+function toggleLoadVariant(setbool){
+	loadVariantFlag = setbool;
+	console.log("Value: " + setbool);
+}
+
+function showLoadVariantPopup(){
+	$("#loadVariantBox").css("display","flex");
+}
+
+function hideLoadVariantPopup(){
+	$("#loadVariantBox").css("display","none");
+}
+
 function showLoadDuggaPopup()
 {
 	$("#loadDuggaBox").css("display","flex");
@@ -2019,6 +2033,10 @@ function displayDuggaStatus(answer,grade,submitted,marked){
 			str+="<div class='StopLight WhiteLight' style='margin:4px;'></div></div><div>Untitled dugga</div>";
 		}
 
+		if(loadVariantFlag){
+			str+="<div style='width:0px;'><input class='submit-button large-button' type='button' value='Load variant' onclick='showLoadVariantPopup();' /></div>";
+		}
+		
 		str+="</div>";
 		$("#duggaStatus").remove();
 		$("<td id='duggaStatus' align='center'>"+str+"</td>").insertAfter("#menuHook");

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -30,9 +30,11 @@ var clicks = 0;
 var locallystoredhash;
 var loadVariantFlag = false;	// Flag to decide if the 'Load Variant' button should be visable or not.
 var varArr;
+var nbrOfVariants;
 var latestKeyUsed;
 var latestTTLUsed;
 var latestLocalHash;
+var latestVariantSet;
 
 
 $(function () {  // Used to set the position of the FAB above the cookie message
@@ -498,6 +500,13 @@ function changeVariant(intvalue){											//Call setExpireTime() but with a sp
 	const value = String(intvalue);											//Value can select from a span 1 to varArr.length, whereas each value is an existing variant of the active dugga.
 	setExpireTime(latestKeyUsed, value, latestTTLUsed, latestLocalHash);	//Sets new variant by only changing the 'value' attribute.
 	location.reload(); 														//Reloads the site to show correct new variant.
+}
+
+function selectNextVariant(){
+	console.log("latest..."+latestVariantSet);
+	var nextVariant = (latestVariantSet + 1) % nbrOfVariants + 1;
+	console.log("next..."+nextVariant);
+	changeVariant(nextVariant);
 }
 
 //Creates TTL for localstorage //TTL value is in milliseconds
@@ -1225,13 +1234,15 @@ function handleHash(){
 	});
 }
 function handleLocalStorage(data){
-	varArr = [];
+	//Set value to nbrOfVariants, this is needed so a teacher can locally change variant.
+	varArr = [];		
 	data['variants'].forEach(element => varArr.push(element.vid));
-	console.log(varArr);
+	nbrOfVariants = varArr.length;
 
 	// Check localstorage variants.
 	var newvariant = data['variantvalue'];
 	console.log("newVariant: " + newvariant);
+	latestVariantSet = newvariant;
 
 	
 	if(localStorage.getItem("ls-allocated-variant-dg"+querystring['did']) == null){
@@ -2053,7 +2064,7 @@ function displayDuggaStatus(answer,grade,submitted,marked){
 		}
 
 		if(loadVariantFlag){	//If the 'Load Variant' button is set to be visable (Teachers only). 
-			str+="<div style='width:0px;'><input class='submit-button large-button' type='button' value='Load variant' onclick='showLoadVariantPopup();' /></div>"; //showLoadVariantPopup() changeVariant(2)
+			str+="<div style='width:0px;'><input class='submit-button large-button' type='button' value='Toggle variant' onclick='selectNextVariant();' /></div>"; 
 		}
 
 		str+="</div>";

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -362,7 +362,7 @@
 	include '../Shared/logoutbox.php';
 ?>
 <script type="text/javascript">
-		if(localStorage.getItem("cookieMessage")=="off"){
+		if(localStorage.getItem("ls-cookie-message")=="off"){
 			$("#cookiemsg").css("display", "none");
 		}else{
 			$("#cookiemsg").css("display", "flex");
@@ -370,7 +370,7 @@
 	setupLoginLogoutButton('<?PHP echo json_encode(checklogin()) ?>');
 	function cookieMessage(){
 		hideCookieMessage();
-		localStorage.setItem("cookieMessage", "off");
+		localStorage.setItem("ls-cookie-message", "off");
 	}
 	function hoverBack(){
 		$(".dropdown-list-container").css("display", "none");


### PR DESCRIPTION
To test this: 
**As a guest:**

- Make sure no "Next variant" button is shown next to the dugga title when not logged in.

**As a teacher/superUser:**

- Enter any dugga, if there is more than one variant of that dugga, a "Next variant" button should appear next to the dugga title. 
- Clear localstorage.
- Reload dugga and enter "application", you should see a variant of a value. Ex: _{"value": "4" ...}_ 
- Press the "Next variant" button, you should be prompted to reload the page.
- See if the value in localstorage and the dugga "question" changes.