### PR TITLE
New feature Relative deadlines

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -189,6 +189,7 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
     $("#relativedeadlinetype").html(makeoptions(splitdeadline[1],typeArrOptions,typeArrValue));
 
     if (relativedeadline !== "null") {
+      console.log(calculateRelativeDeadline(splitdeadline), new Date(deadline));
       if (calculateRelativeDeadline(splitdeadline).getTime() !== new Date(deadline).getTime()) {
         checkDeadlineCheckbox($("#absolutedeadlinecheck"), true);
       } else {
@@ -307,7 +308,6 @@ function calculateRelativeDeadline(rDeadline) {
   newDeadline.setDate(newDeadline.getDate() + daysToAdd);
   newDeadline.setHours(parseInt(rDeadline[2]));
   newDeadline.setMinutes(parseInt(rDeadline[3]));
-  console.log(newDeadline);
   return newDeadline;
 }
 
@@ -517,11 +517,12 @@ function prepareItem() {
   // If absolute deadline is not checked, always use relative deadline
   if (!$('#absolutedeadlinecheck').prop('checked')) {
     var relativeDeadline = new Date(calculateRelativeDeadline(param.relativedeadline.split(":")));
-    var rDeadlineArr = relativeDeadline.toISOString().toString().split("T");
-    var newDeadline = rDeadlineArr[0] + " " + $("#relativedeadlinehours").val()+":"+$("#relativedeadlineminutes").val();
+    var rDeadlineArr = relativeDeadline.toLocaleDateString().split("/");
+    var newDeadline = rDeadlineArr[2] + "-" + rDeadlineArr[0]+ "-" + rDeadlineArr[1] + " " + $("#relativedeadlinehours").val()+":"+$("#relativedeadlineminutes").val();
+    
     param.deadline = newDeadline;
-    console.log(param.deadline);
   }
+
   if ($('#fdbck').prop('checked')){
     param.feedback = 1;
     param.feedbackquestion = $("#fdbckque").val();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -194,6 +194,8 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
       } else {
         checkDeadlineCheckbox($("#absolutedeadlinecheck"), false);
       }
+    } else {
+      checkDeadlineCheckbox($("#absolutedeadlinecheck"), true);
     }
   }
   var groups = [];

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -190,9 +190,9 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
 
     if (relativedeadline !== "null") {
       if (calculateRelativeDeadline(splitdeadline).getTime() !== new Date(deadline).getTime()) {
-        deadlineCheckbox($("#absolutedeadlinecheck"), true);
+        checkDeadlineCheckbox($("#absolutedeadlinecheck"), true);
       } else {
-        deadlineCheckbox($("#absolutedeadlinecheck"), false);
+        checkDeadlineCheckbox($("#absolutedeadlinecheck"), false);
       }
     }
   }
@@ -268,7 +268,7 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
 }
 
 // Handles the logic behind the checkbox for absolute deadline
