### PR TITLE
Allowed for duggor and dugga variants to be deleted by pressing enter #12179

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -579,6 +579,15 @@ function confirmBox(operation, item, type) {
 			$("#sectionConfirmBox").css("display", "none");
 		}
 	}
+
+	// Allows for duggor & dugga variants to be deleted by pressing the enter-key when the confirmBox is visible.
+	document.addEventListener("keyup", event => {
+		if (event.key === 'Enter') {
+			deleteVariant(itemToDelete);
+			deleteDugga(itemToDelete);
+			$("#sectionConfirmBox").css("display", "none");
+		}
+	});
 }
 
 // Storing the celldata for future use. (Needed when editing and such)


### PR DESCRIPTION
- #12179
Added code so duggor and dugga variants can be deleted by pressing enter when the delete confirmation-box is visible, in "Edit dugga".

### To test:
1. Log in as a teacher
2. Go to "Edit dugga"
3. Press diagram dugga (or any dugga, code works for all of them.)
4. Create a dugga in "Variants for:  Diagram Dugga" if there isn't already one present.
5. Press delete by clicking on the bin
6. When the delete confirmation box appears, `**use the ENTER key!**`. 
7. Make sure the variant or dugga got deleted.

![image](https://user-images.githubusercontent.com/81613484/167173952-184502f0-e241-4099-b127-bbf56708f0f7.png)

<img width="946" alt="delete" src="https://user-images.githubusercontent.com/81613484/167175093-83bd6108-31e1-43ec-991e-8cd31ec17303.png">

