### PR TITLE
Pasted elements do not cover messages

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -287,7 +287,7 @@
     left: 100px;
     bottom: 20px;
     position: absolute;
-    z-index: 1;
+    z-index: 100;
     opacity: 1;
     display: block;
     pointer-events: none;


### PR DESCRIPTION
Made it so messages will not hide behind pasted elements. #12196 

Instructions for testing:
1) Click "Demo-Course"
2) Click "Diagram Dugga"
3) "Copy"(ctrl + c) any element/s
4) "Paste"(ctrl + v) anywhere on the screen
5) Drag the pasted element/s towards the message in the down left corner of the diagram (if the elements are behind the message, it is correct)