### PR TITLE
Click to close burgermenu

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -107,6 +107,12 @@ function hamburgerChange(operation = 'click') {
   }
 }
 
+$(document).on('click', function(e) {
+  if ($(e.target).closest("#hamburgerIcon").length === 0) {
+      $("#hamburgerBox").hide();
+  }
+});
+
 function toggleHamburger() {
 
   var x = document.getElementById("hamburgerBox");


### PR DESCRIPTION
The dropdown menu in mobile vers should disappear if user clicks outside of it

Co-Authored-By: a19samke <62887067+a19samke@users.noreply.github.com>