### PR TITLE
Removed delete button from edge creation. Issue #12104

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6855,7 +6855,7 @@ function drawSelectionBox(str)
     deleteBtnY = 0;
     deleteBtnSize = 0;
 
-    if (context.length != 0 || contextLine.length != 0) {
+    if ((context.length != 0 || contextLine.length != 0) && mouseMode != mouseModes.EDGE_CREATION) {
         var lowX;
         var highX;
         var lineLowX;


### PR DESCRIPTION
To test this you go to edge creation and draw a line between objects. No box with delete button should appear when objects are selected. Switch between other modes to see the difference.