### PR TITLE
FIxed the issue.

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2487,7 +2487,7 @@ function showCopyButtons(templateid) {
 	
 	for (var i = 1; i <= totalBoxes; i++) {
 		if (document.querySelector('#box' + i).className == 'box codebox') {
-		document.querySelector('#box' + i + 'wrapper #copyClipboard').style.display = 'block'
+		document.querySelector('#box' + i + 'wrapper #copyClipboard').style.display = 'table-cell'
 		}
 	}
 }


### PR DESCRIPTION
The style.display i set to "block" for the copyclipboard object when the reset button is clicked. Changed so it sets it to table-cell instead. (table.cell is the default for the icon.)