### PR TITLE
Removed faulty code #11476

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -508,11 +508,9 @@ function editImpWords(editType)
 //
 //----------------------------------------------------------------------------------
 
-function displayEditExample(boxid) 
-{
+function displayEditExample() {
 	document.getElementById("title").value = $('<textarea />').html(retData['examplename']).text();
 	document.getElementById("secttitle").value = $('<textarea />').html(retData['sectionname']).text();
-	document.getElementById("boxcontent").value = retData['box'][1][1];
 	changeDirectory(document.getElementById("boxcontent"));
 	document.getElementById("playlink").value = retData['playlink'];
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1541,7 +1541,7 @@ div .navButt:hover {
     .box{
         overflow: hidden;
     }
-    .maximizebtn, .minimizebtn, .resetbtn .editbtn{
+    .maximizebtn, .minimizebtn, .resetbtn{
       
       vertical-align: middle;
     }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1541,7 +1541,7 @@ div .navButt:hover {
     .box{
         overflow: hidden;
     }
-    .maximizebtn, .minimizebtn, .resetbtn{
+    .maximizebtn, .minimizebtn, .resetbtn .editbtn{
       
       vertical-align: middle;
     }


### PR DESCRIPTION
Removed boxid in displayEditExample() because it does not change an individual window-box, but rather the whole example. Removed an fault in displayEditExample() that causes an error to occur when using template 10