### PR TITLE
Hash in resulted.php redirect to the corresponding submission #10851

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -89,7 +89,7 @@ function renderCell(col, celldata, cellid) {
 	str = "<div class='resultTableCell'>";
 	if (col == "hash"){
 		str += "<div class='resultTableText'>";
-		str += "<a href='" + getLinkFromHash(celldata) + "'>" + celldata + "</a>";
+		str += "<a href='http://localhost/LenaSYS/sh/?a=" + celldata + "'>" + celldata + "</a>";
 	}
 	else if(col == "grade"){
 		str += "<div class='gradeContainer resultTableText'>";


### PR DESCRIPTION
Added a url to the a-tag for the hash in the "Edit student results" table.

OBS. Currently, sh / index.php? A = HASH is broken, so you will not be able to get to the right page. Just check that the url is correct when you press the hash on "Edit student results".