### PR TITLE
CHanged the position of the textbox to static.

### DIFF
--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -341,7 +341,7 @@
 
 .normtextwrapper{
     /* Width of codeborder */
-    position: absolute;
+    position: static;
     top: 0px;
     margin-left: 32px;
     padding: 0px 0px 0px 0px;


### PR DESCRIPTION
Changed the position to static from absolute.
This makes it so that the textwrapper will take up all the space available to it instead of taking up all the space it needs to display the text.

For testing: 
1: Go into "Javascript example 1" (Or any example that has a significant amount of text in it.)
2:Go into inspector(Ctrl+Shift+i).
3: Activate select element(Ctrl+Shift+C)
4: When checking the "Normtextwrapper" it should cover the entire box.
![image](https://user-images.githubusercontent.com/102600690/164198842-ab649e67-a2ea-43f8-829a-b523aac14c1f.png)
5: When selecting text you should be able to do it far away from the text.
![image](https://user-images.githubusercontent.com/102600690/164199685-b3baa8cd-fda5-455b-96e6-ad2a48d7e804.png)

