### PR TITLE
Moved icons into options panel and changed them into buttons in diagram dugga #11540

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -79,7 +79,7 @@
 #options-pane {
     position: fixed;
     top: 0px;
-    width: 280px;
+    width: 320px;
     bottom: 0px;
     z-index: 5000;
     background-color: #eb4;
@@ -111,7 +111,7 @@
 }
 
 .hide-options-pane {
-    right: -270px;
+    right: -308px;
 }
 
 .selected-entry {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3693,19 +3693,36 @@ function propFieldSelected(isSelected)
 /**
  * @description Generates fields for all properties of the currently selected element/line in the context. These fields can be used to modify the selected element/line.
  */
+
+
+/**
+ * @description A4-template options pop up only when A4-template function button is pressed inside options panel.
+ */
+ function generateA4TemplateProperties(){
+    //a4 propteries
+    if (document.getElementById("a4Template").style.display === "block") {
+        document.getElementById("a4VerticalButton").style.display = "inline-block";
+        document.getElementById("a4HorizontalButton").style.display = "inline-block";
+    } 
+    else {
+        document.getElementById("a4VerticalButton").style.display = "none";
+        document.getElementById("a4HorizontalButton").style.display = "none";
+    }
+} 
+
 function generateContextProperties()
 {
 
     var propSet = document.getElementById("propertyFieldset");
     var str = "<legend>Properties</legend>";
-    
+/*     
     //a4 propteries
     if (document.getElementById("a4Template").style.display === "block") {
         str += `<text>Change the size of the A4</text>`;
         str += `<input type="range" onchange="setA4SizeFactor(event)" min="100" max="200" value ="${settings.grid.a4SizeFactor*100}" id="slider">`;
         str += `<br><button onclick="toggleA4Vertical()">Vertical</button>`;
         str += `<button onclick="toggleA4Horizontal()">Horizontal</button>`;
-    }
+    } */
 
     //more than one element selected
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3253,14 +3253,18 @@ function toggleEntityLocked()
 function toggleGrid()
 {
     var grid = document.getElementById("svggrid");
+    var gridButton = document.getElementById("gridToggle");
 
     // Toggle active class on button
     document.getElementById("gridToggle").classList.toggle("active");
 
+    // Toggle active grid + color change of button to clarify if button is pressed or not
     if (grid.style.display == "block") {
         grid.style.display = "none";
+        gridButton.style.backgroundColor ="#614875";
      } else {
         grid.style.display = "block";
+        gridButton.style.backgroundColor ="#362049";
    }
 }
 
@@ -3408,8 +3412,14 @@ function toggleA4Template()
 
     if (template.style.display == "block") {
         template.style.display = "none";
+        document.getElementById("a4VerticalButton").style.display = "none";
+        document.getElementById("a4HorizontalButton").style.display = "none";
+        document.getElementById("a4TemplateToggle").style.backgroundColor = "#614875";
      } else {
         template.style.display = "block";
+        document.getElementById("a4VerticalButton").style.display = "inline-block";
+        document.getElementById("a4HorizontalButton").style.display = "inline-block";
+        document.getElementById("a4TemplateToggle").style.backgroundColor = "#362049";
    }
    generateContextProperties();
 }
@@ -3448,6 +3458,16 @@ function toggleSnapToGrid()
 
     // Toggle the boolean
     settings.grid.snapToGrid = !settings.grid.snapToGrid;
+
+    // Color change of button to clarify if button is pressed or not
+    if(settings.grid.snapToGrid)
+    {
+        document.getElementById("rulerSnapToGrid").style.backgroundColor = "#362049";
+    }
+    else
+    {
+        document.getElementById("rulerSnapToGrid").style.backgroundColor = "#614875";
+    }
 }
 
 /**
@@ -3456,14 +3476,19 @@ function toggleSnapToGrid()
 function toggleRuler()
 {
     var ruler = document.getElementById("rulerOverlay");
+    var rulerToggleButton = document.getElementById("rulerToggle");
   
     // Toggle active class on button
     document.getElementById("rulerToggle").classList.toggle("active");
 
+    // Toggle active ruler + color change of button to clarify if button is pressed or not
     if(settings.ruler.isRulerActive){
         ruler.style.display = "none";
+        rulerToggleButton.style.backgroundColor = "#614875";
     } else {
         ruler.style.display = "block";
+        rulerToggleButton.style.backgroundColor = "#362049";
+
     }
   
     settings.ruler.isRulerActive = !settings.ruler.isRulerActive;
@@ -3692,24 +3717,7 @@ function propFieldSelected(isSelected)
 
 /**
  * @description Generates fields for all properties of the currently selected element/line in the context. These fields can be used to modify the selected element/line.
- */
-
-
-/**
- * @description A4-template options pop up only when A4-template function button is pressed inside options panel.
- */
- function generateA4TemplateProperties(){
-    //a4 propteries
-    if (document.getElementById("a4Template").style.display === "block") {
-        document.getElementById("a4VerticalButton").style.display = "inline-block";
-        document.getElementById("a4HorizontalButton").style.display = "inline-block";
-    } 
-    else {
-        document.getElementById("a4VerticalButton").style.display = "none";
-        document.getElementById("a4HorizontalButton").style.display = "none";
-    }
-} 
-
+ */ 
 function generateContextProperties()
 {
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -110,7 +110,7 @@
                 </span>
             </div>
         </fieldset>
-        <fieldset>
+<!--         <fieldset>
             <legend>Toggle</legend>
             <div id="rulerToggle" class="diagramIcons active" onclick='toggleRuler()'>
                 <img src="../Shared/icons/diagram_ruler.svg"/>
@@ -127,7 +127,7 @@
                 </span>
             </div>
 
-        </fieldset>   
+        </fieldset>   --> 
         <fieldset>
             <legend>Camera</legend>
             <div id="camtoOrigo" class="diagramIcons" onclick="centerCamera(); centerCamera();">
@@ -215,9 +215,10 @@
         <div id ="fieldsetBox">
             <fieldset id='propertyFieldset' style="position: absolute;">
             </fieldset>
-            <fieldset style="position: absolute; bottom: 200px;">
+
+            <fieldset style="position: absolute; bottom: 200px; width:82%">
             <legend>Toggle</legend>
-                <div id="gridToggle" class="diagramIcons" onclick='toggleGrid()'>
+                <!-- <div id="gridToggle" class="diagramIcons" onclick='toggleGrid()'>
                     <img src="../Shared/icons/diagram_grid.svg"/>
                     <span class="toolTipText"><b>Toggle grid</b><br>
                         <p>Enable/disable the grid</p><br>
@@ -230,7 +231,25 @@
                         <p>Enable/disable the Snap To Grid</p><br>
                         <p id="tooltip-TOGGLE_SNAPGRID" class="key_tooltip">Keybinding:</p>
                     </span>
-                </div>  
+                <div id="rulerToggle" class="diagramIcons active" onclick='toggleRuler()'>
+                <img src="../Shared/icons/diagram_ruler.svg"/>
+                <span class="toolTipText"><b>Toggle Ruler</b><br>
+                    <p>Enable/disable the ruler</p><br>
+                    <p id="tooltip-TOGGLE_RULER" class="key_tooltip">Keybinding:</p>
+                </span>
+            </div>
+            <div id="a4TemplateToggle" class="diagramIcons" onclick="toggleA4Template()">
+                <img src="../Shared/icons/diagram_a4.svg"/>
+                <span class="toolTipText"><b>Toggle A4 template</b><br>
+                    <p>Enable/disable the A4 template</p><br>
+                    <p id="tooltip-TOGGLE_A4" class="key_tooltip">Keybinding:</p>
+                </span>
+            </div>
+                </div>   -->    
+                <button id="gridToggle" class="saveButton" onclick="toggleGrid();">Toggle grid</button>
+                <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Toggle snap to grid</button>
+                <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Toggle ruler</button>
+                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">Toggle A4 template</button>
             </fieldset>
             <div style="position: absolute; bottom: 20px;">
                 <fieldset>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -112,20 +112,6 @@
         </fieldset>
         <fieldset>
             <legend>Toggle</legend>
-            <div id="gridToggle" class="diagramIcons" onclick='toggleGrid()'>
-                <img src="../Shared/icons/diagram_grid.svg"/>
-                <span class="toolTipText"><b>Toggle grid</b><br>
-                    <p>Enable/disable the grid</p><br>
-                    <p id="tooltip-TOGGLE_GRID" class="key_tooltip">Keybinding:</p>
-                </span>
-            </div>
-            <div id="rulerSnapToGrid" class="diagramIcons" onclick="toggleSnapToGrid()">
-                <img src="../Shared/icons/diagram_gridmagnet.svg"/>
-                <span class="toolTipText"><b>Toggle Snap To Grid</b><br>
-                    <p>Enable/disable the Snap To Grid</p><br>
-                    <p id="tooltip-TOGGLE_SNAPGRID" class="key_tooltip">Keybinding:</p>
-                </span>
-            </div>
             <div id="rulerToggle" class="diagramIcons active" onclick='toggleRuler()'>
                 <img src="../Shared/icons/diagram_ruler.svg"/>
                 <span class="toolTipText"><b>Toggle Ruler</b><br>
@@ -227,10 +213,26 @@
             </span>
         </div>
         <div id ="fieldsetBox">
-            <fieldset id='propertyFieldset'>
-                
+            <fieldset id='propertyFieldset' style="position: absolute;">
             </fieldset>
-            <div style="position: absolute; bottom: 20px">
+            <fieldset style="position: absolute; bottom: 200px;">
+            <legend>Toggle</legend>
+                <div id="gridToggle" class="diagramIcons" onclick='toggleGrid()'>
+                    <img src="../Shared/icons/diagram_grid.svg"/>
+                    <span class="toolTipText"><b>Toggle grid</b><br>
+                        <p>Enable/disable the grid</p><br>
+                        <p id="tooltip-TOGGLE_GRID" class="key_tooltip">Keybinding:</p>
+                    </span>
+                </div>
+                <div id="rulerSnapToGrid" class="diagramIcons" onclick="toggleSnapToGrid()">
+                    <img src="../Shared/icons/diagram_gridmagnet.svg"/>
+                    <span class="toolTipText"><b>Toggle Snap To Grid</b><br>
+                        <p>Enable/disable the Snap To Grid</p><br>
+                        <p id="tooltip-TOGGLE_SNAPGRID" class="key_tooltip">Keybinding:</p>
+                    </span>
+                </div>  
+            </fieldset>
+            <div style="position: absolute; bottom: 20px;">
                 <fieldset>
                     <legend>Export</legend>
                     <button class="saveButton" onclick="saveDiagram();">Save</button>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -216,7 +216,7 @@
             <fieldset id='propertyFieldset' style="position: absolute;">
             </fieldset>
 
-            <fieldset style="position: absolute; bottom: 260px; width:82%">
+            <fieldset style="position: absolute; bottom: 250px; width:82%">
             <legend>Toggle</legend>
                 <!-- <div id="gridToggle" class="diagramIcons" onclick='toggleGrid()'>
                     <img src="../Shared/icons/diagram_grid.svg"/>
@@ -249,7 +249,11 @@
                 <button id="gridToggle" class="saveButton" onclick="toggleGrid();">Grid</button><br><br>
                 <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
                 <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Ruler</button><br><br>
-                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">A4 template</button>
+                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template(), generateA4TemplateProperties()">A4 template</button><br><br>
+                <div id="a4Options" style="display:flex;">
+                    <button id="a4VerticalButton" style="display:none; width:76px; margin-right:45%;" onclick="toggleA4Vertical()">Vertical</button>
+                    <button id="a4HorizontalButton" style="display:none;" onclick="toggleA4Horizontal()">Horizontal</button>
+                </div>
             </fieldset>
             <div style="position: absolute; bottom: 20px;">
                 <fieldset>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -216,7 +216,7 @@
             <fieldset id='propertyFieldset' style="position: absolute;">
             </fieldset>
 
-            <fieldset style="position: absolute; bottom: 200px; width:82%">
+            <fieldset style="position: absolute; bottom: 260px; width:82%">
             <legend>Toggle</legend>
                 <!-- <div id="gridToggle" class="diagramIcons" onclick='toggleGrid()'>
                     <img src="../Shared/icons/diagram_grid.svg"/>
@@ -246,20 +246,20 @@
                 </span>
             </div>
                 </div>   -->    
-                <button id="gridToggle" class="saveButton" onclick="toggleGrid();">Toggle grid</button>
-                <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Toggle snap to grid</button>
-                <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Toggle ruler</button>
-                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">Toggle A4 template</button>
+                <button id="gridToggle" class="saveButton" onclick="toggleGrid();">Grid</button><br><br>
+                <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
+                <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Ruler</button><br><br>
+                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">A4 template</button>
             </fieldset>
             <div style="position: absolute; bottom: 20px;">
                 <fieldset>
                     <legend>Export</legend>
-                    <button class="saveButton" onclick="saveDiagram();">Save</button>
+                    <button class="saveButton" onclick="saveDiagram();">Save</button><br><br>
                     <button class="saveButton" onclick="exportDiagram();">Export</button>
                 </fieldset>
                 <fieldset>
                     <legend>Import</legend>
-                    <input style="width: 100%" id="importDiagramFile" type="file">
+                    <input style="width: 100%" id="importDiagramFile" type="file"><br><br>
                     <button class="saveButton" onclick="loadDiagram();">Load</button>
                 </fieldset>
             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -248,8 +248,8 @@
                 </div>   -->    
                 <button id="gridToggle" class="saveButton" onclick="toggleGrid();">Grid</button><br><br>
                 <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
-                <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Ruler</button><br><br>
-                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template(), generateA4TemplateProperties()">A4 template</button><br><br>
+                <button id="rulerToggle" class="saveButton" style="background-color:#362049;" onclick="toggleRuler()">Ruler</button><br><br>
+                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">A4 template</button><br><br>
                 <div id="a4Options" style="display:flex;">
                     <button id="a4VerticalButton" style="display:none; width:76px; margin-right:45%;" onclick="toggleA4Vertical()">Vertical</button>
                     <button id="a4HorizontalButton" style="display:none;" onclick="toggleA4Horizontal()">Horizontal</button>
@@ -261,7 +261,7 @@
                     <button class="saveButton" onclick="saveDiagram();">Save</button><br><br>
                     <button class="saveButton" onclick="exportDiagram();">Export</button>
                 </fieldset>
-                <fieldset>
+                <fieldset style="margin-top:2%;">
                     <legend>Import</legend>
                     <input style="width: 100%" id="importDiagramFile" type="file"><br><br>
                     <button class="saveButton" onclick="loadDiagram();">Load</button>


### PR DESCRIPTION
Moved icons (Toggle grid, toggle snap to grid, toggle ruler, toggle A4 template) into options panel and changed them into buttons. 
Changed css for options panel and buttons to make it more presentable. 