### PR TITLE
fixed "angel-brackets" with a esc method issue #12095

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -271,7 +271,7 @@
         <fieldset>
             <legend>Include</legend>
             <div id="erTableToggle" class="diagramIcons" onclick="toggleErTable()">
-                <img src="../Shared/icons/lessThen.jpg"/>
+                <img src="../Shared/icons/diagram_errorCheck.svg"/>
                 <span class="toolTipText"><b>To use less than</b><br>
                     <p>To use less than type & #60; <br><strong>"EX: <& #60;Include>>"</STRONG> </p><br>
                 </span>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -271,7 +271,7 @@
         <fieldset>
             <legend>Include</legend>
             <div id="Include" class="diagramIcons" onclick="toggleErTable()">
-                <img src="../Shared/icons/diagram_errorCheck.svg"/>
+                <img src="../Shared/icons/angelBrackets.svg"/>
                 <span class="toolTipText"><b>To use less than</b><br>
                     <p>To use less than type & #60; <br><strong>"EX: <& #60;Include>>"</STRONG> </p><br>
                 </span>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -269,7 +269,6 @@
             </div>
         </fieldset>   
         <fieldset>
-        <fieldset>
             <legend>Include</legend>
             <div id="erTableToggle" class="diagramIcons" onclick="toggleErTable()">
                 <img src="../Shared/icons/lessThen.jpg"/>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -270,7 +270,7 @@
         </fieldset>   
         <fieldset>
             <legend>Include</legend>
-            <div id="erTableToggle" class="diagramIcons" onclick="toggleErTable()">
+            <div id="Include" class="diagramIcons" onclick="toggleErTable()">
                 <img src="../Shared/icons/diagram_errorCheck.svg"/>
                 <span class="toolTipText"><b>To use less than</b><br>
                     <p>To use less than type & #60; <br><strong>"EX: <& #60;Include>>"</STRONG> </p><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -267,7 +267,16 @@
                     <p id="tooltip-TOGGLE_ERROR_CHECK" class="key_tooltip">Keybinding:</p>
                 </span>
             </div>
-        </fieldset>        
+        </fieldset>   
+        <fieldset>
+        <fieldset>
+            <legend>Include</legend>
+            <div id="erTableToggle" class="diagramIcons" onclick="toggleErTable()">
+                <img src="../Shared/icons/lessThen.jpg"/>
+                <span class="toolTipText"><b>To use less than</b><br>
+                    <p>To use less than type & #60; <br><strong>"EX: <& #60;Include>>"</STRONG> </p><br>
+                </span>
+        </fieldset>      
     </div>
 
     <!-- Message prompt -->


### PR DESCRIPTION
Testning:

- go to diagram dugga.

- Click on a double line and type <&# 60 ; Include>> or something else then include.

- After that, all the brackets shall be visible with the text.