### PR TITLE
Table not displaying the rows correctly in Mobile browsers #11172

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -163,8 +163,7 @@ function createSortableTable(data){
         rowFilterCallback: rowFilter,
 		columnOrder: colOrder,
 		hasRowHighlight: true,
-		hasMagicHeadings: true,
-		hasCounterColumn: true
+		hasCounterColumn: true,
 	});
 
 	var sortCol = localStorage.getItem("resultTable___sortcol");

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -618,28 +618,29 @@ function SortableTable(param) {
 					// If top is negative and top+height is positive draw mh otherwise hide
 
 					// Vertical
-					if (thetabhead.top < 50 && thetab.bottom > 0) {
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.left = thetab.left + "px";
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.top = 50 + "px";
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.display = "table";
-					} else {
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.display = "none";
-					}
+						// if (thetabhead.top < 50 && thetab.bottom > 0) {
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.left = thetab.left + "px";
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.top = 50 + "px";
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.display = "table";
+						// } else {
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.display = "none";
+						// }
+
 					// Horizontal
-					if (thetab.left < 0 && thetab.right > 0) {
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.top = tabheadsize + "px";
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.left = -1 + "px";
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.display = "table";
-					} else {
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.display = "none";
-					}
+						// if (thetab.left < 0 && thetab.right > 0) {
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.top = tabheadsize + "px";
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.left = -1 + "px";
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.display = "table";
+						// } else {
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.display = "none";
+						// }
 
 					// Fixed
-					if (thetab.left < 0 && thetab.right > 0 && thetabhead.top < 0 && thetab.bottom > 0) {
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhf").style.display = "table";
-					} else {
-						document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhf").style.display = "none";
-					}
+						// if (thetab.left < 0 && thetab.right > 0 && thetabhead.top < 0 && thetab.bottom > 0) {
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhf").style.display = "table";
+						// } else {
+						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhf").style.display = "none";
+						// }
 				}
 			}
 		}

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -231,7 +231,7 @@ function SortableTable(param) {
 	this.deHighlightRow = getparam(param.rowHighlightOffCallback, defaultRowHighlightOff);
 	this.showEditCell = getparam(param.displayCellEditCallback, null);
 	this.updateCell = getparam(param.updateCellCallback, null);
-	this.hasMagicHeadings = getparam(param.hasMagicHeadings, false);
+	this.hasMagicHeadings = getparam(param.hasMagicHeadings, false); // Mini table option
 	this.hasCounter = getparam(param.hasCounterColumn, false);
 	this.hasFooter = getparam(param.hasFooter, false);
 	
@@ -618,29 +618,29 @@ function SortableTable(param) {
 					// If top is negative and top+height is positive draw mh otherwise hide
 
 					// Vertical
-						// if (thetabhead.top < 50 && thetab.bottom > 0) {
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.left = thetab.left + "px";
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.top = 50 + "px";
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.display = "table";
-						// } else {
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.display = "none";
-						// }
+						if (thetabhead.top < 50 && thetab.bottom > 0) {
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.left = thetab.left + "px";
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.top = 50 + "px";
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.display = "table";
+						} else {
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mh").style.display = "none";
+						}
 
 					// Horizontal
-						// if (thetab.left < 0 && thetab.right > 0) {
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.top = tabheadsize + "px";
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.left = -1 + "px";
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.display = "table";
-						// } else {
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.display = "none";
-						// }
+						if (thetab.left < 0 && thetab.right > 0) {
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.top = tabheadsize + "px";
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.left = -1 + "px";
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.display = "table";
+						} else {
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhv").style.display = "none";
+						}
 
 					// Fixed
-						// if (thetab.left < 0 && thetab.right > 0 && thetabhead.top < 0 && thetab.bottom > 0) {
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhf").style.display = "table";
-						// } else {
-						// 	document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhf").style.display = "none";
-						// }
+						if (thetab.left < 0 && thetab.right > 0 && thetabhead.top < 0 && thetab.bottom > 0) {
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhf").style.display = "table";
+						} else {
+							document.getElementById(table.tableid + DELIMITER + "tbl" + DELIMITER + "mhf").style.display = "none";
+						}
 				}
 			}
 		}


### PR DESCRIPTION
In sortableTable.js it is decided when these other tables should be displayed, but since they don´t seem to work as they should. I removed it and as a result the tables are no longer displayed in mobile mode.

For testing:
Log in as a teacher and go to "Edit student results" in mobile mode. Everything looks as it should (no extra table) when you drag to the right of the table to see more.