### PR TITLE
Diagram: Replay-mode

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -321,11 +321,11 @@
 }
 
 #zoom-message-box{
-    transform: translate(50px, 930px);
     position: absolute;
     background-color: rgba(0, 0, 0, 0.8);
     width: 75px;
-    left: 50px;
+    left: 100px;
+    bottom: 5px;
     color: white;
     border-radius: 5px;
     text-align: center;
@@ -389,3 +389,27 @@
     padding-left:3px;
     padding-right:3px;
 }
+/* REPLAY */
+#diagram-replay-box{
+    position: absolute;
+    background-color: var(--color-primary);
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 50px;
+    visibility: hidden;
+    color: var(--color-text-header);
+}
+#diagram-replay-message{
+     position: absolute;
+     background-color: rgba(0, 0, 0, 0.8);
+     width: 300px;
+     left: calc(50% - 50px);
+     bottom: 70px;
+     color: var(--color-text-header);
+     border-radius: 5px;
+     text-align: center;
+     z-index: 100;
+    visibility: hidden;
+     pointer-events: none;
+ }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2753,8 +2753,9 @@ function toggleReplay()
 
     if (settings.replay.active) {
         // Restore the diagram to state before replay-mode
-        stateMachine.scrubHistory(stateMachine.currentHistoryIndex);
+        stateMachine.scrubHistory(stateMachine.currentHistoryIndex + 1);
 
+        settings.ruler.zoomX -= 50;
         // Change HTML DOM styling
         replayBox.style.visibility = "hidden";
         optionsPane.style.visibility = "visible";
@@ -2765,6 +2766,7 @@ function toggleReplay()
         zoomIndicator.style.left = "100px";
         replyMessage.style.visibility = "hidden";
     } else {
+        settings.ruler.zoomX += 50;
         // Clear selected elements and lines
         clearContext();
         clearContextLine();
@@ -2784,6 +2786,8 @@ function toggleReplay()
         zoomIndicator.style.left = "45px";
         replyMessage.style.visibility = "visible";
     }
+    drawRulerBars(scrollx, scrolly);
+
     // Change the settings boolean for replay active
     settings.replay.active = !settings.replay.active;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -325,11 +325,6 @@ class StateMachine
         this.historyLog = [];
 
         /**
-         * @type Array<StateChange>
-         */
-        this.futureLog = [];
-
-        /**
          * Our initial data values
          */
         this.initialState = {
@@ -446,6 +441,8 @@ class StateMachine
         } else {
             console.error("Passed invalid argument to StateMachine.save() method. Must be a StateChange object!");
         }
+        // Change the sliders max to historyLogs length
+        document.getElementById("replay-range").setAttribute("max", this.historyLog.length.toString());
     }
 
     /**
@@ -486,25 +483,21 @@ class StateMachine
     }
     scrubHistory(endIndex)
     {
-        // Set initial values to data and lines.
-        data = [];
-        lines = [];
-
-        this.initialState.elements.forEach(element => {
-            var obj = {};
-            Object.assign(obj, element);
-            data.push(obj)
-        });
-        this.initialState.lines.forEach(line => {
-            var obj = {};
-            Object.assign(obj, line);
-            lines.push(obj)
-        });
+        this.gotoInitialState();
 
         for (var i = 0; i < endIndex; i++) {
             this.restoreState(this.historyLog[i]);
         }
+
+        // Update diagram
+        clearContext();
+        showdata();
+        updatepos(0, 0);
     }
+    /**
+     * @description Restore an given state
+     * @param {StateChange} state The state that should be restored
+     */
     restoreState(state)
     {
         // Get all keys from the state.
@@ -605,6 +598,69 @@ class StateMachine
                 }
             }
         }
+    }
+    /**
+     * @description Go back to the inital state in the diagram
+     */
+    gotoInitialState()
+    {
+        // Set initial values to data and lines.
+        data = [];
+        lines = [];
+
+        this.initialState.elements.forEach(element => {
+            var obj = {};
+            Object.assign(obj, element);
+            data.push(obj)
+        });
+        this.initialState.lines.forEach(line => {
+            var obj = {};
+            Object.assign(obj, line);
+            lines.push(obj)
+        });
+        clearContext();
+        showdata();
+        updatepos(0, 0);
+    }
+    /**
+     * @description Create a timers and go-through all states
+     * @param {Number} cri The starting index of the replay
+     */
+    replay(cri = parseInt(document.getElementById("replay-range").value))
+    {
+
+        // If no history exists => return
+        if (this.historyLog.length == 0) return;
+
+        // If cri (CurrentReplayIndex) is the last set to beginning
+        if(cri == this.historyLog.length) cri = 0;
+
+        setReplayRunning(true);
+        document.getElementById("replay-range").value = cri.toString();
+
+        // Go back to the beginning.
+        this.scrubHistory(cri);
+
+        var self = this;
+        this.replayTimer = setInterval(function() {
+
+            self.restoreState(self.historyLog[cri]);
+
+            // Update diagram
+            clearContext();
+            showdata();
+            updatepos(0, 0);
+
+            // Update current index for the replay
+            cri++;
+            document.getElementById("replay-range").value = cri;
+
+            if (self.historyLog.length == cri){
+                clearInterval(self.replayTimer);
+                setReplayRunning(false);
+            }
+        }, settings.replay.delay * 1000)
+
     }
 }
 //#endregion ===================================================================================
