### PR TITLE
Fixed navheader and burgermenu ranges #12420

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2656,7 +2656,7 @@ button.option {
  left: auto;
 }
 
-@media only screen and (max-width: 420px) {
+@media only screen and (max-width: 430px) {
   #MOTDbutton {
     width:20%;
    }
@@ -5392,7 +5392,7 @@ only screen and (max-device-width: 860px) {
 
   #versionCog, #versionPlus, #editStudent,
   #testsBTN, #editFiles, #courseIMG,
-  #editCourse, #announcement{
+  #editCourse, #announcement, #messagedialog{
     display: none;
   }
 }
@@ -5405,8 +5405,8 @@ only screen and (max-device-width: 860px) {
   display: none;
   
 }
-@media only screen and (max-width: 320px),
-only screen and (max-device-width: 320px) {
+@media only screen and (max-width: 380px),
+only screen and (max-device-width: 380px) {
 
   #navBurgerIcon { 
     display: block;

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -190,7 +190,7 @@
 								echo "</td>";
 							}
 
-							echo "<td class='access menuButton' style='display: inline-block;'>";
+							echo "<td class='access' style='display: inline-block;'>";
 							echo "    <div class='access menuButton'>";
             			    echo "      <a id='accessBTN' title='Give students access to the selected version' value='Access' href='accessed.php?courseid=".$_SESSION['courseid']."&coursevers=".$_SESSION['coursevers']."' >";
              				echo "        <img alt='give access icon' id='editCourse' class='navButt' src='../Shared/icons/lock_symbol.svg'>";


### PR DESCRIPTION
"access" div box is now the correct size and burger menu is now displayed in other browser widths.

Testing:
1) Logged in as stei
2) Enter Demo-Course
3) When resizing the window width the icons in the navheader should not go outside of the navheader and appear under it.