### PR TITLE
Added home, return and darkmode to burger menu.

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -21,7 +21,16 @@ var compareWeek = -604800000;
 let width = screen.width;
 var time;
 var lid;
+/*navburger*/
+function navBurgerChange(operation = 'click') {
 
+  var x = document.getElementById("navBurgerBox");
+  if (x.style.display === "block") {
+    x.style.display = "none";
+  } else {
+    x.style.display = "block";
+  }
+}
 // Stores everything that relates to collapsable menus and their state.
 var menuState = {
   idCounter: 0,

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -21,6 +21,7 @@ var compareWeek = -604800000;
 let width = screen.width;
 var time;
 var lid;
+
 /*navburger*/
 function navBurgerChange(operation = 'click') {
 
@@ -30,6 +31,29 @@ function navBurgerChange(operation = 'click') {
   } else {
     x.style.display = "block";
   }
+
+}
+
+//function to change darkmode from burger menu
+function burgerToggleDarkmode(operation = 'click'){
+  const storedTheme = localStorage.getItem('themeBlack');
+    if(storedTheme){
+        themeStylesheet.href = storedTheme;
+    }
+    const themeToggle = document.getElementById('theme-toggle');
+    // if it's light -> go dark
+    if(themeStylesheet.href.includes('blackTheme')){
+      themeStylesheet.href = "../Shared/css/whiteTheme.css";
+      localStorage.setItem('themeBlack',themeStylesheet.href)
+    } 
+    else if(themeStylesheet.href.includes('whiteTheme')) {
+      // if it's dark -> go light
+      themeStylesheet.href = "../Shared/css/blackTheme.css";
+      localStorage.setItem('themeBlack',themeStylesheet.href)
+    }
+  
+  //const themeToggle = document.getElementById('theme-toggle');
+  //themeToggle.addEventListener('click', () => {});
 }
 // Stores everything that relates to collapsable menus and their state.
 var menuState = {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5364,6 +5364,11 @@ only screen and (max-device-width: 860px) {
     display: none;
   }
 }
+
+#darkModeBurgerTeacher,#goBackBurgerTeacher,#homeBurgerTeacher {
+  display:none;
+}
+
 #navBurgerIcon { 
   display: none;
   
@@ -5385,7 +5390,7 @@ only screen and (max-device-width: 320px) {
     background-color: var(--color-primary-2);
   }
  
-#homeBurger, #darkModeBurger,#goBackBurger {
+  #darkModeBurgerTeacher,#goBackBurgerTeacher,#homeBurgerTeacher, #homeBurger, #darkModeBurger,#goBackBurger {
     display: block;
   }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5364,6 +5364,35 @@ only screen and (max-device-width: 860px) {
     display: none;
   }
 }
+#navBurgerIcon { 
+  display: none;
+  
+}
+@media only screen and (max-width: 320px),
+only screen and (max-device-width: 320px) {
+
+  #navBurgerIcon { 
+    display: block;
+  }
+ 
+  #navBurgerBox{
+    display: block;
+    position: absolute;
+    top: 50px;
+    width: 32px;
+    padding: 10px;
+    height: 100px;
+    background-color: var(--color-primary-2);
+  }
+ 
+#homeBurger, #darkModeBurger,#goBackBurger {
+    display: block;
+  }
+
+ #homeIcon, #upIcon, #theme-toggle{
+    display: none;
+  }
+}
 
 @media only screen and (max-width: 790px),
 only screen and (max-device-width: 790px) {

--- a/Shared/icons/collapse_icon.svg
+++ b/Shared/icons/collapse_icon.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="23px" height="23px" viewBox="-5 0 23 23" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    
+    <title>right</title>
+    <desc>Created with Sketch.</desc>
+    <g id="icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="ui-gambling-website-lined-icnos-casinoshunter" transform="translate(-484.000000, -159.000000)" fill="#252528" fill-rule="nonzero">
+            <g id="square-filled" transform="translate(50.000000, 120.000000)">
+                <path d="M435.76062,39.2902857 L446.638635,49.7417043 L446.699713,49.7959169 C446.885605,49.9745543 446.985701,50.2044182 447,50.4382227 L447,50.5617773 C446.985701,50.7955818 446.885605,51.0254457 446.699713,51.2040831 L446.646163,51.2479803 L435.76062,61.7097143 C435.357854,62.0967619 434.704841,62.0967619 434.302075,61.7097143 C433.899308,61.3226668 433.899308,60.6951387 434.302075,60.3080911 L444.451352,50.5617773 L434.302075,40.6919089 C433.899308,40.3048613 433.899308,39.6773332 434.302075,39.2902857 C434.704841,38.9032381 435.357854,38.9032381 435.76062,39.2902857 Z" id="right"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -56,26 +56,25 @@
 					echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
 					echo "'>";
 					
-				}
-				echo "<img alt ='home' class='navBurgerButt' src='../Shared/icons/Up.svg'>";
-				echo "</a>";
-				echo"</div>";
-
+					}
+					echo "<img alt ='home' class='navBurgerButt' src='../Shared/icons/Up.svg'>";
+					echo "</a>";
+					echo"</div>";
 					echo "<div id='darkModeBurgerDiv'>";
