### PR TITLE
Simple design and functionality for relative deadlines

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -181,7 +181,7 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
   }
   if(relativedeadline !== undefined) {
     var splitdeadline = relativedeadline.split(":");
-
+    // relativedeadline -> week:weekday:hour:minute
     $("#relativedeadlinehours").html(makeoptions(splitdeadline[2],hourArrOptions,hourArrValue));
     $("#relativedeadlineminutes").html(makeoptions(splitdeadline[3],minuteArrOptions,minuteArrValue));
 
@@ -2585,13 +2585,13 @@ function validateDate2(ddate, dialogid) {
   if (startdate < deadline && enddate > deadline) {
     ddate.style.borderColor = "#383";
     ddate.style.borderWidth = "2px";
-    // x.style.display = "none";
+    x.style.display = "none";
     window.bool8 = true;
 
   } else {
 
     ddate.style.borderColor = "#E54";
-    // x.style.display = "block";
+    x.style.display = "block";
     ddate.style.borderWidth = "2px";
     window.bool8 = false;
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -141,6 +141,10 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
   var hourArrValue=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23];
   var minuteArrOptions=["00","05","10","15","20","25","30","35","40","45","50","55"];
   var minuteArrValue=[0,5,10,15,20,25,30,35,40,45,50,55];
+  var weekArrOptions=["1","2","3","4","5","6","7","8","9","10","11","12"];
+  var weekArrValue=[1,2,3,4,5,6,7,8,9,10,11,12];
+  var weekdayArrOptions=["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+  var weekdayArrValue=[1,2,3,4,5,6,7];
 
   nameSet = false;
   if (entryname == "undefined") entryname = "New Header";
@@ -173,6 +177,12 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
   if(deadline !== undefined){
     $("#deadlinehours").html(makeoptions(deadline.substr(11,2),hourArrOptions,hourArrValue));
     $("#deadlineminutes").html(makeoptions(deadline.substr(14,2),minuteArrOptions,minuteArrValue));
+    $("#relativedeadlinehours").html(makeoptions(deadline.substr(11,2),hourArrOptions,hourArrValue));
+    $("#relativedeadlineminutes").html(makeoptions(deadline.substr(14,2),minuteArrOptions,minuteArrValue));
+
+    // Might want to add selection for weeks and weekdays
+    $("#relativedeadlineweeks").html(makeoptions(1,weekArrOptions,weekArrValue ));
+    $("#relativedeadlineweekdays").html(makeoptions("Monday",weekdayArrOptions,weekdayArrValue));
     $("#setDeadlineValue").val(deadline.substr(0,10));
   }
   var groups = [];
@@ -440,7 +450,7 @@ function prepareItem() {
   param.comments = $("#comments").val();
   param.grptype = $("#grptype").val();
   param.deadline = $("#setDeadlineValue").val()+" "+$("#deadlinehours").val()+":"+$("#deadlineminutes").val();
-
+  param.relativedeadline = $("#relativedeadlineweeks").val()+" "+$("#relativedeadlineweekdays").val()+" "+$("#relativedeadlinehours").val()+":"+$("#relativedeadlineminutes").val();
 
   if ($('#fdbck').prop('checked')){
     param.feedback = 1;
@@ -2572,13 +2582,13 @@ function validateDate2(ddate, dialogid) {
   if (startdate < deadline && enddate > deadline) {
     ddate.style.borderColor = "#383";
     ddate.style.borderWidth = "2px";
-    x.style.display = "none";
+    // x.style.display = "none";
     window.bool8 = true;
 
   } else {
 
     ddate.style.borderColor = "#E54";
-    x.style.display = "block";
+    // x.style.display = "block";
     ddate.style.borderWidth = "2px";
     window.bool8 = false;
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -134,7 +134,7 @@ function toggleHamburger() {
 // selectItem: Prepare item editing dialog after cog-wheel has been clicked
 //----------------------------------------------------------------------------------
 
-function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, highscoremode, comments, grptype, deadline, tabs, feedbackenabled, feedbackquestion) {
+function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, highscoremode, comments, grptype, deadline, relativedeadline, tabs, feedbackenabled, feedbackquestion) {
 
   // Variables for the different options and values for the deadlne time dropdown meny.
   var hourArrOptions=["00","01","02","03","04","05","06","07","08","09","10","11","12","13","14","15","16","17","18","19","20","21","22","23"];
@@ -177,13 +177,16 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
   if(deadline !== undefined){
     $("#deadlinehours").html(makeoptions(deadline.substr(11,2),hourArrOptions,hourArrValue));
     $("#deadlineminutes").html(makeoptions(deadline.substr(14,2),minuteArrOptions,minuteArrValue));
-    $("#relativedeadlinehours").html(makeoptions(deadline.substr(11,2),hourArrOptions,hourArrValue));
-    $("#relativedeadlineminutes").html(makeoptions(deadline.substr(14,2),minuteArrOptions,minuteArrValue));
-
-    // Might want to add selection for weeks and weekdays
-    $("#relativedeadlineweeks").html(makeoptions(1,weekArrOptions,weekArrValue ));
-    $("#relativedeadlineweekdays").html(makeoptions("Monday",weekdayArrOptions,weekdayArrValue));
     $("#setDeadlineValue").val(deadline.substr(0,10));
+  }
+  if(relativedeadline !== undefined) {
+    var splitdeadline = relativedeadline.split(":");
+
+    $("#relativedeadlinehours").html(makeoptions(splitdeadline[2],hourArrOptions,hourArrValue));
+    $("#relativedeadlineminutes").html(makeoptions(splitdeadline[3],minuteArrOptions,minuteArrValue));
+
+    $("#relativedeadlineweeks").html(makeoptions(splitdeadline[0],weekArrOptions,weekArrValue ));
+    $("#relativedeadlineweekdays").html(makeoptions(splitdeadline[1],weekdayArrOptions,weekdayArrValue));
   }
   var groups = [];
   for (var key in retdata['groups']) {
@@ -403,7 +406,7 @@ function showCreateVersion() {
 //kind 0 == Header || 1 == Section || 2 == Code  || 3 == Test (Dugga)|| 4 == Moment || 5 == Link || 6 == Group Activity || 7 == Message
 function createFABItem(kind, itemtitle, comment) {
   if (kind >= 0 && kind <= 7) {
-    selectItem("undefined", itemtitle, kind, "undefined", "undefined", "0", "", "undefined", comment,"undefined", "undefined", 0, null);
+    selectItem("undefined", itemtitle, kind, "undefined", "undefined", "0", "", "undefined", comment,"undefined", "undefined", "undefined", 0, null);
     clearHideItemList();
     newItem(itemtitle);
   }
@@ -450,7 +453,7 @@ function prepareItem() {
   param.comments = $("#comments").val();
   param.grptype = $("#grptype").val();
   param.deadline = $("#setDeadlineValue").val()+" "+$("#deadlinehours").val()+":"+$("#deadlineminutes").val();
-  param.relativedeadline = $("#relativedeadlineweeks").val()+" "+$("#relativedeadlineweekdays").val()+" "+$("#relativedeadlinehours").val()+":"+$("#relativedeadlineminutes").val();
+  param.relativedeadline = $("#relativedeadlineweeks").val()+":"+$("#relativedeadlineweekdays").val()+":"+$("#relativedeadlinehours").val()+":"+$("#relativedeadlineminutes").val();
 
   if ($('#fdbck').prop('checked')){
     param.feedback = 1;
@@ -1134,7 +1137,7 @@ function returnedSection(data) {
           str += "><img alt='settings icon' id='dorf' title='Settings' class='' src='../Shared/icons/Cogwheel.svg' ";
           str += " onclick='selectItem(" + makeparams([item['lid'], item['entryname'],
           item['kind'], item['visible'], item['link'], momentexists, item['gradesys'],
-          item['highscoremode'], item['comments'], item['grptype'], item['deadline'],
+          item['highscoremode'], item['comments'], item['grptype'], item['deadline'], item['relativedeadline'],
           item['tabs'], item['feedbackenabled'], item['feedbackquestion']]) + "), clearHideItemList();' />";
           str += "</td>";
         }

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -224,8 +224,24 @@
 					</div>
 					<div id='inputwrapper-link' class='inputwrapper'><span>Link:</span><select id='link' ></select></div>
 					<div id='inputwrapper-gradesystem' class='inputwrapper'><span>Grade system:</span><select id='gradesys' ></select></div>
-					<div id='inputwrapper-deadline' class='inputwrapper'><span>Set Deadline:</span><span style='float:right'><input onchange="showCourseDate('setDeadlineValue','dialog8')" class='textinput' type='date' id='setDeadlineValue' value='' /><select style='width:55px;' id='deadlineminutes'></select><select style='width:55px;' id='deadlinehours'></select></span></div>
-			        <p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Deadline has to be between start date and end date</p>
+					<div id='inputwrapper-deadline' class='inputwrapper'>
+							<legend><h3>Deadline</h3></legend>
+							<span>Absolute</span>
+							<span style='float:right'>
+								<input onchange="showCourseDate('setDeadlineValue','dialog8')" class='textinput' type='date' id='setDeadlineValue' value='' />
+								<select style='width:55px;' id='deadlineminutes'></select>
+								<select style='width:55px;' id='deadlinehours'></select>
+							</span>
+							<br />
+							<span>Relative</span>
+							<span style='float:right'>
+								<select style='width:140px;' id='relativedeadlineweekdays'></select>
+								<select style='width:55px;' id='relativedeadlineweeks'></select>
+								<select style='width:55px;' id='relativedeadlineminutes'></select>
+								<select style='width:55px;' id='relativedeadlinehours'></select>
+							</span>
+					</div>
+			        <!-- <p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Deadline has to be between start date and end date</p> -->
 					<div id='inputwrapper-tabs' class='inputwrapper'><span>Tabs:</span><select id='tabs' ></select></div>
 					<div id='inputwrapper-highscore' class='inputwrapper'><span>High score:</span><select id='highscoremode' ></select></div>
 					<div id='inputwrapper-moment' class='inputwrapper'><span>Moment:</span><select id='moment'></select></div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -240,8 +240,11 @@
 								<select style='width:55px;' id='relativedeadlineminutes'></select>
 								<select style='width:55px;' id='relativedeadlinehours'></select>
 							</span>
+							<span style='float:left'>
+								<p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;max-height:20px;">Deadline has to be between start date and end date</p>
+							</span>
 					</div>
-			        <!-- <p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Deadline has to be between start date and end date</p> -->
+			        
 					<div id='inputwrapper-tabs' class='inputwrapper'><span>Tabs:</span><select id='tabs' ></select></div>
 					<div id='inputwrapper-highscore' class='inputwrapper'><span>High score:</span><select id='highscoremode' ></select></div>
 					<div id='inputwrapper-moment' class='inputwrapper'><span>Moment:</span><select id='moment'></select></div>

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -55,6 +55,7 @@ $enddate=getOP('enddate');
 $showgrps=getOP('showgrp');
 $grptype=getOP('grptype');
 $deadline=getOP('deadline');
+$relativedeadline=getOP('relativedeadline');
 $pos=getOP('pos');
 $jsondeadline = getOP('jsondeadline');
 $studentTeacher = false;
@@ -351,10 +352,11 @@ if($gradesys=="UNK") $gradesys=0;
 						}
 					}
 				}else if(strcmp($opt,"UPDATEDEADLINE")===0){
-					$deadlinequery = $pdo->prepare("UPDATE quiz SET deadline=:deadline WHERE id=:link;");
+					$deadlinequery = $pdo->prepare("UPDATE quiz SET deadline=:deadline, relativedeadline=:relativedeadline WHERE id=:link;");
 					$deadlinequery->bindParam(':deadline',$deadline);
+					$deadlinequery->bindParam(':relativedeadline',$relativedeadline);
 					$deadlinequery->bindParam(':link',$link);
-
+					
 					if(!$deadlinequery->execute()){
 						$error=$deadlinequery->errorInfo();
 						$debug="ERROR THE DEADLINE QUERY FAILED".$error[2];
@@ -457,7 +459,7 @@ if($gradesys=="UNK") $gradesys=0;
 		$duggor=array();
 		$releases=array();
 
-		$query = $pdo->prepare("SELECT id,qname,qrelease,deadline FROM quiz WHERE cid=:cid AND vers=:vers ORDER BY qname");
+		$query = $pdo->prepare("SELECT id,qname,qrelease,deadline,relativedeadline FROM quiz WHERE cid=:cid AND vers=:vers ORDER BY qname");
 		$query->bindParam(':cid', $courseid);
 		$query->bindParam(':vers', $coursevers);
 
@@ -471,7 +473,8 @@ if($gradesys=="UNK") $gradesys=0;
 		foreach($query->fetchAll() as $row) {
 			$releases[$row['id']]=array(
 					'release' => $row['qrelease'],
-					'deadline' => $row['deadline']
+					'deadline' => $row['deadline'],
+					'relativedeadline' => $row['relativedeadline']
 			);
 			array_push(
 				$duggor,
@@ -479,7 +482,8 @@ if($gradesys=="UNK") $gradesys=0;
 					'id' => $row['id'],
 					'qname' => $row['qname'],
 					'release' => $row['qrelease'],
-					'deadline' => $row['deadline']
+					'deadline' => $row['deadline'],
+					'relativedeadline' => $row['relativedeadline']
 				)
 			);
 		}
@@ -567,7 +571,7 @@ if($gradesys=="UNK") $gradesys=0;
 		$entries=array();
 
 		if($cvisibility){
-			$query = $pdo->prepare("SELECT lid,moment,entryname,pos,kind,link,visible,code_id,listentries.gradesystem,highscoremode,deadline,qrelease,comments, qstart, jsondeadline, groupKind, 
+			$query = $pdo->prepare("SELECT lid,moment,entryname,pos,kind,link,visible,code_id,listentries.gradesystem,highscoremode,deadline,relativedeadline,qrelease,comments, qstart, jsondeadline, groupKind, 
 			 ts, listentries.gradesystem as tabs, feedbackenabled, feedbackquestion FROM listentries LEFT OUTER JOIN quiz ON listentries.link=quiz.id 
 					WHERE listentries.cid=:cid and listentries.vers=:coursevers ORDER BY pos");
 			$query->bindParam(':cid', $courseid);
@@ -595,6 +599,7 @@ if($gradesys=="UNK") $gradesys=0;
 								'gradesys' => $row['gradesystem'],
 								'code_id' => $row['code_id'],
 								'deadline'=> $row['deadline'],
+								'relativedeadline'=> $row['relativedeadline'],
 								'qrelease' => $row['qrelease'],
 								'comments' => $row['comments'],
 								'qstart' => $row['qstart'],

--- a/Shared/SQL/init_db.sql
+++ b/Shared/SQL/init_db.sql
@@ -119,6 +119,7 @@ CREATE TABLE quiz (
 	quizFile 				VARCHAR(255) NOT NULL DEFAULT 'default',
 	qrelease 				DATETIME,
 	deadline 				DATETIME,
+	relativedeadline		varchar(10),
 	modified 				TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	creator 				INTEGER,
 	vers					VARCHAR(8),

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2162,7 +2162,7 @@ input {
   clear: both;
   width: 100%;
   padding: 3px 0 3px 0;
-  height: 30px;
+  /*height: 30px;*/
   line-height: 30px;
 }
 


### PR DESCRIPTION
Added a simple design (subject to change in the future)
Added functionality to take the values of the design and input it into the database
Added functionality so that when the page loads the database values is used in the settings menu for each dugga
Added a column for the table quiz in the database

This is a simple implementation of the functionality to store and fetch relative deadlines. The relative deadlines does nothing as of right now and the design and value of the relative deadlines are subject to change. It is implemented in such a way that the relative deadlines can be stored as we choose to and up until the point where we translate these deadlines into real dates can the design be changed freely without interfering with the functionality of storing them in the database.

To test:
First you need to re-install lenasys OR manually add a column with this below:

`ALTER TABLE quiz ADD relativedeadline varchar(10);`

Next go into any course with a dugga(demo-course for example), login as a teacher and click on the cogwheel next to a dugga.

Change the values of the relative deadline and press save.

Reload the page and press the cogwheel again to check if the relative deadline is properly stored and fetched.

If you want to doublecheck the database then login to your database and run this:

`SELECT relativedeadline FROM quiz;`

If it returns a table showing a column filled with NULL(or the value you picked in the above steps) then it works. If you get an error there's something wrong somewhere.