### PR TITLE
removed the timestamp to avoid cramped view when using phone

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1054,7 +1054,7 @@ function returnedSection(data) {
             str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length);
           } else {
             str += "<span class='dateField'>" + deadline.slice(0, yearFormat.length) + "</span>";
-            str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length + 1 + timeFilterAndFormat.length - 3);
+            str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length + 1);
           }
 
           str += "</div></td>";

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1122,7 +1122,7 @@ function returnedSection(data) {
 
         // checkbox
         if (data['writeaccess'] || data['studentteacher']) {
-          str += `<td style='width:32px;' class='" + makeTextArray(itemKind,
+          str += `<td style='width:25px;' class='" + makeTextArray(itemKind,
             ["header", "section", "code", "test", "moment", "link", "group", "message"]) + " ${hideState}'>`;
             str += "<input type='checkbox' name='arrayCheckBox' onclick='markedItems(this)'>";
             str += "</td>";      


### PR DESCRIPTION
Removed some code from line 1057 that showed time of upload of duggas. This was deemed an unnecessary feature that makes mobile veiw to cramped. No more time stamp, no more cut off.
From:
![image](https://user-images.githubusercontent.com/102599327/163962390-6f6b5847-3936-4f06-a1bc-5db2a6986d3c.png)
To:
![image](https://user-images.githubusercontent.com/102599327/163968660-bab4c5fc-8037-40f3-901e-8f2440849115.png)

I tried to just add a padding but that made the name of the duggas non-visible. This seemed like a worse problem than not having the exact time of upload.

Also changed the width of the square behind the checkboxes to make the names of duggas more visible in phone view and because I felt like it.

To test: Open course of choice, open "inspect"-view, press the second button from the top left to change to mobile view, observe.