### PR TITLE
Showdugga.php now outputs the filename and respective filepath for json diagram #11664

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -990,7 +990,7 @@ var settings = {
 // Demo data - read / write from service later on
 var data = [];
 var lines = [];
-var cid = 0;
+var diagramToLoad = "";
 
 // Ghost element is used for placing new elements. DO NOT PLACE GHOST ELEMENTS IN DATA ARRAY UNTILL IT IS PRESSED!
 var ghostElement = null;
@@ -1138,7 +1138,7 @@ function onSetup()
     // Global statemachine init
     stateMachine = new StateMachine(data, lines);
 
-    mickeTemp();
+    fetchDiagramFileName();
 }
 
 /**
@@ -5867,9 +5867,11 @@ async function loadDiagram(file = null, shouldDisplayMessage = true)
     }
 }
 
-function mickeTemp()
+function fetchDiagramFileName()
 {
-    cid = window.parent.getDiagramToLoadParam();
-    console.log(cid);
+        cid = window.parent.getVariantParam();
+        let start = cid[0].lastIndexOf('diagram File&quot;:&quot;')+25;
+        let finish = cid[0].indexOf('.json') + 5;
+        console.log(cid[0].slice(start, finish));
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -990,6 +990,7 @@ var settings = {
 // Demo data - read / write from service later on
 var data = [];
 var lines = [];
+var cid = 0;
 
 // Ghost element is used for placing new elements. DO NOT PLACE GHOST ELEMENTS IN DATA ARRAY UNTILL IT IS PRESSED!
 var ghostElement = null;
@@ -1136,6 +1137,8 @@ function onSetup()
 
     // Global statemachine init
     stateMachine = new StateMachine(data, lines);
+
+    mickeTemp();
 }
 
 /**
@@ -5862,5 +5865,11 @@ async function loadDiagram(file = null, shouldDisplayMessage = true)
     }else{
         if (shouldDisplayMessage) displayMessage(messageTypes.ERROR, "Error, cant load the given file");
     }
+}
+
+function mickeTemp()
+{
+    cid = window.parent.getDiagramToLoadParam();
+    console.log(cid);
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1140,6 +1140,7 @@ function onSetup()
     // Global statemachine init
     stateMachine = new StateMachine(data, lines);
 
+    //toggleGrid();
     fetchDiagramFileName();
 }
 
@@ -5874,24 +5875,10 @@ function fetchDiagramFileName()
         var temp = window.parent.getVariantParam();
         cid = temp[1];
         cvers = temp[2];
-        AJAXService("GET", { cid: cid, coursevers: cvers }, "FILE");
-        let start = temp[0].lastIndexOf('diagram File&quot;:&quot;')+25;
-        let finish = temp[0].indexOf('.json') + 5;
-        diagramToLoad = temp[0].slice(start, finish);
-        console.log(diagramToLoad);
+        diagramToLoad = temp[3];
+
         console.log(cid);
         console.log(cvers);
-}
-
-function returnedFile(data){
-    retdata = data;
-    filearray = [];
-
-    for (var i = 0; i < retdata['entries'].length; i++){
-		filearray[i] = JSON.parse(retdata['entries'][i].filename);
-	}
-	filteredarray = filearray.filter(x => x.filename === diagramToLoad);
-
-    console.log(filteredarray[0].filePath);
+        console.log(diagramToLoad);
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1141,7 +1141,7 @@ function onSetup()
     stateMachine = new StateMachine(data, lines);
 
     //toggleGrid();
-    fetchDiagramFileName();
+    fetchDiagramFileContentOnLoad();
 }
 
 /**
@@ -5870,13 +5870,15 @@ async function loadDiagram(file = null, shouldDisplayMessage = true)
     }
 }
 
-function fetchDiagramFileName()
+function fetchDiagramFileContentOnLoad()
 {
         var temp = window.parent.getVariantParam();
+        var fullParam = temp[0];
         cid = temp[1];
         cvers = temp[2];
         diagramToLoad = temp[3];
 
+        console.log(fullParam);
         console.log(cid);
         console.log(cvers);
         console.log(diagramToLoad);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5881,7 +5881,6 @@ function fetchDiagramFileName()
         console.log(diagramToLoad);
         console.log(cid);
         console.log(cvers);
-
 }
 
 function returnedFile(data){
@@ -5894,10 +5893,5 @@ function returnedFile(data){
 	filteredarray = filearray.filter(x => x.filename === diagramToLoad);
 
     console.log(filteredarray[0].filePath);
-}
-
-function loadDiagramOnLoad()
-{
-    
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5872,15 +5872,28 @@ async function loadDiagram(file = null, shouldDisplayMessage = true)
 function fetchDiagramFileName()
 {
         var temp = window.parent.getVariantParam();
-        diagramToLoad = temp[0];
         cid = temp[1];
         cvers = temp[2];
+        AJAXService("GET", { cid: cid, coursevers: cvers }, "FILE");
         let start = temp[0].lastIndexOf('diagram File&quot;:&quot;')+25;
         let finish = temp[0].indexOf('.json') + 5;
-        console.log(temp[0].slice(start, finish));
+        diagramToLoad = temp[0].slice(start, finish);
+        console.log(diagramToLoad);
         console.log(cid);
         console.log(cvers);
 
+}
+
+function returnedFile(data){
+    retdata = data;
+    filearray = [];
+
+    for (var i = 0; i < retdata['entries'].length; i++){
+		filearray[i] = JSON.parse(retdata['entries'][i].filename);
+	}
+	filteredarray = filearray.filter(x => x.filename === diagramToLoad);
+
+    console.log(filteredarray[0].filePath);
 }
 
 function loadDiagramOnLoad()

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -991,6 +991,8 @@ var settings = {
 var data = [];
 var lines = [];
 var diagramToLoad = "";
+var cid = "";
+var cvers = "";
 
 // Ghost element is used for placing new elements. DO NOT PLACE GHOST ELEMENTS IN DATA ARRAY UNTILL IT IS PRESSED!
 var ghostElement = null;
@@ -5869,9 +5871,20 @@ async function loadDiagram(file = null, shouldDisplayMessage = true)
 
 function fetchDiagramFileName()
 {
-        cid = window.parent.getVariantParam();
-        let start = cid[0].lastIndexOf('diagram File&quot;:&quot;')+25;
-        let finish = cid[0].indexOf('.json') + 5;
-        console.log(cid[0].slice(start, finish));
+        var temp = window.parent.getVariantParam();
+        diagramToLoad = temp[0];
+        cid = temp[1];
+        cvers = temp[2];
+        let start = temp[0].lastIndexOf('diagram File&quot;:&quot;')+25;
+        let finish = temp[0].indexOf('.json') + 5;
+        console.log(temp[0].slice(start, finish));
+        console.log(cid);
+        console.log(cvers);
+
+}
+
+function loadDiagramOnLoad()
+{
+    
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5877,10 +5877,14 @@ function fetchDiagramFileContentOnLoad()
         cid = temp[1];
         cvers = temp[2];
         diagramToLoad = temp[3];
+        var printthisshit = temp[4];
+        var printisglobalshit = temp[5];
 
         console.log(fullParam);
         console.log(cid);
         console.log(cvers);
         console.log(diagramToLoad);
+        console.log(printthisshit);
+        console.log(printisglobalshit);
 }
 //#endregion =====================================================================================

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -62,7 +62,8 @@
 	foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
 	{
 		$variantParams=$row['jparam'];
-//		array_push($finalArray, $variantParams);
+		array_push($finalArray, $variantParams);
+		$s_to_json=json_encode((array)$finalArray);
 	}
 	$response->closeCursor();
 	
@@ -468,10 +469,15 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 	<script type="text/javascript">
 	function getVariantParam()
 	{
-		const variantArray = [<?php echo "'$variantParams'"#,'$queryArray[1]','$queryArray[2]'" #echo"$mickeResult[0];";?>];
+		var variantArray = [<?php echo "'$variantParams'"#,'$queryArray[1]','$queryArray[2]'" #echo"$mickeResult[0];";?>];
+		variantArray.push(<?php echo "$cid"?>);
+		variantArray.push(<?php echo "$vers"?>);
 		return variantArray;
-		} 
+	} 
 	</script>
+
+	<script>
+</script>
 	<!-- content END -->
 	<?php
 		include '../Shared/loginbox.php';

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -81,29 +81,31 @@
 	}
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$query = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
+	#$query = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
+	$response = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid;");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$count = $count + 1;
 
-	if($query->execute())
+	if($response->execute())
 	{
-		foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row)
+		foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
 		{
-			$isGlobal = $row['isGlobal'];
+			#$isGlobal = $row['isGlobal'];
+			$isGlobal = $row['jparam'];
 			$count = $count + 1;
 			if($isGlobal == 1)
 			{
-				$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
+				#$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
 			}
 			else{
-				$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
+				#$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
 			}
 		}
 	}
 	else{
-		$fileContent = "DATABASE_FETCH_ERROR:\$query->execute() failed.";
+		$fileContent = "DATABASE_FETCH_ERROR:\$query->execute() failed: Select=isGlobal Table=filelink";
 	}
-	$query->closeCursor();
+	$response->closeCursor();
 	#if result is 1, meaning it's global, set $isGlobal boolean to true. $isGlobal exists mainly so it can be returned to diagram.js in the future, if ever needed.
 
 	#if the file is global, get content from global folder. Else, set path to use course-id folder.
@@ -501,7 +503,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 		variantArray.push(<?php echo "$count"?>);
 		variantArray.push(<?php echo "'$splicedFileName'"?>);
 		variantArray.push(<?php echo "'$fileContent'"?>);
-		variantArray.push(<?php echo "$isGlobal"?>);
+		//variantArray.push(<?php echo "$isGlobal"?>);
 		return variantArray;
 	} 
 	</script>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -77,7 +77,7 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$fileLinkResponse = $pdo->prepare("SELECT isGlobal FROM filelink WHERE filename = 'diagram(10).json'");
+	$fileLinkResponse = $pdo->prepare("SELECT isGlobal FROM filelink WHERE filename = $splicedFileName");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$count = $count + 1;
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -77,9 +77,11 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
+	$count = $count + 1;
 	$fileLinkResponse = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$fileLinkResponse->execute();
+
 
 	foreach($fileLinkResponse->fetchAll(PDO::FETCH_ASSOC) as $row)
 	{

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -87,10 +87,10 @@
 		$count = $count + 1;
 		if($isGlobal == 1)
 		{
-			$fileContent = file_get_contents("../courses/global/"."'$splicedFileName'");
+			$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
 		}
 		else{
-			$fileContent = file_get_contents("../courses/".$cid."/"."'$splicedFileName'");
+			$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
 		}
 	}
 	$fileLinkResponse->closeCursor();

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -77,7 +77,7 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$fileLinkResponse = $pdo->prepare("SELECT isGlobal FROM filelink WHERE filename = \''diagram(10).json'\'");
+	$fileLinkResponse = $pdo->prepare("SELECT isGlobal FROM filelink WHERE filename = 'diagram(10).json'");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$count = $count + 1;
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -1,5 +1,7 @@
 <?php
 	include_once "../Shared/sessions.php";
+	pdoConnect();
+	include_once "../Shared/basic.php";
  	session_start();
 ?>
 <!DOCTYPE html>
@@ -21,14 +23,24 @@
 	<script src="timer.js"></script>
 	<script src="clickcounter.js"></script>
 	<script>var querystring=parseGet();</script>
+	<?php
+	//$mickeQuery = "SELECT param FROM variant LEFT JOIN quiz ON quiz.id=variant.quizID WHERE disabled=0 AND quiz.cid = " + querystring['courseid'];
+
+	?>
+	<script type="text/javascript">
+	function getDiagramToLoadParam()
+	{
+		//const queryArray = [querystring['courseid'], querystring['coursevers'], querystring['did']];
+		var queryString = "SELECT param FROM variant LEFT JOIN quiz ON quiz.id=variant.quizID WHERE disabled=0 AND quiz.cid = " + querystring['courseid'];
+		return queryString;
+		} 
+	</script>
+
 <?php
 	date_default_timezone_set("Europe/Stockholm");
 
 	// Include basic application services!
-	include_once "../Shared/basic.php";
-
 	// Connect to database and start session
-	pdoConnect();
 
 	$cid=getOPG('courseid');
 	$vers=getOPG('coursevers');
@@ -50,6 +62,20 @@
 	$duggaid=getOPG('did');
 	$moment=getOPG('moment');
 	$courseid=getOPG('courseid');
+	$queryArray = array($cid, $vers, $quizid);
+
+	$mickeQuery = $pdo->prepare("SELECT param FROM variant LEFT JOIN quiz ON quiz.id=variant.quizID WHERE disabled=0 AND quiz.cid = $cid;");
+//	$mickeResult = $mickeQuery->execute();
+
+	if(!$mickeQuery->execute())
+	{
+		echo "ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR";
+		print_f($mickeQuery->errorInfo());
+	}
+	
+	else{
+		echo "$mickeQuery->fetch(PDO::FETCH_ASSOC)";
+	}
 
 	// if(isset($_SESSION['hashpassword'])){
 	// 	$hashpassword=$_SESSION['hashpassword'];

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -77,7 +77,7 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$fileLinkResponse = $pdo->prepare("SELECT isGlobal FROM filelink WHERE filename = '$splicedFileName'");
+	$fileLinkResponse = $pdo->prepare("SELECT isGlobal FROM filelink WHERE filename = \''diagram(10).json'\'");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$count = $count + 1;
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -102,6 +102,8 @@
 		$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
 	}
 
+
+	#I have no idea what the things below
 	// if(isset($_SESSION['hashpassword'])){
 	// 	$hashpassword=$_SESSION['hashpassword'];
 	// }else{

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -61,7 +61,7 @@
 	$splicedFileName = "UNK";
 	$isGlobal = -1;
 	$count = 0;
-
+	
 	#create request to database and execute it
 	$response = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid;");
 	$response->execute();
@@ -77,7 +77,7 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$fileLinkResponse = $pdo->prepare("SELECT isGlobal FROM filelink WHERE filename = $splicedFileName");
+	$fileLinkResponse = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$count = $count + 1;
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -79,21 +79,25 @@
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
 	$fileLinkResponse = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
-	$fileLinkResponse->execute();
 	$count = $count + 1;
 
-
-	foreach($fileLinkResponse->fetchAll(PDO::FETCH_ASSOC) as $row)
+	if($fileLinkResponse->execute())
 	{
-		$isGlobal = $row['isGlobal'];
-		$count = $count + 1;
-		if($isGlobal == 1)
+		foreach($fileLinkResponse->fetchAll(PDO::FETCH_ASSOC) as $row)
 		{
-			$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
+			$isGlobal = $row['isGlobal'];
+			$count = $count + 1;
+			if($isGlobal == 1)
+			{
+				$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
+			}
+			else{
+				$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
+			}
 		}
-		else{
-			$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
-		}
+	}
+	else{
+		$fileContent = "DATABASE_FETCH_ERROR_500";
 	}
 	$fileLinkResponse->closeCursor();
 	#if result is 1, meaning it's global, set $isGlobal boolean to true. $isGlobal exists mainly so it can be returned to diagram.js in the future, if ever needed.

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -77,7 +77,7 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$fileLinkResponse = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
+	$fileLinkResponse = $pdo->prepare("SELECT isGlobal FROM filelink WHERE filename = '$splicedFileName'");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$count = $count + 1;
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -87,10 +87,10 @@
 		$count = $count + 1;
 		if($isGlobal == 1)
 		{
-			$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
+			$fileContent = file_get_contents("../courses/global/"."'$splicedFileName'");
 		}
 		else{
-			$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
+			$fileContent = file_get_contents("../courses/".$cid."/"."'$splicedFileName'");
 		}
 	}
 	$fileLinkResponse->closeCursor();

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -77,10 +77,10 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$count = $count + 1;
 	$fileLinkResponse = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$fileLinkResponse->execute();
+	$count = $count + 1;
 
 
 	foreach($fileLinkResponse->fetchAll(PDO::FETCH_ASSOC) as $row)

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -77,13 +77,13 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$fileLinkResponse = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
+	$query = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
 	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
 	$count = $count + 1;
 
-	if($fileLinkResponse->execute())
+	if($query->execute())
 	{
-		foreach($fileLinkResponse->fetchAll(PDO::FETCH_ASSOC) as $row)
+		foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row)
 		{
 			$isGlobal = $row['isGlobal'];
 			$count = $count + 1;
@@ -99,7 +99,7 @@
 	else{
 		$fileContent = "DATABASE_FETCH_ERROR_500";
 	}
-	$fileLinkResponse->closeCursor();
+	$query->closeCursor();
 	#if result is 1, meaning it's global, set $isGlobal boolean to true. $isGlobal exists mainly so it can be returned to diagram.js in the future, if ever needed.
 
 	#if the file is global, get content from global folder. Else, set path to use course-id folder.

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -1,7 +1,7 @@
 <?php
 	include_once "../Shared/sessions.php";
-	pdoConnect();
 	include_once "../Shared/basic.php";
+
  	session_start();
 ?>
 <!DOCTYPE html>
@@ -23,24 +23,13 @@
 	<script src="timer.js"></script>
 	<script src="clickcounter.js"></script>
 	<script>var querystring=parseGet();</script>
-	<?php
-	//$mickeQuery = "SELECT param FROM variant LEFT JOIN quiz ON quiz.id=variant.quizID WHERE disabled=0 AND quiz.cid = " + querystring['courseid'];
-
-	?>
-	<script type="text/javascript">
-	function getDiagramToLoadParam()
-	{
-		//const queryArray = [querystring['courseid'], querystring['coursevers'], querystring['did']];
-		var queryString = "SELECT param FROM variant LEFT JOIN quiz ON quiz.id=variant.quizID WHERE disabled=0 AND quiz.cid = " + querystring['courseid'];
-		return queryString;
-		} 
-	</script>
 
 <?php
 	date_default_timezone_set("Europe/Stockholm");
 
 	// Include basic application services!
 	// Connect to database and start session
+	pdoConnect();
 
 	$cid=getOPG('courseid');
 	$vers=getOPG('coursevers');
@@ -62,20 +51,36 @@
 	$duggaid=getOPG('did');
 	$moment=getOPG('moment');
 	$courseid=getOPG('courseid');
-	$queryArray = array($cid, $vers, $quizid);
+//	$queryArray = array($cid, $vers, $quizid);
 
-	$mickeQuery = $pdo->prepare("SELECT param FROM variant LEFT JOIN quiz ON quiz.id=variant.quizID WHERE disabled=0 AND quiz.cid = $cid;");
+	$variantParams = "";
+	$finalArray = [];
+
+	
+	$mickeQuery = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid;");
+	$mickeQuery->execute();
+	foreach($mickeQuery->fetchAll(PDO::FETCH_ASSOC) as $row)
+	{
+		$variantParams=$row['jparam'];
+		array_push($finalArray, $variantParams);
+	}
+	$mickeQuery->closeCursor();
+	
+
+//	echo $mickeResult[0];
+	
 //	$mickeResult = $mickeQuery->execute();
 
-	if(!$mickeQuery->execute())
+/*	if(!$mickeQuery->execute())
 	{
 		echo "ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR";
 		print_f($mickeQuery->errorInfo());
 	}
 	
 	else{
-		echo "$mickeQuery->fetch(PDO::FETCH_ASSOC)";
+		$mickeQuery->fetch(PDO::FETCH_ASSOC);
 	}
+	*/
 
 	// if(isset($_SESSION['hashpassword'])){
 	// 	$hashpassword=$_SESSION['hashpassword'];