-					echo "<a id='darkModeBurger' href='../DuggaSys/darkmodeToggle.js'";
+					echo "<a id='darkModeBurger' onclick = 'burgerToggleDarkmode()'  >";
 					echo "<img alt ='Dark' class='navBurgerButt' src='../Shared/icons/ThemeToggle.svg'></>";
-					echo "<img alt='Dark'  class='navBurgerButt' src='../Shared/icons/ThemeToggle.svg'>";
-							echo "</a>";
+					echo "</a>";
 					echo "</a>";
 					echo"</div>";
 					echo"</div>";
 					
-			}
+				}
+			
 			// Always show home button which links to course homepage
 			echo "<td class='navButt' id='home' title='Home'><a id='homeIcon' class='navButt' href='../DuggaSys/courseed.php'><img alt='home button icon' src='../Shared/icons/Home.svg'></a></td>";
 			// Always show toggle button. When clicked it changes between dark and light mode.
 			echo "<td class='navButt'><img id='theme-toggle' src='../Shared/icons/ThemeToggle.svg' alt='an icon on a moon, which indicates dark mode and light mood'></td>";
-
+			
 			echo "<td class='navButt' style='display:none'; id='motdNav' title='Message of the day 'onclick='showServerMessage();'><img alt='motd icon' src='../Shared/icons/MOTD.svg'></td>";
 			// Generate different back buttons depending on which page is including
 			// this file navheader file. The switch case uses ternary operators to
@@ -241,7 +240,44 @@
 							echo "<img alt='give access icon'  class='burgerButt' src='../Shared/icons/lock_symbol.svg'>";
 							echo "</a>";
 							echo "<a class='burgerButtText' href='accessed.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers']."' >Change student access</a></div>";
-							echo "</div>";
+					
+							//Adding home button to the teacher burger menu
+							echo "<div id='homeBurgerTeacher'>";
+							echo "<a id='homeBurgerT' href='../DuggaSys/courseed.php'>";
+							echo "<img alt ='home' class='burgerButt' src='../Shared/icons/Home.svg'>";
+							echo "<a class = 'burgerButtText' href='../DuggaSys/courseed.php'>Home Page </a>";
+							echo"</div>";
+							echo "<a/>";
+							
+							//Adding return button to the teacher burger menu
+							echo "<div id='goBackBurgerTeacher'>";
+							if($noup=='COURSE'){
+								echo "<a id='goBackBurgeTr' href='../DuggaSys/courseed.php'>";
+								echo "<img alt ='home' class='burgerButt' src='../Shared/icons/Up.svg'>";
+								echo "<a class = 'burgerButtText' href='../DuggaSys/courseed.php'> Return </a>";
+								}
+							else if($noup=='SECTION'){
+								echo "<a id='goBackBurgerT' href='";
+								echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
+								echo "'>";
+								echo "<img alt ='home' class='burgerButt' src='../Shared/icons/Up.svg'>";
+								echo "<a class = 'burgerButtText'";
+								echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
+								echo " > Return </a>";
+								}
+							echo "</a>";
+							echo"</div>";
+							
+							//Adding dark mode button to the teacher burger menu
+							echo "<div id='darkModeBurgerTeacher'>";
+							echo "<a id='darkModeBurgerT' onclick = 'burgerToggleDarkmode()'>";
+							echo "<img alt ='Dark' class='burgerButt' src='../Shared/icons/ThemeToggle.svg'></>";
+							// not working yet
+							echo "<a class = 'burgerButtText'onclick = 'burgerToggleDarkmode()'> Change Theme </a>";
+							echo "</a>";
+							echo "</a>";
+							echo"</div>";
+							echo"</div>";
 					}
 			}			
 			// Sort dialog - accessed / resulted /fileed					

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -34,6 +34,43 @@
 			else
 				$_SESSION['coursevers'] = "UNK";
 
