### PR TITLE
Added labels to input elements missing them

### DIFF
--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -229,7 +229,7 @@ Testing Link:
 							<td>Kind:</td>
 						</tr>
 						<tr>
-							<td><input class='form-control textinput' type='text' id='boxtitle' value='Title' /></td>
+							<td><input class='form-control textinput' type='text' id='boxtitle' placeholder='Title' value='Title' /></td>
 							<td><select id='boxcontent' onchange='changeDirectory(this);'><option value='DOCUMENT'>Document</option><option value='CODE'>Code</option><option value='IFRAME'>Preview</option></select></td>
 						</tr>
 						<tr>
@@ -280,8 +280,8 @@ Testing Link:
 						<legend>Example Info</legend>
 						<table width="100%">
 							<tr>
-								<td>Section Title:<input class='form-control textinput' type='text' id='secttitle' value='&lt;Secrion Title&gt;' /></td>
-								<td>Title:<input class='form-control textinput' type='text' id='title' value='&lt;Title&gt;' /></td>
+								<td>Section Title:<input class='form-control textinput' type='text' id='secttitle' placeholder='Section Title' value='&lt;Secrion Title&gt;' /></td>
+								<td>Title:<input class='form-control textinput' type='text' placeholder='Title' id='title' value='&lt;Title&gt;' /></td>
 							</tr>
 
 							<tr>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -83,14 +83,14 @@ session_start();
         			<div class='flexwrapper'><span>Auto-grade:</span><select id='autograde'></select></div>
         			<div class='flexwrapper'><span>Grade System:</span><select id='gradesys'></select></div>
         			<div class='flexwrapper'><span>Template:</span><select id='template'><option selected='selected' value=""><option value=""></option></select></div>
-              <div class='flexwrapper'><span>Start Date:</span><span><input class='textinput' type='date' id='qstart' value=''  /><select style='width:55px;' id='qstartt'></select><select style='width:55px;' id='qstartm'></select></span></div>
-              <div class='flexwrapper'><span>Deadline 1:</span><span><input class='textinput' type='date' id='deadline' value=''  /><select style='width:55px;' id='deadlinet'></select><select style='width:55px;' id='deadlinem'></select></span></div>
+              <div class='flexwrapper'><span>Start Date:</span><span><input class='textinput' type='date' id='qstart' title='Start date input' value=''  /><select style='width:55px;' id='qstartt'></select><select style='width:55px;' id='qstartm'></select></span></div>
+              <div class='flexwrapper'><span>Deadline 1:</span><span><input class='textinput' type='date' id='deadline' title='Deadline 1 input' value=''  /><select style='width:55px;' id='deadlinet'></select><select style='width:55px;' id='deadlinem'></select></span></div>
   						<div class='flexwrapper'><span>Comment:</span><input class='textinput' type='text' id='deadlinecomments1' placeholder='Deadline Comments' /></div>
-              <div class='flexwrapper'><span>Deadline 2:</span><span><input class='textinput' type='date' id='deadline2' value=''  /><select style='width:55px;' id='deadlinet2'></select><select style='width:55px;' id='deadlinem2'></select></span></div>
+              <div class='flexwrapper'><span>Deadline 2:</span><span><input class='textinput' type='date' id='deadline2' title='Deadline 2 input' value=''  /><select style='width:55px;' id='deadlinet2'></select><select style='width:55px;' id='deadlinem2'></select></span></div>
   						<div class='flexwrapper'><span>Comment:</span><input class='textinput' type='text' id='deadlinecomments2' placeholder='Deadline Comments' /></div>
-              <div class='flexwrapper'><span>Deadline 3:</span><span><input class='textinput' type='date' id='deadline3' value=''  /><select style='width:55px;' id='deadlinet3'></select><select style='width:55px;' id='deadlinem3'></select></span></div>
+              <div class='flexwrapper'><span>Deadline 3:</span><span><input class='textinput' type='date' id='deadline3' title='Deadline 3 input' value=''  /><select style='width:55px;' id='deadlinet3'></select><select style='width:55px;' id='deadlinem3'></select></span></div>
   						<div class='flexwrapper'><span>Comment:</span><input class='textinput' type='text' id='deadlinecomments3' placeholder='Deadline Comments' /></div>
