### PR TITLE
Hide course dropdown menu until a year is selected

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -1060,13 +1060,8 @@ function courseSelection(elem){
   var dropdown = document.getElementById('courseBtn');
   dropdown.options.length=0;
 
-  // Toggle visibility
-  if(elem.value == "ChooseY") {
-    dropdown.style.visibility = "hidden";
-  }
-  else{
-    dropdown.style.visibility = "visible";
-  }
+  // Set visibility
+  dropdown.style.visibility = elem.value == "ChooseY" ? 'hidden' : "visible";
 
   // Default option
   var opt = document.createElement('option');

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -1002,7 +1002,7 @@ function returnedSection(data) {
   
   //Dynamically loads the year selection list based on folders in ../../contributionDBs/
   str += `<select id='yearBtn' class='submit-button'
-  onclick='statSort(value)'onchange='courseSelection(value)'>
+  onclick='statSort(value)'onchange='courseSelection(this)'>
   <option value="ChooseY">Choose Year</option>`;
 
   // Add option for each year folder
@@ -1017,7 +1017,7 @@ function returnedSection(data) {
   str +=`</select>`;
 
   str += `<select id='courseBtn' class='submit-button'
-  onclick='statSort(value)'onchange='courseDBCollection(value)'>
+  onclick='statSort(value)'onchange='courseDBCollection(value)' style="visibility: hidden">
   <option value="ChooseC">Choose Course</option></select>`;
 
   str += "</div>"; 
@@ -1055,10 +1055,18 @@ function returnedSection(data) {
 }
 
 // Update the "Select Course" dropdown options
-function courseSelection(pos){
+function courseSelection(elem){
   // Clear dropdown menu
   var dropdown = document.getElementById('courseBtn');
   dropdown.options.length=0;
+
+  // Toggle visibility
+  if(elem.value == "ChooseY") {
+    dropdown.style.visibility = "hidden";
+  }
+  else{
+    dropdown.style.visibility = "visible";
+  }
 
   // Default option
   var opt = document.createElement('option');
@@ -1067,6 +1075,7 @@ function courseSelection(pos){
   dropdown.appendChild(opt);
 
   // Get file paths
+  var pos = elem.value;
   for(i=0;i<courseFileArr[pos].length;i++)
   {
     // Create button


### PR DESCRIPTION
Creating a multi-level dropdown menu was too complicated and I was unable to find a solution in time, so I made a quick fix instead where the course dropdown is hidden until a year is selected.

To test:
1. Go to http://127.0.0.1/LenaSYS/DuggaSys/contribution.php
2. Verify that there is no visible "Choose Course" button (to the right of "Choose Year")
3. Select a year in the "Choose Year" dropdown menu
4. Verify that the "Choose Course" dropdown menu is now visible