### PR TITLE
Minor layout changes depending on screen width #11646

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1054,7 +1054,7 @@ function returnedSection(data) {
             str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length);
           } else {
             str += "<span class='dateField'>" + deadline.slice(0, yearFormat.length) + "</span>";
-            str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length + 1 + timeFilterAndFormat.length - 3);
+            str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length + 1);
           }
 
           str += "</div></td>";

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -18,6 +18,7 @@ var hideItemList = [];
 var hasDuggs = false;
 var dateToday = new Date().getTime();
 var compareWeek = -604800000;
+let width = screen.width;
 
 // Stores everything that relates to collapsable menus and their state.
 var menuState = {
@@ -1054,7 +1055,12 @@ function returnedSection(data) {
             str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length);
           } else {
             str += "<span class='dateField'>" + deadline.slice(0, yearFormat.length) + "</span>";
-            str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length + 1);
+            if(width > 430){
+              str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length + 1 + timeFilterAndFormat.length - 3);
+            }
+            else{
+              str += deadline.slice(yearFormat.length, yearFormat.length + dateFormat.length + 1);
+            }
           }
 
           str += "</div></td>";

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1122,7 +1122,7 @@ function returnedSection(data) {
 
         // checkbox
         if (data['writeaccess'] || data['studentteacher']) {
-          str += `<td style='width:32px;' class='" + makeTextArray(itemKind,
+          str += `<td style='width:25px;' class='" + makeTextArray(itemKind,
             ["header", "section", "code", "test", "moment", "link", "group", "message"]) + " ${hideState}'>`;
             str += "<input type='checkbox' name='arrayCheckBox' onclick='markedItems(this)'>";
             str += "</td>";      


### PR DESCRIPTION
Now if screen width is 430 or below, the exact time of upload will not be shown. When the width is above, the time will be shown.

![image](https://user-images.githubusercontent.com/102599327/163977460-24c4f32e-5126-4793-9926-967fab1dc286.png)

![image](https://user-images.githubusercontent.com/102599327/163977552-9bf08f19-22d1-4da7-92de-3a776b2629f8.png)

To test: Enter a course with available duggas, open inspect view, push the "phoneview button" ![image](https://user-images.githubusercontent.com/102599327/163977679-a59c4690-15c3-49c4-89a1-948d71ed15bb.png), check the different widths (remember to update the page).
