### PR TITLE
improvement for toolbar selecting UML/ER

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1583,6 +1583,13 @@ function mdown(event)
 {
 
     mouseButtonDown = true;
+    if(document.getElementsByClassName("activeTogglePlacementTypeBox")){
+        for (let index = 0; index < document.getElementsByClassName("activeTogglePlacementTypeBox").length; index++) {
+            setTimeout(() => {
+                document.getElementsByClassName("activeTogglePlacementTypeBox")[index].classList.remove("activeTogglePlacementTypeBox");
+            }, 50);
+        }
+    }
 
         // Mouse pressed over delete button for multiple elements
         if (event.button == 0) {


### PR DESCRIPTION
Added a if statementin mdown to hide the box with selections if one is open.
test by opening the selection between entitys or relations and clicking somewhere. the box should disappear.