### PR TITLE
Fixed clicking elements in line creation mode #11183

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1548,6 +1548,7 @@ function ddown(event)
             if(event.button == 2) return;
             var element = data[findIndex(data, event.currentTarget.id)];
             if (element != null){
+                pointerState = pointerStates.CLICKED_ELEMENT;
                 updateSelection(element);
             }
             break;


### PR DESCRIPTION
Problem was that "selecting element" trigger on mouse down event, and "selecting line" on mouse up event. The changes made prevents "selecting line", if an element has been clicked in "edge_creation mode". 