### PR TITLE
fixed resize problem template 4

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -3496,7 +3496,7 @@ function resizeBoxes(parent, templateId)
 
 		$(boxValArray['box1']['id']).resizable({
 			containment: parent,
-			handles: "e,s",
+			handles: "e",
 			start: function (event, ui) {
 				document.getElementsByTagName("iframe")[0].style.pointerEvents = "none";
 			},
@@ -3519,7 +3519,6 @@ function resizeBoxes(parent, templateId)
 			},
 			resize: function (e, ui) {
 				alignBoxesHeight3boxes(boxValArray, 2, 1, 3);
-				alignBoxesWidth(boxValArray, 2, 1);
 				document.getElementById("box2wrapper").style.left = " ";
 			},
 			stop: function (e, ui) {


### PR DESCRIPTION
Fixed the problem by removing the "alignBoxesWidth" call in the resize for box2 and the event that is handled in box1.

Testing is done in javascript example 2 which uses template4 (two small boxes on top of one large box). Try to resize the boxes and see if the bug remains.