+				//Burger menu that Contains the home, back and darkmode icons when window is small; Only shown if not superuser.
+				if(checklogin() == false|| $_SESSION['uid'] == 0){
+					
+					echo "<td class='navBurger fa fa-bars' id='navBurgerIcon' style='font-size:24px; width: 29px; vertical-align: middle; margin-top: 15px; margin-left: 15px' onclick='navBurgerChange()'</td>";
+					echo "<td id='navBurgerIcon' style='display: none;'> </td>";
+					echo "<div id='navBurgerBox' style='display: none;'>";
+				
+					echo "<div id='homeBurgerDiv'>";
+					echo "<a id='homeBurger' href='../DuggaSys/courseed.php'>";
+					echo "<img alt ='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>";
+					echo "<a/>";
+					echo"</div>";
+					
+					echo "<div id='goBackBurgerDiv'>";
+					if($noup=='COURSE'){
+					echo "<a id='goBackBurger' href='../DuggaSys/courseed.php'>";
+					}
+					else if($noup=='SECTION'){
+					echo "<a id='goBackBurger' href='";
+					echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
+					echo "'>";
+					
+				}
+				echo "<img alt ='home' class='navBurgerButt' src='../Shared/icons/Up.svg'>";
+				echo "</a>";
+				echo"</div>";
+
+					echo "<div id='darkModeBurgerDiv'>";
+					echo "<a id='darkModeBurger' href='../DuggaSys/darkmodeToggle.js'";
+					echo "<img alt ='Dark' class='navBurgerButt' src='../Shared/icons/ThemeToggle.svg'></>";
+					echo "<img alt='Dark'  class='navBurgerButt' src='../Shared/icons/ThemeToggle.svg'>";
+							echo "</a>";
+					echo "</a>";
+					echo"</div>";
+					echo"</div>";
+					
+			}
 			// Always show home button which links to course homepage
 			echo "<td class='navButt' id='home' title='Home'><a id='homeIcon' class='navButt' href='../DuggaSys/courseed.php'><img alt='home button icon' src='../Shared/icons/Home.svg'></a></td>";
 			// Always show toggle button. When clicked it changes between dark and light mode.
@@ -206,7 +243,7 @@
 							echo "<a class='burgerButtText' href='accessed.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers']."' >Change student access</a></div>";
 							echo "</div>";
 					}
-			}
+			}			
 			// Sort dialog - accessed / resulted /fileed					
 			//old search bar for resulted
       if($requestedService=="accessed.php" /*|| $requestedService=="resulted.php"*/ || $requestedService=="fileed.php" || $requestedService=="duggaed.php" ){


### PR DESCRIPTION
When resizing the window, to very small the icons seem to move around a bit. To solve this I added home, return and darkmode to the teacher burger menu when the screen is smaller than 320px in witdth. The problem is that you need to a teacher to have access to this menu. I therefor added a new burger menu that contains home, return and darkmode. This only appear if you are not a teacher and the screensize is less then 320 px.

**For testing:**
**1.**  Log in as stei and navigate to webbprogrammering.
**2.**  Open the inspect window (ctrl+shift+i) and make the inspect window very small.
![image](https://user-images.githubusercontent.com/102605031/167631095-07e51b48-e35d-4f3f-a20e-61ce44662896.png)
**3.**  Open the hamburger menu which should now contain the home, return and and darkmode functions.
![image](https://user-images.githubusercontent.com/102605031/167631908-faeec0b0-a3c6-4908-9482-feef8e7fe9d0.png)
**4.**  Next, log out and see if another hamburger menu should appear. 
It should look like this:
![image](https://user-images.githubusercontent.com/102605031/167632406-1d57a725-aa24-47a5-b722-42acfb9ab88c.png)
