### PR TITLE
in the #motdArea there was a margin-top with -16px that is now changed to 16px

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7972,7 +7972,7 @@ textarea#filecont {
   background-color: var(--color-accent);
   z-index: 1000;
   position: relative;
-  margin-top: -16px;
+  margin-top: 16px;
   margin-bottom: 7px;
   max-width: auto;
 }


### PR DESCRIPTION
In issue #11214 the message of the day was overlapping with the top bar. The margin top has now been adjusted so they're no longer overlapping.