### PR TITLE
Variants are no longer Undefined by default on localhost

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -801,8 +801,8 @@ function renderCell(col, celldata, cellid) {
 
 		case "disabled":	// VARIANT-TABLE - Translades disabled status from integers
 			switch(celldata) {
-				case "0": retString = "<span style='color:black;'>Enabled</span>"; break;
-				case "1": retString = "<span style='color:red;'>Disabled</span>"; break;
+				case 0: retString = "<span style='color:black;'>Enabled</span>"; break;
+				case 1: retString = "<span style='color:red;'>Disabled</span>"; break;
 				default: retString = "<span style='color:black; opacity:0.5;'>Undefined</span>";
 			}
 			break;


### PR DESCRIPTION
When testing variants on local webserver, they're always "Undefined". It works fine on the production but can prove troublesome when testing variants locally. Now they're "Enabled" and Disabled"
![bild](https://user-images.githubusercontent.com/37794783/167083308-ae22d800-0402-405e-9131-7dd3e026ac34.png)
