### PR TITLE
Added label changes to the state machine

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2180,6 +2180,7 @@ function changeLineProperties()
 
     if(line.label != label.value){
         line.label = label.value
+        stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { label: label.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     }
 
     showdata();


### PR DESCRIPTION
Changes to the label text are now added to the state machine and can be undone/redone.