### PR TITLE
Logout redirects to current page

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1546,7 +1546,7 @@ function processLogout() {
             localStorage.removeItem("ls-security-question");
             localStorage.removeItem("securitynotification");
 
-            location.replace("../DuggaSys/courseed.php");
+            reloadPage();
 		},
 		error:function() {
 			console.log("error");


### PR DESCRIPTION
Logout will be now redirected to the current page, while also loggin the user out.


testing

1. Log in to any user.
2. Go to any page. 
3. Log out.
4. If you get redirected to courseed.php, this has failed. But if you're on the same site where logout request was issued it passed.