### PR TITLE
Fixed the designflaw

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -595,34 +595,6 @@ class StateMachine
             return;
         }
 
-        // If index 0 is an object and that object has an value of the key "id"
-        if (state.created != undefined && state.created[0].id != undefined){
-
-            Object.keys(state.created).forEach(index => {
-                var temp = {};
-                Object.keys(state.created[index]).forEach(key => {
-                    if (key == "id") temp.id = state.created[index][key];
-                    else temp[key] = state.created[index][key];
-                });
-
-                // If the object is an element
-                if (state.created[index].x && state.created[index].y){
-                    // Add the defaults to the element
-                    Object.keys(defaults[temp.kind]).forEach(key => {
-                        if (!temp[key]) temp[key] = defaults[temp.kind][key];
-                    });
-                    data.push(temp);
-                }else {
-                    // Add the defaults to the element
-                    Object.keys(defaultLine).forEach(key => {
-                        if (!temp[key]) temp[key] = defaultLine[key];
-                    });
-                    lines.push(temp);
-                }
-            });
-            return;
-        }
-
         if (!Array.isArray(state.id)) state.id = [state.id];
 
         for (var i = 0; i < state.id.length; i++){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -284,8 +284,8 @@ class StateChangeFactory
      */
     static ElementsAndLinesCreated(elements, lines)
     {
-        // Array containing all new added elements
-        var allObj = [];
+        var changesArr = [];
+        var timeStamp = new Date().getTime();
 
         // Filter out defaults from each element and add them to allObj
         elements.forEach(elem => {
@@ -298,7 +298,7 @@ class StateChangeFactory
             });
 
             uniqueKeysArr.forEach(key => values[key] = elem[key]);
-            allObj.push(values);
+            changesArr.push(new StateChange(elem.id, values, timeStamp));
         });
 
         // Filter out defaults from each line and add them to allObj
@@ -312,10 +312,10 @@ class StateChangeFactory
             });
 
             uniqueKeysArr.forEach(key => values[key] = line[key]);
-            allObj.push(values);
+            changesArr.push(new StateChange(line.id, values, timeStamp));
         });
 
-        return new StateChange(null, allObj);
+        return changesArr;
     }
 }
 


### PR DESCRIPTION
The stateMachine does not save the copied and pasted elements in an array in one StateChange anymore, instead many states are created with the same timestamp.