### PR TITLE
Removed MessageOfTheDAyButton

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -89,7 +89,6 @@
 			}if($noup=='COURSE'){
 				echo "<div><a id='upIcon' class='navButt' href='../DuggaSys/courseed.php'>";
 				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></div></td>";
-				echo "<td class='navButt' id='messagedialog' title='Message of the day 'onclick='DisplayMSGofTDY();'><div class='messagedialog-nav' tabindex='0'><img alt='motd icon' src='../Shared/icons/MOTD.svg'></div></td>";
 			}if($noup=='COURSE' && checklogin() && (isTeacher($_SESSION['uid']))){
 				echo '<td class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" style="width: 29px; vertical-align: middle; margin-top: 15px;" onclick=hamburgerChange()>';
 			}if (($noup == 'COURSE') && checkLogin()) {


### PR DESCRIPTION
The removal of this was not included in the week 7 merge. Removing it again.
For testing:
1: Enter a course.
2: The message of the day should still pop up but there should not be a button.
![image](https://user-images.githubusercontent.com/102600690/167860106-3e15e282-4baf-4503-81ed-3f210fec08b9.png)
