### PR TITLE
Option panel open and close functionality #12140

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -98,6 +98,7 @@
     transform-origin: top left;            
     transform: translate(20px,0px) rotate(90deg);
     cursor: pointer;
+    width: 780px;
 }
 
 #options-pane-content {
@@ -341,7 +342,7 @@
 
 .toolTipText{
     top:-5px;
-    left:105%;
+    left: 9.5%;
     visibility: hidden;
     width: 250px;
     background: rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
Issue #12140  (Please note that I missed # in the branch name when you switch to the branch). 

**What has been done**
- Added so that the minimized option panel can be clicked anywhere to view the option panel.
- Adjusted the tooltip so that it still is aligned as it should.

**How to test**
In the diagram dugga check if it works to open/close the option panel by clicking anywhere on the marked part in the image below.
<img src="https://user-images.githubusercontent.com/81772705/167386207-7af9c2b1-147f-4653-b2f1-ad0da0b666e0.png" height="400"/>
In my test, this still worked when resizing the page using the browser zoom. 
