### PR TITLE
"Fixed" Options panel should be the same height as the diagram.

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -80,7 +80,7 @@
     position: fixed;
     top: 0px;
     width: 280px;
-    bottom: 120px;
+    bottom: 0px;
     z-index: 5000;
     background-color: #eb4;
     color: #FFF;


### PR DESCRIPTION


fixed by just replacing the pixel value from 120 px to 0 px on the "bottom" attribute