### PR TITLE
Added code that only highligt/selects text in codviewer.

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -24,7 +24,7 @@
 }
 
 #docucontent h1 {
-		color:#000
+	color:#000;
     display: block;
     font-family: Arial,Sans-Serif;
     text-align: center;
@@ -181,6 +181,10 @@
     width: 22px;
     line-height: 21px; /* Workaround! Should be dynamically set according to selected font-size in code example. This works for font-size 16px. */
 	background-color: #614875;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .codeborder .impono {

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -218,6 +218,10 @@
     width: 22px;
 	background-color: #614875;
 	font-family: Hack,'Ubuntu Mono',"Andale Mono", AndaleMono, monospace;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .codeborder .impono {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -133,6 +133,10 @@ body {
 table {
   border-collapse: collapse;
   font-family: Roboto, Arial Narrow;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 h1 {

--- a/Shared/css/whiteTheme.css
+++ b/Shared/css/whiteTheme.css
@@ -92,6 +92,10 @@
 	background-color: #614875;
 	font-family: Hack,'Ubuntu Mono',"Andale Mono", AndaleMono, monospace;
     line-height: 21px; /* Workaround! Should be dynamically set according to selected font-size in code example. This works for font-size 16px. */
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .codeborder .impono {


### PR DESCRIPTION
Code added so that the number and icons on the pages in codewiver do not become highligted /selectable.