### PR TITLE
Empty dropdown option in "Add diagram to dugga". #12201

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -286,7 +286,9 @@ function selectVariant(vid, el) {
   				}
 				else if(result =="errorActive"){
 					document.getElementById("errorActive").checked = obj[result];
-				}
+				}else if(result == "diagram_File"){
+                    document.getElementById('file').value = obj[result];
+                }
   			}
 		var diagramType = obj.diagram_type; //<-- UML functionality start
 		if(diagramType){

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -402,7 +402,7 @@ function returnedFile(data){
 	filteredarray = filearray.filter(x => x.extension === "json");
 
 	//Not sure how the first parameter works yet, suspect it's to know which object is selected
-	$("#file").html(makeoptionsItem("not doing anything plz fix", filteredarray, 'filename'));
+	$("#file").html(makeoptionsItem("AddEmptyField", filteredarray, 'filename','filename'));
 }
 
 // Adds a submission row
@@ -478,7 +478,7 @@ function createJSONString(formData) {
 	return JSON.stringify({
 		"type":formData[0].value,
 		"filelink":formData[1].value,
-		"diagram_File":$("#file option:selected").text(),
+		"diagram_File":$("#file option:selected").val(),
 		"diagram_type":{ER:document.getElementById("ER").checked,UML:document.getElementById("UML").checked}, //<-- UML functionality
 		"extraparam":$('#extraparam').val(),
 		"submissions":submission_types,

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -183,7 +183,9 @@ session_start();
                       <fieldset style="width:90%">
                       <!-- The json files are fetched and parsed in returnedFile() in duggaed.js -->
                         <legend>Add diagram to dugga</legend>
-                        <select id="file" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()))"></select>
+                        <select id="file" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()))">
+                          <option>Empty canvas</option>
+                        </select>
                       </fieldset>
                     </div>
                     <div id="errorCheck">

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -311,6 +311,9 @@ function makeoptions(option,optionlist,valuelist)
 function makeoptionsItem(option,optionlist,optionstring,valuestring)
 {
 	var str="";
+	if(option=="AddEmptyField"){
+		str += "<option  selected='selected' value=''>Nothing selected</option>";
+	}
 	for(var i=0;i<optionlist.length;i++){
 		str+="<option ";
 		if(optionlist[i][valuestring]==option){


### PR DESCRIPTION
#12201 
**What has been done**
- Made adjustment to the feature that creates dropdowns so an empty option is shown. Since this solution is global and can be used by other dropdowns as well, if the if-statement is correct, we named it "Nothing selected" instead of something related to an empty canvas or demo data.
- Before what was shown in the dropdown was added in "diagram_File":"", which caused issues when we named the empty option "Nothing selected". This was solved by adding a value which for "Nothing selected" is empty and for the JSON files is the file name. 

**How to check solution**
Go to Edit dugga and select the diagram. There try to switch between options in the dropdown and check so that it updates as it should in the parameter section. 


There might still be an issue with what is shown in the diagram when you select the option "Nothing selected". Emil works on a solution for that in another issue, but the intention is that the hardcoded test data should be shown then. 