### PR TITLE
fix for issue #11748 Check if possible to create default toolbar in diagram dugga to show teachers when they are logged in.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -961,7 +961,7 @@ var movingObject = false;
 var movingContainer = false;
 
 //setting the base values for the allowed diagramtypes
-var diagramType = {ER:true,UML:false};
+var diagramType = {ER:false,UML:false};
 
 //Grid Settings
 var settings = {
@@ -1160,33 +1160,23 @@ function getData()
 }
 
 function showDiagramTypes(){
-    if(!!diagramType.ER && !!diagramType.UML){
-        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement0").onmousedown = function() {
-            holdPlacementButtonDown(0);
-        };
-        document.getElementById("elementPlacement4").onmousedown = function() {
-            holdPlacementButtonDown(4);
-        };
-        document.getElementById("elementPlacement1").onmousedown = function() {
-            holdPlacementButtonDown(1);
-        };
-        document.getElementById("elementPlacement5").onmousedown = function() {
-            holdPlacementButtonDown(5);
-        };
-    }
-    else if(!diagramType.ER && !!diagramType.UML){
+    if(!diagramType.ER && !!diagramType.UML){
+        document.getElementById("elementPlacement4").classList.remove("hiddenPlacementType");
+        document.getElementById("elementPlacement5").classList.remove("hiddenPlacementType");
         document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton4").classList.add("hiddenPlacementType");
         document.getElementById("elementPlacement1").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton5").classList.add("hiddenPlacementType");
     }
     else if(!!diagramType.ER && !diagramType.UML){
-        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton0").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton1").classList.add("hiddenPlacementType");
+    }
+    else if (!diagramType.ER && !diagramType.UML){
+        document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement1").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
     }
 }
 
@@ -3542,7 +3532,9 @@ function setElementPlacementType(type = elementTypes.EREntity)
 }
 
 function holdPlacementButtonDown(num){
-    mousePressed=true;
+    if (!!diagramType.ER && !!diagramType.UML){
+        mousePressed=true;
+    }
     if(document.getElementById("togglePlacementTypeBox"+num).classList.contains("activeTogglePlacementTypeBox")){
         mousePressed=false;
         togglePlacementTypeBox(num);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1158,6 +1158,7 @@ function getData()
     setCursorStyles(mouseMode);
     generateKeybindList();
 }
+//<-- UML functionality start
 /**
  * @description Used to determine the tools shown depending on diagram type.
  */
@@ -1201,7 +1202,7 @@ function showDiagramTypes(){
         document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
     }
 }
