### PR TITLE
Created working keybinds for two functionalities #12277

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -756,6 +756,7 @@ const keybinds = {
         MOVING_OBJECT_RIGHT: {key: "ArrowRight", ctrl: false},
         TOGGLE_KEYBINDLIST: {key: "F1", ctrl: false},
         TOGGLE_REPLAY_MODE: {key: "r", ctrl: false},
+        TOGGLE_ER_TABLE: {key: "e", ctrl: false},
 };
 
 /** 
@@ -1511,6 +1512,7 @@ document.addEventListener('keyup', function (e)
         if(isKeybindValid(e, keybinds.PASTE)) pasteClipboard(JSON.parse(localStorage.getItem('copiedElements') || "[]"), JSON.parse(localStorage.getItem('copiedLines') || "[]"));
         if(isKeybindValid(e, keybinds.CENTER_CAMERA)) centerCamera();
         if(isKeybindValid(e, keybinds.TOGGLE_REPLAY_MODE)) toggleReplay();
+        if(isKeybindValid(e, keybinds.TOGGLE_ER_TABLE)) toggleErTable();
 
         if (isKeybindValid(e, keybinds.COPY)){
             // Remove the preivous copy-paste data from localstorage.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -755,6 +755,7 @@ const keybinds = {
         MOVING_OBJECT_LEFT: {key: "ArrowLeft", ctrl: false},
         MOVING_OBJECT_RIGHT: {key: "ArrowRight", ctrl: false},
         TOGGLE_KEYBINDLIST: {key: "F1", ctrl: false},
+        TOGGLE_REPLAY_MODE: {key: "r", ctrl: false},
 };
 
 /** 
@@ -1509,6 +1510,7 @@ document.addEventListener('keyup', function (e)
         if(isKeybindValid(e, keybinds.OPTIONS)) toggleOptionsPane();
         if(isKeybindValid(e, keybinds.PASTE)) pasteClipboard(JSON.parse(localStorage.getItem('copiedElements') || "[]"), JSON.parse(localStorage.getItem('copiedLines') || "[]"));
         if(isKeybindValid(e, keybinds.CENTER_CAMERA)) centerCamera();
+        if(isKeybindValid(e, keybinds.TOGGLE_REPLAY_MODE)) toggleReplay();
 
         if (isKeybindValid(e, keybinds.COPY)){
             // Remove the preivous copy-paste data from localstorage.

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -244,6 +244,7 @@
                 <img src="../Shared/icons/diagram_replay.svg"/>
                 <span class="toolTipText"><b>Enter replay mode</b><br>
                     <p>View history of changes made</p><br>
+                    <p id="tooltip-TOGGLE_REPLAY_MODE" class="key_tooltip">Keybinding:</p>
                 </span>
         </fieldset>
         <fieldset>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -253,6 +253,7 @@
                 <img src="../Shared/icons/diagram_ER_table_info.svg"/>
                 <span class="toolTipText"><b>Toggle ER-Table</b><br>
                     <p>Click to toggle ER-Table in options</p><br>
+                    <p id="tooltip-TOGGLE_ER_TABLE" class="key_tooltip">Keybinding:</p>
                 </span>
         </fieldset>
     </div>

--- a/DuggaSys/diagramkeybinds.md
+++ b/DuggaSys/diagramkeybinds.md
@@ -43,5 +43,8 @@
 
 
 ## Replay-mode
-- Replay the changes made = CTRL + "R"
+- Toggles the replay mode to show the changes made = "R"
 
+
+## Error check
+- Performs error checking if ER element is pressed in the diagram = "E"

--- a/DuggaSys/diagramkeybinds.md
+++ b/DuggaSys/diagramkeybinds.md
@@ -22,7 +22,7 @@
 - Toggle grid = "G"
 - Toggle ruler = "T"
 - Toggle snap to grid = "S"
-- Toggle A4 template = "A"
+- Toggle A4 template = "P"
 
 ## Camera
 
@@ -40,4 +40,8 @@
 - Paste elements or lines = CTRL + ”V”
 - Mark all elements and lines = CTRL + ”A”
 - Toggle keybindlist - ”F1”
+
+
+## Replay-mode
+- Replay the changes made = CTRL + "R"
 


### PR DESCRIPTION
- #12277
### In this pull request working keybinds for the functionalities "Replay mode" & "ER-table" were created.

### To test:
**Make sure that you have pressed inside the diagram iframe first**
1. **Hover over the functionalities "Replay mode" and "ER-table". Make sure that the keybinds are present.**
<img width="351" alt="keybinds" src="https://user-images.githubusercontent.com/81613484/167406442-9c5fbc50-92a6-4adc-9e87-9a7c3ed19335.png">

2. **Try the replay keybind by pressing "r". Make sure that the replay mode is enabled/disabled.** 

3. **Try the ER-toggle button by pressing "e".** 
    - Make sure that an ER-entity is **selected** and the option panel open. 
    - Note: that the option panel doesn't automatically open since you won't be able to toggle between the table and the other functions if that were the case.
