### PR TITLE
cleaned up test functions and now the dropdown box lists only json files

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -18,6 +18,7 @@ var typeOfItem;
 var duggaPages;
 var isClickedElementBox = false;
 var searchterm = "";
+var targetfile;
 
 function setup() {
 	/* Replaced by search bar in navheader.php. Remove this code when the new search bar has been properly tested
@@ -354,11 +355,7 @@ function updateVariantTitle(number) {
 
 // Opens the variant editor.
 function showVariantEditor() {
-	/*Currently switching between "SECTION" and "FILE" to try returnedSection() and returnedFile() below and
-	see which solution works best. Currently "SECTION" and returnedSection() works best to list all files
-	from filelink but they're not doing anything at the moment.*/
-
-	AJAXService("GET", { cid: querystring['courseid'], coursevers: querystring['coursevers'] }, "SECTION");
+	AJAXService("GET", { cid: querystring['courseid'], coursevers: querystring['coursevers'] }, "FILE");
   if(submissionRow == 0){
     // The submission row doesn't go away when leaving the modal
     // so without the if statement a new submission div would be created each time.
@@ -370,16 +367,19 @@ function showVariantEditor() {
 	$("#editVariant").css("display", "flex"); //Display variant-window
 }
 
-function returnedSection(data){
-	/*This function currently works best, it lists all files from filelink.
-	Still need to implement filter to only list .json files*/
-	retdata = data;
-	$("#file").html(makeoptionsItem("test", retdata['links'], 'filename'));
-}
-
 function returnedFile(data){
 	retdata = data;
-	$("#file").html(makeoptionsItem("test", [JSON.parse(retdata.entries[0].filename)], 'filename'));
+	filearray = [];
+
+	/*Because the 'filename' value is just raw JSON, it needs to be parsed. You can test this by printing retdata in the
+	console while in the variant editor. After parsing they're placed in array which then gets filtered for JSON files*/
+	for (var i = 0; i < retdata['entries'].length; i++){
+		filearray[i] = JSON.parse(retdata['entries'][i].filename);
+	}
+	filteredarray = filearray.filter(x => x.extension === "json");
+
+	//Not sure how the first parameter works yet, suspect it's to know which object is selected
+	$("#file").html(makeoptionsItem("not doing anything plz fix", filteredarray, 'filename'));
 }
 
 // Adds a submission row

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -177,6 +177,8 @@ session_start();
                   <div>
                     <div>
                       <fieldset style="width:90%">
+                      <!-- Currently the diagrams aren't doing anything, they're just listed.
+                      They're fetched and parsed in returnedFile() in duggaed.js -->
                         <legend>Add diagram to dugga</legend>
                         <select id="file" style="flex:1"></select>
                       </fieldset>


### PR DESCRIPTION
Removed function returnedSection() as I was using it to test whichever was best between that and returnedFile(). Furthermore, the dropdown now only lists json files. You can test this by uploading a global or local .json file then edit the variant of a dugga in the same course. Also added some comments describing what they do and where.

![bild](https://user-images.githubusercontent.com/37794783/163356475-5b2ecc53-8b7e-403f-8c4d-b4f82a8c41df.png)
