### PR TITLE
Fixed incorrect positioning of cardinality variable in diagram relations.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3461,9 +3461,6 @@ function propFieldSelected(isSelected)
  */
 function generateContextProperties()
 {
-    // Return if double clicking the same element.
-    if(wasDblClicked)return;
-
     var propSet = document.getElementById("propertyFieldset");
     var str = "<legend>Properties</legend>";
     //a4 propteries

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3461,6 +3461,9 @@ function propFieldSelected(isSelected)
  */
 function generateContextProperties()
 {
+    // Return if double clicking the same element.
+    if(wasDblClicked)return;
+
     var propSet = document.getElementById("propertyFieldset");
     var str = "<legend>Properties</legend>";
     //a4 propteries

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4165,6 +4165,16 @@ function sortElementAssociations(element)
  * @param {boolean} stateMachineShouldSave Should this line be added to the stateMachine.
  */
 function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, successMessage = true, cardinal){
+
+    //swaps the initial fromElement and toElement if the initial node is an relational node. Makes sure lines are connected in the right place and cardinalities are placed in the right end.
+    if(fromElement.kind == "ERRelation") {
+        var tempFrom = fromElement;
+        var tempTo = toElement;
+        
+        fromElement = tempTo;
+        toElement = tempFrom;
+    }
+
     // Check so the elements does not have the same kind, exception for the "ERAttr" kind.
     if (fromElement.kind !== toElement.kind || fromElement.kind === "ERAttr" ) {
 


### PR DESCRIPTION
Swaps the start element and destination element, if the start element is a relation. Fixes spacing when adding multiple lines and fixes cardinality placement.

