### PR TITLE
Searching in the result editor now works #11606

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -330,7 +330,7 @@ function rowFilter(row) {
 				if(row[column] == null){
 					isSearchMatch = false;
 				} 
-				else if(row[column].toLowerCase().includes(term.toLowerCase())){
+				else if(row[column].toString().toLowerCase().includes(term.toLowerCase())){
 					isSearchMatch = true;
 					break;
 				}else{


### PR DESCRIPTION
added .toString() to line 333 in resulted.js to make it sure it's a string that is compared to the search term. 

Testing: Enter course as superuser/teacher -> Press button "Edit student results" (paper with pencil) -> Attempt searching. (Note: ALL things can be searched for, including dates published and hashes.)