### PR TITLE
Added handling of null values to sortable table

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -280,7 +280,13 @@ function rowFilter(row) {
 		}else if (a.toLowerCase() > b.toLowerCase()){
 			return -1;
 		}
-	}else{
+	}else if (a == null || b == null){
+		if (a == null){
+			return 1;
+		}else if (b == null){
+			return -1;
+		}
+	} else {
 		var numA = parseInt(a);
 		var numB = parseInt(b);
 		if (numA < numB){


### PR DESCRIPTION
The sortable table in resulted is now fixed so it can handle null values when sorting on a column. 
To test this you have to add a row in the database to the useranswer table with null values (if you do not have null values already)
E.g. INSERT INTO userAnswer (aid,cid,quiz,variant,moment,grade,uid,useranswer,submitted,marked,vers,creator,score,timesGraded,timeUsed,totalTimeUsed,stepsUsed,totalStepsUsed,feedback,gradeExpire,gradeLastExported,seen_status,hash,password, timesSubmitted, timesAccessed) 
VALUES ('235','2','1','3','2002',NULL,NULL,NULL,'2015-01-15 09:12:51',NULL,'97732',NULL,NULL,0,NULL,'0',NULL,'0',NULL,NULL,NULL,'0','E_X-FUTy','yMp0cdW',NULL,NULL);