### PR TITLE
Fixed default colors for pasted elements

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2357,7 +2357,9 @@ function pasteClipboard(elements, elementsLines)
             height: element.height,
             kind: element.kind,
             id: idMap[element.id],
-            state: element.state
+            state: element.state,
+            fill: "#ffccdc",
+            stroke: "black"
         };
         newElements.push(elementObj)
         addObjectToData(elementObj, false);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2358,8 +2358,8 @@ function pasteClipboard(elements, elementsLines)
             kind: element.kind,
             id: idMap[element.id],
             state: element.state,
-            fill: "#ffccdc",
-            stroke: "black"
+            fill: element.fill,
+            stroke: element.stroke
         };
         newElements.push(elementObj)
         addObjectToData(elementObj, false);


### PR DESCRIPTION
Elements are no longer completely black when pasted