### PR TITLE
Made it possible to search multiple columns

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -874,15 +874,36 @@ function renderSortOptionsVariant(col,status,colname) {
 
 //Filtering duggas from the searchfield.
 function duggaFilter(row) {
-	if (row.qname.toLowerCase().indexOf(searchterm.toLowerCase()) != -1){
-		return true;
-	}
-	else if (row.quizFile.toLowerCase().indexOf(searchterm.toLowerCase()) != -1){
-		return true;
-	}
-	else{
-		return false;
-	}
+	var regex = new RegExp('(.*)::(.*)');
+    // Split the searchterm at each &&
+    var splitSearch = searchterm.split("&&");
+
+    var tempSearchTerm;
+    var columnToSearch;
+
+    // Loop through each searchterms. If there is a match set "match" to true.
+    // If "match" is false at the end of an iteration return false since there wasn't a match.
+    for (var i = 0; i < splitSearch.length; i++) {
+        tempSearchTerm = splitSearch[i].trim().match(regex);
+        var match = false;
+        if (tempSearchTerm != null && tempSearchTerm.length > 1) {
+            columnToSearch = tempSearchTerm[1].toLowerCase();
+            tempSearchTerm = tempSearchTerm[2];
+            if (row[columnToSearch].toUpperCase().indexOf(tempSearchTerm.toUpperCase()) != -1) match = true;
+            
+        } else {
+            tempSearchTerm = splitSearch[i].trim();
+            for (var key in row) {
+                if (row[key] != null) {
+                    if (row[key].toString().toUpperCase().indexOf(tempSearchTerm.toUpperCase()) != -1) match = true;
+                    
+                }
+            }
+
+        }
+        if (!match) return false;
+    }
+    return true;
 }
 
 //Filtering variants from the searchfield.


### PR DESCRIPTION
Added the functionality to search in columns other than qname and quizFile. It should now work for columns `"did(index)", "Name", "Template", "Deadline", "Result date", "Last modified"`. It might also work for `"Autograde", "Gradesystem" and "Startdate"` but i couldn't test it because the values in those rows were null on the page i tested. When searching it looks for all matches in any of the columns so it can match the term "dugga" with both the name and template column. It also possible for search for multiple terms using "&&" for example `"dugga&&html"`.
![search_dugga](https://user-images.githubusercontent.com/102533453/166439015-a6878d28-68a0-4d42-951d-6a70fcd7412c.png)

Code is taken from `function rowFilter(row) {` in **filled.js.**