### PR TITLE
Fixed the arrow functionality in diagram dugga #12316

### DIFF
--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -46,7 +46,7 @@
         
         #close_open {
             width: 23px;
-            position: fixed;
+            position: absolute;
             top: 520px;
             left: 272px;
             border-top: 14px solid transparent;

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -72,7 +72,7 @@
         $(document).ready(function() {
             $("#close_open").click(function() {
                 if ($("#pvalue").val() == "0") {
-
+                    // hides description when open
                     $("#assignment_discrb").css('visibility', 'hidden');
                     $("#container__left").animate({
                         width: "10px"
@@ -80,28 +80,22 @@
                     $("#close_open").css({
                         'display': 'fixed',
                         'left': '7px',
-                        'transform': 'scaleX(-1)'
+                        'transform': 'scaleX(-1)',
+                        'transition': '0.55s ease-in-out'
                     });
-
                     $("#pvalue").val("1");
                 } else {
-
-                    $("#container__left").animate({
-                        width: "300px"
-                    });
+                    // opens description when closed
                     $("#container__left").animate({
                         width: "300px"
                     }, "slow");
                     $("#assignment_discrb").css('visibility', 'visible');
                     $("#close_open").css({
                         'display': 'block',
-                        'left': '292px',
-                    });
-                    $("#pvalue").val("0");
-                    $("#close_open").css({
                         'transform': 'scaleX(1)',
                         'left': '272px'
                     });
+                    $("#pvalue").val("0");
                 }
 
 

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -79,7 +79,8 @@
                     }, "slow");
                     $("#close_open").css({
                         'display': 'fixed',
-                        'left': '-18px'
+                        'left': '7px',
+                        'transform': 'scaleX(-1)'
                     });
 
                     $("#pvalue").val("1");
@@ -94,9 +95,13 @@
                     $("#assignment_discrb").css('visibility', 'visible');
                     $("#close_open").css({
                         'display': 'block',
-                        'left': '272px'
+                        'left': '292px',
                     });
                     $("#pvalue").val("0");
+                    $("#close_open").css({
+                        'transform': 'scaleX(1)',
+                        'left': '272px'
+                    });
                 }
 
 

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -52,6 +52,7 @@
             border-top: 14px solid transparent;
             border-bottom: 14px solid transparent;
             border-right: 14px solid #d4d2d2;
+            margin-left:10px;
         }
         
         #close_open:hover {
@@ -64,6 +65,7 @@
             flex: 1;
             display: flex;
             justify-content: space-around;
+            margin-left:10px;
         }
     </style>
     <script>

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -47,7 +47,7 @@
         #close_open {
             width: 23px;
             position: fixed;
-            top: 50%;
+            top: 520px;
             left: 272px;
             border-top: 14px solid transparent;
             border-bottom: 14px solid transparent;


### PR DESCRIPTION
**To make it easier have a duplicated tab opened of the g1-project webserver with and without the branch to preview the changes more clearly.**
### This pull request contains:
- Fixed so the arrow doesn't overlap the scrollbar
- Arrow flips when description is opened/closed.
- Animation is smoother as the arrow now follows the open/close animation of the description.
- Before the arrow scrolled outside of the screen when zoomed in/out but is now positioned absloute in one position in the middle.

## To test:

1. Make sure that the arrow doesn't overlap the scrollbar:
<img width="150" alt="overlap" src="https://user-images.githubusercontent.com/81613484/167620915-a27a0da2-8804-4123-8f2a-39b11cd33ab1.png">

2. Make sure that the arrow flips when opened/closed.
<img width="112" alt="openedclosed" src="https://user-images.githubusercontent.com/81613484/167621465-8a0b90e4-fdcd-4200-ac42-47a10137d45f.png">

3. When opening and closing make sure that the arrow doesn't jump from one place to another but rather follows along the animation when opening and closing the description.

4. Zoom in/out (outside the diagram, making the whole window smaller/bigger). Make sure that the arrow is positioned in the same position at all time (in the middle).
<img width="149" alt="zoomed" src="https://user-images.githubusercontent.com/81613484/167622178-13fa7a09-fe0c-41b5-9ca5-7a3b63f04243.png">