-              <div class='flexwrapper'><span>Result release:</span><span><input class='textinput' type='date' id='release' value=''  /><select style='width:55px;' id='releaset'></select><select style='width:55px;' id='releasem'></select></span></div>
+              <div class='flexwrapper'><span>Result release:</span><span><input class='textinput' type='date' id='release' title='Result release input' value=''  /><select style='width:55px;' id='releaset'></select><select style='width:55px;' id='releasem'></select></span></div>
         		</div>
         		<div style='padding:5px;display:flex;justify-content: flex-end'>
         			<input id='saveDugga' class='submit-button' type='button' value='Save' onclick='updateDugga();' />

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -333,7 +333,7 @@ $js = array(
                             </div>
 
                             <div class="markText" style="flex-grow:1;">
-                                <textarea id="mrkdwntxt" style="font-family:monospace;" oninput="updatePreview(this.value)" name="markdowntext"></textarea>
+                                <textarea id="mrkdwntxt" style="font-family:monospace;" oninput="updatePreview(this.value)" name="markdowntext" placeholder="Enter text here"></textarea>
                             </div>
                         </div>
                     </fieldset>

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -84,8 +84,8 @@ pdoConnect();
 		<!--<div id="resultTable" style='width:fit-content; white-space: nowrap; position: absolute; margin-top: 100px; margin-bottom: 30px;'>-->
 		<div class="resulted-filter-container">
 			<div class="search-filter-container">
-				<label class="filter-label" for="">Search</label>
-				<input class="searchbar-filter" type="text">
+				<label class="filter-label" for="searchbar">Search</label>
+				<input class="searchbar-filter" type="text" id="searchbar">
 			</div>
 			<div class="select-dugga-filter">
 				<div class="dugga-filter-container">
@@ -99,11 +99,11 @@ pdoConnect();
 			</div>
 			<div class="select-date-interval">
 				<div>
-					<label class="filter-label" for="">Earliest Submission</label>
+					<label class="filter-label" for="datepicker-interval-1">Earliest Submission</label>
 					<input class="date-interval-selector" type="date" id="datepicker-interval-1">
 				</div>
 				<div>
-					<label class="filter-label" for="">Latest Submission</label>
+					<label class="filter-label" for="datepicker-interval-2">Latest Submission</label>
 					<input class="date-interval-selector" type="date" id="datepicker-interval-2">
 				</div>
 			</div>
@@ -111,11 +111,11 @@ pdoConnect();
 		</div>
 		<div class="resulted-filter-container">
 			<div>
-				<label class="filter-label" for="">Highlight threshold (Times Accessed)</label>
+				<label class="filter-label" for="highlight-entry">Highlight threshold (Times Accessed)</label>
 				<input class="searchbar-filter" id="highlight-entry" type="text" value="20" onkeyup="updateTable()">
 			</div>
 			<div>
-				<label class="filter-label" for="">Enabled</label>
+				<label class="filter-label" for="highlight-checkbox">Enabled</label>
 				<input type="checkbox" id="highlight-checkbox" onclick="updateTable()">
 			</div>
 		</div>

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1140,9 +1140,9 @@ function returnedSection(data) {
 
         // checkbox
         if (data['writeaccess'] || data['studentteacher']) {
-          str += `<td style='width:25px;' class='" + makeTextArray(itemKind,["header", "section", "code", "test", "moment", "link", "group", "message"]) + " ${hideState}'>`;
-            str += "<input type='checkbox' id='"+ item['lid'] + "-checkbox" + "' value='" + true + "' onclick='markedItems(this)'>";
-            str += "<label for='"+ item['lid'] + "-checkbox" + "' class='checkbox-label' >text</label>"
+          str += `<td style='width:25px;' class='" + makeTextArray(itemKind,
+            ["header", "section", "code", "test", "moment", "link", "group", "message"]) + " ${hideState}'>`;
+            str += "<input type='checkbox' id='"+ item['lid'] + "-checkbox" + "' title='"+item['entryname'] + " - checkbox"+"' onclick='markedItems(this)'>";
             str += "</td>";      
         }
         

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1140,9 +1140,9 @@ function returnedSection(data) {
 
         // checkbox
         if (data['writeaccess'] || data['studentteacher']) {
-          str += `<td style='width:25px;' class='" + makeTextArray(itemKind,
-            ["header", "section", "code", "test", "moment", "link", "group", "message"]) + " ${hideState}'>`;
-            str += "<input type='checkbox' name='arrayCheckBox' onclick='markedItems(this)'>";
+          str += `<td style='width:25px;' class='" + makeTextArray(itemKind,["header", "section", "code", "test", "moment", "link", "group", "message"]) + " ${hideState}'>`;
+            str += "<input type='checkbox' id='"+ item['lid'] + "-checkbox" + "' value='" + true + "' onclick='markedItems(this)'>";
+            str += "<label for='"+ item['lid'] + "-checkbox" + "' class='checkbox-label' >text</label>"
             str += "</td>";      
         }
         

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -211,7 +211,7 @@
 				<input type='hidden' id='comments'  />
 				<div id='inputwrapper-name' class='inputwrapper'>
 					<span>Name:</span>
-					<input onchange="validateSectName('sectionname')" type='text' class='textinput' id='sectionname' value='sectionname' maxlength="64"/>
+					<input onchange="validateSectName('sectionname')" type='text' class='textinput' id='sectionname' placeholder='Enter section name' value='sectionname' maxlength="64"/>
 				</div>
 				<div class="tooltipDugga">
   		      		<span id="dialog10" style="display: none;" class="tooltipDuggatext">Illegal characters found in the title!<br>Valid characters: A-Ö, 0-9, ()</span>
@@ -224,14 +224,14 @@
 					</div>
 					<div id='inputwrapper-link' class='inputwrapper'><span>Link:</span><select id='link' ></select></div>
 					<div id='inputwrapper-gradesystem' class='inputwrapper'><span>Grade system:</span><select id='gradesys' ></select></div>
-					<div id='inputwrapper-deadline' class='inputwrapper'><span>Set Deadline:</span><span style='float:right'><input onchange="showCourseDate('setDeadlineValue','dialog8')" class='textinput' type='date' id='setDeadlineValue' value='' /><select style='width:55px;' id='deadlineminutes'></select><select style='width:55px;' id='deadlinehours'></select></span></div>
+					<div id='inputwrapper-deadline' class='inputwrapper'><span>Set Deadline:</span><span style='float:right'><input onchange="showCourseDate('setDeadlineValue','dialog8')" class='textinput' type='date' id='setDeadlineValue' title='Deadline input' value='' /><select style='width:55px;' id='deadlineminutes'></select><select style='width:55px;' id='deadlinehours'></select></span></div>
 			        <p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Deadline has to be between start date and end date</p>
 					<div id='inputwrapper-tabs' class='inputwrapper'><span>Tabs:</span><select id='tabs' ></select></div>
 					<div id='inputwrapper-highscore' class='inputwrapper'><span>High score:</span><select id='highscoremode' ></select></div>
 					<div id='inputwrapper-moment' class='inputwrapper'><span>Moment:</span><select id='moment'></select></div>
 					<div id='inputwrapper-visibility' class='inputwrapper'><span>Visibility:</span><select style='align:right;' id='visib'></select></div>
 					<div id='inputwrapper-group' class='inputwrapper'><span>Group type:</span><select style='align:right;' id='grptype'></select></div>
-					<div id='inputwrapper-Feedback' class='inputwrapper'><span>Enable Student Feedback:</span><input type="checkbox"  style='align:center;' id='fdbck' onchange='showFeedbackquestion()'></input></div>
+					<div id='inputwrapper-Feedback' class='inputwrapper'><span>Enable Student Feedback:</span><input type="checkbox"  style='align:center;' id='fdbck' title='Student feedback checkbox' onchange='showFeedbackquestion()'></input></div>
 					<div id='inputwrapper-FeedbackQuestion' class='inputwrapper' style='display:none;'><span>Student Feedback Question:</span><input type="input"  class='textinput'' id='fdbckque' value='How would you grade the dugga?'></input></div>
 				</div>
 
@@ -326,12 +326,12 @@
 				<p id="dialog2" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Only numbers(between 3-8 numbers)</p>
 				<div class='inputwrapper'><span>Version Name:</span><input onkeyup="validateVersionName('versname', 'dialog')" class='textinput' type='text' id='versname' placeholder='Version Name' /></div>
 				<p id="dialog" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Must be A-Z 0-9</p>
-				<div class='inputwrapper'><span>Start Date:</span><input onchange="validateDate('startdate','enddate','dialog3')" class='textinput' type='date' id='startdate' value='' /></div>
-				<div class='inputwrapper'><span>End Date:</span><input onchange="validateDate('startdate','enddate','dialog3')" class='textinput' type='date' id='enddate' value='' /></div>
+				<div class='inputwrapper'><span>Start Date:</span><input onchange="validateDate('startdate','enddate','dialog3')" class='textinput' type='date' id='startdate' title='Start date input' value='' /></div>
+				<div class='inputwrapper'><span>End Date:</span><input onchange="validateDate('startdate','enddate','dialog3')" class='textinput' type='date' id='enddate' title='End date input' value='' /></div>
 				<p id="dialog3" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Start date has to be before end date</p>
 				<div class='inputwrapper'><span>MOTD:</span><input onkeyup="validateMOTD('vmotd','dialog4')" class='textinput' type='text' id='vmotd' placeholder='MOTD' value='' /></div>
 				<p id="dialog4" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Message can only contain a maximum of 50 symbols</p>
-				<div class='inputwrapper'><span>Change this to default version</span><input type="checkbox" name="makeactive" id="makeactive" value="yes"></div>
+				<div class='inputwrapper'><span>Change this to default version</span><input type="checkbox" name="makeactive" id="makeactive" title='default version checkbox' value="yes"></div>
 				<div class='inputwrapper'><span>Copy content from:</span><select id='copyvers'></select></div>
 			</div>
 			<div style='padding:5px;'>
@@ -353,12 +353,12 @@
 				<div class='inputwrapper'><span>Version ID:</span><input class="greyedout-textinput" disabled type='text' id='eversid' placeholder='Version ID' /></div>
 				<div class='inputwrapper'><span>Version Name:</span><input onkeyup="validateVersionName('eversname', 'dialog5')" class='textinput' type='text' id='eversname' placeholder='Version Name'/></div>
 				<p id="dialog5" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Must be in of the form HTNN, VTNN or STNN</p>
-				<div class='inputwrapper'><span>Start Date:</span><input onchange="validateDate('estartdate','eenddate','dialog6')" class='textinput' type='date' id='estartdate' value='' /></div>
-				<div class='inputwrapper'><span>End Date:</span><input onchange="validateVersionName('eversname', 'dialog5')" class='textinput' type='date' id='eenddate' value='' /></div>
+				<div class='inputwrapper'><span>Start Date:</span><input onchange="validateDate('estartdate','eenddate','dialog6')" class='textinput' type='date' id='estartdate' title='Start date input' value='' /></div>
+				<div class='inputwrapper'><span>End Date:</span><input onchange="validateVersionName('eversname', 'dialog5')" class='textinput' type='date' id='eenddate' title='End date input' value='' /></div>
 				<p id="dialog6" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Start date has to be before end date</p>
 				<div class='inputwrapper'><span>MOTD:</span><input onkeyup="validateMOTD('eMOTD', 'dialog9')" class='textinput' type='text' id='eMOTD' placeholder='MOTD'/></div>
 				<p id="dialog9" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Message can only contain a maximum of 50 symbols</p>
-				<div class='inputwrapper'><span>Change this to default version</span><input type="checkbox" name="emakeactive" id="emakeactive" value="yes"></div>
+				<div class='inputwrapper'><span>Change this to default version</span><input type="checkbox" name="emakeactive" id="emakeactive" title='Default version checkbox' value="yes"></div>
 			</div>
 			<div style='padding:5px;'>
 				<input class='submit-button' type='button' value='Save' title='Save changes' onclick="validateForm('editCourseVersion')" />


### PR DESCRIPTION
Added titles and placeholders to inputs missing them. Used lighthouse dev tool in order to audit webpages and fixed forms that were missing labels. For input types checkbox and dates i used titles so when the user hovers over the input they get a description of it, for input types text i used placeholder to display text if the input is empty. For resulted.php it was possible to use the label element since they were already in place but in other places it would have been difficult to do so without altering the look of the webpage significantly.

There is most certainly inputs still missing labels on some webpages. I did not fix forms on webpages such as the showdugga.php pages. I also noticed other issues in the lighthouse tool but i did not alter them since they are not a part of this issue. Since i did all my testing logged in as Toddler it is possible that some elements are only visable to students were not found.

The webpages i tested extensively:

- sectioned.php
- fileed.php
- resulted.php
- duggaed.php
- accessed.php
- codeviewer.php
- courseed.php
