### PR TITLE
Set the font'size of the element in question to the  same as the others

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -826,7 +826,7 @@ p {
     font-size: 10pt;
   }
 	.internal-link {
-        font-size: 10px;
+        font-size: 10pt;
     }
 }
 


### PR DESCRIPTION
The font size of the shaderprogramming duggas is now the same as the other duuggas.
For testing:
1: Enter webprogrammering.
2: Reduce the screen size so that mobile view is activated.
![image](https://user-images.githubusercontent.com/102600690/167591532-9a3c54dd-878c-4956-a31c-81ee47b712fe.png)
3:It should look like this: 
![image](https://user-images.githubusercontent.com/102600690/167591645-e224fa01-3924-41fb-bb5b-c19f89cdb6f3.png)
Not like this
![image](https://user-images.githubusercontent.com/102600690/167591730-dcc8b89c-64de-470c-a40a-28f7bbf6f801.png)