@@ -160,9 +165,7 @@
 		}
 ?>
 <script type="text/javascript">
-
 	setHash("<?php /*echo $hash*/ ?>");
-
 </script>
 
 
@@ -462,12 +465,19 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
     		</div>
       </div>
 	</div>
-
+	<script type="text/javascript">
+	function getVariantParam()
+	{
+		const variantArray = [<?php echo "'$variantParams'"#,'$queryArray[1]','$queryArray[2]'" #echo"$mickeResult[0];";?>];
+		return variantArray;
+		} 
+	</script>
 	<!-- content END -->
 	<?php
 		include '../Shared/loginbox.php';
 	?>
 
 </head>
+
 </body>
 </html>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -64,15 +64,20 @@
 
 	#create request to database and execute it
 	$response = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid;");
-	$response->execute();
 
 	#loop through responses, fetch param column in variant table, splice string to extract file name, then close request.
-	foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
+	if($response->execute())
 	{
-		$variantParams=$row['jparam'];
-		$start = strpos($variantParams, "diagram File&quot;:&quot;") + 25;
-		$end = strpos($variantParams, "&quot;,&quot;extraparam&quot;");
-		$splicedFileName = substr($variantParams, strpos($variantParams, "diagram File&quot;:&quot;") + 25, ($end - $start));
+		foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
+		{
+			$variantParams=$row['jparam'];
+			$start = strpos($variantParams, "diagram File&quot;:&quot;") + 25;
+			$end = strpos($variantParams, "&quot;,&quot;extraparam&quot;");
+			$splicedFileName = substr($variantParams, strpos($variantParams, "diagram File&quot;:&quot;") + 25, ($end - $start));
+		}
+	}
+	else{
+		$splicedFileName = "DATABASE_FETCH_ERROR:\$query->execute() failed.";
 	}
 	$response->closeCursor();
 
@@ -97,7 +102,7 @@
 		}
 	}
 	else{
-		$fileContent = "DATABASE_FETCH_ERROR_500";
+		$fileContent = "DATABASE_FETCH_ERROR:\$query->execute() failed.";
 	}
 	$query->closeCursor();
 	#if result is 1, meaning it's global, set $isGlobal boolean to true. $isGlobal exists mainly so it can be returned to diagram.js in the future, if ever needed.

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -57,28 +57,28 @@
 	$finalArray = [];
 
 	
