### PR TITLE
Updated showdata() in diagram.js

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5362,10 +5362,6 @@ function showdata()
         str += drawElement(data[i]);
     }
 
-    if (ghostElement) {
-        str += drawElement(ghostElement, true);
-    }
-
     container.innerHTML = str;
     updatepos(null, null);
 


### PR DESCRIPTION
Ghost elements are no longer drawn.