### PR TITLE
Error message when creating a line on the same element #11479

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4203,6 +4203,11 @@ function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, su
         fromElement = tempElement;
     } 
 
+    if (fromElement.kind == toElement.kind && fromElement.name == toElement.name) {
+        displayMessage(messageTypes.ERROR, `Not possible to draw a line between: ${fromElement.name} and ${toElement.name}, they are the same element`);
+        return;
+    }
+
     // Check so the elements does not have the same kind, exception for the "ERAttr" kind.
     if (fromElement.kind !== toElement.kind || fromElement.kind === "ERAttr" ) {
 


### PR DESCRIPTION
An error message will appear when trying to create a line from a element to itself.

Instructions for testing:

1) Click "Demo-Course"
2) Click "Diagram Dugga"
3) Click the line tool or "6" on the keyboard
4) Create a line from a entity with itself and/or create a line from a attribute with itself, and an error message should appear