### PR TITLE
Fixed malpositioned background for labels

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -878,7 +878,7 @@ const elementheight = 50;
 const textheight = 18;
 const strokewidth = 2.0;
 const baseline = 10;
-const avgcharwidth = 6;
+const avgcharwidth = 6; // <-- This variable is never used anywhere in this file. 
 const colors = ["white", "gold", "#ffccdc", "yellow", "cornflowerBlue", "#FF4D4D"];
 const selectedColors = ["#cccccc", "#ce7f00", "#ff66b3", "#d2cf00", "#505E95", "#A45A5A"];
 const strokeColors = ["black", "white", "grey", "red"];
@@ -4453,11 +4453,21 @@ function drawLine(line, targetGhost = false)
     }
 
     if (line.label && line.label != ""){
+        //Get width of label's text through canvas 
+        var height = Math.round(zoomfact * textheight);
+        var canvas = document.getElementById('canvasOverlay');
+        var canvasContext = canvas.getContext('2d');
+
+        var font = canvasContext.font;
+        font = `${height}px ${font.split('px')[1]}`;
+        canvasContext.font = font;
+        var textWidth = canvasContext.measureText(line.label).width;
+        
         var centerX = (tx + fx) / 2;
         var centerY = (ty + fy) / 2;
-        //add background
-        str += `<rect x="${ centerX - ((9 * line.label.length) * zoomfact)/2 }" y="${centerY - ((textheight / 2) * zoomfact + 4)}" width="${(9 * line.label.length) * zoomfact}" height="${textheight * zoomfact}" style="fill:rgb(255,255,255);" />`
-        //add label
+        //Add background, position and size is determined by text and zoom factor <-- Consider replacing magic numbers
+        str += `<rect x="${centerX - ((textWidth) + zoomfact * 8)/2}" y="${centerY - ((textheight / 2) * zoomfact + zoomfact * 4)}" width="${(textWidth + zoomfact * 4)}" height="${textheight * zoomfact + zoomfact * 3}" style="fill:rgb(255,255,255);" />`
+        //Add label
         str += `<text dominant-baseline="middle" text-anchor="middle" style="font-size:${Math.round(zoomfact * textheight)}px;" x="${centerX-(2 * zoomfact)}" y="${centerY-(2 * zoomfact)}">${line.label}</text>`;
     }
 


### PR DESCRIPTION
Issue #11184 

Updated the drawLine() function in diagram.js which handles the positioning of the white background behind the text. Implemented a way to get the width of the text through the use of canvasContext.  The width is then used to position and scale the background accordingly.