### PR TITLE
Double click on container hides options panel

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1338,6 +1338,11 @@ function mdown(event)
                 sscrolly = scrolly;
                 startX = event.clientX;
                 startY = event.clientY;
+
+                if((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
+                    wasDblClicked = true;
+                    document.getElementById("options-pane").className = "hide-options-pane";
+                }
                 break;
             
             case mouseModes.BOX_SELECTION:


### PR DESCRIPTION
Double clicking on the container now hides the option panel