### PR TITLE
possible fix for the file fetching problem

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -476,7 +476,7 @@ function createJSONString(formData) {
 	return JSON.stringify({
 		"type":formData[0].value,
 		"filelink":formData[1].value,
-		"diagram File":$("#file option:selected").text(),
+		"diagram_File":$("#file option:selected").text(),
 		"diagram_type":{ER:document.getElementById("ER").checked,UML:document.getElementById("UML").checked}, //<-- UML functionality
 		"extraparam":$('#extraparam').val(),
 		"submissions":submission_types,

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -1060,3 +1060,17 @@ function compare(a, b) {
 		return 0;
 	}	
 }
+
+function checkDiagramTypes(num){
+	if(num==0){
+		if(document.getElementById("UML").checked == false){
+			document.getElementById("ER").checked = true;
+		}
+	}
+	if(num==1){
+		if(document.getElementById("ER").checked == false){
+			document.getElementById("UML").checked = true;
+		}
+	}
+	$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));
+}

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -196,9 +196,9 @@ session_start();
                       <legend>Diagram types allowed</legend>
                       <div id="diagramTypesBox" style="display:flex;flex-wrap:wrap;flex-direction:row;">
                         <label for="ER">ER</label>
-                        <input type="checkbox" name="ER" id="ER" value="true" checked="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
+                        <input type="checkbox" name="ER" id="ER" value="true" checked="true" onchange="checkDiagramTypes(0);"/>
                         <label for="UML">UML</label>
-                        <input type="checkbox" name="UML" id="UML" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>  
+                        <input type="checkbox" name="UML" id="UML" value="true" onchange="checkDiagramTypes(1);"/>  
                       </div>
                     </fieldset>
                   </div>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -70,9 +70,12 @@
 	foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
 	{
 		$variantParams=$row['jparam'];
-		$start = strpos($variantParams, "diagram File&quot;:&quot;") + 25;
-		$end = strpos($variantParams, "&quot;:&quot;&quot;,&quot;diagram_type") - 177;
-		$splicedFileName = substr($variantParams, strpos($variantParams, "diagram File&quot;:&quot;") + 25, ($end - $start));
+		/* $start = strpos($variantParams, "diagram File&quot;:&quot;") + 25;
+		$end = strpos($variantParams, "&quot;:&quot;&quot;,&quot;diagram_type") - 176;
+		$splicedFileName = substr($variantParams, strpos($variantParams, "diagram File&quot;:") + 25, ($end - $start));*/
+		$variantParams = str_replace('&quot;','"',$variantParams);
+		$parameterArray = json_decode($variantParams,true);
+		$splicedFileName=$parameterArray["diagram_File"];
 	}
 	$response->closeCursor();
 


### PR DESCRIPTION
possible fix for the file fetching problem in issue #11920
changed the string split to fetching from an array with key.This branch is based of the presentation branch. Changed in showdugga.php at rows 73-79 and duggaed.js.
For testing:
- Start by uploading a diagram file if you haven't before.
- to upload a file:
- - log in as toddler
- - go to demo courses
- - click the electrical plug in the nav bar
- - press the yellow plus and select where you want your file (anywhere should work)
- - select your file
- - if you don't have a diagram json file:
- - 1. go to diagram dugga and change the diagram
- - 2. open options 
- - 3. click export
- - click the upload button
- change the diagram file of the currently enabled variant.
- to change variants:
- - log in as toddler 
- - go to demo courses 
- - press the paper icon in the nav bar
- - press the pen on the same row as the diagram dugga
- - if there is a enabled variant 
- - 1. Click the cogwheel on the same row as the variant
- - 2. Change diagram file(if you only have one diagram file you need to change something else or it won't update)
- - 3. Click update
- - if there isn't a enabled variant 
- - 1. Change diagram file(if you only have one diagram file you need to change something else or it won't update)
- - 2. Click create
- - 3. Click the cogwheel on the same row as the variant
- - 4. Click enable
- go to diagram dugga and se that the diagram is the same as the one in your file

If test passed speak with @c20emili when resolving conflicts.