### PR TITLE
Github and Youtube links now open in new tab and all objects have new tab button #11229

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2365,7 +2365,8 @@ function addClasses() {
   var links = document.getElementsByTagName('a');
 
   for (var i = 0; i < links.length; i++) {
-    links[i].setAttribute('target', '_blank');
+    if(links[i].href.includes("github.com") || links[i].href.includes("youtube.com")){
+      links[i].setAttribute('target', '_blank');}
     if ((links[i].innerHTML.toLowerCase().indexOf("example") !== -1) ||
     (links[i].innerHTML.toLowerCase().indexOf("exempel") !== -1) || (links[i].innerHTML.toLowerCase().indexOf("examples") !== -1)) {
       links[i].classList.add("example-link");

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1096,6 +1096,12 @@ function returnedSection(data) {
           str += "</td>";
         }
 
+        //Generate new tab link
+        str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
+          "code", "test", "moment", "link", "group", "message"])} $[hideState}'>`;
+          str += `<img style='width:16px;' alt='canvasLink icon' id='dorf' title='Open link in new tab' class='' 
+          src='../Shared/icons/link-icon.svg' onclick='openCanvasLink(this);'>`;
+          str += "</td>";
 
         // Generate Canvas Link Button
         if (data['writeaccess'] || data['studentteacher']) {
@@ -1254,10 +1260,15 @@ function returnedSection(data) {
   }
 }
 
+function openCanvasLink(btnobj){
+  link = btnobj.parentNode.parentNode.querySelector('a').href;
+  window.open(link, "_blank");
+}
 
 function showCanvasLinkBox(operation,btnobj){
   if(operation == "open"){
-    var canvasLink = "This is a test link."//"<p><iframe src=\"" + btnobj.parentNode.parentNode.querySelector('.internal-link').href + "\" width=\"800\" height=\"1200\"></iframe></p>";
+    var canvasLink = btnobj.parentNode.parentNode.querySelector('a').href;
+    //var canvasLink = "<p><iframe src=\"" + btnobj.parentNode.parentNode.querySelector('a').href + "\" width=\"800\" height=\"1200\"></iframe></p>";
     if(canvasLink == null){
       canvasLink = "ERROR: Failed to get canvas link.";
     }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2365,6 +2365,7 @@ function addClasses() {
   var links = document.getElementsByTagName('a');
 
   for (var i = 0; i < links.length; i++) {
+    links[i].setAttribute('target', '_blank');
     if ((links[i].innerHTML.toLowerCase().indexOf("example") !== -1) ||
     (links[i].innerHTML.toLowerCase().indexOf("exempel") !== -1) || (links[i].innerHTML.toLowerCase().indexOf("examples") !== -1)) {
       links[i].classList.add("example-link");


### PR DESCRIPTION
All duggor now have a button that will open the link in a new tab but Github and Youtube links will always open in new tab if you directly clicked on the dugga row. Also changed the Show Canvas Link button to no longer just show "This is a test link" but now it displays the link for the dugga.