### PR TITLE
Fixed escape disabling ruler

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3975,10 +3975,12 @@ function toggleRuler()
 
     // Toggle active ruler + color change of button to clarify if button is pressed or not
     if(settings.ruler.isRulerActive){
-        ruler.style.display = "none";
+        ruler.style.left = "-1000px";
+        ruler.style.top = "-1000px";
         rulerToggleButton.style.backgroundColor = "#614875";
     } else {
-        ruler.style.display = "block";
+        ruler.style.left = "50px";
+        ruler.style.top = "0px";
         rulerToggleButton.style.backgroundColor = "#362049";
 
     }


### PR DESCRIPTION
Fixed the problem where after the ruler has been toggled off and on pressing escape hides the ruler while the ruler is still active. #11885 

Instructions for testing:
1) Click "Demo-Course"
2) Click "Diagram Dugga"
3) Open "Options" (Yellow bar to the left of the diagram)
4) Click "Ruler" x2
5) Press ESC/Escape on the keyboard (The ruler souldn't disappear)