### PR TITLE
Teacher history not visible in replay for student: #12145.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -412,7 +412,7 @@ class StateMachine
 
                         if (Array.isArray(changeType)){
                             for (var index = 0; index < changeType.length && isSoft; index++) {
-                                isSoft = cha<ngeType[index].isSoft;
+                                isSoft = changeType[index].isSoft;
                             }
                             var changeTypes = changeType;
                         }else {
@@ -8412,7 +8412,7 @@ function downloadFile(filename, dataObj)
 /**
  * @description Prepares data for file creation, retrieves history and initialState
  */
-function saveDiagram()
+function exportWithHistory()
 {
 
     displayMessage(messageTypes.SUCCESS, "Generating the save file..");
@@ -8432,7 +8432,7 @@ function saveDiagram()
 /**
  * @description Prepares data for file creation, retrieves data and lines, also filter unnecessary values
  */
-function exportDiagram()
+function exportWithoutHistory()
 {
     displayMessage(messageTypes.SUCCESS, "Generating the export file..");
     var objToSave = {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -335,8 +335,8 @@
             </fieldset>
             <fieldset class='options-fieldset options-section' style='position: absolute; top: 33%;'>
                 <legend>Export</legend>
-                <button class="saveButton" onclick="saveDiagram();">Save</button><br><br>
-                <button class="saveButton" onclick="exportDiagram();">Export</button>
+                <button class="saveButton" onclick="exportWithHistory();">With history</button><br><br>
+                <button class="saveButton" onclick="exportWithoutHistory();">Without history</button>
             </fieldset>
             <fieldset class='options-fieldset options-section' style="position: absolute; top: 48%; margin-top: 2%;">
                 <legend>Import</legend>


### PR DESCRIPTION
Now it is clear how to export a diagram with or without history. It was asked that a teacher should be able to do this, so that the student shouldn't be able to replay the teachers progress.

To make this functionality more obvious we changed the names under the export button in the options menu.

To test this you can make changes to a diagram; save with and without history; upload those diagrams and see the difference when using replay.