### PR TITLE
Fixed anchor tag download to default to filename+extension instead of only filename

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -404,7 +404,7 @@ function fileDownload(name, path, extension){
     h1.textContent = "Download file";
     a.href = path;
     a.textContent = name + "." + extension;
-    a.download = name;
+    a.download = "";
     div.appendChild(h1);
     div.appendChild(a);
     document.querySelector(".fileView").appendChild(div);


### PR DESCRIPTION
Error was in **fileDownload()** in **fileed.js**, it set the download attribute to the filename, but as it defaults to a .txt if you only put the name in the download attribute you wont get the correct file type.
This can be fixed by removing the filename from the download attribute and leaving it blank to just indicate that the anchor tag should download. By just indicating that the anchor tag should download it will default to the filename in the filesystem which has the file type preserved together with the filename.

Illustration of how the generation was fixed below:
![image](https://user-images.githubusercontent.com/102584289/162734396-40f2854a-072d-4334-b922-5461482785a6.png)



The generated anchor tag for mdTest.md from the code above will be the following:
**Before** : `<a href="../courses/global/mdTest.md" download="mdTest">mdTest.md</a>`
**After** : `<a href="../courses/global/mdTest.md" download="">mdTest.md</a>`