### PR TITLE
Added an ID in white and black Theme.css file.

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -511,7 +511,20 @@ body {
 #inputwrapperText{
     color:rgba(255,255,255,0.6);
 }
-
+#announcementBoxOverlay{
+    position: relative;
+    display: none;
+    background-color:#121212;
+    z-index: 1004;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    overflow-x: auto;
+    font-family: 'Varela', sans-serif;
+  }
 
 
 }

--- a/Shared/css/whiteTheme.css
+++ b/Shared/css/whiteTheme.css
@@ -474,6 +474,20 @@
     padding: 0px 5px;
 }
 
+#announcementBoxOverlay{
+    position: relative;
+    display: none;
+    background-color:#fff;
+    z-index: 1004;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    overflow-x: auto;
+    font-family: 'Varela', sans-serif;
+  }
 /* #Sectionlist .example {
     color: var(--color-text-secondary);
     /*font-size: 12pt;


### PR DESCRIPTION
The "announcementBoxOverlay" ID had no dark mode styling. Therefore, id was added to both whiteTheme.css and blackTheme.css and changed to the correct color.

(Pull request was re-made as it was commited into master and reverted.)