### PR TITLE
Changed opacity for selection diagram.js

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5333,8 +5333,7 @@ function updateCSSForAllElements()
             updateElementDivCSS(element, elementDiv, useDelta);
 
             // Opacity on selected elements
-            var grandChild = elementDiv.children[0].children[0];
-            grandChild.style.opacity = inContext ? `${0.3}` : `${1.0}`;
+            elementDiv.style.opacity = inContext ? `${0.6}` : `${1.0}`;
         }
     }
 


### PR DESCRIPTION
When an element is selected the opacity changes to highlight the selection. This opacity value was changed to a more subtle value, for less opacity change upon selection. The current value is the best tradeoff in our opinion, since less opacity is almost not visible on a white element. If the opacity change is not ok at this value one needs to skip lighter colors to get a stronger difference on higher values.

Another upgrade is that multivalued attributes and weak entities or relations; i.e. objects with two frames in the diagram, are now, more clearly, changed in opacity. Previously it was just the frame that was changed, which made it hard to actually see a difference.