### PR TITLE
Log in for git users is now somewhat implemented/the groundwork is laid

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -2259,7 +2259,7 @@ function resetForceLogin()
     loginBoxheader_login_password_field.style.visibility = "";
 
     let loginBoxButton = document.querySelector(".buttonLoginBox");
-    loginBoxButton.setAttribute("onClick", "processLogin()");
+    loginBoxButton.setAttribute("onClick", "git_processLogin()");
     
   }
 
@@ -2329,10 +2329,40 @@ function resetForceLogin()
 
     }
   }
+}
 
+function git_processLogin()
+  {
+    let git_username = $("#login #username").val();
+    let git_password = $("#login #password").val();
+
+
+    AJAXService("requestGitUserLogin",{
+      username: git_username,
+      userpass: git_password,
+    }, "CONTRIBUTION_GIT_USER_LOGIN");
+
+
+  }
+
+function git_logout()
+{
+  
+  let git_username = null; // nothing entered will logout
+  let git_password = null;
+
+  AJAXService("requestGitUserLogin",{
+    username: git_username,
+    userpass: git_password,
+  }, "CONTRIBUTION_GIT_USER_LOGIN");
 
 }
 
+function returned_git_user_login(data)
+{
+  if(data)
+    window.location.reload(true);  // TODO should I just reload the page here perhaps? 
+}
 
 
 console.error

--- a/DuggaSys/contribution.php
+++ b/DuggaSys/contribution.php
@@ -61,7 +61,7 @@ $vers=getOPG('coursevers');
 	<?php
 		include '../Shared/loginbox.php';
 
-		if(!checklogin()) // If not logged in, force a log in
+		if(!checklogin() && !git_checklogin()) // If not logged in, force a log in
 		{
 			echo '<script> forceUserLogin(); </script>';
 		}

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1095,6 +1095,14 @@ function AJAXService(opt,apara,kind)
 			dataType: "json",
 			success: returned_lenasys_user_check
 		});
+	}else if(kind=="CONTRIBUTION_GIT_USER_LOGIN"){
+		$.ajax({
+			url: "contributionservice.php",
+			type: "POST",
+			data: "&opt="+opt+para,
+			dataType: "json",
+			success: returned_git_user_login
+		});
 	}else if(kind=="CONTRIBUTION_LENASYS_USER_CREATION"){
 		$.ajax({
 			url: "contributionservice.php",
@@ -2549,11 +2557,5 @@ var ClickCounter = {
 
 //if changes has been done a promt is made to ask user if they want to discard them.
 function addAlertOnUnload(){
-	window.onbeforeunload = function() {
-		try {
-			//add things here to run showing the popup for alerting someone that they got unsaved changes.
-			//for example storing stuff to localstorage.
-		}catch(e){}
-		return "Changes will be discarded by leaving page.";
-	}
+	window.onbeforeunload = function() {return "Changes will be discarded by leaving page.";}
 }

--- a/Shared/sessions.php
+++ b/Shared/sessions.php
@@ -69,6 +69,20 @@ function checklogin()
 }
 
 //------------------------------------------------------------------------------------------------
+// git_checklogin
+//------------------------------------------------------------------------------------------------
+// checks against session to see if we are logged in as a git user
+// this is a special function just for the contribution page
+// this should not be used anywhere else on the entire webpage and should be kept to contribution.php
+//------------------------------------------------------------------------------------------------
+function git_checklogin()
+{
+        return (array_key_exists('git_loginname', $_SESSION));
+}
+
+
+
+//------------------------------------------------------------------------------------------------
 // showLoginPopup
 //------------------------------------------------------------------------------------------------
 // Helper function to display the login box if the user is not authenticated


### PR DESCRIPTION
We will have to further work on also handling a teacher login on contribution.php but we also have to further work on what is loaded for every git user, the current logged in git user is stored in the session variables : 
![image](https://user-images.githubusercontent.com/102584289/166456418-6820b52b-6466-4edf-9ffc-4d24d375952f.png)
Please check 
![image](https://user-images.githubusercontent.com/102584289/166456672-0626b44f-ac97-4fbd-9f5e-d7da3a5431c0.png)
for how we check if the git user is logged in

the contributionservice.php has a new function for logging git users in differing from the normal login.
----------------------- Testing -----------------

Test this by trying to log in with for example "proci" and password "password"  on conttribution.php

to logout the feature is not yet implemented so you will have to type in console git_logout() to logout the git user

information might not load correctly if you are logged in yet as only the login has been fixed and not what is associated with that git login



