### PR TITLE
Removed light highlight on text in dark mode.

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -307,9 +307,9 @@
 }
 
 .descbox .impword {
-    color: #000000;
+    /* color: #000000; // Commented out this, to resolve another issue go to codeviewer.css (class ".descbox .impword") to see similar changes.
     background-color: #fff;
-    border: 1px solid #f44;
+    border: 1px solid #f44; */
 }
 
 .normtext .imphi {

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -587,9 +587,10 @@
 }
 
 .descbox .impword {
-  background-color: #F2F2F2;
-  color: #000;
+  /* background-color: #F2F2F2;
+  color: #000; */
   border-bottom: 2px solid #9971AF; 
+  cursor: pointer;
 }
 
 .descbox code .impword {


### PR DESCRIPTION
Fixed the text where there are bright highlights in dark mode, it should not exist.