### PR TITLE
G2-2022-24-#11727

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6665,7 +6665,7 @@ only screen and (max-device-width: 320px) {
   width: 100%;
   list-style: none;
   text-align: center;
-  bottom: 90px;
+  bottom: 80px;
 }
 
 .fab-btn-list2 {


### PR DESCRIPTION
Updated the distance between the FAB icon (yellow icon with a + inside at the bottom of the page) and the content that is displayed when hovering over FAB.

**For testing:**
1. Switch to the group branch.
2. Login as stei
3. Go to: [this_link](http://project-g2.webug.his.se/DuggaSys/sectioned.php?courseid=1&coursename=Webbprogrammering&coursevers=45656)
4. Try to create a new example with the yellow icon at the bottom of the page.
5. Repeat the process with the branch: G2-2022-W4-#11727
6. See if the items disapear when you try to hover over them. If not, the bug is fixed.
