### PR TITLE
Fix for issue #12238 Create a button for turning on off the error checking

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -944,7 +944,7 @@ const zoom0_75 = -0.775;
 const zoom0_5 = -3;
 const zoom0_25 = -15.01;
 
-var errorActive = true;
+var errorActive = false;
 
 // Arrow drawing stuff - diagram elements, diagram lines and labels 
 var lines = [];
@@ -3937,6 +3937,19 @@ function toggleA4Template()
         document.getElementById("a4TemplateToggle").style.backgroundColor = "#362049";
    }
    generateContextProperties();
+}
+/**
+ * @description turns the error checking functionality on/off
+ */
+function toggleErrorCheck(){
+    if (errorActive) {
+        document.getElementById("errorCheckToggle").classList.add("active");
+    }  
+    else{
+        document.getElementById("errorCheckToggle").classList.remove("active");
+    }
+    errorActive=!errorActive;
+    showdata();
 }
 
 function setA4SizeFactor(e){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3942,13 +3942,13 @@ function toggleA4Template()
  * @description turns the error checking functionality on/off
  */
 function toggleErrorCheck(){
+    errorActive =! errorActive;
     if (errorActive) {
         document.getElementById("errorCheckToggle").classList.add("active");
     }  
     else{
         document.getElementById("errorCheckToggle").classList.remove("active");
     }
-    errorActive=!errorActive;
     showdata();
 }
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -245,6 +245,7 @@
                 <span class="toolTipText"><b>Enter replay mode</b><br>
                     <p>View history of changes made</p><br>
                 </span>
+            </div>
         </fieldset>
         <fieldset>
             <legend>ER-Table</legend>
@@ -253,7 +254,16 @@
                 <span class="toolTipText"><b>Toggle ER-Table</b><br>
                     <p>Click to toggle ER-Table in options</p><br>
                 </span>
-        </fieldset>
+            </div>
+        </fieldset>     
+        <fieldset>
+            <div id="errorCheckToggle" class="diagramIcons" onclick="toggleErrorCheck()">
+                <img src="../Shared/icons/diagram_a4.svg"/>
+                <span class="toolTipText"><b>Toggle error check</b><br>
+                    <p>Click to toggle error checking on/off</p><br>
+                </span>
+            </div>
+        </fieldset>        
     </div>
 
     <!-- Message prompt -->

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -84,14 +84,14 @@ function returnedDugga(data)
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type;
             // getting the error finder allowed or not
-            document.getElementById("diagram-iframe").contentWindow.errorActive = param.errorActive;
+            // document.getElementById("diagram-iframe").contentWindow.errorActive = param.errorActive;
             // Getting the instructions to the side of the dugga -currently using filelink which is wrong
             window.parent.getInstructions(param.filelink);
         }
         else{
             var diagramType={ER:true,UML:true};
             document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
-            document.getElementById("diagram-iframe").contentWindow.errorActive = true;
+            // document.getElementById("diagram-iframe").contentWindow.errorActive = true;
         }
         document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();//<-- UML functionality end
     }


### PR DESCRIPTION
Added a button in diagram.php and a function in diagram.js.
Test by creating an error in the diagram and turning on/off error checking by pressing the button.
![image](https://user-images.githubusercontent.com/81320323/167357555-b889a768-ebc4-4ae1-94a9-288e778725c8.png)
- Fix for issue #12238 

