### PR TITLE
Made the commitDiv function better

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -1708,6 +1708,8 @@ function showCommits(object, cid){
   var text = document.getElementById('commitDiv');
   text.style.display="block";
   text.innerHTML = commitChangeArray[cid];
+  text.style.left = (document.documentElement.scrollLeft) + "px";
+  text.style.top = (document.documentElement.scrollTop) + "px";
 }
 //Hide a div when hover the commit links
  function hideCommits(){

--- a/DuggaSys/contribution.php
+++ b/DuggaSys/contribution.php
@@ -37,7 +37,7 @@ $vers=getOPG('coursevers');
 	<!-- content START -->
 	<div id="content"></div>
 	
-	<div id='commitDiv' style=' position: sticky; background: #f5e7ff;box-shadow: 1px 1px 6px rgba(0, 0, 0, 0.6); border-radius: 5px; width:500px; height: 500px; white-space: nowrap; display:none; top: 15px; margin-left: 50px; z-index: 100; overflow-y:scroll;'></div>
+	<div id='commitDiv' style=' position: absolute; background: #f5e7ff;box-shadow: 1px 1px 6px rgba(0, 0, 0, 0.6); border-radius: 5px; width:500px; height: 500px; white-space: nowrap; display:none; margin-top: 15px; margin-left: 50px; z-index: 100; overflow-y:scroll;'></div>
 
 	<div id='commitDiagram' style='margin-left: 12px; width:70%;'></div>
 


### PR DESCRIPTION
Solution for https://github.com/HGustavs/LenaSYS/issues/11786 and submission of https://github.com/HGustavs/LenaSYS/pull/11798
Changed from a position: sticky to absolute which means that the webpage won't lengthen when hovering over a commit link. The position is then changed to where the user is on the webpage when hovering over a commit link.