### PR TITLE
Scroll zoom in/out function is now mostly fixed #11058

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -872,6 +872,8 @@ var scrollx = 100;
 var scrolly = 100;
 var zoomOrigo = new Point(0, 0); // Zoom center coordinates relative to origo
 var camera = new Point(0, 0); // Relative to coordinate system origo
+var lastZoomPos = new Point(0, 0);
+var lastMousePosCoords = new Point(0, 0);
 
 // Constants
 const elementwidth = 200;
@@ -3337,13 +3339,42 @@ function zoomin(scrollEvent = undefined)
         zoomOrigo.x = window.innerWidth / 2;
         zoomOrigo.y = window.innerHeight / 2;
     }else if (zoomfact < 4.0){ // ELSE zoom towards mouseCoordinates
-        var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
+       var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
+
+       if (scrollEvent.clientX != lastZoomPos.x || scrollEvent.clientY != lastZoomPos.y) {
+          
+        var delta = {
+               x: mouseCoordinates.x - zoomOrigo.x,
+               y: mouseCoordinates.y - zoomOrigo.y
+           }
+
+           scrollx = scrollx / zoomfact;
+           scrolly = scrolly / zoomfact;
+           scrollx += delta.x;
+           scrolly += delta.y;
+           scrollx = scrollx * zoomfact;
+           scrolly = scrolly * zoomfact;
+
+           zoomOrigo.x = mouseCoordinates.x;
+           zoomOrigo.y = mouseCoordinates.y;
+           lastMousePosCoords = mouseCoordinates;
+
+           lastZoomPos.x = scrollEvent.clientX;
+           lastZoomPos.y = scrollEvent.clientY;
+       }
+       else if (scrollEvent.clientX == lastZoomPos.x && scrollEvent.clientY == lastZoomPos.y) {
+
+            zoomOrigo.x = lastMousePosCoords.x;
+            zoomOrigo.y = lastMousePosCoords.y;
+       }
+       
+        /* var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
         var delta = {
             x: mouseCoordinates.x - zoomOrigo.x,
             y: mouseCoordinates.y - zoomOrigo.y
         };
         zoomOrigo.x += delta.x * settings.zoomPower;
-        zoomOrigo.y += delta.y * settings.zoomPower;
+        zoomOrigo.y += delta.y * settings.zoomPower; */
     }
 
     scrollx = scrollx / zoomfact;
@@ -3361,6 +3392,8 @@ function zoomin(scrollEvent = undefined)
     
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;
+
+
 
     camera = {
         x: (window.innerWidth * 0.5 - (scrollx / zoomfact) + 1) / zoomfact,
@@ -3390,12 +3423,41 @@ function zoomout(scrollEvent = undefined)
         zoomOrigo.y = window.innerHeight / 2;
     }else if (zoomfact > 0.25) { // ELSE zoom towards mouseCoordinates
         var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
+
+        if (scrollEvent.clientX != lastZoomPos.x || scrollEvent.clientY != lastZoomPos.y) {
+           
+         var delta = {
+                x: mouseCoordinates.x - zoomOrigo.x,
+                y: mouseCoordinates.y - zoomOrigo.y
+            }
+ 
+            scrollx = scrollx / zoomfact;
+            scrolly = scrolly / zoomfact;
+            scrollx += delta.x;
+            scrolly += delta.y;
+            scrollx = scrollx * zoomfact;
+            scrolly = scrolly * zoomfact;
+ 
+            zoomOrigo.x = mouseCoordinates.x;
+            zoomOrigo.y = mouseCoordinates.y;
+            lastMousePosCoords = mouseCoordinates;
+
+            lastZoomPos.x = scrollEvent.clientX;
+            lastZoomPos.y = scrollEvent.clientY;
+        }
+        else if (scrollEvent.clientX == lastZoomPos.x && scrollEvent.clientY == lastZoomPos.y) {
+ 
+             zoomOrigo.x = lastMousePosCoords.x;
+             zoomOrigo.y = lastMousePosCoords.y;
+        }
+        
+        /*var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
         var delta = {
             x: mouseCoordinates.x - zoomOrigo.x,
             y: mouseCoordinates.y - zoomOrigo.y
         };
         zoomOrigo.x -= delta.x * settings.zoomPower;
-        zoomOrigo.y -= delta.y * settings.zoomPower;
+        zoomOrigo.y -= delta.y * settings.zoomPower;*/
     }
 
     scrollx = scrollx / zoomfact;
