### PR TITLE
Fixed so "Uploaded diagram"-window doesn't shrink anymore so scrolling isn't as frustrating #12181

### DIFF
--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -209,7 +209,7 @@ session_start();
                       <!-- Submissions for dugga -->
                   <div>
                     <div id="duggaSubmissionForm">
-                      <fieldset style="width:90%; margin-top:5%;">
+                      <fieldset style="width:90%;">
                         <legend>Submission types</legend>
                         <div id="submissions" style="display:flex;flex-wrap:wrap;flex-direction:column;overflow:hidden;"></div>
                       </fieldset>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -144,7 +144,7 @@ session_start();
         </div>
 
         <div class='loginBoxbody' id='variantBody' style='width:100%; height:100%;'>
-            <div id="variant" style='width:100%; border-top: solid 3px #fdcb60; border-bottom: #7f7f7f solid 3px; background-color: white; overflow-y: auto; overflow-x: hidden; margin-bottom: 5px; max-height: 300px; flex-shrink: 99; min-height: 100px;' ></div> <!-- A div to place the variant-table within. -->
+            <div id="variant" style='width:100%; border-top: solid 3px #fdcb60; border-bottom: #7f7f7f solid 3px; background-color: white; overflow-y: auto; overflow-x: hidden; margin-bottom: 5px; max-height: 300px; flex-shrink: 99; min-height: 220px;' ></div> <!-- A div to place the variant-table within. -->
           <div id='editVariantDiv' style="display:flex; flex-shrink: 0;">
             <input type='hidden' id='vid' value='Toddler'/>
             <input type='hidden' id='disabled' value='0'/>


### PR DESCRIPTION
This pull request contains:
- #12181
- Set a minimum height on uploaded diagram window so it doesn't shrink when adding more submisson types leading to less  frustration when scrolling.
- Also removed the margin that was between "Diagram types allowed" and "Submission types".

Test by:
1. Log in as teacher
2. Go to "Edit dugga"
3. Click the pen on Diagram dugga 
4. Add submission types by pressing the (+)-button
5. Make sure that uploaded diagrams window doesn't shrink. 
6. Make sure there is no margin between "Diagram types allowed" and "Submission types".
*Note that it does make a little "jump" when the first submission type is added, the reason for that is the scroll being added to the side.

### After:
<img width="900" alt="doesntshrink" src="https://user-images.githubusercontent.com/81613484/167159928-5b7a6892-5967-4b0a-ba25-d422f9498da7.png">

### Before:
![image](https://user-images.githubusercontent.com/81613484/167160164-bc1d64e6-a150-4397-b5eb-10945faaca21.png)

 