### PR TITLE
Copyclipboard should never have a style of 'block'

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2465,7 +2465,7 @@ function showCopyButtons(templateid) {
 
 		for (var i = 1; i <= totalBoxes; i++) {
 		if (document.querySelector('#box' + i).className == 'box codebox') {
-		document.querySelector('#box' + i + 'wrapper #copyClipboard').style.display = 'block'
+		document.querySelector('#box' + i + 'wrapper #copyClipboard').style.display = 'table-cell'
 		}
 	}
 }


### PR DESCRIPTION
The issue is not present in the current version, however for correctness sake the change is made today.