### PR TITLE
Tool tip not positioned correctly #12423

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -337,10 +337,9 @@
 
 /*tooltip*/
 
-
 .toolTipText{
     top:-5px;
-    left: 9.5%;
+    left: 132%;
     visibility: hidden;
     width: 250px;
     background: rgba(0, 0, 0, 0.8);
@@ -353,9 +352,12 @@
     z-index: 2;
 }
 
-
 .diagramIcons:hover .toolTipText{
     visibility: visible;
+}
+
+#tooltip-OPTIONS{
+    left: 9.5%;
 }
 
 .colorMenu{

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -314,9 +314,9 @@
     </div>  
     <div id="options-pane" class="hide-options-pane"> <!-- Yellow menu on right side of screen -->
         <div id="options-pane-button" onclick="toggleOptionsPane();"><span id='optmarker'>&#9660;Options</span>
-            <span class="toolTipText"><b>Show Option Panel</b><br>
+            <span id="tooltip-OPTIONS" class="toolTipText"><b>Show Option Panel</b><br>
                 <p>Enable/disable the Option Panel</p><br>
-                <p id="tooltip-OPTIONS" class="key_tooltip">Keybinding:</p>
+                <p class="key_tooltip">Keybinding:</p>
             </span>
         </div>
         <div id ="fieldsetBox">


### PR DESCRIPTION
Issue #12423

**What has been done**
- Used already existing ID for tooltip in the options panel to give different styling for it.
- Corrected the changed styling that caused the issue after the weekly merge for tooltip in the toolbar.

**How to test**
Hover over the toolbar and options panel to see that the tooltip is positioned correctly. 

**What it should look like**
![image](https://user-images.githubusercontent.com/81772705/167911224-74a2e32a-5a6b-415c-9c27-ccff1d623374.png)
![image](https://user-images.githubusercontent.com/81772705/167911278-10448539-3bb6-41dc-9a34-9f9d22628839.png)
