### PR TITLE
Fixed option pane issue #12127

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1677,7 +1677,7 @@ function mdown(event)
                         cursorStyle.cursor = "grabbing";
                         if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
                             wasDblClicked = true;
-                            document.getElementById("options-pane").className = "hide-options-pane";
+                            toggleOptionsPane();
                         }
                         break;
                     }
@@ -4654,7 +4654,6 @@ function generateContextProperties()
 function toggleOptionsPane()
 {
     if (document.getElementById("options-pane").className == "show-options-pane") {
-        document.getElementById("BGColorMenu").style.visibility = "hidden";
         document.getElementById('optmarker').innerHTML = "Options";
         document.getElementById("options-pane").className = "hide-options-pane";
     } else {


### PR DESCRIPTION
Now you can close the options menu even if an element isn't selected. 
Also enabled the ability to double click the canvas in pointer mouse mode to show the option menu.

To test: Try opening and closing the option menu in different mouse modes; with one, many and zero selected elements.
Also open and close the option menu by double clicking the canvas in pointer mouse mode.