### PR TITLE
Fixed fab-btn not staying up when hovering

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6665,7 +6665,7 @@ only screen and (max-device-width: 320px) {
   width: 100%;
   list-style: none;
   text-align: center;
-  bottom: 90px;
+  bottom: 85px;
 }
 
 .fab-btn-list2 {


### PR DESCRIPTION
Fixed the issue with not being able to keep fab-btn up when hovering. The issue appears to be a a miscalculation. the fab-btn got a margin of 30 but the fab-btn-list got a margin increase of 35 which meant there probably was a gap of 5 pixels which would count as no longer hovering over the element thus hiding the option.

Related to this issue 
https://github.com/HGustavs/LenaSYS/commit/ce8e8a92e0f705285ce4ff79f46c1e3edef378e8
The problem is because of this change
![cause](https://user-images.githubusercontent.com/102533453/164239740-3df7f1b0-a664-456a-8539-4a67fb2ce874.png)
