### PR TITLE
Implemented zooming function

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2656,12 +2656,20 @@ function getTotalBoxes(template) {
 
 function zoomText(boxid, increment)
 {
+	//Upper & lower limit of how small text can get.
+	var upperLimit = 21;
+	var lowerLimit = 6; 
+
 	var fontSize = parseInt(document.getElementById("box" + boxid).style.fontSize);
+	
+	if (increment > 0 && fontSize < upperLimit || increment < 0 && fontSize > lowerLimit){
 
-	fontSize = fontSize + increment; 
+		fontSize = fontSize + increment; 
 
-	document.getElementById("box" + boxid).style.fontSize = fontSize + "px";
-
+		document.getElementById("box" + boxid).style.fontSize = fontSize + "px";
+	
+	}
+	
 }
 
 //-----------------------------------------------------------------------------

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -953,8 +953,8 @@ function createboxmenu(contentid, boxid, type) {
 
 		// Add resize, reset and edit buttons
 		//This functionality should be changed to allow zooming.
-		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' title='Zoom in' onclick='zoomIn(" + boxid + ", 5);'><img src='../Shared/icons/MaxButton.svg' /></div>";
-		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' title='Zoom out' onclick='zoomOut(" + boxid + ");'><img src='../Shared/icons/MinButton.svg' /></div>";
+		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' title='Zoom in' onclick='zoomText(" + boxid + ", 5);'><img src='../Shared/icons/MaxButton.svg' /></div>";
+		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' title='Zoom out' onclick='zoomText(" + boxid + ", -5);'><img src='../Shared/icons/MinButton.svg' /></div>";
 		str += "<div id='resetBoxes'><td class='butto2 resetbtn' title='Reset' onclick='resetBoxes();'><img src='../Shared/icons/ResetButton.svg' /></div>";
     
 
@@ -2648,35 +2648,19 @@ function getTotalBoxes(template) {
 }
 
 //-----------------------------------------------------------------------------
-// zoomIn: Adding zooming functionaity for the content of the boxes.
-//			Is called with onclick() by zoomInButton. Size refers to the increment of the font size.
+// zoomText: Adding zooming functionality for text content of the boxes.
+//			Is called by zoomIn & zoomOut buttons. 
+//			Increment refers to the increment in font size.
+//			Setting increment to a negative value allows for making the text smaller.
 //-----------------------------------------------------------------------------
 
-function zoomIn(boxid, size)
+function zoomText(boxid, increment)
 {
-	var boxid = boxid;
+	var fontSize = parseInt(document.getElementById("box" + boxid).style.fontSize);
 
-	var contentDiv = document.getElementById("box" + boxid);
+	fontSize = fontSize + increment; 
 
-	console.log("Zoom In " + size + "px in box " + contentDiv);	
-
-	var fontSize = document.getElementById("box" + boxid).style.fontSize;
-	
-	console.log(fontSize);
-	
-	contentDiv.style.fontSize = size +"px";
-}
-
-//-----------------------------------------------------------------------------
-// zoomOut: Adding zooming functionaity for the content of the boxes.
-//			Is called with onclick() by zoomOutButton
-//-----------------------------------------------------------------------------
-
-function zoomOut(boxid)
-{
-	var boxid = boxid;
-	//document.getElementById("box2").fontsize 
-	console.log("Zoom Out" + document.getElementById("box" + boxid).style.fontSize);
+	document.getElementById("box" + boxid).style.fontSize = fontSize + "px";
 }
 
 //-----------------------------------------------------------------------------

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -953,9 +953,9 @@ function createboxmenu(contentid, boxid, type) {
 
 		// Add resize, reset and edit buttons
 		//This functionality should be changed to allow zooming.
-		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' title='Zoom in' onclick='zoomText(" + boxid + ", 5);'><img src='../Shared/icons/MaxButton.svg' /></div>";
-		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' title='Zoom out' onclick='zoomText(" + boxid + ", -5);'><img src='../Shared/icons/MinButton.svg' /></div>";
-		str += "<div id='resetBoxes'><td class='butto2 resetbtn' title='Reset' onclick='resetBoxes();'><img src='../Shared/icons/ResetButton.svg' /></div>";
+		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' title='Zoom in' onclick='zoomText(" + boxid + ", 3);'><img src='../Shared/icons/MaxButton.svg' /></div>";
+		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' title='Zoom out' onclick='zoomText(" + boxid + ", -3);'><img src='../Shared/icons/MinButton.svg' /></div>";
+		str += "<div id='resetBoxes'><td class='butto2 resetbtn' title='Reset zoom' onclick='resetText(" + boxid + ");'><img src='../Shared/icons/ResetButton.svg' /></div>";
     
 
 		// Show the copy to clipboard button for code views only
@@ -2661,6 +2661,17 @@ function zoomText(boxid, increment)
 	fontSize = fontSize + increment; 
 
 	document.getElementById("box" + boxid).style.fontSize = fontSize + "px";
+
+}
+
+//-----------------------------------------------------------------------------
+// resetText: Resets the text size to the default value. (9px)
+//-----------------------------------------------------------------------------
+function resetText(boxid)
+{
+
+document.getElementById("box" + boxid).style.fontSize = "9px";
+
 }
 
 //-----------------------------------------------------------------------------

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -951,8 +951,7 @@ function createboxmenu(contentid, boxid, type) {
 			var kind = 2;
 		}
 
-		// Add resize, reset and edit buttons
-		//This functionality should be changed to allow zooming.
+		// Add zoom in, zoom out and reset buttons.
 		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' title='Zoom in' onclick='zoomText(" + boxid + ", 3);'><img src='../Shared/icons/MaxButton.svg' /></div>";
 		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' title='Zoom out' onclick='zoomText(" + boxid + ", -3);'><img src='../Shared/icons/MinButton.svg' /></div>";
 		str += "<div id='resetBoxes'><td class='butto2 resetbtn' title='Reset zoom' onclick='resetText(" + boxid + ");'><img src='../Shared/icons/ResetButton.svg' /></div>";

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -952,8 +952,9 @@ function createboxmenu(contentid, boxid, type) {
 		}
 
 		// Add resize, reset and edit buttons
-		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' title='Maximize box' onclick='maximizeBoxes(" + boxid + ");'><img src='../Shared/icons/MaxButton.svg' /></div>";
-		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' title='Minimize box' onclick='minimizeBoxes(" + boxid + ");'><img src='../Shared/icons/MinButton.svg' /></div>";
+		//This functionality should be changed to allow zooming.
+		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' title='Zoom in' onclick='zoomIn(" + boxid + ", 5);'><img src='../Shared/icons/MaxButton.svg' /></div>";
+		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' title='Zoom out' onclick='zoomOut(" + boxid + ");'><img src='../Shared/icons/MinButton.svg' /></div>";
 		str += "<div id='resetBoxes'><td class='butto2 resetbtn' title='Reset' onclick='resetBoxes();'><img src='../Shared/icons/ResetButton.svg' /></div>";
     
 
@@ -2644,6 +2645,38 @@ function getTotalBoxes(template) {
 		totalboxes = 1;
 	}
 	return totalBoxes;
+}
+
+//-----------------------------------------------------------------------------
+// zoomIn: Adding zooming functionaity for the content of the boxes.
+//			Is called with onclick() by zoomInButton. Size refers to the increment of the font size.
+//-----------------------------------------------------------------------------
+
+function zoomIn(boxid, size)
+{
+	var boxid = boxid;
+
+	var contentDiv = document.getElementById("box" + boxid);
+
+	console.log("Zoom In " + size + "px in box " + contentDiv);	
+
+	var fontSize = document.getElementById("box" + boxid).style.fontSize;
+	
+	console.log(fontSize);
+	
+	contentDiv.style.fontSize = size +"px";
+}
+
+//-----------------------------------------------------------------------------
+// zoomOut: Adding zooming functionaity for the content of the boxes.
+//			Is called with onclick() by zoomOutButton
+//-----------------------------------------------------------------------------
+
+function zoomOut(boxid)
+{
+	var boxid = boxid;
+	//document.getElementById("box2").fontsize 
+	console.log("Zoom Out" + document.getElementById("box" + boxid).style.fontSize);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The Zoom In & zoom out - text buttons now make text smaller and larger. 
The reset button resets the font size to the default value of 9px.
There are limits in place to avoid the text overlapping with itself. 

This issue can be tested by: 

- Open a code example, preferably one with files ready. 
    - e.g Webbprogrammering -> JavaScript Example 2.
 - Pressing the Zoom in button will make text larger. Pressing the Zoom out button will text smaller. Pressing the reset button will make the text return to the default size of 9px.
![image](https://user-images.githubusercontent.com/102584401/167161581-1d599cff-8cca-4be0-a8a3-25f1fa5087fd.png)
- The user will not be allowed to zoom in so much that the text overlaps
