### PR TITLE
Fixed error in "Edit course" version name #12202

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2537,7 +2537,15 @@ function validateVersionName(versionName, dialogid) {
   var Name = /^[A-Za-z0-9_ \-.]+$/;
   var name = document.getElementById(versionName);
   var x = document.getElementById(dialogid);
-  var val = document.getElementById("versname").value;
+  
+  if (versionName === 'versname') {
+    var Name = /^[A-Z]{2}[0-9]{2}$/;
+    var val = document.getElementById("versname").value;
+  }
+  if (versionName === 'eversname') {
+    var Name = /^[A-Z]{2}[0-9]{2}$/;
+    var val = document.getElementById("eversname").value;
+  }
 
   //if versionname is 2 capital letters, 2 numbers
   if (val.match(Name)) {

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -391,7 +391,7 @@
 				<div class='inputwrapper'><span>Version ID:</span><input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); validateCourseID('cversid', 'dialog2')" class='textinput' type='text' id='cversid' placeholder='Version ID' maxlength='8'/></div>
 				<p id="dialog2" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Only numbers(between 3-8 numbers)</p>
 				<div class='inputwrapper'><span>Version Name:</span><input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); validateVersionName('versname', 'dialog')" class='textinput' type='text' id='versname' placeholder='Version Name' /></div>
-				<p id="dialog" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Must be A-Z 0-9</p>
+				<p id="dialog" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Must be in of the form HTNN, VTNN or STNN</p>
 				<div class='inputwrapper'><span>Start Date:</span><input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); validateDate('startdate','enddate','dialog3')" class='textinput' type='date' id='startdate' value='' /></div>
 				<div class='inputwrapper'><span>End Date:</span><input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); validateDate('startdate','enddate','dialog3')" class='textinput' type='date' id='enddate' value='' /></div>
 				<p id="dialog3" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Start date has to be before end date</p>


### PR DESCRIPTION
Before when you edited the current course it showed an error in "version name" even though it was correct according to the standards. This is fixed for both when you add new courses and when you edit existing courses.