### PR TITLE
Removed the top margin from the message of the day

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8033,7 +8033,6 @@ textarea#filecont {
   background-color: var(--color-accent);
   z-index: 1000;
   position: relative;
-  margin-top: 16px;
   margin-bottom: 7px;
   max-width: auto;
 }


### PR DESCRIPTION
Removed the top margin from the message of the day so no more white space is visible above the message of the day banner. #11799 

<img width="960" alt="beforeafter" src="https://user-images.githubusercontent.com/81613484/165086553-1cd8a7e3-5a9b-4be6-991f-e6ff79ec2d8b.png">