-function deadlineCheckbox(e, check) {
+function checkDeadlineCheckbox(e, check) {
 
   if (check !== undefined) e.checked = check;
 
@@ -303,7 +303,6 @@ function calculateRelativeDeadline(rDeadline) {
       var daysToAdd = parseInt(rDeadline[0]);
       break;
   }
-  // var daysToAdd = rDeadline[0] * 7 + parseInt(rDeadline[1]);
   var newDeadline = new Date(retdata['startdate']);
   newDeadline.setDate(newDeadline.getDate() + daysToAdd);
   newDeadline.setHours(parseInt(rDeadline[2]));

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -189,7 +189,6 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
     $("#relativedeadlinetype").html(makeoptions(splitdeadline[1],typeArrOptions,typeArrValue));
 
     if (relativedeadline !== "null") {
-      console.log(calculateRelativeDeadline(splitdeadline), new Date(deadline));
       if (calculateRelativeDeadline(splitdeadline).getTime() !== new Date(deadline).getTime()) {
         checkDeadlineCheckbox($("#absolutedeadlinecheck"), true);
       } else {
@@ -2684,7 +2683,7 @@ function validateDate(startDate, endDate, dialogID) {
 
 function showCourseDate(ddate, dialogid){
   var isCorrect = validateDate2(ddate,dialogid);
-  var startdate = new Date(retdata['startdate']);;
+  var startdate = new Date(retdata['startdate']);
   var enddate = new Date(retdata['enddate']);
   var startdate = new String(startdate.getFullYear()+ "-" + startdate.getMonth() + "-" + startdate.getDate());
   var enddate = new String(enddate.getFullYear()+ "-" + ("0" + enddate.getMonth()).slice(-2) + "-" + ("0" + enddate.getDate()).slice(-2));
@@ -2697,32 +2696,40 @@ function showCourseDate(ddate, dialogid){
 function validateDate2(ddate, dialogid) {
   var inputDeadline = document.getElementById("inputwrapper-deadline");
   if (window.getComputedStyle(inputDeadline).display !== "none") {
-  
-  var ddate = document.getElementById(ddate);
-  var x = document.getElementById(dialogid);
-  var deadline = new Date(ddate.value);
-  // Dates from database
-  var startdate = new Date(retdata['startdate']);
-  var enddate = new Date(retdata['enddate']);
+    var ddate = document.getElementById(ddate);
+    var x = document.getElementById(dialogid);
+    var deadline = new Date(ddate.value);
+    // Dates from database
+    var startdate = new Date(retdata['startdate']);
+    var enddate = new Date(retdata['enddate']);
 
-  // If deadline is between start date and end date
-  if (startdate < deadline && enddate > deadline) {
-    ddate.style.borderColor = "#383";
-    ddate.style.borderWidth = "2px";
-    x.style.display = "none";
-    window.bool8 = true;
+    // If absolute deadline is not being used
+    if (!$("#absolutedeadlinecheck").is(":checked")) {
+      ddate.style.borderWidth = "0px";
+      x.style.display = "none";
+      window.bool8 = true;
 
-    return true;
-  } else {
-
-    ddate.style.borderColor = "#E54";
-    x.style.display = "block";
-    ddate.style.borderWidth = "2px";
-    window.bool8 = false;
+      return true;
 
     }
-  }
-  else{
+
+    // If deadline is between start date and end date
+    if (startdate < deadline && enddate > deadline) {
+      ddate.style.borderColor = "#383";
+      ddate.style.borderWidth = "2px";
+      x.style.display = "none";
+      window.bool8 = true;
+
+      return true;
+    } else {
+
+      ddate.style.borderColor = "#E54";
+      x.style.display = "block";
+      ddate.style.borderWidth = "2px";
+      window.bool8 = false;
+
+    }
+  } else {
     window.bool8 = true;
   }
   return false;

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -242,7 +242,7 @@
 								<input onchange="showCourseDate('setDeadlineValue','dialog8')" class='textinput' type='date' id='setDeadlineValue' value='' />
 								<select style='width:55px;' id='deadlineminutes'></select>
 								<select style='width:55px;' id='deadlinehours'></select>
-								<input type='checkbox' id='absolutedeadlinecheck' style='margin:3px 5px; height:20px' onclick='deadlineCheckbox(this)'/>
+								<input type='checkbox' id='absolutedeadlinecheck' style='margin:3px 5px; height:20px' onclick='checkDeadlineCheckbox(this)'/>
 							</span>
 							<br />
 							<span>Relative</span>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -239,15 +239,16 @@
 							<legend><h3>Deadline</h3></legend>
 							<span>Absolute</span>
 							<span style='float:right'>
-								<input onchange="showCourseDate('setDeadlineValue','dialog8');quickValidateForm('editSection', 'saveBtn');" class='textinput' type='date' id='setDeadlineValue' value='' />
+								<input onchange="showCourseDate('setDeadlineValue','dialog8')" class='textinput' type='date' id='setDeadlineValue' value='' />
 								<select style='width:55px;' id='deadlineminutes'></select>
 								<select style='width:55px;' id='deadlinehours'></select>
+								<input type='checkbox' id='absolutedeadlinecheck' style='margin:3px 5px; height:20px' onclick='deadlineCheckbox(this)'/>
 							</span>
 							<br />
 							<span>Relative</span>
 							<span style='float:right'>
-								<select style='width:140px;' id='relativedeadlineweekdays'></select>
-								<select style='width:55px;' id='relativedeadlineweeks'></select>
+								<select style='width:140px;' id='relativedeadlinetype'></select>
+								<select style='width:55px;' id='relativedeadlineamount'></select>
 								<select style='width:55px;' id='relativedeadlineminutes'></select>
 								<select style='width:55px;' id='relativedeadlinehours'></select>
 							</span>


### PR DESCRIPTION
## Relative Deadlines

The relative deadline calculates a deadline from the course start up until the amount of time you pick. So if the course starts at 2020-05-01 and you pick 2 weeks as the relative deadline then this dugga will have its deadline set to 2020-05-01 plus 14 days. This is, in general, what relative deadlines do.

The relative deadlines are chosen through the menu that appears when you press the cogwheel(logged in as a teacher) on a dugga or quiz. You'll then have the option to choose a time, a amount, and a type to store in the database for this particular dugga.

- Time = Hour and minute of the day
- Amount = Amount of the type
- Type = Days, Weeks or Months

Currently, what happens behind the scenes is that you'll have the option to choose absolute deadlines(as it was before) if you want by ticking a checkbox next to the absolute deadline date picker as the picture below shows. Doing this, this will then override the relative deadline. The relative deadline will still be stored and saved but the absolute deadline will be used as it was prior to the implementation of relative deadlines.

![image](https://user-images.githubusercontent.com/82010032/166444226-1ee6354b-4fc4-42fa-b8b2-af45130c81cb.png)

When the site loads, a check will be made whether the relative deadline and the absolute deadline are the same or not. If they are the same, the websites assume that the relative should be used and shows a unchecked absolute deadline. If these two dates differ, then it will show as the above picture show. When a teacher then clicks save, the website will check whether the absolute deadline checkbox is checked, if it isn't then it will override the deadline datepicker date with the previously calculated relative deadline and then store that data in the database. This way, we can assure ourselves with the fact that relative deadlines will never cause any issue with how the deadlines are being used in any other part of the website. All we're essentially doing is changing what deadline should be stored prior to storing it. This also gives the flexibility for relative deadlines to be stored in a json format as a string and retrieved and read after the fetching has happened, so we could potentially store many other variables to do with relative deadlines that has not to do with a date. 

Keep in mind that currently, all relative deadlines will be NULL once you re-install the database and I choose to automatically pick absolute deadline if the relative deadline is NULL and therefore when you click on the cogwheel for the first time for each dugga, it will always pick absolute deadline. Reasoning behind this is that I didn't want to disrupt any ongoing deadlines by overriding the current deadline. Once you uncheck the absolute deadline checkbox and save it, it should pick the relative deadline over the absolute one.

If we're ever storing deadlines outside of the sectioned.js file then maybe there would be some issues but as far as I've seen, there is no ajax requests besides the one I've been working with that handles deadlines and that one only points to sectionedservice.php which is the file that handles all SQL requests to the database.

Just to emphasize:
These changes *do not* interfere with the current logic with comparing absolute deadline validation for it being within the course dates or not. 

They *do not* interfere with how the deadlines are being stored in the database.

They *do not* interfere with how the deadline are being handled subsequent any deadline being fetched from the database.

### Tests
In order to test this, I would simply play around with deadlines and see which one is being picked after saving a dugga.
Here's a few tests that can be made:

**Remember to re-install the DB by running install.php if you didn't do that since last merge.**

- Open any dugga through the cogwheel menu and change the relative deadline. Press save and open again(can be done without refreshing the site) and check whether your change persisted or not.
- Open any dugga through the cogwheel menu and change both relative and absolute deadline by checking the absolute checkbox. Then proceed to save and open the same dugga again to see whether the absolute deadline checkbox is checked or not and if the dates are the dates you previously picked.
- Open any dugga through the cogwheel menu and do the same as the previous step but this time before saving uncheck the absolute deadline checkbox and then check again whether the absolute or relative is being used. The one being used will be the one displayed to the left of the cogwheel menu button. The picture below shows where this is.
![image](https://user-images.githubusercontent.com/82010032/166445895-edf79536-63e7-47e6-bae6-f6c6d5debddb.png)

I'm sure there are many other ways to test this, but this is the simple way or figuring out whether the data is being stored *and* if it's being displayed correctly.

### Known issues
- When copying a course the old absolute deadlines will still be prioritized
- There is no "preview text" yet as requested in the original issue request
- The absolute deadlines checkbox positioning behaves strange on smaller devices