### PR TITLE
Fix for issue #12089 Diagram is not visible until you scroll 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7371,8 +7371,10 @@ function fetchDiagramFileContentOnLoad()
         console.log(cid);
         console.log(cvers);
         console.log(diagramToLoad);
-
-        loadDiagramFromString(JSON.parse(diagramToLoadContent));
+        //check so that it is a file with content
+        if(diagramToLoadContent!="NO_FILE_FETCHED" && diagramToLoadContent != ""){
+            loadDiagramFromString(JSON.parse(diagramToLoadContent));
+        }
 }
 
 function loadDiagramFromString(temp, shouldDisplayMessage = true)


### PR DESCRIPTION
#12089
If no file enabled, or there is no file a default diagram is now shown.
Test by having no variants for diagram dugga, disabling all variants and logging in as teacher and looking at diagram dugga.