-	$mickeQuery = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid;");
-	$mickeQuery->execute();
-	foreach($mickeQuery->fetchAll(PDO::FETCH_ASSOC) as $row)
+	$response = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid;");
+	$response->execute();
+	foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
 	{
 		$variantParams=$row['jparam'];
-		array_push($finalArray, $variantParams);
+//		array_push($finalArray, $variantParams);
 	}
-	$mickeQuery->closeCursor();
+	$response->closeCursor();
 	
 
-//	echo $mickeResult[0];
+//	echo $response[0];
 	
-//	$mickeResult = $mickeQuery->execute();
+//	$response = $response->execute();
 
-/*	if(!$mickeQuery->execute())
+/*	if(!$response->execute())
 	{
 		echo "ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR_ERROR";
-		print_f($mickeQuery->errorInfo());
+		print_f($response->errorInfo());
 	}
 	
 	else{
-		$mickeQuery->fetch(PDO::FETCH_ASSOC);
+		$response->fetch(PDO::FETCH_ASSOC);
 	}
 	*/
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -79,7 +79,6 @@
 	else{
 		$splicedFileName = "DATABASE_FETCH_ERROR:\$query->execute() failed.";
 	}
-	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
 	$query = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -55,12 +55,12 @@
 
 	#vars for handling fetching of diagram variant file name
 	$variantParams = "UNK";
