### PR TITLE
Made columns sizes remain consistent when searching. Changed code related to the alternating row colors.

### DIFF
--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -395,6 +395,7 @@ function SortableTable(param)
     	// Render table body
     	str += "<tbody id='"+this.tableid+DELIMITER+"body'>";
     	mhvstr += "<tbody id='"+this.tableid+DELIMITER+"mhvbody'>";
+      var n = 0;
     	for (var i = 0; i < tbl.tblbody.length; i++) {
           str += "<tr id='"+this.tableid+DELIMITER+i+"'"
           if (this.hasRowHighlight)str+=" onmouseover='rowHighlightInternal(event,this)' onmouseout='rowDeHighlightInternal(event,this)'";
@@ -404,11 +405,17 @@ function SortableTable(param)
           // Not adding this data would make the columns change size every time the table is changed.
           var row = tbl.tblbody[i];
           if (rowFilter(row)) {
-            str += " style='box-sizing:border-box'>";
+            str += " style='box-sizing:border-box";
+            // Alternate row colors
+            if(++n%2)
+            {
+              str += ";background: #ccc"; // --color-background-2;
+            }
           }
           else {
-            str += " style='visibility:collapse'>";
+            str += " style='visibility:collapse";
           }
+          str += "'>";
 
           mhvstr += "<tr id='"+this.tableid+DELIMITER+i+DELIMITER+"mhv' onmouseover='rowHighlightInternal(event,this)' onmouseout='rowDeHighlightInternal(event,this)' style='box-sizing:border-box'>";
 

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -396,52 +396,60 @@ function SortableTable(param)
     	str += "<tbody id='"+this.tableid+DELIMITER+"body'>";
     	mhvstr += "<tbody id='"+this.tableid+DELIMITER+"mhvbody'>";
     	for (var i = 0; i < tbl.tblbody.length; i++) {
-      		var row = tbl.tblbody[i];
-      		if (rowFilter(row)) {
-              str += "<tr id='"+this.tableid+DELIMITER+i+"'"
-              if (this.hasRowHighlight)str+=" onmouseover='rowHighlightInternal(event,this)' onmouseout='rowDeHighlightInternal(event,this)'";
-              str+=" style='box-sizing:border-box'>";
-              mhvstr += "<tr id='"+this.tableid+DELIMITER+i+DELIMITER+"mhv' onmouseover='rowHighlightInternal(event,this)' onmouseout='rowDeHighlightInternal(event,this)' style='box-sizing:border-box'>";
+          str += "<tr id='"+this.tableid+DELIMITER+i+"'"
+          if (this.hasRowHighlight)str+=" onmouseover='rowHighlightInternal(event,this)' onmouseout='rowDeHighlightInternal(event,this)'";
 
-        			// Add Counter cell to the row. The class <tableid>_counter can be used to style the counterText
-        			if(this.hasCounter) {
-                  str += "<td style='white-space:nowrap;' onclick='clickedInternal(event,this);' class='" + this.tableid + DELIMITER+"counter'><span>"+ this.rowIndex +"</span></td>";
-                  mhvstr += "<td style='white-space:nowrap;' onclick='clickedInternal(event,this);' class='" + this.tableid + DELIMITER+"counter'><span>"+ this.rowIndex++ +"</span></td>";
-              }
-        			result++;
-              for(var columnOrderIdx=0;columnOrderIdx<columnOrder.length;columnOrderIdx++){
-        				if (columnfilter[columnOrderIdx] !== null) {
-                    // check if this column is a row-sum column
-                    for (let j=0;j<rowsumList.length;j++){                      
-                        if (columnOrder[columnOrderIdx].indexOf(rowsumList[j][0]['id'])>-1) {
-                            tbl.tblbody[i][columnOrder[columnOrderIdx]]=0;
-                            for(let k=1;k<rowsumList[j].length;k++){                                
-                                if (typeof(tbl.tblbody[i][rowsumList[j][k].substring(0,rowsumList[j][k].indexOf('.'))])==='object'){
-                                    tbl.tblbody[i][columnOrder[columnOrderIdx]]+=parseFloat(byString(tbl.tblbody[i][rowsumList[j][k].substring(0,rowsumList[j][k].indexOf('.'))],rowsumList[j][k]));
-                                }else{
-                                    tbl.tblbody[i][columnOrder[columnOrderIdx]]+=parseFloat(tbl.tblbody[i][rowsumList[j][k]]);
-                                } 
-                                
-                            }                  						
-                        }
-                    }
-                  
-          					// This condition is true if column is in summing list and in that case perform the sum like a BOSS
-          					if (colsumList.indexOf(columnOrder[columnOrderIdx]) >- 1) {
-            						if (typeof(sumContent[columnOrder[columnOrderIdx]]) == "undefined") sumContent[columnOrder[columnOrderIdx]]=0;
-            						sumContent[columnOrder[columnOrderIdx]]+=sumFunc(columnOrder[columnOrderIdx],tbl.tblbody[i][columnOrder[columnOrderIdx]],row);
-          					}
-                      
-                    var cellid = "r"+i+DELIMITER+this.tableid+DELIMITER+columnOrder[columnOrderIdx];
-          					str += "<td style='white-space:nowrap;' id='"+cellid+"' onclick='clickedInternal(event,this);' class='"+this.tableid+"-"+columnOrder[columnOrderIdx]+"'>"+renderCell(columnOrder[columnOrderIdx],tbl.tblbody[i][columnOrder[columnOrderIdx]],cellid)+"</td>";  
-                    if(columnOrderIdx<freezePaneIndex){
-                        mhvstr+="<td style='white-space:nowrap;' id='"+cellid+DELIMITER+"mhv' onclick='clickedInternal(event,this);' class='"+this.tableid+"-"+columnOrder[columnOrderIdx]+"'>"+renderCell(columnOrder[columnOrderIdx],tbl.tblbody[i][columnOrder[columnOrderIdx]],cellid)+"</td>";  
-                    }
-        				}
-      			}
-      			str += "</tr>";
-      			mhvstr += "</tr>";
+          // Hide filtered rows
+          // Filtered data is loaded into the table in order to keep column widths the same.
+          // Not adding this data would make the columns change size every time the table is changed.
+          var row = tbl.tblbody[i];
+          if (rowFilter(row)) {
+            str += " style='box-sizing:border-box'>";
           }
+          else {
+            str += " style='visibility:collapse'>";
+          }
+
+          mhvstr += "<tr id='"+this.tableid+DELIMITER+i+DELIMITER+"mhv' onmouseover='rowHighlightInternal(event,this)' onmouseout='rowDeHighlightInternal(event,this)' style='box-sizing:border-box'>";
+
+          // Add Counter cell to the row. The class <tableid>_counter can be used to style the counterText
+          if(this.hasCounter) {
+              str += "<td style='white-space:nowrap;' onclick='clickedInternal(event,this);' class='" + this.tableid + DELIMITER+"counter'><span>"+ this.rowIndex +"</span></td>";
+              mhvstr += "<td style='white-space:nowrap;' onclick='clickedInternal(event,this);' class='" + this.tableid + DELIMITER+"counter'><span>"+ this.rowIndex++ +"</span></td>";
+          }
+          result++;
+          for(var columnOrderIdx=0;columnOrderIdx<columnOrder.length;columnOrderIdx++){
+            if (columnfilter[columnOrderIdx] !== null) {
+                // check if this column is a row-sum column
+                for (let j=0;j<rowsumList.length;j++){                      
+                    if (columnOrder[columnOrderIdx].indexOf(rowsumList[j][0]['id'])>-1) {
+                        tbl.tblbody[i][columnOrder[columnOrderIdx]]=0;
+                        for(let k=1;k<rowsumList[j].length;k++){                                
+                            if (typeof(tbl.tblbody[i][rowsumList[j][k].substring(0,rowsumList[j][k].indexOf('.'))])==='object'){
+                                tbl.tblbody[i][columnOrder[columnOrderIdx]]+=parseFloat(byString(tbl.tblbody[i][rowsumList[j][k].substring(0,rowsumList[j][k].indexOf('.'))],rowsumList[j][k]));
+                            }else{
+                                tbl.tblbody[i][columnOrder[columnOrderIdx]]+=parseFloat(tbl.tblbody[i][rowsumList[j][k]]);
+                            } 
+                            
+                        }                  						
+                    }
+                }
+              
+                // This condition is true if column is in summing list and in that case perform the sum like a BOSS
+                if (colsumList.indexOf(columnOrder[columnOrderIdx]) >- 1) {
+                    if (typeof(sumContent[columnOrder[columnOrderIdx]]) == "undefined") sumContent[columnOrder[columnOrderIdx]]=0;
+                    sumContent[columnOrder[columnOrderIdx]]+=sumFunc(columnOrder[columnOrderIdx],tbl.tblbody[i][columnOrder[columnOrderIdx]],row);
+                }
+                  
+                var cellid = "r"+i+DELIMITER+this.tableid+DELIMITER+columnOrder[columnOrderIdx];
+                str += "<td style='white-space:nowrap;' id='"+cellid+"' onclick='clickedInternal(event,this);' class='"+this.tableid+"-"+columnOrder[columnOrderIdx]+"'>"+renderCell(columnOrder[columnOrderIdx],tbl.tblbody[i][columnOrder[columnOrderIdx]],cellid)+"</td>";  
+                if(columnOrderIdx<freezePaneIndex){
+                    mhvstr+="<td style='white-space:nowrap;' id='"+cellid+DELIMITER+"mhv' onclick='clickedInternal(event,this);' class='"+this.tableid+"-"+columnOrder[columnOrderIdx]+"'>"+renderCell(columnOrder[columnOrderIdx],tbl.tblbody[i][columnOrder[columnOrderIdx]],cellid)+"</td>";  
+                }
+            }
+        }
+        str += "</tr>";
+        mhvstr += "</tr>";
     	}
     	str += "</tbody>";
       mhvstr += "</tbody>";

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -407,8 +407,7 @@ function SortableTable(param)
           if (rowFilter(row)) {
             str += " style='box-sizing:border-box";
             // Alternate row colors
-            if(++n%2)
-            {
+            if(++n%2){
               str += ";background: #ccc"; // --color-background-2;
             }
           }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3219,9 +3219,11 @@ div.submit-button:disabled {
   padding: 0px;
 }
 
+/*
 .list tbody tr:nth-child(odd) {
   background-color: var(--color-background-2);
 }
+*/
 
 .list#testTable tr:nth-child(odd),
 .list#testTable tr:nth-child(even) {


### PR DESCRIPTION
Fixed the issue of columns changing sizes when searching by hiding filtered columns rather than removing them. Fixed a subsequent issue caused by this change that alternates the row colors with javascript code directly rather than using code in style.css. This appears to work well for duggaed.php, fileed.php, and resulted.php, but further testing may be necessary to prevent unintended bugs.

To test:
1. Go to any table that can be filtered by typing in the search bar (ex. duggaed.php)
2. Enter a search term. The column sizes should remain the same when the table updates. Note that the table width itself may change size if a scroll bar appears/disappears in the browser window as a result of the change in size of the table. This could be a separate issue but may be unavoidable.
3. Look at the row colors. The colors should alternate between grey and white.