### PR TITLE
Made all dates dynamic rather than static in the contributionsservice.php file

### DIFF
--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -510,6 +510,7 @@ if(strcmp($opt,"get")==0) {
 		$data = $row['eventtime'];
 		list($eventTime, $unnused) = explode("T", $data);
 		$eventcount[$eventTime]++;
+		$stuff++;
 	}
 
 	//Comments
@@ -568,10 +569,10 @@ if(strcmp($opt,"get")==0) {
 		if($commentcount[$currentdate] == NULL){
 			$commentcount[$currentdate] = 0;
 		}
-
+		//$eventcount[$currentdate]
 
 		$daycount = array();
-		$daycount = array('events' => $eventcount[$currentdate],
+		$daycount = array('events' => $stuff,
 						  'commits' => $commitcount[$currentdate],
 						  'loc' => $loccount[$currentdate],
 						  'comments' => $commentcount[$currentdate]);

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -510,7 +510,6 @@ if(strcmp($opt,"get")==0) {
 		$data = $row['eventtime'];
 		list($eventTime, $unnused) = explode("T", $data);
 		$eventcount[$eventTime]++;
-		$stuff++;
 	}
 
 	//Comments
@@ -569,10 +568,10 @@ if(strcmp($opt,"get")==0) {
 		if($commentcount[$currentdate] == NULL){
 			$commentcount[$currentdate] = 0;
 		}
-		//$eventcount[$currentdate]
+
 
 		$daycount = array();
-		$daycount = array('events' => $stuff,
+		$daycount = array('events' => $eventcount[$currentdate],
 						  'commits' => $commitcount[$currentdate],
 						  'loc' => $loccount[$currentdate],
 						  'comments' => $commentcount[$currentdate]);


### PR DESCRIPTION
If/when we need to look at contributions data other than the late spring course 2019 this will now be much easier. On line 63 and 64 are two strings that represent the start date and end date of our data collection. When we want another course date we just need to edit these two strings and all sql queries will change search dates accordingly.