### PR TITLE
Description field design  #12182

### DIFF
--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -11,6 +11,18 @@
             width: 100%;
             justify-content: space-between;
         }
+
+        #container_header{
+            cursor: pointer;
+            background-color: #ccc;
+            width:100%;
+            display:inline-block;
+            position:relative;
+            padding:3px 10px;
+            box-sizing: border-box;
+            -webkit-box-sizing: border-box;
+            -moz-box-sizing: border-box;
+        }
         
          ::-webkit-scrollbar {
             width: 5px;
@@ -30,6 +42,7 @@
             height: 800px;
             overflow: auto;
             margin: 0px;
+            border: 1px solid #ccc;
         }
         
         #close_open {
@@ -104,7 +117,7 @@
         </div>
         <div class='instructions-container'>
             <div class='instructions-button' onclick='toggleInstructions(this)'>
-                <h3>Instructions</h3>
+                <h3>General information</h3>
             </div>
             <div class="instructions-content">
                 <p style="margin-left: 4px;">Diagram-duggan går ut på att producera det diagrammet som beskrivs i beskrivningen.
@@ -119,8 +132,8 @@
 
             <input type="hidden" id="pvalue" value="0" />
             <div class="assignment_left" id="container__left" style="overflow: auto;">
+                <div id="container_header"><h3>Instructions</h3></div>
                 <div class="assignment_discrb" id="assignment_discrb" cellpadding="0" cellspacing="0" style=" visibility: visible; color: rgb(0, 0, 0); padding: 4px; ">
-                    <h2 style="margin-left: 14px;">Beskrivningen</h2>
                     <h2 style="margin-left: 14px;">Modellering</h2>
                     <p style="margin-left: 14px;">Modellera nedanstående uppgifter i notationerna ER och UML.</p>
                     <ol type="1">

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -13,7 +13,6 @@
         }
 
         #container_header{
-            cursor: pointer;
             background-color: #ccc;
             width:100%;
             display:inline-block;


### PR DESCRIPTION
**Pull request for #12182**

**Changes made**
- Added a new header section in the description that follows CSS standards for instruction fields on other dugga pages. 
- Renamed "Instructions" to "General information"
- Added a border around the assignment instruction container that follows CSS standards for other dugga pages.

**How to test**
Dugga page should look like the image below
<img src="https://user-images.githubusercontent.com/81772705/166937189-373bc4af-7fda-46b7-a3c5-d2aab2e39fe4.png" width="500"/>