### PR TITLE
Trying to open a dugga via hash, without an on-going session, now properly generates the hash in the hash field on the validateHash.php page.

### DIFF
--- a/sh/index.php
+++ b/sh/index.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 date_default_timezone_set("Europe/Stockholm");
 
 // Include basic application services
@@ -14,7 +15,6 @@ $submission = getOPG("s");
 
 // Connect to database and start session
 pdoConnect();
-session_start();
 
 if(isset($_SESSION['uid'])){
 	$userid=$_SESSION['uid'];


### PR DESCRIPTION
Always put session_start() at the top to resume the session before doing anything else. $_SESSION variable was reset when transitioning between pages, as a new session was opened up. Might solve issue regarding user being prompted, multiple times, for hash password when loading a dugga. However, needs more testing to verify as it's a hard to reproduce bug.

To Test:
1. Open diagram dugga and make any changes to the existing diagram.
2. Save the diagram and copy receipt.
3. Close all browsers currently having lenasys open. (to destroy session)
4. click receipt link (or open browser and insert URL) 
5. Hash field on the page that opens should properly contain the hash given when saving diagram.

Note: It took half a day to find this error, please make sure session_start() is ALWAYS at the top.