### PR TITLE
Added code so that the button does not flex-wrap and so that the window is appropriate for smaller screens.

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -384,7 +384,7 @@ function returnedFile(data){
 
 // Adds a submission row
 function addVariantSubmissionRow() {
-  var subDivContent = `<div style='width:100%;display:flex;flex-wrap:wrap;flex-direction:row;'>
+  var subDivContent = `<div style='width:100%;display:flex;flex-wrap:nowrap;flex-direction:row; margin-right:2%;'>
 		<select name='s_type' id='submissionType${submissionRow}' style='width:65px;' onchange='$(\"#variantparameterText\").val(createJSONString($(\"#jsonForm\").serializeArray()));'>
 		<option value='pdf'>PDF</option>
 		<option value='zip'>Zip</option>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -154,7 +154,7 @@ session_start();
                   </div>
                       <!-- Instruction for assignment -->
                   <div>
-                    <fieldset style="width:90%">
+                    <fieldset style="width:90%;">
                       <legend>Instruction file</legend>
                       <div style="display:flex;flex-wrap:wrap;flex-direction:row;">
                         <select name="type" id="type" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));">
@@ -187,9 +187,9 @@ session_start();
                       <!-- Submissions for dugga -->
                   <div>
                     <div id="duggaSubmissionForm">
-                      <fieldset style="width:90%">
+                      <fieldset style="width:90%; margin-top:5%;">
                         <legend>Submission types</legend>
-                        <div id="submissions" style="display:flex;flex-wrap:wrap;flex-direction:row;overflow:auto;"></div>
+                        <div id="submissions" style="display:flex;flex-wrap:wrap;flex-direction:column;overflow:hidden;"></div>
                       </fieldset>
                       <input type="button" class="submit-button" name="addfieldname" id="addfieldname" value="+" style="width:32px;" onclick="addVariantSubmissionRow();" />
                     </div>
@@ -199,9 +199,9 @@ session_start();
                 </form>
               </div>
               <div id="rightDivDialog" style='width: 50%; height:100%; display: inline-block;'>
-                <fieldset style="width:90%">
+                <fieldset style="width:90%; margin-left:5%;">
                   <legend>Search in the Table</legend>
-                  <div style="width:100%; height: 25px; display:flex; flex-wrap:wrap; flex-direction:row;">
+                  <div style="width:100%; height: 25px; display:flex; flex-wrap:nowrap; flex-direction:row;">
                     <input id="variantSearch" class="searchFiled" type="search" placeholder="Search.." style="flex-grow: 99; margin: 0px; border: 1px; border-bottom-right-radius: 0px; border-top-right-radius: 0px; height: 25px;"
                     onkeyup="searchterm=document.getElementById('variantSearch').value; searchKeyUp(event); variantTable.renderTable();"onsearch="searchterm=document.getElementById('variantSearch').value; searchKeyUp(event); variantTable.renderTable();"/>
                                         <button id="searchbutton" class="switchContent" onclick="return searchKeyUp(event);" type="button">
@@ -209,16 +209,16 @@ session_start();
                     </button>
                   </div>
                 </fieldset>
-                <fieldset style="width:90%">
+                <fieldset style="width:90%; margin-left:5%;">
                   <legend>Generated Param JSON</legend>
-                  <div id='parameter' style='min-height:120px'>
-                    <textarea id='variantparameterText' rows="5" style="min-height:100px" onchange="createJSONFormData()"></textarea>
+                  <div id='parameter' style='min-height:75px'>
+                    <textarea id='variantparameterText' rows="2" style="min-height:80px" onchange="createJSONFormData()"></textarea>
                   </div>
                 </fieldset>
-                <fieldset style="width:90%">
+                <fieldset style="width:90%; margin-left:5%;">
                   <legend>Answer</legend>
-                    <div id='variantanswer' style='min-height:120px;'>
-                      <textarea id='variantanswerText' rows="5" style="min-height:100px"></textarea>
+                    <div id='variantanswer' style='min-height:40px;'>
+                      <textarea id='variantanswerText' rows="2" style="min-height:40px"></textarea>
                     </div>
                 </fieldset>
               </div>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -217,8 +217,8 @@ session_start();
                 </fieldset>
                 <fieldset style="width:90%; margin-left:5%;">
                   <legend>Answer</legend>
-                    <div id='variantanswer' style='min-height:40px;'>
-                      <textarea id='variantanswerText' rows="2" style="min-height:40px"></textarea>
+                    <div id='variantanswer' style='min-height:15px;'>
+                      <textarea id='variantanswerText' rows="2" style="min-height:40px; height:53px;"></textarea>
                     </div>
                 </fieldset>
               </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2299,7 +2299,7 @@ label.login-label {
 
 .loginBox form,
 .logoutBox form {
-  padding: 20px;
+  padding-bottom: 20px;
 }
 
 .loginBox .text,


### PR DESCRIPTION
Added code so that the button does not flex-wrap and so that the row doesn't overflow. I also made the "Answer" box smaller alongside margin corrections on correct elements so that the elements would fit properly on smaller screens.

<img width="348" alt="fix" src="https://user-images.githubusercontent.com/81613484/165268796-38ba595e-6859-4535-b11c-07fc7b9d9d1a.png">

Compare with #11728. 