-	$isGlobalBool = -1;
 	$filePath ="";
 	#$finalArray = [];
 	$fileContent="UNK";
 	$splicedFileName = "UNK";
-	$isGlobal=false;
+	$isGlobal = -1;
+	$count = 0;
 
 	#create request to database and execute it
 	$response = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid;");
@@ -77,30 +77,26 @@
 	$response->closeCursor();
 
 	#repeat for filelink table, checking if the corresponding file is global or not (if it's global, file is found in ../courses/global/ rather than course specific)
-	$fileLinkResponse = $pdo->prepare("SELECT isGlobal as isglobal FROM filelink WHERE filename = $splicedFileName");
-	$response->execute();
-	foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
+	$fileLinkResponse = $pdo->prepare("SELECT isGlobal as isGlobal FROM filelink WHERE filename = '$splicedFileName'");
+	#$fileLinkResponse->bindParam(':isGlobal', $isGlobal);
+	$fileLinkResponse->execute();
+
+	foreach($fileLinkResponse->fetchAll(PDO::FETCH_ASSOC) as $row)
 	{
-		$response->bindParam(':isGlobalBool', $isGlobal);
+		$isGlobal = $row['isGlobal'];
+		$count = $count + 1;
+		if($isGlobal == 1)
+		{
+			$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
+		}
+		else{
+			$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
+		}
 	}
