### PR TITLE
Dugga deadlines are now displayed the same for all screen widths.

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5053,8 +5053,8 @@ only screen and (max-device-width: 1085px) {
 
   /* moment date and course version */
   .dateField {
-    opacity: 0.0;
-    max-width: 0px;
+    opacity: 1.0;
+    max-width: 1000px;
     pointer-events: none;
     transition: opacity 300ms, width 300ms;
     -webkit-transition: opacity 300ms, width 300ms;


### PR DESCRIPTION
Fixed issue#11494 by matching opacity and max-width for both .dateField in style.css. 