### PR TITLE
Added the examplename to the drop down list.

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -132,13 +132,13 @@ function returned(data)
 			retData['after'].push(sectionData['entries'][posAfter + j]);
 			retData['after'][j][1] = sectionData['entries'][posAfter + j]['entryname'];
 			retData['after'][j][0] = (String)(sectionData['entries'][posAfter + j]['link']);
-			for(k = 1; k < sectionData['codeexamples'].length; k++){
-				if(retData['after'][j][0] == sectionData['codeexamples'][k]['exampleid']){
-					retData['after'][j][2] = sectionData['codeexamples'][k]['examplename'];
-					continue;
+
+			for(k = 0; k < retData['beforeafter'].length; k++){
+				if(retData['beforeafter'][k][0] == retData['after'][j][0]){			
+					retData['after'][j][2] = retData['beforeafter'][k][2]
+					break;
 				}
 			}
-			
 			retData['exampleno'] = posAfter;
 			j++;
 		}else{
@@ -164,10 +164,11 @@ function returned(data)
 			retData['before'].push(sectionData['entries'][posBefore - j]);
 			retData['before'][j][1] = sectionData['entries'][posBefore - j]['entryname'];
 			retData['before'][j][0] = (String)(sectionData['entries'][posBefore - j]['link']);
-			for(k = 0; k < sectionData['entries'].length; k++){
-				if(retData['before'][j][0] == sectionData['entries'][k]['link']){
-					retData['before'][j][2] = sectionData['entries']['examplename'];
-					continue;
+
+			for(k = 0; k < retData['beforeafter'].length; k++){
+				if(retData['beforeafter'][k][0] == retData['before'][j][0] ){					
+					retData['before'][j][2] = retData['beforeafter'][k][2]
+					break;
 				}
 			}
 			retData['exampleno'] = posBefore;


### PR DESCRIPTION
The examplename used to be undefined. it should now always be the examplename.

For testing: 
1:when holding down the backward/forward the examplenames should be shown like the picture below.
![image](https://user-images.githubusercontent.com/102600690/162735145-fbaa7d01-b322-4df9-90b9-41fd406e507a.png)

What it looked like before for reference:
![image](https://user-images.githubusercontent.com/102600690/162735329-06a5301e-ee31-4989-987e-b1c9a2ccbbb0.png)
