### PR TITLE
"Minor error is thrown, noticed when reviewed issue #10954" - #10986

### DIFF
--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -133,8 +133,6 @@ pdoConnect();
 	<!-- -------------------=============####### Result Popover #######=============------------------- -->
 
 	<div id='resultpopover' class='resultPopover' style='display: none'>
-	<?php if(isSuperUser($_SESSION['uid'])){echo '<script type="text/javascript">','displayDownloadIcon();','</script>';}?>
-	<?php if(isSuperUser($_SESSION['uid'])){echo '<script type="text/javascript">','noUploadForTeacher();','</script>';}?>
 		<div class='loginBoxheader'>
 			<span id="hoverRes" ></span>
 			<h3 style='width:100%;' id='Nameof' onmouseover="hoverResult();"


### PR DESCRIPTION
The reason I can remove the accessibility checks "if (isSuperUser...)" is because the functionality of resulted.php have been changed. As a teacher, we no longer preview a dugga directly in resulted.php. We only enter it as a showDugga.php link. The same if statements are already implemented on showDugga.php.

To try this:
- Log in as teacher.
- Enter resulted.php ("edit student results" icon).
- Copy URL.
- Logout.
- Paste and enter the copied URL.
- Open console, make sure no SyntaxError occurs.