### PR TITLE
Added another clause that blocks this behaviour.

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -5313,7 +5313,7 @@ function toggleTitleWrapper(targetBox, boxNum, boxW){
 			once: true,
 			passive: false
 	  });
-	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85 && boxNum == 3 && (retData['templateid']) != 5){
+	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85 && boxW < 98 && boxNum == 3 && (retData['templateid']) != 5){
 	  box.classList.add('visuallyhidden');
 	  box.addEventListener('transitionend', function(e) {
 			box.classList.add('hidden');
@@ -5322,7 +5322,7 @@ function toggleTitleWrapper(targetBox, boxNum, boxW){
 			once: true,
 			passive: false
 	  });
-	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85 && boxNum == 4 && boxW < 98){
+	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85 && boxW < 98 && boxNum == 4 && boxW < 98){
 	  box.classList.add('visuallyhidden');
 	  box.addEventListener('transitionend', function(e) {
 			box.classList.add('hidden');
@@ -5331,7 +5331,7 @@ function toggleTitleWrapper(targetBox, boxNum, boxW){
 			once: true,
 			passive: false
 	  });
-	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85 && boxNum == 1 && (retData['templateid']) == 6){
+	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85  && boxW < 98 && boxNum == 1 && (retData['templateid']) == 6){
 	  box.classList.add('visuallyhidden');
 	  box.addEventListener('transitionend', function(e) {
 			box.classList.add('hidden');
@@ -5340,7 +5340,7 @@ function toggleTitleWrapper(targetBox, boxNum, boxW){
 			once: true,
 			passive: false
 	  });
-	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85 && boxNum == 1 && (retData['templateid']) == 3){
+	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85  && boxW < 98 && boxNum == 1 && (retData['templateid']) == 3){
 	  box.classList.add('visuallyhidden');
 	  box.addEventListener('transitionend', function(e) {
 			box.classList.add('hidden');
@@ -5349,7 +5349,7 @@ function toggleTitleWrapper(targetBox, boxNum, boxW){
 			once: true,
 			passive: false
 	  });
-	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85 && boxNum == 1 && (retData['templateid']) == 9){
+	}else if(box.classList.contains('visuallyhidden') == false && boxW > 85  && boxW < 98 && boxNum == 1 && (retData['templateid']) == 9){
 	  box.classList.add('visuallyhidden');
 	  box.addEventListener('transitionend', function(e) {
 			box.classList.add('hidden');


### PR DESCRIPTION
Added new clauses that check for boxW being 100( boxW > 98).
For testing:
1: Go into javascript example 1.
![image](https://user-images.githubusercontent.com/102600690/163352859-dac7696a-2926-460e-a7fd-d7fae61e4085.png)

2: Open the inspect elements box(Ctrl+Shift+i).
3:Drag the inspect elements box so that the hamburger menue appears
![image](https://user-images.githubusercontent.com/102600690/163353402-13598909-05c8-4f82-a13a-65531b79ad8b.png)
4:Click the hamburger menue and pick JavaScript_Exx1.html (or Ex1.js)
5:The description box should not be hidden.
![image](https://user-images.githubusercontent.com/102600690/163353859-4102c3af-a88a-4102-915d-156125b6039e.png)