### PR TITLE
Removed the square around the delete button #11387

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5371,7 +5371,6 @@ function drawSelectionBox(str)
         deleteBtnY = lowY - 5;
 
         //Delete button visual representation
-        str += `<rect width='${deleteBtnSize}' height='${deleteBtnSize}' x='${deleteBtnX}' y='${deleteBtnY}'; style='fill:transparent;stroke-width:2;stroke:rgb(0,0,0)'/>`;
         str += `<line x1='${deleteBtnX + 2}' y1='${deleteBtnY + 2}' x2='${deleteBtnX + deleteBtnSize - 2}' y2='${deleteBtnY + deleteBtnSize - 2}' style='stroke:rgb(0,0,0);stroke-width:2'/>`;
         str += `<line x1='${deleteBtnX + 2}' y1='${deleteBtnY + deleteBtnSize - 2}' x2='${deleteBtnX + deleteBtnSize - 2}' y2='${deleteBtnY + 2}' style='stroke:rgb(0,0,0);stroke-width:2'/>`;
     }


### PR DESCRIPTION
Removed the square around the delete button, now there is only an X.

Instructions for testing:
1) Click "Demo-Course"
2) Click "Diagram Dugga"
3) Click or box select any element/s
4) Click cross icon in the right upper corner of the selection box and the elements selected should get deleted