### PR TITLE
fix for issue #11643 Teachers should be able to select which type of diagram the student are able to draw in diagram dugga's.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1161,7 +1161,8 @@ function getData()
 }
 
 function showDiagramTypes(){
-    if(!!diagramType.ER && !!diagramType.UML){
+    console.log(diagramType);
+    /*if(!!diagramType.ER && !!diagramType.UML){
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
     }
     else if(!diagramType.ER && !!diagramType.UML){
@@ -1174,7 +1175,7 @@ function showDiagramTypes(){
     }
     else{
         alert("NONE");
-    }
+    }*/
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -960,8 +960,8 @@ var pointerState = pointerStates.DEFAULT;
 var movingObject = false;
 var movingContainer = false;
 
-//getting the allowed diagram types from the page that the iframe is in
-var diagramType = window.parent.diagramType;
+//setting the base values for the allowed diagramtypes
+var diagramType = {ER:true,UML:false};
 
 //Grid Settings
 var settings = {
@@ -1147,7 +1147,6 @@ function onSetup()
 function getData()
 {
     container = document.getElementById("container");
-    showDiagramTypes();
     onSetup();
     showdata();
     drawRulerBars(scrollx,scrolly);
@@ -1161,7 +1160,6 @@ function getData()
 }
 
 function showDiagramTypes(){
-    console.log(diagramType);
     if(!!diagramType.ER && !!diagramType.UML){
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
         document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
@@ -1189,9 +1187,6 @@ function showDiagramTypes(){
         document.getElementById("togglePlacementTypeButton0").classList.add("hiddenPlacementType");
         document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton1").classList.add("hiddenPlacementType");
-    }
-    else{
-        alert("NONE");
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -960,6 +960,9 @@ var pointerState = pointerStates.DEFAULT;
 var movingObject = false;
 var movingContainer = false;
 
+//getting the allowed diagram types from the page that the iframe is in
+var diagramType = window.parent.diagramType;
+
 //Grid Settings
 var settings = {
     ruler: {
@@ -1144,6 +1147,7 @@ function onSetup()
 function getData()
 {
     container = document.getElementById("container");
+    showDiagramTypes();
     onSetup();
     showdata();
     drawRulerBars(scrollx,scrolly);
@@ -1154,6 +1158,23 @@ function getData()
     updateGridSize();
     setCursorStyles(mouseMode);
     generateKeybindList();
+}
+
+function showDiagramTypes(){
+    if(!!diagramType.ER && !!diagramType.UML){
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
+    }
+    else if(!diagramType.ER && !!diagramType.UML){
+        document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton0").classList.add("hiddenPlacementType");
+    }
+    else if(!!diagramType.ER && !diagramType.UML){
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton4").classList.add("hiddenPlacementType");
+    }
+    else{
+        alert("NONE");
+    }
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1162,20 +1162,37 @@ function getData()
 
 function showDiagramTypes(){
     console.log(diagramType);
-    /*if(!!diagramType.ER && !!diagramType.UML){
+    if(!!diagramType.ER && !!diagramType.UML){
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement0").onmousedown = function() {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement4").onmousedown = function() {
+            holdPlacementButtonDown(4);
+        };
+        document.getElementById("elementPlacement1").onmousedown = function() {
+            holdPlacementButtonDown(1);
+        };
+        document.getElementById("elementPlacement5").onmousedown = function() {
+            holdPlacementButtonDown(5);
+        };
     }
     else if(!diagramType.ER && !!diagramType.UML){
         document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");
-        document.getElementById("togglePlacementTypeButton0").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton4").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement1").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton5").classList.add("hiddenPlacementType");
     }
     else if(!!diagramType.ER && !diagramType.UML){
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
-        document.getElementById("togglePlacementTypeButton4").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton0").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton1").classList.add("hiddenPlacementType");
     }
     else{
         alert("NONE");
-    }*/
+    }
 }
 
 /**

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -49,7 +49,7 @@
                     </span>
                 </div>
                 <div>
-                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmousedown='holdPlacementButtonDown(0);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an entity to the diagram</p><br>
@@ -75,7 +75,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement4" class="diagramIcons toolbarMode hiddenPlacementType" onclick='setElementPlacementType(4); setMouseMode(2);'  onmousedown='holdPlacementButtonDown(4);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement4" class="diagramIcons toolbarMode" onclick='setElementPlacementType(4); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_UML_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an UML entity to the diagram</p><br>
@@ -101,7 +101,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmousedown='holdPlacementButtonDown(1);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_relation.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>
@@ -127,7 +127,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement5" class="diagramIcons toolbarMode hiddenPlacementType" onclick='setElementPlacementType(5); setMouseMode(2);' onmousedown='holdPlacementButtonDown(5);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement5" class="diagramIcons toolbarMode" onclick='setElementPlacementType(5); setMouseMode(2);'onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_inheritance.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -285,7 +285,11 @@ function selectVariant(vid, el) {
   					document.getElementById('extraparam').value = obj[result];
   				}
   			}
-
+		var diagramType = obj.diagram_type;
+		if(diagramType){
+			document.getElementById('ER').checked = diagramType[0].ER;
+			document.getElementById('UML').checked = diagramType[0].UML;
+		}
         var submissionTypes = obj.submissions;
         if (submissionTypes) {
   			  document.getElementById('submissionType0').value = submissionTypes[0].type;

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -432,6 +432,8 @@ function removeExtraSubmissionRows() {
 function createJSONString(formData) {
 	var submission_types = [];
 	var type, fieldname, instruction, diagramFile;
+	var diagram_types = [];
+	var ER, UML;
 
 	formData.forEach(element => {
 		if (element.name == "s_type") type = element;
@@ -449,6 +451,29 @@ function createJSONString(formData) {
 			fieldname = undefined;
 			instruction = undefined;
 		}
+		if (element.name == "ER") ER = element;
+		if (element.name == "UML") UML = element;
+		if (!ER && UML) {
+			diagram_types.push({
+				ER:false,
+				UML:true
+			});
+		}
+		else if (ER && !UML) {
+			diagram_types.push({
+				ER:true,
+				UML:false
+			});
+		}
+		else if (ER && UML) {
+			diagram_types.push({
+				ER:true,
+				UML:true
+			});
+		}
+		for (let index = 0; index < diagram_types.length-1; index++) {
+			diagram_types.shift();
+		}
 	});
 
 
@@ -456,6 +481,7 @@ function createJSONString(formData) {
 		"type":formData[0].value,
 		"filelink":formData[1].value,
 		"diagram File":$("#file option:selected").text(),
+		"diagram type":diagram_types,
 		"extraparam":$('#extraparam').val(),
 		"submissions":submission_types
 	});

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -481,7 +481,7 @@ function createJSONString(formData) {
 		"type":formData[0].value,
 		"filelink":formData[1].value,
 		"diagram File":$("#file option:selected").text(),
-		"diagram type":diagram_types,
+		"diagram_type":diagram_types,
 		"extraparam":$('#extraparam').val(),
 		"submissions":submission_types
 	});

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -181,10 +181,6 @@ session_start();
                       They're fetched and parsed in returnedFile() in duggaed.js -->
                         <legend>Add diagram to dugga</legend>
                         <select id="file" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()))"></select>
-                        <label for="ER">ER</label>
-                        <input type="checkbox" name="ER" id="ER" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
-                        <label for="UML">UML</label>
-                        <input type="checkbox" name="UML" id="UML" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
                       </fieldset>
                     </div>
                   </div>
@@ -199,6 +195,17 @@ session_start();
                     </div>
                   </div>
                     <!-- Submissions for dugga -->
+                  <div>
+                    <fieldset style="width:90%">
+                      <legend>Diagram type</legend>
+                      <div id="diagramTypesBox" style="display:flex;flex-wrap:wrap;flex-direction:row;">
+                        <label for="ER">ER</label>
+                        <input type="checkbox" name="ER" id="ER" value="true" checked="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
+                        <label for="UML">UML</label>
+                        <input type="checkbox" name="UML" id="UML" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>  
+                      </div>
+                    </fieldset>
+                  </div>
                   <!-- End of leftDivDialog -->
                 </form>
               </div>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -184,6 +184,18 @@ session_start();
                       </fieldset>
                     </div>
                   </div>
+                    <!-- diagram types -->
+                  <div>
+                    <fieldset style="width:90%">
+                      <legend>Diagram types allowed</legend>
+                      <div id="diagramTypesBox" style="display:flex;flex-wrap:wrap;flex-direction:row;">
+                        <label for="ER">ER</label>
+                        <input type="checkbox" name="ER" id="ER" value="true" checked="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
+                        <label for="UML">UML</label>
+                        <input type="checkbox" name="UML" id="UML" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>  
+                      </div>
+                    </fieldset>
+                  </div>
                       <!-- Submissions for dugga -->
                   <div>
                     <div id="duggaSubmissionForm">
@@ -195,17 +207,6 @@ session_start();
                     </div>
                   </div>
                     <!-- Submissions for dugga -->
-                  <div>
-                    <fieldset style="width:90%">
-                      <legend>Diagram type</legend>
-                      <div id="diagramTypesBox" style="display:flex;flex-wrap:wrap;flex-direction:row;">
-                        <label for="ER">ER</label>
-                        <input type="checkbox" name="ER" id="ER" value="true" checked="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
-                        <label for="UML">UML</label>
-                        <input type="checkbox" name="UML" id="UML" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>  
-                      </div>
-                    </fieldset>
-                  </div>
                   <!-- End of leftDivDialog -->
                 </form>
               </div>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -181,6 +181,10 @@ session_start();
                       They're fetched and parsed in returnedFile() in duggaed.js -->
                         <legend>Add diagram to dugga</legend>
                         <select id="file" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()))"></select>
+                        <label for="ER">ER</label>
+                        <input type="checkbox" name="ER" id="ER" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
+                        <label for="UML">UML</label>
+                        <input type="checkbox" name="UML" id="UML" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
                       </fieldset>
                     </div>
                   </div>

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -122,7 +122,7 @@
             <div class="assignment_left">
                 <h1 style="text-align: center;">Diagram-duggan</h1>
                 <div class="assignment_discrb" style=" margin-left: 2%; color: white; ">
-                    <p>Sed ut
+                    <p id="assigment-instructions">Sed ut
                         perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium,
                         totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae
                         dicta sunt explicabo. Nemo enim ipsam voluptatem

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -21,9 +21,7 @@ function beforeUnloadingPage()
 function setup()
 {
     diagramWindow = document.getElementById("diagram-iframe");
-    inParams = parseGet();   
-    console.log(inParams);
-    diagramType =  inParams.diagram_types;
+    inParams = parseGet();
     AJAXService("GETPARAM", { }, "PDUGGA");
     document.getElementById("saveDuggaButton").onclick = function (){ uploadFile();};
     diagramWindow.contentWindow.addEventListener('mouseup', canSaveController);
@@ -75,9 +73,11 @@ function uploadFile()
  * */
 function returnedDugga(data)
 {
+    console.log(data);
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
-        document.getElementById("assigment-instructions").innerHTML = param.instructions;     
+        document.getElementById("assigment-instructions").innerHTML = param.instructions;
+        diagramType = param.diagram_types;
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -1,7 +1,5 @@
 var lastFile = null;
 var diagramWindow;
-var diagramType = {ER:true,UML:true};
-
 /** 
  * @description Alert message appears before closing down or refreshing the dugga viewer page window.
 
@@ -73,12 +71,12 @@ function uploadFile()
  * */
 function returnedDugga(data)
 {
-    console.log(data);
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
         document.getElementById("assigment-instructions").innerHTML = param.instructions;
-        diagramType.ER = param.ER;
-        diagramType.UML = param.UML;
+        // getting the diagram types allowed and calling a function in diagram.js where the values are now set UML functionality
+        document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type[0];
+        document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -1,5 +1,6 @@
 var lastFile = null;
 var diagramWindow;
+var diagramType = {ER:false,UML:false};
 
 /** 
  * @description Alert message appears before closing down or refreshing the dugga viewer page window.
@@ -74,7 +75,8 @@ function returnedDugga(data)
 {
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
-        document.getElementById("assigment-instructions").innerHTML = param.instructions;
+        document.getElementById("assigment-instructions").innerHTML = param.instructions;        
+        diagramType =  param.diagram_types;
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -1,6 +1,6 @@
 var lastFile = null;
 var diagramWindow;
-var diagramType = {ER:false,UML:false};
+var diagramType = {ER:true,UML:false};
 
 /** 
  * @description Alert message appears before closing down or refreshing the dugga viewer page window.

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -1,6 +1,6 @@
 var lastFile = null;
 var diagramWindow;
-var diagramType = {ER:true,UML:false};
+var diagramType = {ER:true,UML:true};
 
 /** 
  * @description Alert message appears before closing down or refreshing the dugga viewer page window.
@@ -73,6 +73,7 @@ function uploadFile()
  * */
 function returnedDugga(data)
 {
+    console.log(data);
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
         document.getElementById("assigment-instructions").innerHTML = param.instructions;

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -73,11 +73,11 @@ function uploadFile()
  * */
 function returnedDugga(data)
 {
-    console.log(data);
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
         document.getElementById("assigment-instructions").innerHTML = param.instructions;
-        diagramType = param.diagram_types;
+        diagramType.ER = param.ER;
+        diagramType.UML = param.UML;
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -21,7 +21,9 @@ function beforeUnloadingPage()
 function setup()
 {
     diagramWindow = document.getElementById("diagram-iframe");
-    inParams = parseGet();
+    inParams = parseGet();   
+    console.log(inParams);
+    diagramType =  inParams.diagram_types;
     AJAXService("GETPARAM", { }, "PDUGGA");
     document.getElementById("saveDuggaButton").onclick = function (){ uploadFile();};
     diagramWindow.contentWindow.addEventListener('mouseup', canSaveController);
@@ -75,8 +77,7 @@ function returnedDugga(data)
 {
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
-        document.getElementById("assigment-instructions").innerHTML = param.instructions;        
-        diagramType =  param.diagram_types;
+        document.getElementById("assigment-instructions").innerHTML = param.instructions;     
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1016,6 +1016,7 @@ function AJAXService(opt,apara,kind)
 			success: returnedanswersDugga
 		});
 	}else if(kind=="DUGGA"){
+		console.log(para);
 		$.ajax({
 			url: "duggaedservice.php",
 			type: "POST",

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1016,7 +1016,6 @@ function AJAXService(opt,apara,kind)
 			success: returnedanswersDugga
 		});
 	}else if(kind=="DUGGA"){
-		console.log(para);
 		$.ajax({
 			url: "duggaedservice.php",
 			type: "POST",


### PR DESCRIPTION
changed diagram.js mainly in showDiagramTypes(), diagram.php, duggaed.php, duggaed.js mainly in createJSONString(formData) and diagram_dugga.js. added checkboxes to the duggaed interface and added that the diagram types changes depending on what checkboxes was checked when creating the dugga variant.
![image](https://user-images.githubusercontent.com/81320323/164448531-7d05e03e-7963-4ed7-a962-fa1990addd1c.png)
![image](https://user-images.githubusercontent.com/81320323/164449242-8a9d779f-ae53-4e50-80a9-5ee664631942.png)
![image](https://user-images.githubusercontent.com/81320323/164450419-cd91fccb-b6f5-4479-bef7-3130b5e98853.png)
![image](https://user-images.githubusercontent.com/81320323/164448969-aee5e76c-597a-46b4-8fff-84879d9cd807.png)
test by:
-logging in as toddler
-go to demo courses 
-click show test 
-click the pen on the same line as Diagram Dugga 
-select an enabled existing variant by pressing the cogwheel on the same line
-change the checkboxes to select the types allowed
-press update
-log out
-go to diagram dugga
-look at the availible entitys
-repeat to test different types
