### PR TITLE
Hide dropdownmenu when pressing the other button #11633

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -49,7 +49,7 @@ document.addEventListener("click", function(e) {
 	for (let i = 0; i < parent.length; i++) {
 		var bool = (!parent[i].classList.contains("hidden") && (child.classList.contains("filter-btn-duggaName") || parent[i].contains(child)));
 
-		if (bool) parent[i].classList.remove("hidden")	
+		if (bool) parent[i].classList.remove("hidden")
 		else parent[i].classList.add("hidden")
 	}
 });

--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -49,7 +49,7 @@ document.addEventListener("click", function(e) {
 	for (let i = 0; i < parent.length; i++) {
 		var bool = (!parent[i].classList.contains("hidden") && (child.classList.contains("filter-btn-duggaName") || parent[i].contains(child)));
 
-		if (bool) parent[i].classList.remove("hidden")
+		if (bool) parent[i].classList.remove("hidden")	
 		else parent[i].classList.add("hidden")
 	}
 });
@@ -112,9 +112,15 @@ function selectAll(elem) {
 }
 
 function showAvailableDuggaFilter() {
+	//Hides other dropdown
+	showColumnFilterElement.classList.add("hidden");
+
 	showDuggaFilterElement.classList.toggle("hidden");
 }
 function showAvailableColumnFilter() {
+	//Hides other dropdown
+	showDuggaFilterElement.classList.add("hidden");
+
 	showColumnFilterElement.classList.toggle("hidden");
 }
 


### PR DESCRIPTION
Now when pressing one of the buttons in the result editor, the other dropdown will be closed, meaing that the two will no longer be open at the same time. 

![image](https://user-images.githubusercontent.com/102599327/163364432-f011f6b4-f950-4456-b692-e3d4b40e27e2.png)

Testing: Enter course as superuser/teacher -> Press button "Edit student results" (paper with pencil) -> Attempt opening both dropdowns by pressing both buttons.
![image](https://user-images.githubusercontent.com/102599327/163364845-f19e6476-0322-4e62-8dec-982331cb7902.png)
