### PR TITLE
Move load, save and load dugga button further down on page. #12143

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2932,6 +2932,7 @@ div.submit-button:disabled {
 #submitButtonTable{
   position: relative;
   z-index:500;
+  margin-top: 20px;
 }
 
 #submitButtonTable input.large-button {


### PR DESCRIPTION
- Added a margin at the top of the submitButtonTable to increase the distance between the buttons and the diagram dugga iframe as Henrik requested.

Result should look as the image below.
<img src="https://user-images.githubusercontent.com/81772705/166943000-67584def-d932-4f64-b049-f3da33e0ffaa.png" width="400" />

**Notice:** Solution had to be implemented in style.css which affects the whole LenaSYS page.  Therefore I've also checked multiple other dugga pages to see how the change affected these pages and my conclusion is that the change is so minimal that it doesn't affect them in a bad. 