### PR TITLE
Implemented teacher & user login for contribution.

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -2221,12 +2221,13 @@ function resetForceLogin()
 
   let userExists_Git = null; // if it exists in the git data
   let userExists_Lenasys = null; // if it exists in the lenasys data
+  let userStatus_Lenasys = null; // if it is a super/teache
  
   function checkIfGitUserExists(username, _callback) // checks if user exists in the git data and or the lenasys data
 {
   userExists_Git = null; // reset back to null if we want to do a check for another user
   userExists_Lenasys = null;
-
+  userStatus_Lenasys = null;
 
   if(username == null || username == "" || !(typeof(username) === 'string'))
   {
@@ -2246,12 +2247,12 @@ function resetForceLogin()
 
       function checkAsyncFlags() 
       {
-        if(userExists_Git == null || userExists_Lenasys == null) 
+        if(userExists_Git == null || userExists_Lenasys == null || userStatus_Lenasys == null) 
         {
            window.setTimeout(checkAsyncFlags, 100);
         } else 
         {
-          _callback(userExists_Git,userExists_Lenasys);
+          _callback(userExists_Git,userExists_Lenasys, userStatus_Lenasys);
 
         }
       }
@@ -2366,13 +2367,8 @@ function resetForceLogin()
 
   function returned_lenasys_user_check(data)
   {
-    if(typeof data == "boolean")
-    {
-      userExists_Lenasys = data;
-    }
-    else
-      alert("invalid data returned from lenasys-data");
-
+    userExists_Lenasys = Boolean(data['success']);
+    userStatus_Lenasys = data['status'];
     return userExists_Lenasys;
   }
 
@@ -2421,7 +2417,7 @@ function resetForceLogin()
     else
     {
 
-      checkIfGitUserExists(username ,function(_onGit, _onLena) 
+      checkIfGitUserExists(username ,function(_onGit, _onLena, _userStatus) 
         {
           
 
@@ -2438,7 +2434,23 @@ function resetForceLogin()
 
           if(_onLena) // log in with lena
           {
-            restoreAndLockLogin();
+            if(_userStatus == "super" || _userStatus == "student") // if youre a teacher or youre a student with a created git account on the git_user table
+            { 
+              restoreAndLockLogin();
+            }
+            else // youre on solely lena but not a teacher/super
+            {
+              displayAlertText("#login #message", "User does not have permission <br />");
+
+              $("input#username").addClass("loginFail");
+		      	  $("input#password").addClass("loginFail");
+			        setTimeout(function()
+              {
+		      	    $("input#username").removeClass("loginFail");
+                $("input#password").removeClass("loginFail");
+                displayAlertText("#login #message", "Try again");
+					    }, 2000);
+            }
           }
           if(!_onLena && _onGit) // onlena is false, ongit true, create new user
           {
@@ -2479,7 +2491,7 @@ function git_processLogin()
     let git_password = $("#login #password").val();
 
 
-    AJAXService("requestGitUserLogin",{
+    AJAXService("requestContributionUserLogin",{
       username: git_username,
       userpass: git_password,
     }, "CONTRIBUTION_GIT_USER_LOGIN");
@@ -2493,7 +2505,7 @@ function git_logout()
   let git_username = null; // nothing entered will logout
   let git_password = null;
 
-  AJAXService("requestGitUserLogin",{
+  AJAXService("requestContributionUserLogin",{
     username: git_username,
     userpass: git_password,
   }, "CONTRIBUTION_GIT_USER_LOGIN");
@@ -2504,6 +2516,17 @@ function returned_git_user_login(data)
 {
   if(data)
     window.location.reload(true);  // TODO should I just reload the page here perhaps? 
+  else
+  {
+    displayAlertText("#login #message", "Invalid password <br />");
+
+    $("input#password").addClass("loginFail");
+    setTimeout(function()
+    {
+      $("input#password").removeClass("loginFail");
+      displayAlertText("#login #message", "Try again");
+    }, 2000);
+  }
 }
 
 console.error


### PR DESCRIPTION
Fixed so you can log in with the users from the "USER" table and not only "git_users" table

Added so if you exist on the "USER" table but dont have superuser status youre not allowed to login, this can be changed so all users on the "USER" table are allowed to log in with more priviliges than a normal git-student user. This is how it looks if you attempt to log in with a non super user
![image](https://user-images.githubusercontent.com/102584289/166937024-6aee6cb4-e608-4184-a81e-9b2cd7bf3757.png)

If you now try to log in with a user that exists on the "git_user" table youre allowed to but your stored session variables dont get stored in the same variables as a teacher/super/one who logged in with someone who exists on the "user" table. The rest of the contribution file will need to take this into account for what is shown; Following is an example of where the user who logged in with the "git_user" table gets their session variables stored
![image](https://user-images.githubusercontent.com/102584289/166937046-c317d832-0c13-430c-aa2f-4b632fda915a.png)

Currently the check for viewing contribution content is done with 2 separate checks, in the future we might want to combine these into one dedicated check for viewing contribution data
![image](https://user-images.githubusercontent.com/102584289/166937061-c36cdfe8-0b3d-4a1d-80ce-b7f65b27df85.png)


----------------------------------------------- Testing ----------------------------------------------
make sure you run install.php so you have the new git_user table

Check if you can create a new git_user
check if you can log in with a user without login privs an example can be teacher2
check if you can log in with a newly created git_user
try to type in wrong password for user/git_user
