### PR TITLE
Solution for issue #11549

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5118,7 +5118,7 @@ function drawElement(element, ghosted = false)
             str += `z-index: 1;`;
         }
         if (ghosted) {
-            str += `pointer-events: none; opacity: ${ghostLine ? 0 : 0.5};`;
+            str += `pointer-events: none; opacity: ${ghostLine ? 0 : 0.0};`;
         }
         str += `'>`;
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5183,7 +5183,7 @@ function drawElement(element, ghosted = false)
         if (ghosted) {
             str += `
                 pointer-events: none;
-                opacity: ${ghostLine ? 0 : 0.5};
+                opacity: ${ghostLine ? 0 : 0.0};
             `;
         }
         str += `'>`;


### PR DESCRIPTION
Issue: #11549

Changed the opacity of the ghost element from 0.5 to 0. In other words, the ghost element is still there, but it is invisible. The "ghost lines" should still be visible. It seems to me that the ghost elements are not only visible features but also have a functional purpose. I didn't find any other solution without breaking parts of the system.

Test by selecting one of each element and see if the ghost appears before placing it. Only the lines should be visible when attaching it to the first object.