### PR TITLE
change text color in dark mode on page Testing-course

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -790,7 +790,6 @@ p {
 #Sectionlist {
   margin: 10px;
   background-color: var(--color-background);
-  color: var(--color-text-secondary);
   display: block;
   padding-top: 1px;
   border-radius: 5px;


### PR DESCRIPTION
Text was almost in the same color as background before but should now be white, solution was to remove the color from #Sectionlist to make the text inherit the color from #content.

Testing:
1. go to Testing-Course. It should look like something below before the solution was implemented.
![image](https://user-images.githubusercontent.com/81631818/167563912-6e261fbd-8f80-4e2a-b171-fb9b4defa6bb.png)
2. switch to this branch and go to Testing-course. The text should now look like below.
![image](https://user-images.githubusercontent.com/81631818/167564371-e58f8397-f003-42e4-b9b8-f1bba79b7a8d.png)


