### PR TITLE
Fixed color issue #11396

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -880,9 +880,9 @@ const textheight = 18;
 const strokewidth = 2.0;
 const baseline = 10;
 const avgcharwidth = 6; // <-- This variable is never used anywhere in this file. 
-const colors = ["white", "gold", "#ffccdc", "yellow", "cornflowerBlue", "#FF4D4D"];
-const selectedColors = ["#cccccc", "#ce7f00", "#ff66b3", "#d2cf00", "#505E95", "#A45A5A"];
-const strokeColors = ["black", "white", "grey", "red"];
+const colors = ["white", "gold", "#ffccdc", "yellow", "cornflowerBlue", "#CDF5F6"];
+// const selectedColors = ["#cccccc", "#ce7f00", "#ff66b3", "#d2cf00", "#505E95", "#A45A5A"]; // Uncomment if an entity should change color when selected (1 of 2).
+const strokeColors = ["black", "white", "grey", "#614875"];
 const multioffs = 3;
 // Zoom values for offsetting the mouse cursor positioning
 const zoom1_25 = 0.36;
@@ -5038,11 +5038,11 @@ function updateCSSForAllElements()
             if (data[i].isLocked) useDelta = false;
             updateElementDivCSS(element, elementDiv, useDelta);
 
-            // Handle coloring
-            var sColor = selectedColors[colors.indexOf(element.fill)];
-            var grandChild = elementDiv.children[0].children[0];
-            grandChild.style.fill = inContext ? `${sColor}` : `${element.fill}`;
-            grandChild.style.stroke = data[i].stroke;
+            // Handle coloring // Uncomment if an entity should change color when selected (2 of 2).
+            // var sColor = selectedColors[colors.indexOf(element.fill)];
+            // var grandChild = elementDiv.children[0].children[0];
+            // grandChild.style.fill = inContext ? `${sColor}` : `${element.fill}`;
+            // grandChild.style.stroke = data[i].stroke;
         }
     }
 


### PR DESCRIPTION
We changed the possibility to chose a red color for an entity, by picking another color.

We also modified so that an entity does not change color when it's clicked on. Since the entity gets a clear box around it when it is clicked on, we see no point in changing the color as well. However, if this feature is ever asked for in the future, it is easy to just uncomment the parts mentioned in the code. This is commented in the file so that this process should be a no brainer.