-	$response->closeCursor();
+	$fileLinkResponse->closeCursor();
 	#if result is 1, meaning it's global, set $isGlobal boolean to true. $isGlobal exists mainly so it can be returned to diagram.js in the future, if ever needed.
-	if($isGlobalBool != 0)
-	{
-		$isGlobal = false;
-	}
-	else{
-		$isGlobal = true;
-	}
 
 	#if the file is global, get content from global folder. Else, set path to use course-id folder.
-	if($isGlobal == true)
-	{
-		$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
-	}
-	else{
-		$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
-	}
 
 
 	#I have no idea what the things below
@@ -492,8 +488,10 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 	{
 		var variantArray = [<?php echo "'$variantParams'"#,'$queryArray[1]','$queryArray[2]'" #echo"$mickeResult[0];";?>];
 		variantArray.push(<?php echo "$cid"?>);
-		variantArray.push(<?php echo "$vers"?>);
+		variantArray.push(<?php echo "$count"?>);
+		variantArray.push(<?php echo "'$splicedFileName'"?>);
 		variantArray.push(<?php echo "'$fileContent'"?>);
+		variantArray.push(<?php echo "$isGlobal"?>);
 		return variantArray;
 	} 
 	</script>


### PR DESCRIPTION
Added functionality where showdugga.php now lists the filename and filepath for the selected json diagram in variant editor. You can test this by selecting a json diagram and creating a new variant on a diagram dugga, then view said dugga from sectioned and look at the console output, you should see a json filename and filepath. Will add functionality where we read its content to generate a new diagram in #11666 
![bild](https://user-images.githubusercontent.com/37794783/164710629-e1cd4cef-d28e-4792-bdf5-bbecce7e5a71.png)
