### PR TITLE
Created a working keybind for the new error check functionality #12360

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -757,6 +757,7 @@ const keybinds = {
         TOGGLE_KEYBINDLIST: {key: "F1", ctrl: false},
         TOGGLE_REPLAY_MODE: {key: "r", ctrl: false},
         TOGGLE_ER_TABLE: {key: "e", ctrl: false},
+        TOGGLE_ERROR_CHECK:  {key: "h", ctrl: false},
 };
 
 /** 
@@ -1514,6 +1515,7 @@ document.addEventListener('keyup', function (e)
         if(isKeybindValid(e, keybinds.CENTER_CAMERA)) centerCamera();
         if(isKeybindValid(e, keybinds.TOGGLE_REPLAY_MODE)) toggleReplay();
         if(isKeybindValid(e, keybinds.TOGGLE_ER_TABLE)) toggleErTable();
+        if(isKeybindValid(e, keybinds.TOGGLE_ERROR_CHECK)) toggleErrorCheck();
 
         if (isKeybindValid(e, keybinds.COPY)){
             // Remove the preivous copy-paste data from localstorage.
@@ -4352,7 +4354,8 @@ function toggleA4Template()
  * @description turns the error checking functionality on/off
  */
 function toggleErrorCheck(){
-    errorActive =! errorActive;
+    // Inverts the errorActive variable to true or false
+    errorActive = !errorActive;
     if (errorActive) {
         document.getElementById("errorCheckToggle").classList.add("active");
     }  

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -264,6 +264,7 @@
                 <img src="../Shared/icons/diagram_errorCheck.svg"/>
                 <span class="toolTipText"><b>Toggle error check</b><br>
                     <p>Click to toggle error checking on/off</p><br>
+                    <p id="tooltip-TOGGLE_ERROR_CHECK" class="key_tooltip">Keybinding:</p>
                 </span>
             </div>
         </fieldset>        

--- a/DuggaSys/diagramkeybinds.md
+++ b/DuggaSys/diagramkeybinds.md
@@ -32,7 +32,8 @@
 
 - Toggle step forward = CTRL + ”Y”
 - Toggle step backward = CTRL + ”Z”
-- Toggle replay = Klick to start replay 
+- Toggles the replay mode to show the changes made = "R"
+
 
 ## Other
 
@@ -42,9 +43,9 @@
 - Toggle keybindlist - ”F1”
 
 
-## Replay-mode
-- Toggles the replay mode to show the changes made = "R"
+## ER-Table
+- Toggles between ER-table functionality when an ER-element is selected and option panel is open = "E"
 
 
 ## Error check
-- Performs error checking if ER element is pressed in the diagram = "E"
+- Performs error checking if an error is present = "H"


### PR DESCRIPTION
This pull request contains:
- Added the keybind "h" for _help_ to the error check functionality 
(and corrected some errors in diagramkeybinds.md and added a comment in the code).
- #12360


## To test:
1. Press on the _Ssn_ attribute attached to the _Employee_ ER-entity
2. Open the option panel
3. Change the variant from "candidate" to "weakKey" and press save.
4. Press "h"
5. Make sure the boxes turn red/not red- enabled/disabled

<img width="686" alt="errorcheck" src="https://user-images.githubusercontent.com/81613484/167632906-508a4f4d-1ede-4bce-af27-ef12b14f0cbc.png">


