### PR TITLE
Dark mode on forgot password page.

### DIFF
--- a/Shared/loginbox.php
+++ b/Shared/loginbox.php
@@ -67,7 +67,7 @@
 				</table>
 			</form>
 		</div>
-		<div id='newpassword' class='newpassword' style="display:none">
+		<div id='newpassword' class='newpassword DarkModeBackgrounds DarkModeText' style="display:none">
 			<div class='loginBoxheader'>
 				<h3> Reset Password</h3>
 				<div class="cursorPointer" onclick="closeWindows(); resetLoginStatus();" title="Close window">x</div>


### PR DESCRIPTION
Added dark mode background & text on "Forgot password?" page.

The yellow text on white background while hovering will be fixed once the hovering color has been adjusted globally in dark mode.