### PR TITLE
Fix for issue #12137

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -79,7 +79,7 @@
 		$splicedFileName = substr($variantParams, strpos($variantParams, "diagram File&quot;:") + 25, ($end - $start));*/
 		$variantParams = str_replace('&quot;','"',$variantParams);
 		$parameterArray = json_decode($variantParams,true);
-		if(!$parameterArray["diagram_File"]){
+		if(!empty($parameterArray)){
 			$splicedFileName=$parameterArray["diagram_File"];
 			$fileName=$parameterArray["filelink"];
 			$fileType=$parameterArray["type"];
@@ -281,7 +281,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 	 * */
 	function getInstructions(fileName)
 	{
-		if(<?php echo json_encode($finalArray);?>.length >0){
+		if(<?php echo json_encode($finalArray);?>.length > 0){
 			for (let index = 0; index < <?php echo json_encode($finalArray);?>.length; index++) {
 				if(<?php echo json_encode($finalArray);?>[index][2]==fileName){
 					document.getElementById("assignment_discrb").innerHTML =<?php echo json_encode($finalArray);?>[index][3];


### PR DESCRIPTION
#12137
If no file enabled, user logged in as teacher or there is no file a default instruction is shown on the left of the diagram.
Test by having no variants for diagram dugga, disabling all variants and logging in as teacher and looking at diagram dugga.
also test by looking at diagram dugga logged out and having an enabled variant to se that the intsructions change to the selected instructions