### PR TITLE
Lines are now deselected on copy paste

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2270,7 +2270,9 @@ function pasteClipboard(elements)
     stateMachine.save(StateChangeFactory.ElementsAndLinesCreated(newElements, newLines), StateChange.ChangeTypes.ELEMENT_AND_LINE_CREATED);
     displayMessage(messageTypes.SUCCESS, `You have successfully pasted ${elements.length} elements and ${connectedLines.length} lines!`);
     clearContext(); // Deselect old selected elements
+    clearContextLine();
     context = newElements; // Set context to the pasted elements
+    contextLine = newLines; // Set contextline to the pasted lines
     showdata();
 }
 


### PR DESCRIPTION
Previous lines are now deselected when copy-pasting all elements at once