### PR TITLE
Added alternative display option

### DIFF
--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -329,11 +329,28 @@ if(isSuperUser($userid)){
 					$link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "https") . "://$_SERVER[HTTP_HOST]/sh/?s=$hash";
 					processDuggaFiles();
 				}else{
-					$debug="[Superuser] Could not load dugga! no userAnswer entries with moment: $moment \nline 338 showDuggaservice.php";
-					$variant="UNK";
-					$answer="UNK";
-					$variantanswer="UNK";
-					$param=html_entity_decode('{}');
+					$sql="SELECT vid, variant.variantanswer AS variantanswer, variant.param AS param, quiz.cid AS cid, quiz.vers AS vers, quiz.id AS id
+					FROM listentries 
+					LEFT JOIN quiz ON listentries.link=quiz.id LEFT JOIN variant ON quiz.id=variant.quizID
+					WHERE lid=:lid";
+					$query = $pdo->prepare($sql);
+					$query->bindParam(':lid', $moment);
+					$query->execute();
+					foreach($query->fetchAll() as $row){
+						$savedvariant=$row['vid'];
+						$answer="[Superuser] Could not load dugga! no userAnswer entries with moment: $moment line 338 showDuggaservice.php";
+						$variantanswer=html_entity_decode($row['variantanswer']);
+						$param=html_entity_decode($row['param']);
+						$newcourseid=$row['cid'];
+						$newcoursevers=$row['vers'];
+						$newduggaid=$row['id'];
+					}
+					$duggatitle="$duggatitle - Useranswer not found!";
+					//$debug="[Superuser] Could not load dugga! no userAnswer entries with moment: $moment \nline 338 showDuggaservice.php";
+					//$variant="UNK";
+					//$answer="UNK";
+					//$variantanswer="UNK";
+					//$param=html_entity_decode('{}');
 				}
 			} else {
 				$debug="[Superuser] Could not load dugga! Incorrect hash/password! $hash";


### PR DESCRIPTION
Removed the alert and instead moved it into the dugga title. This code is questionable, there is so a lot of things that just don't work and the problem probably has to be solved at the database level. This code will make the alert disappear but it won't make the root issue go away, for that the database needs to a lot more entries. 

Explanation of what i mean:
![entries](https://user-images.githubusercontent.com/102533453/167366965-3429c1c9-76da-4d05-9033-c99cd0efb6a8.png)

listentries is the table used for duggas and dugga headers (Webbprogrammering uses listentries as headers and links and not duggas). lid is moment for the useranswer table. link is the id to the corresponding entry in quiz. (things which are headers don't have a link)
![listentries](https://user-images.githubusercontent.com/102533453/167367049-ac731f09-d685-4970-88d2-5f2cdb741f5f.png)

Every dugga with a link has an entry in quiz corresponding to it. There are some duggor which use the same quiz. The problem is that there are quizes without a variant which means they can't have a useranswer since the table for useranswer uses variant to associate the answer to a dugga. 
Another problem is that useranswer does not have entries for each moment this is a problem in the code but might not be in reality. For example if the dugga hasn't been taken by anyone then it would be strange to expect there to be a useranswer waiting for the teacher when he checks it. This is what the alert is about, that there is no useranswer for that dugga.

My recommendation is to

- [ ] Go through all the problematic duggor and fix the database so that the error does not occur.
- This will mean adding data to the the variant and useranswer table where needed.
- A problematic dugga can be identified either by the duggatitle or if that doesn't work using the network tab to check the response.

![network_response](https://user-images.githubusercontent.com/102533453/167374296-096e7202-be89-440f-b96e-45b37cf7f55e.png)


Also found a new issue caused by this pull request at the very tail-end of writing this when a user goes to linjedugga2. This is because the $answer is a string when they expected a specific format to draw the cordinates. This is only a issue for duggor with a variant but no useranswer which is a minority of them. Fixing the underlying issue with no entries in useranswer will fix this.
![new_issue](https://user-images.githubusercontent.com/102533453/167373563-507d1a8d-86c7-43a9-bba8-4ebaadc4fc0d.png)

