### PR TITLE
Prevented deleted headers from reappearing

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -560,6 +560,7 @@ function deleteItem(item_lid = null) {
    }, 60000);
 }
 
+// Permanently delete elements
 function deleteAll()
 {
   for(var i = delArr.length-1; i >= 0; --i){
@@ -574,6 +575,15 @@ function deleteAll()
 // Cancel deletion
 function cancelDelete() {
   location.reload();
+}
+
+// Set all "deleted" items as hidden
+// Used when refreshing the table
+function hideDeleted()
+{
+  for(var i = 0; i < delArr.length; ++i){
+    document.getElementById("lid" + delArr[i]).style.display = "none";
+  }
 }
 
 //----------------------------------------------------------------------------------
@@ -1342,6 +1352,8 @@ function returnedSection(data) {
 
   }
 
+  // Hide items set to be deleted
+  hideDeleted();
 
   // The next 5 lines are related to collapsable menus and their state.
   getHiddenElements();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -19,7 +19,8 @@ var hasDuggs = false;
 var dateToday = new Date().getTime();
 var compareWeek = -604800000;
 let width = screen.width;
-var time;
+var delArr = [];
+var delTimer;
 var lid;
 
 // Stores everything that relates to collapsable menus and their state.
@@ -546,27 +547,33 @@ function prepareItem() {
 // deleteItem: Deletes Item from Section List
 //----------------------------------------------------------------------------------
 
-function deleteItem(item_lid = null) { 
+function deleteItem(item_lid = null) {
   lid = item_lid ? item_lid : $("#lid").val();
   document.getElementById("lid" + lid).style.display = "none";
   alert("Press recycle button within 60 seconds to undo the deletion");
   document.querySelector("#undoButton").style.display = "block";
   // Makes deletefunction sleep for 60 sec so it is possible to undo an accidental deletion
-  time = setTimeout(() => {
+  delArr.push(lid);
+  clearTimeout(delTimer);
+  delTimer = setTimeout(() => {
+    deleteAll();
+   }, 60000);
+}
+
+function deleteAll()
+{
+  for(var i = delArr.length-1; i >= 0; --i){
     AJAXService("DEL", {
-      lid: lid
+      lid: delArr.pop()
     }, "SECTION");
-    $("#editSection").css("display", "none");
-    document.querySelector("#undoButton").style.display = "none";
-   }, 60000)
+  }
+  $("#editSection").css("display", "none");
+  document.querySelector("#undoButton").style.display = "none";
 }
 
 // Cancel deletion
 function cancelDelete() {
-  clearTimeout(time);
-  document.getElementById("lid" + lid).style.display = "block";
   location.reload();
-  document.querySelector("#undoButton").style.display = "none";
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
All headers (and other items) should now delete properly. Changed the behavior slightly so that all items are deleted at the same time, and the timer refreshes every time an item is set to be deleted. This means that if you press the delete button on one item, wait 50 seconds, then press to delete another, the timer will be reset back to 60 seconds. After 60 seconds, both the items are deleted at the same time.

To test:
1. Create a couple of headers.
2. Delete as many as you want.
3. 60 seconds after the last item was set to be deleted, all items should delete. The table will briefly reload when this happens. However, there is no message. You can see when this happens by looking in the console log.
4. Only the headers you set to delete should be gone. The deleted headers should still be gone after refreshing the page or after adding new headers.
5. (optional) Add a header, delete it, and click the undo button. The header should reappear.