### PR TITLE
Maximize boxes burger menu available also for desktop #12146

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1511,14 +1511,26 @@ div .navButt:hover {
 
 }
 
+#codeBurger {
+  display: table-cell;
+}
+#burgerMenu {
+  position: absolute;
+  z-index: 9999;
+  background-color: var(--color-background-2);
+  border: 2px solid var(--color-border);
+  display: none;
+}
+.burgerOption {
+  padding: 15px 15px 15px 15px;
+  cursor: pointer;
+}
+
 @media only screen and (max-width: 800px) {
         #div2 {
         top: 80px;
         }
-        #codeBurger {
-        display: table-cell;
-    }
-        
+       
     .access menuButton{
       width: 20px;
     }
@@ -1537,17 +1549,7 @@ div .navButt:hover {
 
     }
 
-    #burgerMenu {
-        position: absolute;
-        z-index: 9999;
-        background-color: var(--color-background-2);
-        border: 2px solid var(--color-border);
-        display: none;
-    }
-    .burgerOption {
-        padding: 15px 15px 15px 15px;
-        cursor: pointer;
-    }
+    
     .GS2, .CO2, .PG2, .OP2, .BP2, .SU2, .SS2, .SC2, .FF2, .PF2, .UI2{display:none;}
 
     .CD{


### PR DESCRIPTION
The burger menu to maximize boxes i mobile view was made available for desktop so that you can maximize one box at a time in codeviewer.
Felt redundant to make another button when the function already existed i mobile view.