### PR TITLE
Reset button was missing from diagram

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -94,9 +94,10 @@
                 </span>
             </div>
             <div class="diagramIcons" onclick="zoomreset()">
-                <img src="../Shared/icons/diagram_replay.svg"/>
-                <span class="toolTipText"><b>Reset zoom</b><br>
+                <img src="../Shared/icons/fullscreen.svg"/>
+                <span class="toolTipText"><b>Zoom RESET</b><br>
                     <p>Reset size of all elements</p><br>
+                    <p id="tooltip-ZOOM_RESET" class="key_tooltip">Keybinding:</p>
                 </span>
             </div>
         </fieldset>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -93,6 +93,12 @@
                     <p id="tooltip-ZOOM_IN" class="key_tooltip">Keybinding:</p>
                 </span>
             </div>
+            <div class="diagramIcons" onclick="zoomreset()">
+                <img src="../Shared/icons/diagram_replay.svg"/>
+                <span class="toolTipText"><b>Reset zoom</b><br>
+                    <p>Reset size of all elements</p><br>
+                </span>
+            </div>
         </fieldset>
         <fieldset>
             <legend>Toggle</legend>


### PR DESCRIPTION
The function for zoom reset already existed, but there was no button for it in the diagram. Made a new button and used the fullscreen svg icon that best matched the request (youtube full screen button).