### PR TITLE
Fixed broken show selected dates in contribution

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -657,7 +657,7 @@ function changeDay() {
       alert("Second week can't be earlier than first week");
     } else {
       AJAXService("updateday", {
-        userid: document.getElementById('userid').value,
+        userid: localStorage.getItem('GitHubUser'),
         //userid: "HGustavs",
         today: firstSelWeek,
         secondday: secondSelWeek
@@ -725,7 +725,7 @@ function renderCircleDiagram(data, day) {
   str += '</select>';
   
   str += `<button style='margin-left: 20px' onclick='changeDay()'>Show selected dates</button>`;
-  if (updateShowAct) {
+  if (updateShowAct || firstSelWeek == null && secondSelWeek == null) {
     str += "<p style='margin-left: 10px'>Showing all activities</p>";
     updateShowAct = false;
   } else {


### PR DESCRIPTION
The wrong userid was used for the ajax which meant that instead of getting the current user the ajax was sending the option selected in <select id="userid> button which is  "select Git user". 
Also fixed a problem with the "showing activities for period" string displaying undefined dates if the user hadn't selected any dates for a user. (issue recreation: refresh page -> select HGustavs -> the hourly activites string will look as shown below without the fix)
![hourly undefined string](https://user-images.githubusercontent.com/102533453/165745905-a6a16cf1-eeb2-42d7-8822-9cc3e935024a.png)
