### PR TITLE
Added a check to only create an alert box if the user has clicked a button

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -2550,10 +2550,12 @@ var ClickCounter = {
 //if changes has been done a promt is made to ask user if they want to discard them.
 function addAlertOnUnload(){
 	window.onbeforeunload = function() {
-		try {
-			//add things here to run showing the popup for alerting someone that they got unsaved changes.
-			//for example storing stuff to localstorage.
-		}catch(e){}
-		return "Changes will be discarded by leaving page.";
+		if(ClickCounter.score > 0){
+			try {
+				//add things here to run showing the popup for alerting someone that they got unsaved changes.
+				//for example storing stuff to localstorage.
+			}catch(e){}
+			return "Changes will be discarded by leaving page.";
+		}
 	}
 }


### PR DESCRIPTION
Refreshing or leaving a dugga would warn the user that any unsaved changes may be lost even if no changes had been made. This message should now only appear if the user has clicked any of the dugga buttons at least once.

To test:

1. Open any dugga in the demo course.
2. Before clicking anything, refresh the page. There should not be a confirm message.
3. Click any button related to the dugga, then refresh the page. There should now be a confirm message.
4. Try other buttons unrelated to the dugga. There shouldn't be a confirm message when refreshing.