### PR TITLE
G3 2022 w5 #11956

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -363,7 +363,12 @@ function confirmBox(operation, item = null) {
 // Creates an array over all checked items
 function markedItems(item = null){
   var removed = false;
+  var kind = $(item).parents('tr').attr('value');
+    if(kind == "section"){
+      console.log(kind);
+    }
     active_lid = item ? $(item).parents('table').attr('value') : null;
+    console.log("Active lid: "+active_lid);
     if (hideItemList.length != 0){
       for( var i = 0; i < hideItemList.length; i++){ 
         if ( hideItemList[i] === active_lid) { 
@@ -831,7 +836,7 @@ function returnedSection(data) {
 
         // Content table
         str += `<table id='lid${item['lid']}' value='${item['lid']}' 
-        style='width:100%;table-layout:fixed;'><tr style='height:32px;' `;
+        style='width:100%;table-layout:fixed;'><tr value='${makeTextArray(item['kind'], valarr)}' style='height:32px;' `;
 
         if (kk % 2 == 0) {
           str += " class='hi' ";
@@ -1135,7 +1140,7 @@ function returnedSection(data) {
 
         //Generate new tab link
         str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
-          "code", "test", "moment", "link", "group", "message"])} $[hideState}'>`;
+          "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='width:16px;' alt='canvasLink icon' id='dorf' title='Open link in new tab' class='' 
           src='../Shared/icons/link-icon.svg' onclick='openCanvasLink(this);'>`;
           str += "</td>";
@@ -1143,7 +1148,7 @@ function returnedSection(data) {
         // Generate Canvas Link Button
         if (data['writeaccess'] || data['studentteacher']) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
-          "code", "test", "moment", "link", "group", "message"])} $[hideState}'>`;
+          "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='width:16px;' alt='canvasLink icon' id='dorf' title='Get Canvas Link' class='' 
           src='../Shared/icons/canvasduggalink.svg' onclick='showCanvasLinkBox(\"open\",this);'>`;
           str += "</td>";
@@ -1151,14 +1156,11 @@ function returnedSection(data) {
 
         // Cog Wheel
         if (data['writeaccess'] || data['studentteacher']) {
-          str += "<td style='width:32px;' ";
-
-          if (itemKind === 0) str += "class='header" + hideState + "' ";
-          if (itemKind === 1) str += "class='section" + hideState + "' ";
-          if (itemKind === 4) str += "class='moment" + hideState + "' ";
+          str += `<td style='width:32px;' class='${makeTextArray(itemKind,
+            ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
 
 
-          str += "><img alt='settings icon' id='dorf' title='Settings' class='' src='../Shared/icons/Cogwheel.svg' ";
+          str += "<img alt='settings icon' id='dorf' title='Settings' class='' src='../Shared/icons/Cogwheel.svg' ";
           str += " onclick='selectItem(" + makeparams([item['lid'], item['entryname'],
           item['kind'], item['visible'], item['link'], momentexists, item['gradesys'],
           item['highscoremode'], item['comments'], item['grptype'], item['deadline'], item['relativedeadline'],
@@ -1169,7 +1171,7 @@ function returnedSection(data) {
         // Trashcan
         if (data['writeaccess'] || data['studentteacher']) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
-          "code", "test", "moment", "link", "group", "message"])} $[hideState}'>`;
+          "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img alt='trashcan icon' id='dorf' title='Delete item' class='' 
           src='../Shared/icons/Trashcan.svg' onclick='confirmBox(\"openConfirmBox\", this);'>`;
           str += "</td>";
@@ -1177,8 +1179,8 @@ function returnedSection(data) {
 
         // Checkbox
         if (data['writeaccess'] || data['studentteacher']) {
-          str += `<td style='width:25px;' class='" + makeTextArray(itemKind,
-            ["header", "section", "code", "test", "moment", "link", "group", "message"]) + " ${hideState}'>`;
+          str += `<td style='width:25px;' class='${makeTextArray(itemKind,
+            ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
             str += "<input type='checkbox' id='"+ item['lid'] + "-checkbox" + "' title='"+item['entryname'] + " - checkbox"+"' onclick='markedItems(this)'>";
             str += "</td>";      
         }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -363,11 +363,32 @@ function confirmBox(operation, item = null) {
 // Creates an array over all checked items
 function markedItems(item = null){
   var removed = false;
-  var kind = $(item).parents('tr').attr('value');
-    if(kind == "section"){
-      console.log(kind);
+  var kind = item ? $(item).parents('tr').attr('value') : null;
+  active_lid = item ? $(item).parents('table').attr('value') : null;
+  var subItems = [];
+
+    //if the checkbox belongs to one of these kinds then all elements below it should also be selected.
+    if(kind == "section" || kind == "moment"){
+      var itemInSection = true;
+      var sectionStart = false;
+      
+      $("#Sectionlist").find(".item").each(function (i) {
+        var tempItem = $(this).attr('value');
+        if(itemInSection && sectionStart){
+          var tempKind = $(this).parents('tr').attr('value');
+          if(tempKind == "section" || tempKind == "moment" || tempKind == "header"){
+            itemInSection = false;
+            //console.log("loop breaker: "+tempItem);
+          }else{
+            subItems.push(tempItem);
+            //console.log("added: "+tempItem);
+          } 
+        }else if(tempItem==active_lid) sectionStart=true;
+      });
+
     }
-    active_lid = item ? $(item).parents('table').attr('value') : null;
+
+    
     console.log("Active lid: "+active_lid);
     if (hideItemList.length != 0){
       for( var i = 0; i < hideItemList.length; i++){ 
@@ -377,13 +398,25 @@ function markedItems(item = null){
           var removed = true;
           console.log("Removed from list");
         }   
+        for(var j = 0; j < subItems.length; j++){
+          if ( hideItemList[i] === subItems[j]) { 
+            hideItemList.splice(i, 1);
+            //console.log(subItems[j]+" Removed from list");
+          }
+        }
       } if(removed != true){
         hideItemList.push(active_lid);
         console.log("Adding !empty list");
+        for(var j = 0; j < subItems.length; j++){
+          hideItemList.push(subItems[j]);
+        }
       }
     } else {
       hideItemList.push(active_lid);
       console.log("Added");
+      for(var j = 0; j < subItems.length; j++){
+        hideItemList.push(subItems[j]);
+      }
     } 
     console.log(hideItemList);
 }
@@ -1002,7 +1035,7 @@ function returnedSection(data) {
         }
 
         // Close Information
-        str += "  onclick='duggaRowClick(this)' >";
+        str += " value='"+item['lid']+"' onclick='duggaRowClick(this)' >";
         // Content of Section Item
         if (itemKind == 0) {
           // Header


### PR DESCRIPTION
Commit 1: Fixed the incorrect syntax for creating class names and some steps to solve this issue.
Commit 2: Made it so that the checkbox for the section and moment kinds also adds all the elements under them to the hideItemList. Still need to fix the visual for this problem since there is no indication that the sub elements are selected.

Website + console view of solution.
![checkbox_gui](https://user-images.githubusercontent.com/102533453/166256459-958e3e64-8f39-45b9-92a5-3c614db77f6b.png)


Selecting and unselecting items.
![working_checkbox_option](https://user-images.githubusercontent.com/102533453/166256479-7f1f5375-aec1-46c0-bada-95587a089d84.png)


The incorrect class syntax:
![bad_syntax](https://user-images.githubusercontent.com/102533453/166257914-13290992-a012-4255-84d3-2ef1df59a693.png)


The syntax fix: (There is an empty space afterwards because the value hideState is null when not hidden. When hidden it will be something like class="section hidden")
![better_syntax](https://user-images.githubusercontent.com/102533453/166257922-71bb1d46-35a5-4c37-af0c-269d3d68c2ef.png)
