### PR TITLE
Fixed ghost on inheritance and remove stroke color option from options panel

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4600,9 +4600,6 @@ function generateContextProperties()
           str += `<div style="color: white">BG Color</div>`;
           str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
               `<span id="BGColorMenu" class="colorMenu"></span></button>`;
-          str += `<div style="color: white">Stroke Color</div>`;
-          str += `<button id="colorMenuButton2" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton2')" style="background-color: ${context[0].stroke}">` +
-              `<span id="StrokeColorMenu" class="colorMenu"></span></button>`;
       }
 
       if (context.length > 0) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4526,15 +4526,14 @@ function generateContextProperties()
               }            
           }
 
-           // Creates button for selecting element background color
-           str += `<div style="color: white">BG Color</div>`;
-           str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
-               `<span id="BGColorMenu" class="colorMenu"></span></button>`;
-           str += `<div style="color: white">Stroke Color</div>`;
-           str += `<button id="colorMenuButton2" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton2')" style="background-color: ${context[0].stroke}">` +
-               `<span id="StrokeColorMenu" class="colorMenu"></span></button>`;
-           str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();generateContextProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
+        // Creates button for selecting element background color if not a UML relation since they should not be able change color
+        if (element.kind != 'UMLRelation') {
+            str += `<div style="color: white">BG Color</div>`;
+            str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
+                `<span id="BGColorMenu" class="colorMenu"></span></button>`;
+        }
 
+        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();generateContextProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
       }
 
       // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.
@@ -5956,17 +5955,15 @@ function drawElement(element, ghosted = false)
         str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh - (linew * 2)}'
         stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />
         <text x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
-        str += `</svg>`;
         //end of svg for UML header
-        str += `</div>`;
+        str += `</svg>`;
         //end of div for UML header
-
+        str += `</div>`;
+        
         //div to encapuslate UML content
         str += `<div class='uml-content' style='margin-top: ${-8 * zoomfact}px;'>`;
-
         //Draw UML-content if there exist at least one attribute
         if (elemAttri != 0) {
-
             //svg for background
             str += `<svg width='${boxw}' height='${boxh * elemAttri}'>`;
             str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh * elemAttri - (linew * 2)}'
@@ -5977,11 +5974,13 @@ function drawElement(element, ghosted = false)
             //end of svg for background
             str += `</svg>`;
         }
+        //end of div for UML content
+        str += `</div>`;
 
+        //div for UML footer
+        str += `<div class='uml-footer' style='margin-top: ${-8 * zoomfact}px;'>`;
         //Draw UML-footer if there exist at least one function
         if (elemFunc != 0) {
-            //div for UML footer
-            str += `<div class='uml-footer' style='margin-top: ${-8 * zoomfact}px;'>`;
             //svg for background
             str += `<svg width='${boxw}' height='${boxh * elemFunc}'>`;
             str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh * elemFunc - (linew * 2)}'
@@ -5991,11 +5990,8 @@ function drawElement(element, ghosted = false)
             }
             //end of svg for background
             str += `</svg>`;
-            //end of div for UML footer
-            str += `</div>`;
         }
-
-        //end of div for UML content
+        //end of div for UML footer
         str += `</div>`;
     }
     //Check if element is UMLRelation
@@ -6008,7 +6004,7 @@ function drawElement(element, ghosted = false)
             str += `z-index: 1;`;
         }
         if (ghosted) {
-            str += `pointer-events: none; opacity: ${ghostLine ? 0 : 0.5};`;
+            str += `pointer-events: none; opacity: ${ghostLine ? 0 : 0.0};`;
         }
         str += `'>`;
 


### PR DESCRIPTION
Things I have done:

- Updated the UML inheritance to remove the ghost (made it transparent)
- Removed the stroke color option in the options panel for all elements
- Removed the background color options in the options panel for UML inheritance element

Things to test:

- Check if the option to change the color of the stroke is not present in the options panel. Try with one element selected and multiple elements selected.
- Check if a ghost appears when placing the UML inheritance icon.
- With a UML inheritance icon selected, the options for background and stroke color should not appear in the options panel.  