### PR TITLE
Lock-icon is now correct size in the hamburger menu. Issue#10887

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7723,9 +7723,6 @@ textarea#filecont {
     display: none;
   }
 
-  header #accessBTN img{
-    width: 20px;
-  }
 
   .navheader {
     height: 20px;


### PR DESCRIPTION
Removed code that made the button 20 px wide instead of 32

CO-authos: @a19isada 