### PR TITLE
Zoom buttons zoom from center of screen #11342

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3332,8 +3332,9 @@ function zoomin(scrollEvent = undefined)
 {
     // If mousewheel is not used, we zoom towards origo (0, 0)
     if (!scrollEvent){
-        zoomOrigo.x = 0;
-        zoomOrigo.y = 0;
+        // Origo set to center of screen in pixels
+        zoomOrigo.x = window.innerWidth / 2;
+        zoomOrigo.y = window.innerHeight / 2;
     }else if (zoomfact < 4.0){ // ELSE zoom towards mouseCoordinates
         var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
         var delta = {
@@ -3383,8 +3384,9 @@ function zoomout(scrollEvent = undefined)
 {
     // If mousewheel is not used, we zoom towards origo (0, 0)
     if (!scrollEvent){
-        zoomOrigo.x = 0;
-        zoomOrigo.y = 0;
+        // Origin set to center of screen in pixels
+        zoomOrigo.x = window.innerWidth / 2;
+        zoomOrigo.y = window.innerHeight / 2;
     }else if (zoomfact > 0.25) { // ELSE zoom towards mouseCoordinates
         var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
         var delta = {


### PR DESCRIPTION
The zoom buttons will now zoom from the center of the diagram.
NOTE: in some situations, mainly if the diagram is not altered, the zoom will go to the side when zooming out.
![4bbcda6357b5b2667c21d722a30e8c97](https://user-images.githubusercontent.com/102611046/161721508-7e4f3556-ea99-43eb-b7ba-c2ccfb5f6068.png)
After pressing "Zoom OUT"
![050ca54f477dd85e8161631d36889121](https://user-images.githubusercontent.com/102611046/161721585-d91ecae4-19f9-47bd-b688-9b69e82249d0.png)

