### PR TITLE
Updated commitDiv to not show empty lines

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -2078,6 +2078,7 @@ function mouseUp(e) {
     
     for(var j = 0; j < blameLength; j++){
       var offsetRunner = offset;
+      var emptyLine = 0;
       //Adds blame string
       str += "<h3>" + commitChange[i]['blame'][j].filename + " - " + commitChange[i]['blame'][j].rowk + " lines changed </h3>";
 
@@ -2086,10 +2087,13 @@ function mouseUp(e) {
       codeLength = commitChange[i]['blame'][j].rowk;
       for(var x = 0; x < codeLength; x++){
         //console.log("index: " + i + " x: "+ x + " code length: "+ codeLength + " offset: "+ offset);
-        str += "<p><b>" + commitChange[i]['codechange'][x+offset].rowno + "</b> - " + commitChange[i]['codechange'][x+offset].code;
+        if(commitChange[i]['codechange'][x+offset].code != ""){
+          str += "<p><b>" + commitChange[i]['codechange'][x+offset].rowno + "</b> - " + commitChange[i]['codechange'][x+offset].code;
+        }else emptyLine++
         offsetRunner++;
       }
       offset = offsetRunner;
+      str+="<p><b>"+emptyLine+" / "+codeLength+" Lines were empty</b></p><br>"
       //console.log("After for "+offset);
     }
     //If a commit didn't change anything display this instead


### PR DESCRIPTION
Changed it so that empty lines of code no longer show in the list. Instead empty lines are counted and the total amount is displayed at the end of the section.

Before
![commitdiv_blank_rows](https://user-images.githubusercontent.com/102533453/167413991-f61e56fd-48ab-44f3-8cfd-dd75997cda46.png)

After
![commitdiv_empty_count](https://user-images.githubusercontent.com/102533453/167414001-2dd2db1f-8749-4691-9073-79d9edf98ea2.png)

