### PR TITLE
Updated diagram.js - zoomreset() - issue #11810

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3761,9 +3761,25 @@ function zoomout(scrollEvent = undefined)
  */
 function zoomreset()
 {
-    zoomOrigo.x = 0;
-    zoomOrigo.y = 0;
+    
+    var midScreen = screenToDiagramCoordinates((window.innerWidth / 2), (window.innerHeight / 2));
+                
+    var delta = { // Calculate the difference between last zoomOrigo and current midScreen coordinates.
+        x: midScreen.x - zoomOrigo.x,
+        y: midScreen.y - zoomOrigo.y
+    }
 
+    //Update scroll x/y to center screen on new zoomOrigo
+    scrollx = scrollx / zoomfact;
+    scrolly = scrolly / zoomfact;
+    scrollx += delta.x * zoomfact;
+    scrolly += delta.y * zoomfact;
+    scrollx = scrollx * zoomfact;
+    scrolly = scrolly * zoomfact;
+
+    zoomOrigo.x = midScreen.x;
+    zoomOrigo.y = midScreen.y;
+    
     scrollx = scrollx / zoomfact;
     scrolly = scrolly / zoomfact;
    


### PR DESCRIPTION
Issue: #11810 

zoomreset now resets the zoom to 1x without repositioning the camera, regardless of where it is.

How to test:
1. Move the camera without zooming, remember what the screen currently looks like (when zoomfactor is 1x)
2. Zoom in or out as much as you want with the zoom buttons. 
3. Press Zoom RESET.
4.  Does the screen look the same as it did in step 1?

Also try:
1. Move the camera without zooming.
2. Zoom in or out with the mousewheel.
3. Remember what is currently in the middle of the screen.
4. Press Zoom RESET
5. Is the screen still centered on the same spot as in step 3?
(Note: It may be difficult to pinpoint the exact center of the screen, I recommend zooming in on a specific element in the diagram as much as possible, and see if the same element is still in the center of the screen, after step 4.