### PR TITLE
Fixed incorrect double click not counting as a single click and preventing properties from appearing.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3461,10 +3461,13 @@ function propFieldSelected(isSelected)
  */
 function generateContextProperties()
 {
-    // Return if double clicking the same element.
-    if(wasDblClicked)return;
-
     var propSet = document.getElementById("propertyFieldset");
+
+    //Adds double click event which instantly returns. Makes double clicks on two different elements act as single clicks.
+    propSet.addEventListener("dblclick", function(){
+        return;
+    });
+
     var str = "<legend>Properties</legend>";
     //a4 propteries
     if (document.getElementById("a4Template").style.display === "block") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3461,14 +3461,10 @@ function propFieldSelected(isSelected)
  */
 function generateContextProperties()
 {
+
     var propSet = document.getElementById("propertyFieldset");
-
-    //Adds double click event which instantly returns. Makes double clicks on two different elements act as single clicks.
-    propSet.addEventListener("dblclick", function(){
-        return;
-    });
-
     var str = "<legend>Properties</legend>";
+    
     //a4 propteries
     if (document.getElementById("a4Template").style.display === "block") {
         str += `<text>Change the size of the A4</text>`;


### PR DESCRIPTION
Updated the generateContextProperties() function to not return wasDblClicked at the start as it was always true in case of a double click, no matter where it happened, preventing the second click from acting as a single click.