@@ -3412,6 +3474,9 @@ function zoomout(scrollEvent = undefined)
 
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;
+
+    //lastZoomPos.x = scrollEvent.clientX;
+    //lastZoomPos.y = scrollEvent.clientY;
 
     updateGridSize();
     updateA4Size();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -872,8 +872,8 @@ var scrollx = 100;
 var scrolly = 100;
 var zoomOrigo = new Point(0, 0); // Zoom center coordinates relative to origo
 var camera = new Point(0, 0); // Relative to coordinate system origo
-var lastZoomPos = new Point(0, 0);
-var lastMousePosCoords = new Point(0, 0);
+var lastZoomPos = new Point(0, 0); //placeholder for the previous zoom position relative to the screen (Screen position for previous zoom)
+var lastMousePosCoords = new Point(0, 0); //placeholder for the previous mouse coordinates relative to the diagram (Coordinates for the previous zoom) 
 
 // Constants
 const elementwidth = 200;
@@ -3341,13 +3341,14 @@ function zoomin(scrollEvent = undefined)
     }else if (zoomfact < 4.0){ // ELSE zoom towards mouseCoordinates
        var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
 
-       if (scrollEvent.clientX != lastZoomPos.x || scrollEvent.clientY != lastZoomPos.y) {
+       if (scrollEvent.clientX != lastZoomPos.x || scrollEvent.clientY != lastZoomPos.y) { //IF mouse has moved since last zoom, then zoom towards new position
           
-        var delta = {
+        var delta = { // Calculate the difference between the current mouse coordinates and the previous zoom coordinates (Origo)
                x: mouseCoordinates.x - zoomOrigo.x,
                y: mouseCoordinates.y - zoomOrigo.y
            }
 
+           //Update scroll variables with delta in order to move the screen to the new zoom position
            scrollx = scrollx / zoomfact;
            scrolly = scrolly / zoomfact;
            scrollx += delta.x;
@@ -3355,28 +3356,24 @@ function zoomin(scrollEvent = undefined)
            scrollx = scrollx * zoomfact;
            scrolly = scrolly * zoomfact;
 
+           //Set new zoomOrigo to the current mouse coordinates
            zoomOrigo.x = mouseCoordinates.x;
            zoomOrigo.y = mouseCoordinates.y;
            lastMousePosCoords = mouseCoordinates;
 
+           //Save current mouse position (Position on the SCREEN, not coordinates in the diagram)
            lastZoomPos.x = scrollEvent.clientX;
            lastZoomPos.y = scrollEvent.clientY;
        }
-       else if (scrollEvent.clientX == lastZoomPos.x && scrollEvent.clientY == lastZoomPos.y) {
+       else if (scrollEvent.clientX == lastZoomPos.x && scrollEvent.clientY == lastZoomPos.y) { //ELSE IF mouse has not moved, zoom towards same position as before.
 
             zoomOrigo.x = lastMousePosCoords.x;
             zoomOrigo.y = lastMousePosCoords.y;
        }
-       
-        /* var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
-        var delta = {
-            x: mouseCoordinates.x - zoomOrigo.x,
-            y: mouseCoordinates.y - zoomOrigo.y
-        };
-        zoomOrigo.x += delta.x * settings.zoomPower;
-        zoomOrigo.y += delta.y * settings.zoomPower; */
     }
 
+
+    //Update scroll variables to match the new zoomfact
     scrollx = scrollx / zoomfact;
     scrolly = scrolly / zoomfact;
 
@@ -3393,17 +3390,10 @@ function zoomin(scrollEvent = undefined)
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;
 
-
-
-    camera = {
-        x: (window.innerWidth * 0.5 - (scrollx / zoomfact) + 1) / zoomfact,
-        y: (window.innerHeight * 0.5 - (scrolly / zoomfact) + 1) / zoomfact
-    };
+    //Note: scroll variables (scrollx, scrolly) does not scale properly sometimes, not sure what causes it. zoomout() has the same problem.
 
     updateGridSize();
     updateA4Size();
-
-    // Update scroll position - missing code for determining that center of screen should remain at nevw zoom factor
     showdata();
 
     // Draw new rules to match the new zoomfact
@@ -3424,42 +3414,38 @@ function zoomout(scrollEvent = undefined)
     }else if (zoomfact > 0.25) { // ELSE zoom towards mouseCoordinates
         var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
 
-        if (scrollEvent.clientX != lastZoomPos.x || scrollEvent.clientY != lastZoomPos.y) {
+        if (scrollEvent.clientX != lastZoomPos.x || scrollEvent.clientY != lastZoomPos.y) { //IF mouse has moved since last zoom, then zoom towards new position
            
-         var delta = {
+         var delta = { // Calculate the difference between the current mouse coordinates and the previous zoom coordinates (Origo)
                 x: mouseCoordinates.x - zoomOrigo.x,
                 y: mouseCoordinates.y - zoomOrigo.y
             }
  
+            //Update scroll variables with delta in order to move the screen to the new zoom position
             scrollx = scrollx / zoomfact;
             scrolly = scrolly / zoomfact;
             scrollx += delta.x;
             scrolly += delta.y;
             scrollx = scrollx * zoomfact;
             scrolly = scrolly * zoomfact;
- 
+            
+            //Set new zoomOrigo to the current mouse coordinates
             zoomOrigo.x = mouseCoordinates.x;
             zoomOrigo.y = mouseCoordinates.y;
             lastMousePosCoords = mouseCoordinates;
 
+            //Save current mouse position (Position on the SCREEN, not coordinates in the diagram)
             lastZoomPos.x = scrollEvent.clientX;
             lastZoomPos.y = scrollEvent.clientY;
         }
-        else if (scrollEvent.clientX == lastZoomPos.x && scrollEvent.clientY == lastZoomPos.y) {
+        else if (scrollEvent.clientX == lastZoomPos.x && scrollEvent.clientY == lastZoomPos.y) { //ELSE IF mouse has not moved, zoom towards same position as before.
  
              zoomOrigo.x = lastMousePosCoords.x;
              zoomOrigo.y = lastMousePosCoords.y;
         }
-        
-        /*var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
-        var delta = {
-            x: mouseCoordinates.x - zoomOrigo.x,
-            y: mouseCoordinates.y - zoomOrigo.y
-        };
-        zoomOrigo.x -= delta.x * settings.zoomPower;
-        zoomOrigo.y -= delta.y * settings.zoomPower;*/
     }
 
+    //Update scroll variables to match the new zoomfact
     scrollx = scrollx / zoomfact;
     scrolly = scrolly / zoomfact;
 
@@ -3475,13 +3461,10 @@ function zoomout(scrollEvent = undefined)
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;
 
-    //lastZoomPos.x = scrollEvent.clientX;
-    //lastZoomPos.y = scrollEvent.clientY;
+    //Note: scroll variables (scrollx, scrolly) does not scale properly sometimes, not sure what causes it. zoomin() has the same problem.
 
     updateGridSize();
     updateA4Size();
-    
-    // Update scroll position - missing code for determining that center of screen should remain at new zoom factor
     showdata();
 
     // Draw new rules to match the new zoomfact

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3482,6 +3482,7 @@ function zoomreset()
     scrolly = scrolly / zoomfact;
    
     zoomfact = 1.0;
+    document.getElementById("zoom-message").innerHTML = zoomfact + "x";
 
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;


### PR DESCRIPTION
Scroll will now zoom in and out and remain at the current mouse pointer coordinates. It still has some issues that occur if user moves the mouse in between zooms but it corrects itself after one zoom event. This is testable by opening any diagram and scrolling in and out, it should now remain at the same position.

What currently isn't working as intended as mentioned is alternating between move > zoom-in and move > zoom-out. However, the original issue is that when selecting a box and zooming in, the cursor moves away from the box that isn't updating it's position. Instead of updating the element position, the mouse should remain at the same place. 

If any future developer solves the issue of alternating between zoom and move, it should solve the issue about the element moving away from the cursor completely. This commit should be considered a basis for a full solution.