### PR TITLE
Adding functionality for creating new users from git login and password popup for contribution.php #11416

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -1570,4 +1570,29 @@ function hideTooltip() {
     }
 }
 
+function forceUserLogin()
+{
+      /* 
+      make sure the loginBox is generated before you run this function as 
+      it queries for elements that exist in the loginbox and changes their properties
+      */
+      let loginBoxheader_login_close = document.querySelector("#login div.loginBoxheader div.cursorPointer");
+			let loginBoxheader_forgot_close = document.querySelector("#newpassword div.loginBoxheader div.cursorPointer");
+
+			// prepare replacement of onclick
+			loginBoxheader_login_close.removeAttribute("onClick"); // remove auto generated 
+			loginBoxheader_forgot_close.removeAttribute("onClick"); // remove auto generated
+			
+			/*
+      replace with a history back, this makes sure you dont get a blank page if you dont want to enter a password
+      and instead press the button to close down the loginBox
+      */
+			loginBoxheader_login_close.setAttribute("onClick", "history.back();"); 
+			loginBoxheader_forgot_close.setAttribute("onClick", "history.back();"); 
+
+      // After the loginbox has been prepared/modified we display it to the user
+      showLoginPopup();
+
+}
+
 console.error

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -1579,6 +1579,19 @@ function forceUserLogin()
       let loginBoxheader_login_close = document.querySelector("#login div.loginBoxheader div.cursorPointer");
 			let loginBoxheader_forgot_close = document.querySelector("#newpassword div.loginBoxheader div.cursorPointer");
 
+
+
+
+      let loginBoxheader_login_username_field = document.querySelector("#username");
+      loginBoxheader_login_username_field.setAttribute("Placeholder","Github username");
+
+      let loginBoxheader_login_password_field = document.querySelector("#password");
+      loginBoxheader_login_password_field.style.visibility = "hidden";
+
+      let loginBoxButton = document.querySelector(".buttonLoginBox");
+      loginBoxButton.setAttribute("onClick", "showNewGitLogin()");
+
+
 			// prepare replacement of onclick
 			loginBoxheader_login_close.removeAttribute("onClick"); // remove auto generated 
 			loginBoxheader_forgot_close.removeAttribute("onClick"); // remove auto generated
@@ -1590,9 +1603,79 @@ function forceUserLogin()
 			loginBoxheader_login_close.setAttribute("onClick", "history.back();"); 
 			loginBoxheader_forgot_close.setAttribute("onClick", "history.back();"); 
 
+
+      // ----
+      let FP = document.querySelector("#newpassword .forgotPw");
+      FP.setAttribute("onClick", "toggleloginnewpass(); resetForceLogin();");
+
       // After the loginbox has been prepared/modified we display it to the user
       showLoginPopup();
+      
 
 }
+
+function showNewGitLogin()
+{
+      let loginBoxheader_login_close = document.querySelector("#login div.loginBoxheader div.cursorPointer");
+			let loginBoxheader_forgot_close = document.querySelector("#newpassword div.loginBoxheader div.cursorPointer");
+      let loginBox = document.querySelector("#password");
+      let loginBoxParent = loginBox.closest("tr");
+
+
+      let loginBoxheader_login_username_field = document.querySelector("#username");
+      let loginBoxheader_login_password_field = document.querySelector("#password");
+      let loginBoxButton = document.querySelector(".buttonLoginBox");
+
+      loginBoxheader_login_password_field.style.visibility = "";
+
+
+      // create another loginbox and create a new id
+      let originalId = loginBox.getAttribute("id");
+      loginBox.setAttribute("id", originalId+1);
+      loginBoxParent.outerHTML += loginBoxParent.innerHTML;
+      loginBox = document.querySelector("#"+originalId+1);
+      loginBox.setAttribute("id", originalId);
+
+
+      let login_first = document.querySelector("#"+originalId);
+      let login_second = document.querySelector("#"+originalId+1);
+
+      login_first.setAttribute("placeholder", "Create new password");
+      login_second.setAttribute("placeholder","Repeat new password");
+
+      loginBoxButton.setAttribute("onClick", "");
+      loginBoxButton.setAttribute("Value", "Create");
+
+     
+      
+
+
+
+}
+
+function resetForceLogin()
+{
+  let originalId = ("password");
+  let login_second = document.querySelector("#"+originalId+1);
+  if(login_second != null)
+    login_second.remove();
+  let loginBoxButton = document.querySelector(".buttonLoginBox");
+  loginBoxButton.setAttribute("Value", "Login");
+  forceUserLogin();
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 console.error

--- a/DuggaSys/contribution.php
+++ b/DuggaSys/contribution.php
@@ -57,6 +57,11 @@ $vers=getOPG('coursevers');
 
 	<?php
 		include '../Shared/loginbox.php';
+
+		if(!checklogin()) // If not logged in, force a log in
+		{
+			echo '<script> forceUserLogin(); </script>';
+		}
 	?>
 
 </body>

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1411,7 +1411,14 @@ function processResetPasswordCheckUsername() {
 				toggleloginnewpass();
 			}else if(result['getname'] == "limit"){
         displayAlertText("#newpassword #message2", "You have exceeded the maximum <br /> amount of tries within 5 min");
-      }else{
+      }
+	 	else if(result['getname'] == "pending"){
+			displayAlertText("#newpassword #message2", "Not yet confirmed");
+		 }
+		 else if(result['getname'] == "revoked"){
+			displayAlertText("#newpassword #message2", "Permission revoked");
+		 } else{
+
 				if(typeof result.reason != "undefined") {
           displayAlertText("#newpassword #message2", result.reason);
 				} else {
@@ -1441,7 +1448,15 @@ function processResetPasswordCheckSecurityAnswer() {
         toggleloginnewpass();
       }else if(result['requestchange'] == "limit"){
         displayAlertText("#showsecurityquestion #message3", "You have exceeded the maximum <br /> amount of tries within 5 min");
-      }else if(result['requestchange'] == "wrong"){
+
+      }else if(result['requestchange'] == "pending"){
+		displayAlertText("#showsecurityquestion #message3",  "Not yet confirmed");
+	  }
+	  else if(result['requestchange'] == "revoked"){
+		displayAlertText("#showsecurityquestion #message3",  "Permission revoked");
+	  }
+
+	  else if(result['requestchange'] == "wrong"){
         displayAlertText("#showsecurityquestion #message3", "Wrong answer");
       }else{
         $("#showsecurityquestion #answer").css("background-color", "rgba(255, 0, 0, 0.2)");


### PR DESCRIPTION
Its on its good way to be completed but it is not completed as of yet, the changes made however will only affect contribution.php if you arent logged in and shouldnt break other parts of the system.

Changed resetpw.php to handle more states of "user creation"
contribution.js changed to add UI functionality for this special case of contribution login.
dugga.js changed to add functionality of special cases to login-change-password case when you are in the pending/revoked states.

One quite special thing which might cause problems for other parts of the system can be how i handled the column requestedpasswordchange in the user table; at the moment it is a tinyint when i assume it should have been a boolean, however because it is a tinyint this allows me to store **more** "requestedpasswordchange"-states in it like the states described in issue #11223 for the states **pending**, **revoked** and **accepted** currently they are represented numerically in requestedpasswordchange with **101**, **102** and **103** respectively(the **103** accepted state might not be needed). 