### PR TITLE
Made text the same nuance as the rest text and icons

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -587,8 +587,8 @@ body {
 
 .DateColorInDarkMode{
     cursor: pointer;
-    filter: invert(80%);
-    -webkit-filter: invert(100%);
+    filter: invert(30%);
+    -webkit-filter: invert(30%);
 }
 /* } */
 /* BOXMENU STYLING STOP */


### PR DESCRIPTION
Made the text the same nuance as the rest text and nuance in dark mode in by changing the percentage of the inverted filter.

Testing:

1. Go to dark mode
2. Go to course Demo-Course

Bafore the text looked something like this:
![image](https://user-images.githubusercontent.com/81631818/167856603-2b19ab45-6d66-45dc-88bb-c62047ccb5d8.png)


On this branch it should look something like this:
![image](https://user-images.githubusercontent.com/81631818/167856477-64c75e18-9f67-4911-ab81-7ce8522380c0.png)
