### PR TITLE
G1 2022 w3 #11342

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -892,7 +892,7 @@ var scrolly = 100;
 var zoomOrigo = new Point(0, 0); // Zoom center coordinates relative to origo
 var camera = new Point(0, 0); // Relative to coordinate system origo
 var lastZoomPos = new Point(0, 0); //placeholder for the previous zoom position relative to the screen (Screen position for previous zoom)
-var lastMousePosCoords = new Point(0, 0); //placeholder for the previous mouse coordinates relative to the diagram (Coordinates for the previous zoom) 
+var lastMousePosCoords = new Point(0, 0); //placeholder for the previous mouse coordinates relative to the diagram (Coordinates for the previous zoom)
 
 var zoomAllowed = true; // Boolean value to slow down zoom on touchpad.
 
@@ -3489,31 +3489,25 @@ function zoomin(scrollEvent = undefined)
 {
     // If mousewheel is not used, we zoom towards origo (0, 0)
     if (!scrollEvent){
-        console.log("ZOOMIN:");
-        console.log("Window x/y: " + window.innerWidth / 2 + ", " + window.innerHeight / 2);
-        console.log("zoomOrigo x/y: " + zoomOrigo.x + ", " + zoomOrigo.y);
-        console.log("Scroll x/y: " + scrollx + ", " + scrolly);
-        console.log("SScroll x/y: " + sscrollx + ", " + sscrolly);
-        console.log("zoomfact: " + zoomfact);
-        var midScreen = screenToDiagramCoordinates((window.innerWidth / 2), (window.innerHeight / 2));
-        var delta = { // Calculate the difference between last zoomOrigo and current midScreen coordinates.
-            x: midScreen.x - zoomOrigo.x,
-            y: midScreen.y - zoomOrigo.y
+        if (zoomfact < 4) {
+            var midScreen = screenToDiagramCoordinates((window.innerWidth / 2), (window.innerHeight / 2));
+                
+            var delta = { // Calculate the difference between last zoomOrigo and current midScreen coordinates.
+                x: midScreen.x - zoomOrigo.x,
+                y: midScreen.y - zoomOrigo.y
+            }
+
+            //Update scroll x/y to center screen on new zoomOrigo
+            scrollx = scrollx / zoomfact;
+            scrolly = scrolly / zoomfact;
+            scrollx += delta.x * zoomfact;
+            scrolly += delta.y * zoomfact;
+            scrollx = scrollx * zoomfact;
+            scrolly = scrolly * zoomfact;
+
+            zoomOrigo.x = midScreen.x;
+            zoomOrigo.y = midScreen.y;
         }
-
-        console.log("midScreen x/y: " + midScreen.x + ", " + midScreen.y);
-        console.log("delta x/y: " + delta.x + ", " + delta.y);
-
-        //Update scroll x/y to center screen on new zoomOrigo
-        scrollx = scrollx / zoomfact;
-        scrolly = scrolly / zoomfact;
-        scrollx += delta.x;
-        scrolly += delta.y;
-        scrollx = scrollx * zoomfact;
-        scrolly = scrolly * zoomfact;
-
-        zoomOrigo.x = midScreen.x;
-        zoomOrigo.y = midScreen.y;
 
     }else if (zoomfact < 4.0){ // ELSE zoom towards mouseCoordinates
        var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
@@ -3528,8 +3522,8 @@ function zoomin(scrollEvent = undefined)
            //Update scroll variables with delta in order to move the screen to the new zoom position
            scrollx = scrollx / zoomfact;
            scrolly = scrolly / zoomfact;
-           scrollx += delta.x;
-           scrolly += delta.y;
+           scrollx += delta.x * zoomfact;
+           scrolly += delta.y * zoomfact;
            scrollx = scrollx * zoomfact;
            scrolly = scrolly * zoomfact;
 
@@ -3567,12 +3561,6 @@ function zoomin(scrollEvent = undefined)
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;
 
-    console.log("UPDATED Scroll x/y: " + scrollx + ", " + scrolly);
-    console.log ("UPDATED zoomOrigo x/y: " + zoomOrigo.x + ", " + zoomOrigo.y);
-    console.log("/////////////////////////////////////");
-
-    //Note: scroll variables (scrollx, scrolly) does not scale properly sometimes, not sure what causes it. zoomout() has the same problem.
-
     updateGridSize();
     updateA4Size();
     showdata();
@@ -3589,34 +3577,25 @@ function zoomout(scrollEvent = undefined)
 {
     // If mousewheel is not used, we zoom towards origo (0, 0)
     if (!scrollEvent){
-            console.log("ZOOMOUT:");
-            console.log("Window x/y: " + window.innerWidth / 2 + ", " + window.innerHeight / 2);
-            console.log("zoomOrigo x/y: " + zoomOrigo.x + ", " + zoomOrigo.y);
-            console.log("Scroll x/y: " + scrollx + ", " + scrolly);
-            console.log("SScroll x/y: " + sscrollx + ", " + sscrolly);
-            console.log("zoomfact: " + zoomfact);
+        if (zoomfact > 0.25) {
             var midScreen = screenToDiagramCoordinates((window.innerWidth / 2), (window.innerHeight / 2));
+                
             var delta = { // Calculate the difference between last zoomOrigo and current midScreen coordinates.
                 x: midScreen.x - zoomOrigo.x,
                 y: midScreen.y - zoomOrigo.y
             }
-
-            console.log("midScreen x/y: " + midScreen.x + ", " + midScreen.y);
-            console.log("delta x/y: " + delta.x + ", " + delta.y);
   
-
-
             //Update scroll x/y to center screen on new zoomOrigo
             scrollx = scrollx / zoomfact;
             scrolly = scrolly / zoomfact;
-            scrollx += delta.x;
-            scrolly += delta.y;
+            scrollx += delta.x * zoomfact;
+            scrolly += delta.y * zoomfact;
             scrollx = scrollx * zoomfact;
             scrolly = scrolly * zoomfact;
 
             zoomOrigo.x = midScreen.x;
             zoomOrigo.y = midScreen.y;
-
+        }
     }else if (zoomfact > 0.25) { // ELSE zoom towards mouseCoordinates
         var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
 
@@ -3630,12 +3609,12 @@ function zoomout(scrollEvent = undefined)
             //Update scroll variables with delta in order to move the screen to the new zoom position
             scrollx = scrollx / zoomfact;
             scrolly = scrolly / zoomfact;
-            scrollx += delta.x;
-            scrolly += delta.y;
+            scrollx += delta.x * zoomfact;
+            scrolly += delta.y * zoomfact;
             scrollx = scrollx * zoomfact;
             scrolly = scrolly * zoomfact;
             
-            //Set new zoomOrigo to the current mouse coordinates
+            //Set new zoomOrigo to the current mouse coordinatest
             zoomOrigo.x = mouseCoordinates.x;
             zoomOrigo.y = mouseCoordinates.y;
             lastMousePosCoords = mouseCoordinates;
@@ -3666,12 +3645,6 @@ function zoomout(scrollEvent = undefined)
 
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;
-
-    console.log("UPDATED Scroll x/y: " + scrollx + ", " + scrolly);
-    console.log ("UPDATED zoomOrigo x/y: " + zoomOrigo.x + ", " + zoomOrigo.y);
-    console.log("/////////////////////////////////////");
-
-    //Note: scroll variables (scrollx, scrolly) does not scale properly sometimes, not sure what causes it. zoomin() has the same problem.
 
     updateGridSize();
     updateA4Size();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3489,9 +3489,32 @@ function zoomin(scrollEvent = undefined)
 {
     // If mousewheel is not used, we zoom towards origo (0, 0)
     if (!scrollEvent){
-        // Origo set to center of screen in pixels
-        zoomOrigo.x = window.innerWidth / 2;
-        zoomOrigo.y = window.innerHeight / 2;
+        console.log("ZOOMIN:");
+        console.log("Window x/y: " + window.innerWidth / 2 + ", " + window.innerHeight / 2);
+        console.log("zoomOrigo x/y: " + zoomOrigo.x + ", " + zoomOrigo.y);
+        console.log("Scroll x/y: " + scrollx + ", " + scrolly);
+        console.log("SScroll x/y: " + sscrollx + ", " + sscrolly);
+        console.log("zoomfact: " + zoomfact);
+        var midScreen = screenToDiagramCoordinates((window.innerWidth / 2), (window.innerHeight / 2));
+        var delta = { // Calculate the difference between last zoomOrigo and current midScreen coordinates.
+            x: midScreen.x - zoomOrigo.x,
+            y: midScreen.y - zoomOrigo.y
+        }
+
+        console.log("midScreen x/y: " + midScreen.x + ", " + midScreen.y);
+        console.log("delta x/y: " + delta.x + ", " + delta.y);
+
+        //Update scroll x/y to center screen on new zoomOrigo
+        scrollx = scrollx / zoomfact;
+        scrolly = scrolly / zoomfact;
+        scrollx += delta.x;
+        scrolly += delta.y;
+        scrollx = scrollx * zoomfact;
+        scrolly = scrolly * zoomfact;
+
+        zoomOrigo.x = midScreen.x;
+        zoomOrigo.y = midScreen.y;
+
     }else if (zoomfact < 4.0){ // ELSE zoom towards mouseCoordinates
        var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
 
@@ -3544,6 +3567,10 @@ function zoomin(scrollEvent = undefined)
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;
 
+    console.log("UPDATED Scroll x/y: " + scrollx + ", " + scrolly);
+    console.log ("UPDATED zoomOrigo x/y: " + zoomOrigo.x + ", " + zoomOrigo.y);
+    console.log("/////////////////////////////////////");
+
     //Note: scroll variables (scrollx, scrolly) does not scale properly sometimes, not sure what causes it. zoomout() has the same problem.
 
     updateGridSize();
@@ -3562,9 +3589,34 @@ function zoomout(scrollEvent = undefined)
 {
     // If mousewheel is not used, we zoom towards origo (0, 0)
     if (!scrollEvent){
-        // Origin set to center of screen in pixels
-        zoomOrigo.x = window.innerWidth / 2;
-        zoomOrigo.y = window.innerHeight / 2;
+            console.log("ZOOMOUT:");
+            console.log("Window x/y: " + window.innerWidth / 2 + ", " + window.innerHeight / 2);
+            console.log("zoomOrigo x/y: " + zoomOrigo.x + ", " + zoomOrigo.y);
+            console.log("Scroll x/y: " + scrollx + ", " + scrolly);
+            console.log("SScroll x/y: " + sscrollx + ", " + sscrolly);
+            console.log("zoomfact: " + zoomfact);
+            var midScreen = screenToDiagramCoordinates((window.innerWidth / 2), (window.innerHeight / 2));
+            var delta = { // Calculate the difference between last zoomOrigo and current midScreen coordinates.
+                x: midScreen.x - zoomOrigo.x,
+                y: midScreen.y - zoomOrigo.y
+            }
+
+            console.log("midScreen x/y: " + midScreen.x + ", " + midScreen.y);
+            console.log("delta x/y: " + delta.x + ", " + delta.y);
+  
+
+
+            //Update scroll x/y to center screen on new zoomOrigo
+            scrollx = scrollx / zoomfact;
+            scrolly = scrolly / zoomfact;
+            scrollx += delta.x;
+            scrolly += delta.y;
+            scrollx = scrollx * zoomfact;
+            scrolly = scrolly * zoomfact;
+
+            zoomOrigo.x = midScreen.x;
+            zoomOrigo.y = midScreen.y;
+
     }else if (zoomfact > 0.25) { // ELSE zoom towards mouseCoordinates
         var mouseCoordinates = screenToDiagramCoordinates(scrollEvent.clientX, scrollEvent.clientY);
 
@@ -3614,6 +3666,10 @@ function zoomout(scrollEvent = undefined)
 
     scrollx = scrollx * zoomfact;
     scrolly = scrolly * zoomfact;
+
+    console.log("UPDATED Scroll x/y: " + scrollx + ", " + scrolly);
+    console.log ("UPDATED zoomOrigo x/y: " + zoomOrigo.x + ", " + zoomOrigo.y);
+    console.log("/////////////////////////////////////");
 
     //Note: scroll variables (scrollx, scrolly) does not scale properly sometimes, not sure what causes it. zoomin() has the same problem.
 


### PR DESCRIPTION
This is for issue #11342:

With this pull-request, there are three fixes:

**1. The zoom-buttons will now allow you to zoom towards/from the center of the screen, regardless of the position of the diagram.** 
The previous implementation was zooming towards a constant coordinate based on half the width and height of the screen (the "window" that the diagram is in), regardless of the position of the diagram. 

Consider the following example:
The size of the diagram screen is 1000 * 800.
the range of coordinates of the diagram that is currently visible is x: -1200 to 0 & y: -950 to 0.
With the old implementation, the screen would zoom towards x: 1000 / 2, y: 800 / 2, a coordinate that is not even visible on screen (because the length and height of the screen are constants, as long as you don't resize the browser and also completely unrelated to the coordinates in the diagram).
With the new implementation, the screen would zoom towards x: -600, y: -475, the coordinate that is CURRENTLY in the middle of the screen.

How to test:
(Do this on both the old and the new version to compare)
1. Move the diagram far away. 
2. Remember the approximate coordinate that is currently in the middle of the screen.
3. Zoom in or out.
4. After zooming, is the coordinate in the middle of the screen the same as before?

**2. The same fix for zooming with the buttons has also been applied to zooming with the mousewheel.**
The previous implementation had scaling problems with certain variables, making the screen jump around, seemingly at random, when zooming in or out after moving the diagram far away. The new implementation always zooms towards the mouse.

How to test:
(Do this on both the old and the new version to compare)
1. Zoom in with the mousewheel.
2. Move the mouse to a new coordinate. Remember this coordinate.
3. Zoom in again without moving the mouse.
4. After zooming, is the mouse on the same coordinate as in step 3?
5. Repeat step 1 - 4 but zoom out instead of zooming in.

**3. With the old implementation, you could zoom in and out with the zoom buttons even though minimum/maximum zoom had been reached. It would not zoom any further but it would still update variables with incorrect values, making the screen jump. This has been fixed with the new implementation.**

How to test:
(Do this on both the old and the new version to compare)
1. Zoom in until you reach zoom factor x4 (visible in bottom left corner)
2. Zoom in again. Did the screen jump?
3. Repeat with zooming out instead of zooming in.