### PR TITLE
G3 2022 w4 #11112 Fixed some more of the load time issue

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -152,6 +152,7 @@ function renderBarDiagram(data) {
   var maxDayCount = 0;
   for (var i = 0; i < 7 * numOfWeeks; i++) {
     var day = data['count'][dateString];
+    //console.log(data['count']);
     var commits = parseInt(day["commits"][0][0]);
     var events = parseInt(day["events"][0][0]);
     var comments = parseInt(day["comments"][0][0]);
@@ -361,11 +362,14 @@ function drawCommitDots(x1, y1, xmul, ymul, x_spacing, y_spacing){
   return str;
 }
 
+
+
 function renderLineDiagram(data) {
   weeks = data.weeks;
   daycounts = data['count'];
-  var firstweek = data.weeks[0].weekstart;
+  console.log('test');
 
+  var firstweek = data.weeks[0].weekstart;
 
   //Selectbox to choose week
   str = "<h2 style='padding-left:5px'>Weekly line chart</h2>";

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -152,11 +152,10 @@ function renderBarDiagram(data) {
   var maxDayCount = 0;
   for (var i = 0; i < 7 * numOfWeeks; i++) {
     var day = data['count'][dateString];
-    //console.log(data['count']);
-    var commits = parseInt(day["commits"][0][0]);
-    var events = parseInt(day["events"][0][0]);
-    var comments = parseInt(day["comments"][0][0]);
-    var loc = parseInt(day["loc"][0][0] == null ? 0 : day["loc"][0][0]);
+    var commits = parseInt(day["commits"]);
+    var events = parseInt(day["events"]);
+    var comments = parseInt(day["comments"]);
+    var loc = parseInt(day["loc"]);
     var total = commits + events + comments + loc;
     if (total > maxDayCount) {
       maxDayCount = total;
@@ -367,7 +366,6 @@ function drawCommitDots(x1, y1, xmul, ymul, x_spacing, y_spacing){
 function renderLineDiagram(data) {
   weeks = data.weeks;
   daycounts = data['count'];
-  console.log('test');
 
   var firstweek = data.weeks[0].weekstart;
 
@@ -527,11 +525,10 @@ function weekchoice(dateString) {
     var daycounter = 0;
     var weekarray = [];
     for (i = 0; i < 70; i++) {
-
-      events = parseInt(daycounts[dateString].events[0][0]);
-      commits = parseInt(daycounts[dateString].commits[0][0]);
-      loc = parseInt(daycounts[dateString].loc[0][0] == null ? 0 : daycounts[dateString].loc[0][0]);
-      comments = parseInt(daycounts[dateString].comments[0][0]);
+      events = parseInt(daycounts[dateString].events);
+      commits = parseInt(daycounts[dateString].commits);
+      loc = parseInt(daycounts[dateString].loc);
+      comments = parseInt(daycounts[dateString].comments);
 
       weekarray[i] = [dateString, commits, events, loc, comments];
 
@@ -564,10 +561,10 @@ function weekchoice(dateString) {
   for (var key in daycounts) {
     if (key == dateString) {
       for (i = 0; i < 7; i++) {
-        var events = parseInt(daycounts[dateString].events[0][0]);
-        var commits = parseInt(daycounts[dateString].commits[0][0]);
-        var loc = parseInt(daycounts[dateString].loc[0][0] == null ? 0 : daycounts[dateString].loc[0][0]);
-        var comments = parseInt(daycounts[dateString].comments[0][0]);
+        events = parseInt(daycounts[dateString].events);
+        commits = parseInt(daycounts[dateString].commits);
+        loc = parseInt(daycounts[dateString].loc);
+        comments = parseInt(daycounts[dateString].comments);
 
         dailyCount[i] = [dateString, commits, events, loc, comments];
 

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -463,6 +463,7 @@ if(strcmp($opt,"get")==0) {
 		array_push($hourlyevents, $issue);
 	}
 
+	//error_log("message",1);
 
 	$count = array();
 	$currentdate = $startweek;
@@ -472,6 +473,8 @@ if(strcmp($opt,"get")==0) {
         $tomorrowdate=date('Y-m-d',$tomorrowdate);
 		$daycount = array();
 		//Events
+		//$eventcount = $log_db->get_var('SELECT count(*) FROM event WHERE author='$gituser' AND eventtime>'$currentdate' AND eventtime<'$tomorrowdate' AND kind!="comment"');
+		
 		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND eventtime>:currentdate AND eventtime<:tomorrowdate AND kind!="comment"');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
@@ -482,7 +485,9 @@ if(strcmp($opt,"get")==0) {
 		}
 		$eventcount = $query->fetchAll();
 
-	  //Comments
+	  	//Comments
+		//$commentcount = $log_db->get_var('SELECT count(*) FROM event WHERE author='$gituser' AND eventtime>'$currentdate' AND eventtime<'$tomorrowdate' AND kind="comment"');
+
 		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND eventtime>:currentdate AND eventtime<:tomorrowdate AND kind="comment"');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
@@ -492,8 +497,10 @@ if(strcmp($opt,"get")==0) {
 			$debug="Error reading entries".$error[2];
 		}
 		$commentcount = $query->fetchAll();
-
+ 
 		//Commits
+		//$commitcount = $log_db->get_var("SELECT count(*) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser='$gituser' and blamedate>'$currentdate' AND blamedate<'$tomorrowdate'");
+
 		$query = $log_db->prepare('SELECT count(*) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and blamedate>:currentdate AND blamedate<:tomorrowdate');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
@@ -503,8 +510,10 @@ if(strcmp($opt,"get")==0) {
 			$debug="Error reading entries".$error[2];
 		}
 		$commitcount = $query->fetchAll();
-
+		
 		//LOC
+		//$loccount = $log_db->get_var("SELECT sum(rowcnt) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser='$gituser' and blamedate>'$currentdate' AND blamedate<'$tomorrowdate'");
+
 		$query = $log_db->prepare('SELECT sum(rowcnt) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and blamedate>:currentdate AND blamedate<:tomorrowdate');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
@@ -518,10 +527,13 @@ if(strcmp($opt,"get")==0) {
 		$daycount = array('events' => $eventcount,
 						  'commits' => $commitcount,
 						  'loc' => $loccount,
-				'comments' => $commentcount);
+						  'comments' => $commentcount);
 		$count[$currentdate] = $daycount;
 		$currentdate=strtotime("+1 day",strtotime($currentdate));
 	}
+	//error_log($count);
+
+
 	$timesheets = array();
 	$query = $pdo->prepare('SELECT day, week, type, reference, comment FROM timesheet WHERE uid=:userid AND cid=:cid AND vers=:vers;');
 	$query->bindParam(':userid', $userid);
@@ -543,7 +555,7 @@ if(strcmp($opt,"get")==0) {
 			array_push($timesheets, $timesheet);
 		}
 	}
-
+	
 	$array = array(
 		'debug' => $debug,
 		'weeks' => $weeks,

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -463,7 +463,7 @@ if(strcmp($opt,"get")==0) {
 		array_push($hourlyevents, $issue);
 	}
 
-	//error_log("message",1);
+
 
 	$count = array();
 	$currentdate = $startweek;
@@ -472,9 +472,8 @@ if(strcmp($opt,"get")==0) {
 		$tomorrowdate=strtotime("+1 day",strtotime($currentdate));
         $tomorrowdate=date('Y-m-d',$tomorrowdate);
 		$daycount = array();
+
 		//Events
-		//$eventcount = $log_db->get_var('SELECT count(*) FROM event WHERE author='$gituser' AND eventtime>'$currentdate' AND eventtime<'$tomorrowdate' AND kind!="comment"');
-		
 		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND eventtime>:currentdate AND eventtime<:tomorrowdate AND kind!="comment"');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
@@ -483,11 +482,9 @@ if(strcmp($opt,"get")==0) {
 			$error=$query->errorInfo();
 			$debug="Error reading entries".$error[2];
 		}
-		$eventcount = $query->fetchAll();
+		$eventcount = $query->fetchColumn(); 
 
 	  	//Comments
-		//$commentcount = $log_db->get_var('SELECT count(*) FROM event WHERE author='$gituser' AND eventtime>'$currentdate' AND eventtime<'$tomorrowdate' AND kind="comment"');
-
 		$query = $log_db->prepare('SELECT count(*) FROM event WHERE author=:gituser AND eventtime>:currentdate AND eventtime<:tomorrowdate AND kind="comment"');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
@@ -496,11 +493,9 @@ if(strcmp($opt,"get")==0) {
 			$error=$query->errorInfo();
 			$debug="Error reading entries".$error[2];
 		}
-		$commentcount = $query->fetchAll();
+		$commentcount = $query->fetchColumn(); 
  
 		//Commits
-		//$commitcount = $log_db->get_var("SELECT count(*) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser='$gituser' and blamedate>'$currentdate' AND blamedate<'$tomorrowdate'");
-
 		$query = $log_db->prepare('SELECT count(*) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and blamedate>:currentdate AND blamedate<:tomorrowdate');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
@@ -509,11 +504,9 @@ if(strcmp($opt,"get")==0) {
 			$error=$query->errorInfo();
 			$debug="Error reading entries".$error[2];
 		}
-		$commitcount = $query->fetchAll();
+		$commitcount = $query->fetchColumn(); 
 		
 		//LOC
-		//$loccount = $log_db->get_var("SELECT sum(rowcnt) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser='$gituser' and blamedate>'$currentdate' AND blamedate<'$tomorrowdate'");
-
 		$query = $log_db->prepare('SELECT sum(rowcnt) FROM Bfile,Blame where Blame.fileid=Bfile.id and blameuser=:gituser and blamedate>:currentdate AND blamedate<:tomorrowdate');
 		$query->bindParam(':gituser', $gituser);
 		$query->bindParam(':currentdate', $currentdate);
@@ -522,7 +515,10 @@ if(strcmp($opt,"get")==0) {
 			$error=$query->errorInfo();
 			$debug="Error reading entries".$error[2];
 		}
-		$loccount = $query->fetchAll();
+		$loccount = $query->fetchColumn(); 
+		if($loccount == NULL){
+			$loccount = 0;
+		}
 
 		$daycount = array('events' => $eventcount,
 						  'commits' => $commitcount,
@@ -531,7 +527,7 @@ if(strcmp($opt,"get")==0) {
 		$count[$currentdate] = $daycount;
 		$currentdate=strtotime("+1 day",strtotime($currentdate));
 	}
-	//error_log($count);
+
 
 
 	$timesheets = array();


### PR DESCRIPTION
I have improved the speed at witch the file loads when using larger databases. What I have changed is the way that the for($i=0;$i<70;$i++){} loop in contributionservice.php works.  This loop makes 4 queries that all count the number of rows in that database that match with the query parameters. This would mean that we have 70 iterations of the loop times 4 queries equalling 280 queries total. But the way that the queries are done actually uses two queries per row count. Meaning that we actually have a total of 560 queries. This was because we used to use the syntax fetchAll() after every query as a part of the counting process. fetchAll() is a query in and of itself. I have changed this to need only the expected 280 by replacing fetchAll().  Meaning that we now have 280 queries less than previously. I also needed to change the way that some functions in contribution.js accessed this data. Since it used to be stored in a superfluously large array. Now its stored as a more practical int. 

To test that the site still works after changes just switch to branch G3-2022-W4-#11112 and go to http://localhost/LenaSYS/DuggaSys/contribution.php.

To test that load time is faster use that software that b20jonlu used to measure load difference while using the largest database we have. 