### PR TITLE
Make handle hash great again #10830

### DIFF
--- a/DuggaSys/templates/clipping_masking_dugga.js
+++ b/DuggaSys/templates/clipping_masking_dugga.js
@@ -181,7 +181,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true && ishashinurl ==true){				//If the hash already exist in database.
+			if(ishashindb==true && blockhashgen ==true || ishashindb==true && blockhashgen ==false && ishashinurl==true || ishashindb==true && locallystoredhash != "null"){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
   	Timer.stopTimer();
 

--- a/DuggaSys/templates/clipping_masking_dugga.js
+++ b/DuggaSys/templates/clipping_masking_dugga.js
@@ -181,7 +181,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true){				//If the hash already exist in database.
+			if(ishashindb==true && ishashinurl ==true){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
   	Timer.stopTimer();
 

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -117,7 +117,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true){				//If the hash already exist in database.
+			if(ishashindb==true && ishashinurl ==true){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 					Timer.stopTimer();
 

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -117,7 +117,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true && ishashinurl ==true){				//If the hash already exist in database.
+			if(ishashindb==true && blockhashgen ==true || ishashindb==true && blockhashgen ==false && ishashinurl==true || ishashindb==true && locallystoredhash != "null"){
 				if (confirm("You already have a saved version!")) {
 					Timer.stopTimer();
 

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -110,7 +110,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true){				//If the hash already exist in database.
+			if(ishashindb==true && ishashinurl ==true){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 	Timer.stopTimer();
 	timeUsed = Timer.score;

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -110,7 +110,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true && ishashinurl ==true){				//If the hash already exist in database.
+			if(ishashindb==true && blockhashgen ==true || ishashindb==true && blockhashgen ==false && ishashinurl==true || ishashindb==true && locallystoredhash != "null"){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 	Timer.stopTimer();
 	timeUsed = Timer.score;

--- a/DuggaSys/templates/dugga3.js
+++ b/DuggaSys/templates/dugga3.js
@@ -358,7 +358,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true){				//If the hash already exist in database.
+			if(ishashindb==true && blockhashgen ==true || ishashindb==true && blockhashgen ==false && ishashinurl==true || ishashindb==true && locallystoredhash != "null"){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 	Timer.stopTimer();
 

--- a/DuggaSys/templates/dugga4.js
+++ b/DuggaSys/templates/dugga4.js
@@ -147,7 +147,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true){				//If the hash already exist in database.
+			if(ishashindb==true && blockhashgen ==true || ishashindb==true && blockhashgen ==false && ishashinurl==true || ishashindb==true && locallystoredhash != "null"){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 	Timer.stopTimer();
 

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -137,7 +137,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true && ishashinurl ==true){				//If the hash already exist in database.
+			if(ishashindb==true && blockhashgen ==true || ishashindb==true && blockhashgen ==false && ishashinurl==true || ishashindb==true && locallystoredhash != "null"){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 	Timer.stopTimer();
 

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -137,7 +137,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true){				//If the hash already exist in database.
+			if(ishashindb==true && ishashinurl ==true){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 	Timer.stopTimer();
 

--- a/DuggaSys/templates/html_css_dugga.js
+++ b/DuggaSys/templates/html_css_dugga.js
@@ -148,7 +148,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true){				//If the hash already exist in database.
+			if(ishashindb==true && blockhashgen ==true || ishashindb==true && blockhashgen ==false && ishashinurl==true || ishashindb==true && locallystoredhash != "null"){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 					Timer.stopTimer();
 

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -138,7 +138,7 @@ function saveClick()
 		dataType: "json",
 		success: function(data) {
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			if(ishashindb==true){				//If the hash already exist in database.
+			if(ishashindb==true && blockhashgen ==true || ishashindb==true && blockhashgen ==false && ishashinurl==true || ishashindb==true && locallystoredhash != "null"){				//If the hash already exist in database.
 				if (confirm("You already have a saved version!")) {
 					Timer.stopTimer();
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1255,7 +1255,6 @@ function handleLocalStorage(data){
 	nbrOfVariants = varArr.length;
 	if(nbrOfVariants == 1){
 		document.getElementById("nextVariantBtn").style.display="none";
-		console.log("test");
 	}
 
 	// Check localstorage variants.

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -77,10 +77,6 @@ function getHash(){
 function setHash(h){
 	// Check if hash is unknown
 	if(h == "UNK"){
-		
-		//hash = generateHash();
-
-		
 		//From localstorage we load what we have into our locallystoredhash variable, that is then compared against. 
 		//On the first dugga load, it will be undefined, and thereafter a hash value will be generated.
 		//If a hash is already stored in localstorage, we will load that hash instead.
@@ -1119,9 +1115,9 @@ function AJAXService(opt,apara,kind)
 			datatype: "json",
 			success: function(data){
 				getVariantValue(data, opt, para);	//Get variant, set localstorage lifespan and set password.
-				if(!localStorage.getItem("ls-hash-dg"+(querystring['did']))){ //If hash exists in local storage, don't create a new one
-					handleHash();	//Makes sure hash is unique.
-				}
+				//if(!localStorage.getItem("ls-hash-dg"+(querystring['did']))){ //If hash exists in local storage, don't create a new one
+				handleHash();	//Makes sure hash is unique.
+				//}
 			}
 		})
 	}else if(kind=="RESULT"){

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -84,6 +84,7 @@ function setHash(h){
 
 		if((locallystoredhash == null) || (locallystoredhash == undefined) || (!locallystoredhash)){
 			hash = generateHash();
+			//hash = "vtmS2_kr";
 			//locallystoredhash has not been set at this point, but will be after this.
 			localStorage.setItem("ls-hash-dg"+(querystring['did']), hash);
 			hash = localStorage.getItem("ls-hash-dg"+(querystring['did']));
@@ -97,6 +98,7 @@ function setHash(h){
 		hash = h;
 		ishashinurl = true;		//Hash is referenced in the url -> A resubmission, this dugga already have a hash in the database.
 	}
+	
 }
 
 function setPassword(p){
@@ -1311,8 +1313,14 @@ function getVariantValue(ajaxdata, opt, para){
 
 //If the first generated hash isn't unique this method is recursively called until a hash is unique.
 function recursiveAjax(){
+
 	hash = generateHash();						//A new hash is generated.
-	console.log("Not a unique hash! generating new hash => " + hash);
+	localStorage.setItem("ls-hash-dg"+(querystring['did']), hash);
+	hash = localStorage.getItem("ls-hash-dg"+(querystring['did']));
+
+	var currentVariantValue = getExpireTime(latestKeyUsed);
+	setExpireTime(latestKeyUsed, currentVariantValue, latestTTLUsed, hash);
+	console.log("Not a unique hash! generating new hash => " + hash + ". Latest variant=" + currentVariantValue);
 	$.ajax({									//Ajax call to see if the new hash have a match with any hash in the database.
 		url: "showDuggaservice.php",
 		type: "POST",

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1245,6 +1245,7 @@ function clearDuggaLocalStorage(){
 	window.localStorage.removeItem("ls-hash-dg"+(querystring['did']));
 	window.localStorage.removeItem("ls-highest-variant-quizid");
 	window.localStorage.removeItem("ls-allocated-variant-dg"+querystring['did']);
+	//window.localStorage.removeItem("ls-highscore-dg"+querystring['did']); //This is commented out since 'highscore' currently doesn't share any purpose.
 }
 
 function handleLocalStorage(data){

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -91,8 +91,6 @@ function setHash(h){
 		else{
 			hash = localStorage.getItem("ls-hash-dg"+(querystring['did']));
 		}
-
-		
 		pwd = randomPassword();
 		ishashinurl = false;	//Hash is not referenced in the url -> Not a resubmission.
 	}else{
@@ -1230,8 +1228,10 @@ function handleHash(){
 		success: function(data) {
 			returnedDugga(data);
 			ishashindb = data['ishashindb'];	//Ajax call return - ishashindb == true: not unique hash, ishashindb == false: unique hash.
-			console.log("Hash="+hash+". isHashInDB="+ishashindb + ". ClickedSave=" +blockhashgen + ". isHashInURL="+ishashinurl);	//For debugging!
-			if(ishashindb==true && blockhashgen == false && ishashinurl == false){	//If the hash already exist in database AND the save button hasn't been pressed yet AND this isn't a resubmission.
+			//var getLocalStorageHash = localStorage.getItem("ls-hash-dg"+(querystring['did']));
+
+			console.log("Hash="+hash+". isHashInDB="+ishashindb + ". ClickedSave=" +blockhashgen + ". isHashInURL="+ishashinurl + " lsHash= " + locallystoredhash);	//For debugging!
+			if(ishashindb==true && blockhashgen == false && ishashinurl == false && !locallystoredhash){	//If the hash already exist in database AND the save button hasn't been pressed yet AND this isn't a resubmission.
 				recursiveAjax();													//This recursive method will generate a hash until it is unique. One in a billion chance of not being unique...
 			}
 		}


### PR DESCRIPTION
**Edited since last review!**
recursiveAjax() is now replaced with a method clearing the localstorage for that dugga, then refreshing the browser. This results in a new hash being generated and stored to the localstorage. 
Also, a student gets notified whenever he/she tries to save an already saved dugga.

To try this:

- Clear local storage, enter a dugga and press 'Save' and everything should work. Now press 'Save' again. This time a popup should appear and alert that you already have a save made on this dugga.
- Next up, don't clear the local storage, exit & enter the same dugga again. Press 'Save'. The same popup should be visable.
- **Load** an already existing dugga with URL and Password. Change something on the dugga and press 'Save'. Again, the popup should appear. 
- Make sure the popup doesn't appear when doing a dugga for the first time (when you haven't saved any changes yet).
- Unfortunately I haven't found a smart way of testing the handleHash() method changes. You can force a value of hash (a value that you already have in your database) in dugga.js, on row 89. Doing so the site will just spam-refresh since the forced value will continue to overwrite the newest generated hash. I would argue that if the site refreshes, it proves that it indeed noticed a non-unique hash. In addition, the odds of this happening without forcing a value is about 1 : 5000 000 000. 