@@ -836,6 +892,10 @@ var settings = {
         errorMsgMap: {},
     },
     zoomPower: 1 / 3,
+    replay: {
+        active: false,
+        delay: 1,
+    }
 };
 
 
@@ -1035,7 +1095,11 @@ document.addEventListener('keydown', function (e)
 
         if (isKeybindValid(e, keybinds.ESCAPE) && escPressed != true) {
             escPressed = true;
-            if(context.length > 0 || contextLine.length > 0) {
+            if (settings.replay.active){
+                toggleReplay();
+                setReplayRunning(false);
+                clearInterval(stateMachine.replayTimer);
+            }else if(context.length > 0 || contextLine.length > 0) {
                 clearContext();
                 clearContextLine();
             } else {
@@ -1182,8 +1246,8 @@ function mwheel(event)
  */
 function mdown(event)
 {
-    // If the middle mouse button (mouse3) is pressed set scroll start values
-    if(event.button == 1) {
+    // If the middle mouse button (mouse3) is pressed OR replay-mode is active, set scroll start values
+    if(event.button == 1  || settings.replay.active) {
         pointerState = pointerStates.CLICKED_CONTAINER;
         sscrollx = scrollx;
         sscrolly = scrolly;
@@ -1223,7 +1287,7 @@ function mdown(event)
     }
 
     // Check if not an element OR node has been clicked at the event
-    if(pointerState !== pointerStates.CLICKED_NODE && pointerState !== pointerStates.CLICKED_ELEMENT){
+    if(pointerState !== pointerStates.CLICKED_NODE && pointerState !== pointerStates.CLICKED_ELEMENT && !settings.replay.active){
         // Used when clicking on a line between two elements.
         determinedLines = determineLineSelect(event.clientX, event.clientY);
         if (determinedLines){
@@ -1254,8 +1318,8 @@ function ddown(event)
         }
     }   
 
-    // If the middle mouse button (mouse3) is pressed => return
-    if(event.button == 1) return;
+    // If the middle mouse button (mouse3) is pressed OR replay-mode is active => return
+    if(event.button == 1 || settings.replay.active) return;
 
     switch (mouseMode) {
         case mouseModes.POINTER:
@@ -2667,6 +2731,101 @@ function toggleGrid()
    }
 }
 
+/**
+ * @description Toggles the replay-mode, shows replay-panel, hides unused elements
+ */
+function toggleReplay()
+{
+    // If there is no history => display error and return
+    if (stateMachine.historyLog.length == 0){
+        displayMessage(messageTypes.ERROR, "Sorry, you need to make changes before enter the replay-mode");
+        return;
+    }
+
+    // Get DOM-elements for styling
+    var replayBox = document.getElementById("diagram-replay-box");
+    var optionsPane = document.getElementById("options-pane");
+    var fab = document.getElementById("fab");
+    var toolbar = document.getElementById("diagram-toolbar");
+    var ruler = document.getElementById("rulerOverlay");
+    var zoomIndicator = document.getElementById("zoom-message-box");
+    var replyMessage = document.getElementById("diagram-replay-message");
+
+    if (settings.replay.active) {
+        // Restore the diagram to state before replay-mode
+        stateMachine.scrubHistory(stateMachine.currentHistoryIndex);
+
+        // Change HTML DOM styling
+        replayBox.style.visibility = "hidden";
+        optionsPane.style.visibility = "visible";
+        fab.style.visibility = "visible";
+        toolbar.style.visibility = "visible";
+        ruler.style.left = "50px";
+        zoomIndicator.style.bottom = "5px";
+        zoomIndicator.style.left = "100px";
+        replyMessage.style.visibility = "hidden";
+    } else {
+        // Clear selected elements and lines
+        clearContext();
+        clearContextLine();
+
+        // Set mousemode to Pointer
+        setMouseMode(0);
+
+        stateMachine.scrubHistory(parseInt(document.getElementById("replay-range").value));
+
+        // Change HTML DOM styling
+        replayBox.style.visibility = "visible";
+        optionsPane.style.visibility = "hidden";
+        fab.style.visibility = "hidden";
+        toolbar.style.visibility = "hidden";
+        ruler.style.left = "0";
+        zoomIndicator.style.bottom = "55px";
+        zoomIndicator.style.left = "45px";
+        replyMessage.style.visibility = "visible";
+    }
+    // Change the settings boolean for replay active
+    settings.replay.active = !settings.replay.active;
+}
+/**
+ * @description Sets the replay-delay value
+ */
+function setReplayDelay(value)
+{
+    var replayDelayMap = {
+        1: 0.1,
+        2: 0.25,
+        3: 0.50,
+        4: 0.75,
+        5: 1,
+        6: 1.25,
+        7: 1.5,
+        8: 1.75,
+        9: 2
+    }
+    settings.replay.delay = replayDelayMap[value];
+    document.getElementById("replay-time-label").innerHTML = `Delay (${settings.replay.delay}s)`;
+}
+/**
+ * @description Changes the play/pause button and locks/unlocks the sliders in replay-mode
+ * @param {boolean} state The state if the replay-mode is running
+ */
+function setReplayRunning(state)
+{
+    var button = document.getElementById("diagram-replay-switch");
+    var delaySlider = document.getElementById("replay-time");
+    var stateSlider = document.getElementById("replay-range");
+
+    if (state){
+        button.innerHTML = '<div class="diagramIcons" onclick="clearInterval(stateMachine.replayTimer);setReplayRunning(false)"><img src="../Shared/icons/pause.svg"></div>';
+        delaySlider.disabled = true;
+        stateSlider.disabled = true;
+    }else{
+        button.innerHTML = '<div class="diagramIcons" onclick="stateMachine.replay()"><img src="../Shared/icons/Play.svg"></div>';
+        delaySlider.disabled = false;
+        stateSlider.disabled = false;
+    }
+}
 /**
  * @description Toggles the A4 template ON/OFF.
  */

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -118,6 +118,9 @@
                     <p id="tooltip-TOGGLE_A4" class="key_tooltip">Keybinding:</p>
                 </span>
             </div>
+        </fieldset>
+        <fieldset>
+            <legend>History</legend>
             <div id="stepForwardToggle" class="diagramIcons" onclick="toggleStepForward()">
                 <img src="../Shared/icons/diagram_stepforward.svg"/>
                 <span class="toolTipText"><b>Toggle step forward</b><br>
@@ -131,8 +134,10 @@
                     <p>Click to step back in history</p><br>
                     <p id="tooltip-HISTORY_STEPBACK" class="key_tooltip">Keybinding:</p>
                 </span>
-            </div>            
+            </div>
+            <button class="diagramIcons" onclick="toggleReplay()">Replay</button>
         </fieldset>
+
     </div>
 
     <!-- Message prompt -->
@@ -195,6 +200,34 @@
             </fieldset>
         </div>
     </div>
+    </div>
+    <!-- Replay-mode -->
+    <div id="diagram-replay-box">
+        <div style=";display: flex;">
+            <fieldset style="display: flex; justify-content: space-between">
+                <div id="diagram-replay-switch">
+                    <div class="diagramIcons" onclick="stateMachine.replay()">
+                        <img src="../Shared/icons/Play.svg">
+                    </div>
+                </div>
+                <div class="diagramIcons" onclick="stateMachine.replay(0)">
+                    <img src="../Shared/icons/ResetButton.svg">
+                </div>
+            </fieldset>
+            <div style="width: 250px">
+                <label id="replay-time-label" for="replay-time">Delay (1s)</label>
+                <input id="replay-time" onchange="setReplayDelay(this.value)" class="zoomSlider" type="range" min="1" max="9" value="5">
+            </div>
+
+            <div>
+                <label for="replay-range">Change</label>
+                <input id="replay-range" class="zoomSlider" onchange="stateMachine.scrubHistory(parseInt(this.value))" type="range" min="0" max="0">
+            </div>
+        </div>
+    </div>
+    <div id="diagram-replay-message">
+        <h2>Replay mode</h2>
+        <p>Press "Escape" to exit the replay-mode.</p>
     </div>
     <!-- content END -->
     <?php


### PR DESCRIPTION
Added replay-mode

- By pressing reply button the tool-bar, fab button and the options panel gets hidden.
- If the user presses play from the current state and forward the diagram will be displayed.
- The delay between changes is editable.
- If the replay is on last state, if press play the replay will begin from the beginning.
- When the user is exiting the replay-mode, the diagram will be restored to the state before entering.