### PR TITLE
duggaTitle argument missing or invalid.

### DIFF
--- a/DuggaSys/templates/curve-dugga.js
+++ b/DuggaSys/templates/curve-dugga.js
@@ -143,7 +143,7 @@ function returnedDugga(data) {
 	}
 	$("#submitButtonTable").appendTo("#content");
 	$("#lockedDuggaInfo").prependTo("#content");
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 function reset()

--- a/DuggaSys/templates/daily-minutes.js
+++ b/DuggaSys/templates/daily-minutes.js
@@ -180,7 +180,7 @@ function returnedDugga(data)
 
 		}
 	}
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -111,7 +111,7 @@ function returnedDugga(data)
 		}
 		$("#submitButtonTable").appendTo("#content");
 		$("#lockedDuggaInfo").prependTo("#content");
-		displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+		displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 //--------------------================############================--------------------

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -99,7 +99,7 @@ function returnedDugga(data)
 			document.getElementById('feedbackBox').style.display = "block";
 			$("#showFeedbackButton").css("display","block");
 	}
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 //----------------------------------------------------------------------------------

--- a/DuggaSys/templates/dugga3.js
+++ b/DuggaSys/templates/dugga3.js
@@ -138,7 +138,7 @@ function returnedDugga(data) {
 			document.getElementById('feedbackBox').style.display = "block";
 			$("#showFeedbackButton").css("display","block");
 	}
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 function reset()

--- a/DuggaSys/templates/duggaTest.js
+++ b/DuggaSys/templates/duggaTest.js
@@ -111,7 +111,7 @@ function returnedDugga(data)
 		}
 		$("#submitButtonTable").appendTo("#content");
 		$("#lockedDuggaInfo").prependTo("#content");
-		displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+		displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 //--------------------================############================--------------------

--- a/DuggaSys/templates/feedback_dugga.js
+++ b/DuggaSys/templates/feedback_dugga.js
@@ -156,7 +156,7 @@ function returnedDugga(data)
 
 
 	}
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 function reset()

--- a/DuggaSys/templates/group-assignment.js
+++ b/DuggaSys/templates/group-assignment.js
@@ -107,7 +107,7 @@ function returnedDugga(data)
 
 
 	}
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 function reset()

--- a/DuggaSys/templates/html_css_dugga.js
+++ b/DuggaSys/templates/html_css_dugga.js
@@ -120,7 +120,7 @@ function returnedDugga(data)
 			document.getElementById('feedbackBox').style.display = "block";
 			$("#showFeedbackButton").css("display","block");
 	}
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 function reset()

--- a/DuggaSys/templates/html_css_dugga_light.js
+++ b/DuggaSys/templates/html_css_dugga_light.js
@@ -143,7 +143,7 @@ function returnedDugga(data)
 			document.getElementById('feedbackBox').style.display = "block";
 			$("#showFeedbackButton").css("display","block");
 	}
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 function reset()

--- a/DuggaSys/templates/kryss.js
+++ b/DuggaSys/templates/kryss.js
@@ -105,7 +105,7 @@ function returnedDugga(data)
 			});
 		}
 	}		
-	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 
 	// Get answer from previously saved dugga
 	if (data.answer != "UNK") {

--- a/DuggaSys/templates/placeholder_dugga.js
+++ b/DuggaSys/templates/placeholder_dugga.js
@@ -66,7 +66,7 @@ function returnedDugga(data)
 				document.getElementById('instructions').innerHTML = msg;
 			});
 		}		
-		displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"]);
+		displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 //--------------------================############================--------------------

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -2209,7 +2209,7 @@ function displayPreview(filepath, filename, fileseq, filetype, fileext, fileinde
 
 }
 
-function displayDuggaStatus(answer,grade,submitted,marked,duggatitle){
+function displayDuggaStatus(answer,grade,submitted,marked,duggaTitle){
 		var str="<div style='display:flex;justify-content:center;align-items:center;'><div id='duggaTitleSibling' class='LightBox'>";
 		// Get proper dates
 		if(submitted!=="UNK") {
@@ -2221,10 +2221,9 @@ function displayDuggaStatus(answer,grade,submitted,marked,duggatitle){
 			marked=new Date(tt[0], tt[1]-1, tt[2], tt[3], tt[4], tt[5]);
 		}
 
-		//If there is no name of the dugga.
-		// if(duggaTitle == undefined || duggaTitle == "UNK" || duggaTitle == "null" || duggaTitle == ""){	
-		// 	duggaTitle = "Untitled dugga";
-		// }
+		if(duggaTitle == undefined || duggaTitle == "UNK" || duggaTitle == "null" || duggaTitle == ""){	
+			duggaTitle = "Untitled dugga";
+		}
   
 		str+="<div class='' style='margin:4px;'></div></div>";
 


### PR DESCRIPTION
DuggaTitle was missing or invalid in the as an argument when calling the funciton displayDuggaStatus(), from the dugga some of the dugga templates in their returnedDugga() function.

This still only works aslong as the dugga is loaded correctly since it requires data from an json file coming from an AJAX thing.

To test open a dugga while not logged in, not in demo course. Dugga Title Should now appear at the top if the dugga was loaded correctly.