### PR TITLE
Implementation of relative deadlines

### DIFF
--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -194,7 +194,7 @@ if(checklogin()){
 						$debug="Error reading quiz\n".$error[2];
 				}else{
 						foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-								$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
+								$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
 								$ruery->bindParam(':oldid', $row['id']);
 								$ruery->bindParam(':newvers', $versid);
 								if(!$ruery->execute()) {

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -194,8 +194,8 @@ if(checklogin()){
 						$debug="Error reading quiz\n".$error[2];
 				}else{
 						foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-							$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
-							$ruery->bindParam(':oldid', $row['id']);
+								$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
+								$ruery->bindParam(':oldid', $row['id']);
 								$ruery->bindParam(':newvers', $versid);
 								if(!$ruery->execute()) {
 									$error=$ruery->errorInfo();

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -194,8 +194,8 @@ if(checklogin()){
 						$debug="Error reading quiz\n".$error[2];
 				}else{
 						foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-								$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
-								$ruery->bindParam(':oldid', $row['id']);
+							$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
+							$ruery->bindParam(':oldid', $row['id']);
 								$ruery->bindParam(':newvers', $versid);
 								if(!$ruery->execute()) {
 									$error=$ruery->errorInfo();

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -245,17 +245,18 @@
 							<legend><h3>Deadline</h3></legend>
 							<span>Absolute</span>
 							<span style='float:right'>
-								<input onchange="quickValidateForm('editSection', 'saveBtn');" class='textinput' type='date' id='setDeadlineValue' value='' />
+								<input onchange="showCourseDate('setDeadlineValue','dialog8')" class='textinput' type='date' id='setDeadlineValue' value='' />
 								<select style='width:55px;' id='deadlineminutes'></select>
 								<select style='width:55px;' id='deadlinehours'></select>
+								<input type='checkbox' id='absolutedeadlinecheck' style='margin:3px 5px; height:20px' onclick='checkDeadlineCheckbox(this)'/>
 							</span>
 							<br />
 							<span title="Relative deadline that relates to the start of the course instead of a set date">Relative</span>
 							<span style='float:right'>
-								<select style='width:140px;' id='relativedeadlineweekdays'title="Weekday"></select>
-								<select style='width:55px;' id='relativedeadlineweeks' title="Course Week"></select>
-								<select style='width:55px;' id='relativedeadlineminutes'title="Minute"></select>
-								<select style='width:55px;' id='relativedeadlinehours' title="Hour"></select>
+								<select style='width:140px;' id='relativedeadlinetype'></select>
+								<select style='width:55px;' id='relativedeadlineamount'></select>
+								<select style='width:55px;' id='relativedeadlineminutes'></select>
+								<select style='width:55px;' id='relativedeadlinehours'></select>
 							</span>
 							<span style='float:left'>
 								<p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;max-height:20px;">Deadline has to be between start date and end date</p>


### PR DESCRIPTION
## Relative Deadlines

The relative deadline calculates a deadline from the course start up until the amount of time you pick. So if the course starts at 2020-05-01 and you pick 2 weeks as the relative deadline then this dugga will have its deadline set to 2020-05-01 plus 14 days. This is, in general, what relative deadlines do.

The relative deadlines are chosen through the menu that appears when you press the cogwheel(logged in as a teacher) on a dugga or quiz. You'll then have the option to choose a time, a amount, and a type to store in the database for this particular dugga.

- Time = Hour and minute of the day
- Amount = Amount of the type
- Type = Days, Weeks or Months

Currently, what happens behind the scenes is that you'll have the option to choose absolute deadlines(as it was before) if you want by ticking a checkbox next to the absolute deadline date picker as the picture below shows. Doing this, this will then override the relative deadline. The relative deadline will still be stored and saved but the absolute deadline will be used as it was prior to the implementation of relative deadlines.

![image](https://user-images.githubusercontent.com/82010032/166444226-1ee6354b-4fc4-42fa-b8b2-af45130c81cb.png)

When the site loads, a check will be made whether the relative deadline and the absolute deadline are the same or not. If they are the same, the websites assume that the relative should be used and shows a unchecked absolute deadline. If these two dates differ, then it will show as the above picture show. When a teacher then clicks save, the website will check whether the absolute deadline checkbox is checked, if it isn't then it will override the deadline datepicker date with the previously calculated relative deadline and then store that data in the database. This way, we can assure ourselves with the fact that relative deadlines will never cause any issue with how the deadlines are being used in any other part of the website. All we're essentially doing is changing what deadline should be stored prior to storing it. This also gives the flexibility for relative deadlines to be stored in a json format as a string and retrieved and read after the fetching has happened, so we could potentially store many other variables to do with relative deadlines that has not to do with a date. 

Keep in mind that currently, all relative deadlines will be NULL once you re-install the database and I choose to automatically pick absolute deadline if the relative deadline is NULL and therefore when you click on the cogwheel for the first time for each dugga, it will always pick absolute deadline. Reasoning behind this is that I didn't want to disrupt any ongoing deadlines by overriding the current deadline. Once you uncheck the absolute deadline checkbox and save it, it should pick the relative deadline over the absolute one.

If we're ever storing deadlines outside of the sectioned.js file then maybe there would be some issues but as far as I've seen, there is no ajax requests besides the one I've been working with that handles deadlines and that one only points to sectionedservice.php which is the file that handles all SQL requests to the database.

Just to emphasize:
These changes *do not* interfere with the current logic with comparing absolute deadline validation for it being within the course dates or not. 

They *do not* interfere with how the deadlines are being stored in the database.

They *do not* interfere with how the deadline are being handled subsequent any deadline being fetched from the database.

### Tests
In order to test this, I would simply play around with deadlines and see which one is being picked after saving a dugga.
Here's a few tests that can be made:

**Remember to re-install the DB by running install.php if you didn't do that since last merge.**

- Open any dugga through the cogwheel menu and change the relative deadline. Press save and open again(can be done without refreshing the site) and check whether your change persisted or not.
- Open any dugga through the cogwheel menu and change both relative and absolute deadline by checking the absolute checkbox. Then proceed to save and open the same dugga again to see whether the absolute deadline checkbox is checked or not and if the dates are the dates you previously picked.
- Open any dugga through the cogwheel menu and do the same as the previous step but this time before saving uncheck the absolute deadline checkbox and then check again whether the absolute or relative is being used. The one being used will be the one displayed to the left of the cogwheel menu button. The picture below shows where this is.
![image](https://user-images.githubusercontent.com/82010032/166445895-edf79536-63e7-47e6-bae6-f6c6d5debddb.png)

I'm sure there are many other ways to test this, but this is the simple way or figuring out whether the data is being stored *and* if it's being displayed correctly.

### Added from last pull request

Added functionality behind loading null deadlines since that seems to be the most simple way of resetting deadlines when copying a course. I did not change how the deadlines are stored upon copying a course in this pull request but might be in the next week if this one works. I have implemented it and tested it but reverted it as to keep this pull request a little more slim.

### Known issues
- When copying a course the old absolute deadlines will still be prioritized
- There is no "preview text" yet as requested in the original issue request
- The absolute deadlines checkbox positioning behaves strange on smaller devices