### PR TITLE
Dropdown boxes are now hidden when selected dugga is not diagram #11614

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -355,10 +355,12 @@ function updateVariantTitle(number) {
 
 // Opens the variant editor.
 function showVariantEditor() {
-	AJAXService("GET", { cid: querystring['courseid'], coursevers: querystring['coursevers'] }, "FILE");
-
 	//check if the selected dugga is a diagram dugga
 	if(globalData['entries'][globalVariant].quizFile == "diagram_dugga"){
+		/*For now it only fetches the files when it's a diagram dugga. 
+		This might change in the future if other duggor should have
+		additional files as parameters*/
+		AJAXService("GET", { cid: querystring['courseid'], coursevers: querystring['coursevers'] }, "FILE");
 		$("#selectBox").css("display", "flex");
 	}
 	else{

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -356,6 +356,14 @@ function updateVariantTitle(number) {
 // Opens the variant editor.
 function showVariantEditor() {
 	AJAXService("GET", { cid: querystring['courseid'], coursevers: querystring['coursevers'] }, "FILE");
+
+	//check if the selected dugga is a diagram dugga
+	if(globalData['entries'][globalVariant].quizFile == "diagram_dugga"){
+		$("#selectBox").css("display", "flex");
+	}
+	else{
+		$("#selectBox").css("display", "none");
+	}
   if(submissionRow == 0){
     // The submission row doesn't go away when leaving the modal
     // so without the if statement a new submission div would be created each time.

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -175,10 +175,9 @@ session_start();
                     </div>
                   </div>
                   <div>
-                    <div>
+                    <div id="selectBox" style="display:none;">
                       <fieldset style="width:90%">
-                      <!-- Currently the diagrams aren't doing anything, they're just listed.
-                      They're fetched and parsed in returnedFile() in duggaed.js -->
+                      <!-- The json files are fetched and parsed in returnedFile() in duggaed.js -->
                         <legend>Add diagram to dugga</legend>
                         <select id="file" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()))"></select>
                       </fieldset>


### PR DESCRIPTION
The dropdown box for selecting json diagrams is now hidden when the selected dugga is not of diagram type as per stated in issue #11614 ,

![bild](https://user-images.githubusercontent.com/37794783/165077997-e3348c8f-ed12-4fe7-9e8e-b6f372a17920.png)
