### PR TITLE
Updated cursor style with responsive behavior in diagram.js #12001

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -903,7 +903,8 @@ var selectionBoxHighX;
 var selectionBoxLowY;
 var selectionBoxHighY;
 var lastClickedElement = null;
-
+var mouseOverElement = false;
+var mouseOverLine = false;
 
 // Zoom variables
 var desiredZoomfact = 1.0;
@@ -1702,6 +1703,7 @@ function mdown(event)
                             targetElementDiv = document.getElementById(targetElement.id);
                         } else {
                             pointerState = pointerStates.CLICKED_CONTAINER;
+                            cursorStyle.cursor = "grabbing";
                             if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
                                 wasDblClicked = true;
                                 document.getElementById("options-pane").className = "hide-options-pane";
@@ -1711,6 +1713,7 @@ function mdown(event)
                     }
                     else {
                         pointerState = pointerStates.CLICKED_CONTAINER;
+                        cursorStyle.cursor = "grabbing";
                         if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
                             wasDblClicked = true;
                             document.getElementById("options-pane").className = "hide-options-pane";
@@ -1887,6 +1890,7 @@ function mouseMode_onMouseUp(event)
 
  function tup(event) 
  {
+     mouseButtonDown = false;
      pointerState = pointerStates.DEFAULT;
      deltaExceeded = false;
  }
@@ -1899,8 +1903,10 @@ function mouseMode_onMouseUp(event)
 
 function mup(event)
 {
+    if(!mouseOverLine && !mouseOverElement){
+        setCursorStyles(mouseMode);
+    }
     mouseButtonDown = false;
-
     targetElement = null;
     deltaX = startX - event.clientX;
     deltaY = startY - event.clientY;
@@ -1974,6 +1980,23 @@ function mup(event)
 }
 
 /**
+ * @description change cursor style when mouse hovering over an element.
+ */
+function mouseEnter(){
+    if(!mouseButtonDown){
+        mouseOverElement = true;
+        cursorStyle.cursor = "pointer";
+    }
+}
+
+/**
+ * @description change cursor style when mouse is hovering over the container.
+ */
+function mouseLeave(){
+    mouseOverElement = false;
+    setCursorStyles(mouseMode);
+}
+/**
 
  * @description Calculates if any line or label is present on x/y position in pixels.
 
@@ -1992,6 +2015,29 @@ function checkDeleteBtn(){
     
             updateSelection();
         }
+    }
+}
+/**
+ *  @description change cursor style if mouse position is over a selection box or the deletebutton.
+ */
+function mouseOverSelection(mouseX, mouseY){
+    if(context.length > 0 || contextLine.length > 0){
+        // If there is a selection box and mouse position is inside it.
+        if (mouseX > selectionBoxLowX && mouseX < selectionBoxHighX && mouseY > selectionBoxLowY && mouseY < selectionBoxHighY){
+            cursorStyle.cursor = "pointer";
+        }
+        // If mouse position is over the delete button.
+        else if (mouseX > deleteBtnX && mouseX < (deleteBtnX + deleteBtnSize) && mouseY > deleteBtnY && mouseY < (deleteBtnY + deleteBtnSize)){
+            cursorStyle.cursor = "pointer";
+        }
+        // Not inside selection box, nor over an element or line.
+        else if(!mouseOverElement && !mouseOverLine){
+            setCursorStyles(mouseMode);
+        }
+    }
+    // There is no selection box, and mouse position is not over any element or line.
+    else if(!mouseOverElement && !mouseOverLine){
+        setCursorStyles(mouseMode);
     }
 }
 
@@ -2141,12 +2187,18 @@ function didClickLine(a, b, c, circle_x, circle_y, circle_radius, line_data)
          return false
      }
  }
-
 /**
  * @description Called on mouse moving if no pointer state has blocked the event in mmoving()-function.
  */
 function mouseMode_onMouseMove(event)
 {
+    mouseOverLine = determineLineSelect(event.clientX, event.clientY);
+    // Change cursor style if mouse pointer is over a line.
+    if(mouseOverLine && !mouseButtonDown){
+        cursorStyle.cursor = "pointer";
+    } else if(!mouseOverElement){
+        setCursorStyles(mouseMode);
+    }
      switch (mouseMode) {
         case mouseModes.EDGE_CREATION:
         case mouseModes.PLACING_ELEMENT:
@@ -2166,12 +2218,14 @@ function mouseMode_onMouseMove(event)
             }
             break;
 
-        case mouseModes.POINTER: // do nothing
+        case mouseModes.POINTER:
+            mouseOverSelection(event.clientX, event.clientY);
             break;
             
         case mouseModes.BOX_SELECTION:
             boxSelect_Update(event.clientX, event.clientY);
             updatepos(0, 0);
+            mouseOverSelection(event.clientX, event.clientY);
             break;
             
         default:
@@ -3169,7 +3223,7 @@ function setCursorStyles(cursorMode = mouseModes.POINTER)
 
     switch(cursorMode) {
         case mouseModes.POINTER:
-            cursorStyle.cursor = "pointer";
+            cursorStyle.cursor = "grab";
             break;
         case mouseModes.BOX_SELECTION:
             cursorStyle.cursor = "crosshair";
@@ -3178,7 +3232,7 @@ function setCursorStyles(cursorMode = mouseModes.POINTER)
             cursorStyle.cursor = "default";
             break;
         case mouseModes.EDGE_CREATION:
-            cursorStyle.cursor = "grab";
+            cursorStyle.cursor = "default";
             break;
         default:
             break;
@@ -5938,7 +5992,7 @@ function drawElement(element, ghosted = false)
         elemAttri = element.attributes.length;
         elemFunc = element.functions.length;
         //div to encapuslate UML element
-        str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' 
+        str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
         style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
@@ -6001,7 +6055,7 @@ function drawElement(element, ghosted = false)
     //Check if element is UMLRelation
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
-        str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' 
+        str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
         style='left:0px; top:0px; width:${boxw}px;height:${boxh}px;`;
 
         if(context.includes(element)){
@@ -6034,7 +6088,7 @@ function drawElement(element, ghosted = false)
     else {
         // Create div & svg element
         str += `
-                    <div id='${element.id}'	class='element' onmousedown='ddown(event);' style='
+                    <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
                             width:${boxw}px;


### PR DESCRIPTION
Changed cursor to "grab" for Pointer mousemode.
Changed cursor to "default" for Edge_creation mousemode.
Cursor switches to "pointer" when mouse hovers over elements and lines in all mousemodes.
Cursor switches to "pointer" when mouse hovers over selection box and delete button for Pointer and Selection_box mousemodes.
Cursor switches from "grab" to "grabbing" when moving the canvas for Pointer mousemode.