### PR TITLE
Checkboxes should now skip invisible headers

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -383,8 +383,9 @@ function markedItems(item = null){
       $("#Sectionlist").find(".item").each(function (i) {
         var tempItem = $(this).attr('value');
         if(itemInSection && sectionStart){
+          var tempDisplay = document.getElementById("lid"+tempItem).style.display;
           var tempKind = $(this).parents('tr').attr('value');
-          if(tempKind == "section" || tempKind == "moment" || tempKind == "header"){
+          if(tempDisplay != "none" && (tempKind == "section" || tempKind == "moment" || tempKind == "header")){
             itemInSection = false;
             //console.log("loop breaker: "+tempItem);
           }else{
@@ -1351,6 +1352,9 @@ function returnedSection(data) {
 
   }
 
+  // Reset checkboxes
+  // Prevents a bug if they are checked when for example an item is deleted and the table refreshes
+  clearHideItemList();
 
   // The next 5 lines are related to collapsable menus and their state.
   getHiddenElements();


### PR DESCRIPTION
Added an if-statement to skip headers with style.display set to "none".

To test:
1. Go to Demo Course
2. Create a new header
3. Delete the header
4. Click the checkbox on the top of the table to select all
5. All checkboxes down to the next visible header should be selected. Any deleted (hidden) headers should be skipped.