### PR TITLE
G1-2022-W2-#11497

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -578,7 +578,7 @@ function rowFilter(row) {
                         if (fileNameSearch(row, key, tempSearchTerm) &&
                             !(key == "counter" || key == "editor" || key == "trashcan")) match = true;
                     } else {
-                        if (row[key].toUpperCase().indexOf(tempSearchTerm.toUpperCase()) != -1 &&
+                        if (row[key].toString().toUpperCase().indexOf(tempSearchTerm.toUpperCase()) != -1 &&
                             !(key == "counter" || key == "editor" || key == "trashcan")) match = true;
                     }
                 }


### PR DESCRIPTION
Should work now. Problem was at line 581, where upperCase() tried "uppercasing" a non-string element. By adding toString() before solved the issue.