### PR TITLE
made the home button bigger in original file to match the implementation of the other icons

### DIFF
--- a/Shared/icons/Home.svg
+++ b/Shared/icons/Home.svg
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Generator: Adobe Illustrator 23.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="32.57px" height="31.975px" viewBox="1.215 2.019 32.57 31.975" enable-background="new 1.215 2.019 32.57 31.975"
-	 xml:space="preserve">
-<path id="home-icon" fill="#FCFCFC" d="M17.712,13.089l9.729,7.986v8.431h-7.07v-4.867h-5.321v4.867H7.983v-8.369L17.712,13.089z
-	 M17.709,10.918l10.792,8.991l1.896-1.801L17.714,7.328L4.885,18.19l1.895,1.804L17.709,10.918z"/>
+	 viewBox="0 0 32.6 32" style="enable-background:new 0 0 32.6 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FCFCFC;}
+</style>
+<path id="home-icon" class="st0" d="M16.4,8.4l12.4,11.5V32h-9v-7H13v7H4V20L16.4,8.4z M16.4,5.3l13.8,12.9l2.4-2.6L16.4,0.1L0,15.7
+	l2.4,2.6L16.4,5.3z"/>
 </svg>


### PR DESCRIPTION
made the house / home button bigger in the global navigation bar, changes were made in the original file to match the other icon implementations.

Testing:

Go to any page where the global navigation bar can be seen.

Home button looked like this before:
![image](https://user-images.githubusercontent.com/81631818/167851734-1571f2f6-308d-4a62-b948-4173deb448ef.png)

Should on this branch be larger and look something like this:
![image](https://user-images.githubusercontent.com/81631818/167851867-0e9bead9-8c1c-42e9-9c5b-5a39a9324f41.png)

