### PR TITLE
Fix for issue #12239 Hide the button to turn on of error checking when error checking is not allowed

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4240,7 +4240,17 @@ function toggleErrorCheck(){
     }
     showdata();
 }
-
+/**
+ * @description hides the error check button when not allowed
+ */
+function hideErrorCheck(show){
+    if(show == true){
+        document.getElementById("errorCheckToggle").style.display = "flex";
+    }
+    else{
+        document.getElementById("errorCheckToggle").style.display = "none";
+    }
+}
 function setA4SizeFactor(e){
     //store 1 + increased procent amount
     settings.grid.a4SizeFactor = parseInt(e.target.value)/100;

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -190,7 +190,7 @@ session_start();
                     </div>
                     <div id="errorCheck">
                       <fieldset style="width:90%">
-                        <legend>Error check</legend>
+                        <legend>Error check button</legend>
                         <label for="errorActive">Active</label>
                         <input type="checkbox" name="errorActive" id="errorActive" value="true" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"/>
                       </fieldset>

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -77,26 +77,21 @@ function returnedDugga(data)
     //temporary solution to get the correct link in the receipt
     //updateReceiptText(data['duggaTitle'], createUrl(data['hash']), data['hash'], data['hashpwd']);
   
-    if (data.param.length!=0){
+    if (data.param.length!=0 ||){
         var param = JSON.parse(data.param);
         //document.getElementById("assigment-instructions").innerHTML = param.instructions;
         //checking if the user is a teacher or if there's no variant by checking if the paramater object is empty
-        if(!(Object.keys(param).length === 0)){
+        if(!(Object.keys(param).length === 0) && data.isTeacher == 0){
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type;
+            // getting the error checker allowed or not
+            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
             // Getting the instructions to the side of the dugga -currently using filelink which is wrong
             window.parent.getInstructions(param.filelink);
         }
         else{
             var diagramType={ER:true,UML:true};
             document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
-        }
-         //checking if the user is not a teacher 
-        if (data.isTeacher == 0){
-            // getting the error checker allowed or not
-            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
-        }
-        else{
             document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(true);
         }
         document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();//<-- UML functionality end

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -83,14 +83,19 @@ function returnedDugga(data)
         if(!(Object.keys(param).length === 0)){
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type;
-            // getting the error checker allowed or not
-            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
             // Getting the instructions to the side of the dugga -currently using filelink which is wrong
             window.parent.getInstructions(param.filelink);
         }
         else{
             var diagramType={ER:true,UML:true};
             document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
+        }
+         //checking if the user is not a teacher 
+        if (data.isTeacher == 0){
+            // getting the error checker allowed or not
+            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
+        }
+        else{
             document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(true);
         }
         document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();//<-- UML functionality end

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -77,7 +77,7 @@ function returnedDugga(data)
     //temporary solution to get the correct link in the receipt
     //updateReceiptText(data['duggaTitle'], createUrl(data['hash']), data['hash'], data['hashpwd']);
   
-    if (data.param.length!=0 ||){
+    if (data.param.length!=0){
         var param = JSON.parse(data.param);
         //document.getElementById("assigment-instructions").innerHTML = param.instructions;
         //checking if the user is a teacher or if there's no variant by checking if the paramater object is empty

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -83,15 +83,15 @@ function returnedDugga(data)
         if(!(Object.keys(param).length === 0)){
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type;
-            // getting the error finder allowed or not
-            // document.getElementById("diagram-iframe").contentWindow.errorActive = param.errorActive;
+            // getting the error checker allowed or not
+            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
             // Getting the instructions to the side of the dugga -currently using filelink which is wrong
             window.parent.getInstructions(param.filelink);
         }
         else{
             var diagramType={ER:true,UML:true};
             document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
-            // document.getElementById("diagram-iframe").contentWindow.errorActive = true;
+            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(true);
         }
         document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();//<-- UML functionality end
     }

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -71,6 +71,7 @@ function uploadFile()
  * */
 function returnedDugga(data)
 {
+    console.log(data);
     var textBox = document.getElementById('submission-receipt');  
     textBox.innerHTML=(`${data['duggaTitle']}</br></br>Direct link (to be submitted in canvas): </br>` + `<a href='${createUrl(data['hash'])}'> ${createUrl(data['hash'])}` + `</a> </br></br> Hash: </br> ${data['hash']}</br></br>Hash password:</br>${data['hashpwd']}`);
     //temporary solution to get the correct link in the receipt


### PR DESCRIPTION
Added so the techer can choose if the error checking button is shown.
For testing:
When logged in as teacher, no variant is selected, no variant exists or error check button is deaktivated it should look like below
![image](https://user-images.githubusercontent.com/81320323/167419911-5debe181-90a1-47c1-95a3-636cce742b04.png)
if error check button is deactivated it should look like below
![image](https://user-images.githubusercontent.com/81320323/167419957-4cd597b9-a2f6-405f-a94a-2031b5ae4557.png)
- #12239 