-
+//<-- UML functionality end
 /**
  * @description Used to determine if returned data is correct.
  * @param {*} ret Returned data to determine.
@@ -3552,7 +3553,10 @@ function setElementPlacementType(type = elementTypes.EREntity)
 {
     elementTypeSelected = type;
 }
-
+//<-- UML functionality start
+/**
+ * @description starts a mousepress on placecment type.
+ */
 function holdPlacementButtonDown(num){
     mousePressed=true;
     if(document.getElementById("togglePlacementTypeBox"+num).classList.contains("activeTogglePlacementTypeBox")){
@@ -3628,7 +3632,7 @@ function togglePlacementType(num,type){
         document.getElementById("togglePlacementTypeBox5").classList.remove("activeTogglePlacementTypeBox");
     }
     document.getElementById("elementPlacement"+num).classList.remove("hiddenPlacementType");
-}
+}//<-- UML functionality end
 /**
  * @description Increases the current zoom level if not already at maximum. This will magnify all elements and move the camera appropriatly. If a scrollLevent argument is present, this will be used top zoom towards the cursor position.
  * @param {MouseEvent} scrollEvent The current mouse event.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1158,8 +1158,11 @@ function getData()
     setCursorStyles(mouseMode);
     generateKeybindList();
 }
-
+/**
+ * @description Used to determine the tools shown depending on diagram type.
+ */
 function showDiagramTypes(){
+    //if both diagramtypes are allowed hides the uml elements and adds the function to show the selection box
     if(!!diagramType.ER && !!diagramType.UML){
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
         document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
@@ -1176,18 +1179,21 @@ function showDiagramTypes(){
             holdPlacementButtonDown(5);
         };
     }
+    //if only UML is allowed hides ER and the arrows that shows more options
     else if(!diagramType.ER && !!diagramType.UML){
         document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton4").classList.add("hiddenPlacementType");
         document.getElementById("elementPlacement1").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton5").classList.add("hiddenPlacementType");
     }
+    //if only ER is allowed hides UML and the arrows that shows more options
     else if(!!diagramType.ER && !diagramType.UML){
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton0").classList.add("hiddenPlacementType");
         document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton1").classList.add("hiddenPlacementType");
     }
+    // if neither are allowed hides all
     else if (!diagramType.ER && !diagramType.UML){
         document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1160,16 +1160,32 @@ function getData()
 }
 
 function showDiagramTypes(){
-    if(!diagramType.ER && !!diagramType.UML){
-        document.getElementById("elementPlacement4").classList.remove("hiddenPlacementType");
-        document.getElementById("elementPlacement5").classList.remove("hiddenPlacementType");
+    if(!!diagramType.ER && !!diagramType.UML){
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement0").onmousedown = function() {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement4").onmousedown = function() {
+            holdPlacementButtonDown(4);
+        };
+        document.getElementById("elementPlacement1").onmousedown = function() {
+            holdPlacementButtonDown(1);
+        };
+        document.getElementById("elementPlacement5").onmousedown = function() {
+            holdPlacementButtonDown(5);
+        };
+    }
+    else if(!diagramType.ER && !!diagramType.UML){
         document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton4").classList.add("hiddenPlacementType");
         document.getElementById("elementPlacement1").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton5").classList.add("hiddenPlacementType");
     }
     else if(!!diagramType.ER && !diagramType.UML){
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton0").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
         document.getElementById("togglePlacementTypeButton1").classList.add("hiddenPlacementType");
     }
     else if (!diagramType.ER && !diagramType.UML){
@@ -3532,9 +3548,7 @@ function setElementPlacementType(type = elementTypes.EREntity)
 }
 
 function holdPlacementButtonDown(num){
-    if (!!diagramType.ER && !!diagramType.UML){
-        mousePressed=true;
-    }
+    mousePressed=true;
     if(document.getElementById("togglePlacementTypeBox"+num).classList.contains("activeTogglePlacementTypeBox")){
         mousePressed=false;
         togglePlacementTypeBox(num);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -960,6 +960,9 @@ var pointerState = pointerStates.DEFAULT;
 var movingObject = false;
 var movingContainer = false;
 
+//setting the base values for the allowed diagramtypes
+var diagramType = {ER:true,UML:false};
+
 //Grid Settings
 var settings = {
     ruler: {
@@ -1154,6 +1157,37 @@ function getData()
     updateGridSize();
     setCursorStyles(mouseMode);
     generateKeybindList();
+}
+
+function showDiagramTypes(){
+    if(!!diagramType.ER && !!diagramType.UML){
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement0").onmousedown = function() {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement4").onmousedown = function() {
+            holdPlacementButtonDown(4);
+        };
+        document.getElementById("elementPlacement1").onmousedown = function() {
+            holdPlacementButtonDown(1);
+        };
+        document.getElementById("elementPlacement5").onmousedown = function() {
+            holdPlacementButtonDown(5);
+        };
+    }
+    else if(!diagramType.ER && !!diagramType.UML){
+        document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton4").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement1").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton5").classList.add("hiddenPlacementType");
+    }
+    else if(!!diagramType.ER && !diagramType.UML){
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton0").classList.add("hiddenPlacementType");
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");
+        document.getElementById("togglePlacementTypeButton1").classList.add("hiddenPlacementType");
+    }
 }
 
 /**

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -49,7 +49,7 @@
                     </span>
                 </div>
                 <div>
-                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmousedown='holdPlacementButtonDown(0);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an entity to the diagram</p><br>
@@ -75,7 +75,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement4" class="diagramIcons toolbarMode hiddenPlacementType" onclick='setElementPlacementType(4); setMouseMode(2);' onmousedown='holdPlacementButtonDown(4);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement4" class="diagramIcons toolbarMode" onclick='setElementPlacementType(4); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_UML_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an UML entity to the diagram</p><br>
@@ -101,7 +101,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmousedown='holdPlacementButtonDown(1);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_relation.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>
@@ -127,7 +127,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement5" class="diagramIcons toolbarMode hiddenPlacementType" onclick='setElementPlacementType(5); setMouseMode(2);' onmousedown='holdPlacementButtonDown(5);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement5" class="diagramIcons toolbarMode" onclick='setElementPlacementType(5); setMouseMode(2);'onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_inheritance.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -49,7 +49,7 @@
                     </span>
                 </div>
                 <div>
-                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmousedown='holdPlacementButtonDown(0);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an entity to the diagram</p><br>
@@ -75,7 +75,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement4" class="diagramIcons toolbarMode" onclick='setElementPlacementType(4); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement4" class="diagramIcons toolbarMode hiddenPlacementType" onclick='setElementPlacementType(4); setMouseMode(2);' onmousedown='holdPlacementButtonDown(4);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_UML_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an UML entity to the diagram</p><br>
@@ -101,7 +101,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmousedown='holdPlacementButtonDown(1);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_relation.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>
@@ -127,7 +127,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement5" class="diagramIcons toolbarMode" onclick='setElementPlacementType(5); setMouseMode(2);'onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement5" class="diagramIcons toolbarMode hiddenPlacementType" onclick='setElementPlacementType(5); setMouseMode(2);' onmousedown='holdPlacementButtonDown(5);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_inheritance.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -49,7 +49,7 @@
                     </span>
                 </div>
                 <div>
-                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an entity to the diagram</p><br>
@@ -59,7 +59,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg"/>
                         </div>
                     </div>    
-                    <div id="togglePlacementTypeBox0" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
+                    <div id="togglePlacementTypeBox0" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                         <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                             <img src="../Shared/icons/diagram_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>ER</b><br>
@@ -99,9 +99,9 @@
                             </span>
                         </div>
                     </div>
-                </div>
+                </div><!--<-- UML functionality end -->
                 <div>
-                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>
@@ -111,7 +111,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg"/>
                         </div>
                     </div>    
-                    <div id="togglePlacementTypeBox1" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
+                    <div id="togglePlacementTypeBox1" class="togglePlacementTypeBox togglePlacementTypeBoxRI"><!--<-- UML functionality start-->
                         <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
                             <img src="../Shared/icons/diagram_relation.svg"/>
                             <span class="placementTypeToolTipText"><b>ER</b><br>
@@ -151,7 +151,7 @@
                             </span>
                         </div>
                     </div>
-                </div>
+                </div><!--<-- UML functionality end -->
                 <div id="elementPlacement2" class="diagramIcons toolbarMode" onclick='setElementPlacementType(2); setMouseMode(2);'>
                     <img src="../Shared/icons/diagram_attribute.svg"/>
                     <span class="toolTipText"><b>Attribute</b><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -49,7 +49,7 @@
                     </span>
                 </div>
                 <div>
-                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmousedown='holdPlacementButtonDown(0);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement0" class="diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an entity to the diagram</p><br>
@@ -75,7 +75,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement4" class="diagramIcons toolbarMode hiddenPlacementType" onclick='setElementPlacementType(4); setMouseMode(2);'  onmousedown='holdPlacementButtonDown(4);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement4" class="diagramIcons toolbarMode" onclick='setElementPlacementType(4); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_UML_entity.svg"/>
                         <span class="toolTipText"><b>Entity</b><br>
                             <p>Add an UML entity to the diagram</p><br>
@@ -101,7 +101,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmousedown='holdPlacementButtonDown(1);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement1" class="diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_relation.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>
@@ -127,7 +127,7 @@
                     </div>
                 </div>
                 <div>
-                    <div id="elementPlacement5" class="diagramIcons toolbarMode hiddenPlacementType" onclick='setElementPlacementType(5); setMouseMode(2);' onmousedown='holdPlacementButtonDown(5);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement5" class="diagramIcons toolbarMode" onclick='setElementPlacementType(5); setMouseMode(2);'onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_inheritance.svg"/>
                         <span class="toolTipText"><b>Relation</b><br>
                             <p>Add a relation between entities</p><br>

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -359,6 +359,13 @@ function updateVariantTitle(number) {
 
 // Opens the variant editor.
 function showVariantEditor() {
+	if(globalData['entries'][globalVariant].quizFile == "diagram_dugga"){
+		$("#typeCheckbox").css("display", "flex");
+	}
+	else{
+		$("#typeCheckbox").css("display", "none");
+	}
+
 	AJAXService("GET", { cid: querystring['courseid'], coursevers: querystring['coursevers'] }, "FILE");
   if(submissionRow == 0){
     // The submission row doesn't go away when leaving the modal

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -285,11 +285,11 @@ function selectVariant(vid, el) {
   					document.getElementById('extraparam').value = obj[result];
   				}
   			}
-		var diagramType = obj.diagram_type;
+		var diagramType = obj.diagram_type; //<-- UML functionality start
 		if(diagramType){
 			document.getElementById('ER').checked = diagramType[0].ER;
 			document.getElementById('UML').checked = diagramType[0].UML;
-		}
+		}//<-- UML functionality end
         var submissionTypes = obj.submissions;
         if (submissionTypes) {
   			  document.getElementById('submissionType0').value = submissionTypes[0].type;
@@ -436,8 +436,6 @@ function removeExtraSubmissionRows() {
 function createJSONString(formData) {
 	var submission_types = [];
 	var type, fieldname, instruction, diagramFile;
-	var diagram_types = [];
-	var ER, UML;
 
 	formData.forEach(element => {
 		if (element.name == "s_type") type = element;
@@ -455,35 +453,6 @@ function createJSONString(formData) {
 			fieldname = undefined;
 			instruction = undefined;
 		}
-		if (element.name == "ER") ER = element;
-		if (element.name == "UML") UML = element;
-		if (!ER && UML) {
-			diagram_types.push({
-				ER:false,
-				UML:true
-			});
-		}
-		else if (ER && !UML) {
-			diagram_types.push({
-				ER:true,
-				UML:false
-			});
-		}
-		else if (ER && UML) {
-			diagram_types.push({
-				ER:true,
-				UML:true
-			});
-		}
-		else if (!ER && !UML) {
-			diagram_types.push({
-				ER:false,
-				UML:false
-			});
-		}
-		for (let index = 0; index < diagram_types.length-1; index++) {
-			diagram_types.shift();
-		}
 	});
 
 
@@ -491,7 +460,7 @@ function createJSONString(formData) {
 		"type":formData[0].value,
 		"filelink":formData[1].value,
 		"diagram File":$("#file option:selected").text(),
-		"diagram_type":diagram_types,
+		"diagram_type":{ER:document.getElementById("ER").checked,UML:document.getElementById("UML").checked}, //<-- UML functionality
 		"extraparam":$('#extraparam').val(),
 		"submissions":submission_types
 	});

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -285,7 +285,11 @@ function selectVariant(vid, el) {
   					document.getElementById('extraparam').value = obj[result];
   				}
   			}
-
+		var diagramType = obj.diagram_type;
+		if(diagramType){
+			document.getElementById('ER').checked = diagramType[0].ER;
+			document.getElementById('UML').checked = diagramType[0].UML;
+		}
         var submissionTypes = obj.submissions;
         if (submissionTypes) {
   			  document.getElementById('submissionType0').value = submissionTypes[0].type;
@@ -432,6 +436,8 @@ function removeExtraSubmissionRows() {
 function createJSONString(formData) {
 	var submission_types = [];
 	var type, fieldname, instruction, diagramFile;
+	var diagram_types = [];
+	var ER, UML;
 
 	formData.forEach(element => {
 		if (element.name == "s_type") type = element;
@@ -449,6 +455,29 @@ function createJSONString(formData) {
 			fieldname = undefined;
 			instruction = undefined;
 		}
+		if (element.name == "ER") ER = element;
+		if (element.name == "UML") UML = element;
+		if (!ER && UML) {
+			diagram_types.push({
+				ER:false,
+				UML:true
+			});
+		}
+		else if (ER && !UML) {
+			diagram_types.push({
+				ER:true,
+				UML:false
+			});
+		}
+		else if (ER && UML) {
+			diagram_types.push({
+				ER:true,
+				UML:true
+			});
+		}
+		for (let index = 0; index < diagram_types.length-1; index++) {
+			diagram_types.shift();
+		}
 	});
 
 
@@ -456,6 +485,7 @@ function createJSONString(formData) {
 		"type":formData[0].value,
 		"filelink":formData[1].value,
 		"diagram File":$("#file option:selected").text(),
+		"diagram_type":diagram_types,
 		"extraparam":$('#extraparam').val(),
 		"submissions":submission_types
 	});

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -475,6 +475,12 @@ function createJSONString(formData) {
 				UML:true
 			});
 		}
+		else if (!ER && !UML) {
+			diagram_types.push({
+				ER:false,
+				UML:false
+			});
+		}
 		for (let index = 0; index < diagram_types.length-1; index++) {
 			diagram_types.shift();
 		}

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -185,7 +185,7 @@ session_start();
                     </div>
                   </div>
                     <!-- diagram types -->
-                  <div>
+                  <div id="typeCheckbox">
                     <fieldset style="width:90%">
                       <legend>Diagram types allowed</legend>
                       <div id="diagramTypesBox" style="display:flex;flex-wrap:wrap;flex-direction:row;">

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -184,6 +184,18 @@ session_start();
                       </fieldset>
                     </div>
                   </div>
+                    <!-- diagram types -->
+                  <div>
+                    <fieldset style="width:90%">
+                      <legend>Diagram types allowed</legend>
+                      <div id="diagramTypesBox" style="display:flex;flex-wrap:wrap;flex-direction:row;">
+                        <label for="ER">ER</label>
+                        <input type="checkbox" name="ER" id="ER" value="true" checked="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
+                        <label for="UML">UML</label>
+                        <input type="checkbox" name="UML" id="UML" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>  
+                      </div>
+                    </fieldset>
+                  </div>
                       <!-- Submissions for dugga -->
                   <div>
                     <div id="duggaSubmissionForm">

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -122,7 +122,7 @@
             <div class="assignment_left">
                 <h1 style="text-align: center;">Diagram-duggan</h1>
                 <div class="assignment_discrb" style=" margin-left: 2%; color: white; ">
-                    <p>Sed ut
+                    <p id="assigment-instructions">Sed ut
                         perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium,
                         totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae
                         dicta sunt explicabo. Nemo enim ipsam voluptatem

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -77,14 +77,14 @@ function returnedDugga(data)
         document.getElementById("assigment-instructions").innerHTML = param.instructions;
         //checking if the user is a teacher
         if(data.isTeacher==0){
-            // getting the diagram types allowed and calling a function in diagram.js where the values are now set UML functionality
+            // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type[0];
         }
         else{
             var diagramType={ER:true,UML:true};
             document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
         }
-        document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();
+        document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();//<-- UML functionality end
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -79,12 +79,12 @@ function returnedDugga(data)
         if(data.isTeacher==0){
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set UML functionality
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type[0];
-            document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();
         }
         else{
             var diagramType={ER:true,UML:true};
             document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
         }
+        document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -1,6 +1,5 @@
 var lastFile = null;
 var diagramWindow;
-
 /** 
  * @description Alert message appears before closing down or refreshing the dugga viewer page window.
 
@@ -75,6 +74,9 @@ function returnedDugga(data)
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
         document.getElementById("assigment-instructions").innerHTML = param.instructions;
+        // getting the diagram types allowed and calling a function in diagram.js where the values are now set UML functionality
+        document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type[0];
+        document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -71,12 +71,20 @@ function uploadFile()
  * */
 function returnedDugga(data)
 {
+    console.log(data);
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
         document.getElementById("assigment-instructions").innerHTML = param.instructions;
-        // getting the diagram types allowed and calling a function in diagram.js where the values are now set UML functionality
-        document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type[0];
-        document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();
+        //checking if the user is a teacher
+        if(data.isTeacher==0){
+            // getting the diagram types allowed and calling a function in diagram.js where the values are now set UML functionality
+            document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type[0];
+            document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();
+        }
+        else{
+            var diagramType={ER:true,UML:true};
+            document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
+        }
     }
 
     if (data.files[inParams["moment"]] && Object.keys(data.files[inParams["moment"]]).length != 0) {


### PR DESCRIPTION
changed diagram_dugga.
Student version
![image](https://user-images.githubusercontent.com/81320323/164479399-62c484c2-e610-436e-bd04-fff328433cbc.png)
Teacher version
![image](https://user-images.githubusercontent.com/81320323/164479541-f2685e33-a012-48e7-a0ff-8b9f1e8e69ff.png)
test by:
-logging in as toddler
-go to demo courses
-click show test
-click the pen on the same line as Diagram Dugga
-select an enabled existing variant by pressing the cogwheel on the same line
-change the checkboxes to select the types allowed
-press update
-log out
-go to diagram dugga
-look at the availible entitys
-log in as teacher and look at the icons for entitys and relations
-repeat to test different types
