### PR TITLE
Added support for uploading .json files

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -232,7 +232,8 @@ function validateDummyFile() {
         "md",
         "py",
         "bat",
-        "xsl"
+        "xsl",
+        "json"
     ];
 
     var filterSymbols = [

--- a/DuggaSys/filereceive.php
+++ b/DuggaSys/filereceive.php
@@ -174,6 +174,7 @@ if ($storefile) {
         "dtd" => ["application/octet-stream"],
         "py" => ["text/plain"],
         "bat" => ["text/plain"],
+        "json" => ["text/application"],
         //	"xslt"	=> [
         "xsl" => ["text/xml"]
         //	"sl"		=> [


### PR DESCRIPTION
Added two elements to allow .json files to be added to the filelink table in the database.

Further allowance of file types into the database should most likely be done via allowing file extensions in these two tables.

PS: Uploaded global files can be found in the filelink table in the phpmyadmin database.