### PR TITLE
Made contributionservice.php slightly faster

### DIFF
--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -468,11 +468,14 @@ if(strcmp($opt,"get")==0) {
 	$currentdate = $startweek;
 	for($i=0;$i<70;$i++){
 		$currentdate=date('Y-m-d',$currentdate);
+		$tomorrowdate=strtotime("+1 day",strtotime($currentdate));
+        $tomorrowdate=date('Y-m-d',$tomorrowdate);
 		$daycount = array();
 		//Events
-		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND Date(eventtime)=:currentdate AND kind!="comment"');
+		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND eventtime>:currentdate AND eventtime<:tomorrowdate AND kind!="comment"');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
+		$query->bindParam(':tomorrowdate', $tomorrowdate);
 		if(!$query->execute()) {
 			$error=$query->errorInfo();
 			$debug="Error reading entries".$error[2];
@@ -480,9 +483,10 @@ if(strcmp($opt,"get")==0) {
 		$eventcount = $query->fetchAll();
 
 	  //Comments
-		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND Date(eventtime)=:currentdate AND kind="comment"');
+		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND eventtime>:currentdate AND eventtime<:tomorrowdate AND kind="comment"');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
+		$query->bindParam(':tomorrowdate', $tomorrowdate);
 		if(!$query->execute()) {
 			$error=$query->errorInfo();
 			$debug="Error reading entries".$error[2];
@@ -490,9 +494,10 @@ if(strcmp($opt,"get")==0) {
 		$commentcount = $query->fetchAll();
 
 		//Commits
-		$query = $log_db->prepare('SELECT count(*) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and Date(blamedate)=:currentdate');
+		$query = $log_db->prepare('SELECT count(*) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and blamedate>:currentdate AND blamedate<:tomorrowdate');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
+		$query->bindParam(':tomorrowdate', $tomorrowdate);
 		if(!$query->execute()) {
 			$error=$query->errorInfo();
 			$debug="Error reading entries".$error[2];
@@ -500,9 +505,10 @@ if(strcmp($opt,"get")==0) {
 		$commitcount = $query->fetchAll();
 
 		//LOC
-		$query = $log_db->prepare('SELECT sum(rowcnt) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and Date(blamedate)=:currentdate');
+		$query = $log_db->prepare('SELECT sum(rowcnt) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and blamedate>:currentdate AND blamedate<:tomorrowdate');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
+		$query->bindParam(':tomorrowdate', $tomorrowdate);
 		if(!$query->execute()) {
 			$error=$query->errorInfo();
 			$debug="Error reading entries".$error[2];


### PR DESCRIPTION
Changed the queries so that they don't rely on the Date() function to convert dates into the correct format. Instead uses interval which is about 100 ms faster from my testing.

Original speed. (283 ms for contibutionservice.php)
![ogSpeed](https://user-images.githubusercontent.com/102533453/163988650-10088888-629a-4fa8-8e25-0effe0e226bc.png)


New speed. (182 ms for contibutionservice.php)
![newSpeed](https://user-images.githubusercontent.com/102533453/163988637-337a22c1-d055-486e-9590-1c4bf5ad0530.png)

This speed increase didn't fix this problem when the database is large but it makes a big impact on the performance when using the database from the usb.