### PR TITLE
Fix for issue #12137 Display default instructions if no file found for the diagram dugga.

### DIFF
--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -79,12 +79,14 @@ function returnedDugga(data)
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
         //document.getElementById("assigment-instructions").innerHTML = param.instructions;
-        //checking if the user is a teacher
-        if(data.isTeacher==0){
+        //checking if the user is a teacher and that it exists a variant
+        if(param.diagramtype){
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type;
             // getting the error finder allowed or not
             document.getElementById("diagram-iframe").contentWindow.errorActive = param.errorActive;
+            // Getting the instructions to the side of the dugga -currently using filelink which is wrong
+            window.parent.getInstructions(param.filelink);
         }
         else{
             var diagramType={ER:true,UML:true};

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -79,8 +79,8 @@ function returnedDugga(data)
     if (data.param.length!=0){
         var param = JSON.parse(data.param);
         //document.getElementById("assigment-instructions").innerHTML = param.instructions;
-        //checking if the user is a teacher and that it exists a variant
-        if(param.diagramtype){
+        //checking if the user is a teacher or if there's no variant by checking if the paramater object is empty
+        if(!(Object.keys(param).length === 0)){
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type;
             // getting the error finder allowed or not


### PR DESCRIPTION
#12137
If no file enabled, user logged in as teacher or there is no file a default instruction is shown on the left of the diagram.
Test by having no variants for diagram dugga, disabling all variants and logging in as teacher and looking at diagram dugga.