### PR TITLE
User no longer gets prompted to press OK multiple times when opening dugga

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -81,10 +81,8 @@
 		$splicedFileName = substr($variantParams, strpos($variantParams, "diagram File&quot;:") + 25, ($end - $start));*/
 		$variantParams = str_replace('&quot;','"',$variantParams);
 		$parameterArray = json_decode($variantParams,true);
-		if(!empty($parameterArray)){
+		if(!empty($parameterArray) && !isset($parameterArray["variant"])){
 
-			//exception handling for default variants, should not try to read file if using testdata
-			if(!isset($parameterArray["variant"])){
 				$splicedFileName=$parameterArray["diagram_File"];
 				$fileName=$parameterArray["filelink"];
 				$fileType=$parameterArray["type"];
@@ -120,7 +118,6 @@
 				{
 					$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
 				}
-			}
 
 			//
 			$pattern = '/\s*/m';

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -83,14 +83,14 @@
 		$parameterArray = json_decode($variantParams,true);
 
 		//exception handling for default variants
-		if(!empty($parameterArray)){
+		if(!empty($parameterArray) && !isset($parameterArray["variant"])){
 
 				$splicedFileName=$parameterArray["diagram_File"];
 				$fileName=$parameterArray["filelink"];
 				$fileType=$parameterArray["type"];
 				$gFileName=$parameterArray["gFilelink"];
 				$gFileType=$parameterArray["gType"];
-			}
+			
 			// for fetching file content
 			if(isset($fileName)){
 				if(file_exists("../courses/global/"."$fileName"))
@@ -120,7 +120,7 @@
 				{
 					$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
 				}
-
+			}
 			//
 			$pattern = '/\s*/m';
 			$replace = '';

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -83,8 +83,8 @@
 		$parameterArray = json_decode($variantParams,true);
 		if(!empty($parameterArray)){
 
-			//exception handling for default variants
-			if($parameterArray["variant"] == "Diagram" || !isset($parameterArray["variant"])){
+			//exception handling for default variants, should not try to read file if using testdata
+			if(!isset($parameterArray["variant"])){
 				$splicedFileName=$parameterArray["diagram_File"];
 				$fileName=$parameterArray["filelink"];
 				$fileType=$parameterArray["type"];

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -88,31 +88,36 @@
 			$gFileName=$parameterArray["gFilelink"];
 			$gFileType=$parameterArray["gType"];
 			// for fetching file content
-			if(file_exists("../courses/global/"."$fileName"))
-			{
-				$instructions = file_get_contents("../courses/global/"."$fileName");
-			}
-			else if(file_exists("../courses/".$cid."/"."$fileName"))
-			{
-				$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
-			}
-			else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))
-			{
-				$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+			if(isset($fileName)){
+				if(file_exists("../courses/global/"."$fileName"))
+				{
+					$instructions = file_get_contents("../courses/global/"."$fileName");
+				}
+				else if(file_exists("../courses/".$cid."/"."$fileName"))
+				{
+					$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
+				}
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))
+				{
+					$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+				}
 			}
 
-			if(file_exists("../courses/global/"."$gFileName"))
-			{
-				$information = file_get_contents("../courses/global/"."$gFileName");
+			if(isset($gFileName)){
+				if(file_exists("../courses/global/"."$gFileName"))
+				{
+					$information = file_get_contents("../courses/global/"."$gFileName");
+				}
+				else if(file_exists("../courses/".$cid."/"."$gFileName"))
+				{
+					$information = file_get_contents("../courses/".$cid."/"."$gFileName");
+				}
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))
+				{
+					$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
+				}
 			}
-			else if(file_exists("../courses/".$cid."/"."$gFileName"))
-			{
-				$information = file_get_contents("../courses/".$cid."/"."$gFileName");
-			}
-			else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))
-			{
-				$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
-			}
+
 			//
 			$pattern = '/\s*/m';
 			$replace = '';
@@ -182,25 +187,27 @@
 	}
 	
   // for fetching file content
-	if(file_exists("../courses/global/"."$fileName"))
-	{
-		$instructions = file_get_contents("../courses/global/"."$fileName");
+	if(isset($fileName)){
+		if(file_exists("../courses/global/"."$fileName"))
+		{
+			$instructions = file_get_contents("../courses/global/"."$fileName");
+		}
+		else if(file_exists("../courses/".$cid."/"."$fileName"))
+		{
+			$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
+		}
+		else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))
+		{
+			$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+		}
+		if($instructions === "UNK")
+		{
+			$instructions = "NO_FILE_FETCHED";
+		}
+		$pattern = '/\s*/m';
+		$replace = '';
+		$instructions = preg_replace( $pattern, $replace,$instructions);
 	}
-	else if(file_exists("../courses/".$cid."/"."$fileName"))
-	{
-		$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
-	}
-	else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))
-	{
-		$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
-	}
-	if($instructions === "UNK")
-	{
-		$instructions = "NO_FILE_FETCHED";
-	}
-	$pattern = '/\s*/m';
-  	$replace = '';
-	$instructions = preg_replace( $pattern, $replace,$instructions);
 
 	#I have no idea what the things below
 	// if(isset($_SESSION['hashpassword'])){

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -83,7 +83,7 @@
 		$parameterArray = json_decode($variantParams,true);
 
 		//exception handling for default variants
-		if(!empty($parameterArray) && !isset($parameterArray["variant"])){
+		if(!empty($parameterArray)){
 
 				$splicedFileName=$parameterArray["diagram_File"];
 				$fileName=$parameterArray["filelink"];

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -83,7 +83,7 @@
 		$parameterArray = json_decode($variantParams,true);
 
 		//exception handling for default variants
-		if(!empty($parameterArray) && !isset($variantParams["variant"])){
+		if(!empty($parameterArray) && !isset($parameterArray["variant"])){
 
 				$splicedFileName=$parameterArray["diagram_File"];
 				$fileName=$parameterArray["filelink"];

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -82,11 +82,15 @@
 		$variantParams = str_replace('&quot;','"',$variantParams);
 		$parameterArray = json_decode($variantParams,true);
 		if(!empty($parameterArray)){
-			$splicedFileName=$parameterArray["diagram_File"];
-			$fileName=$parameterArray["filelink"];
-			$fileType=$parameterArray["type"];
-			$gFileName=$parameterArray["gFilelink"];
-			$gFileType=$parameterArray["gType"];
+
+			//exception handling for default variants
+			if($parameterArray["variant"] == "Diagram" || !isset($parameterArray["variant"])){
+				$splicedFileName=$parameterArray["diagram_File"];
+				$fileName=$parameterArray["filelink"];
+				$fileType=$parameterArray["type"];
+				$gFileName=$parameterArray["gFilelink"];
+				$gFileType=$parameterArray["gType"];
+			}
 			// for fetching file content
 			if(isset($fileName)){
 				if(file_exists("../courses/global/"."$fileName"))

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -65,6 +65,8 @@
 	$json = "UNK";
 	$fileName = "UNK";
 	$gFileName = "UNK";
+	$fileType = "";
+	$gFileType = "";
 	$instructions = "";
 	$information = "";
 	
@@ -85,11 +87,21 @@
 		//exception handling for default variants
 		if(!empty($parameterArray) && !isset($parameterArray["variant"])){
 
+			if(isset($parameterArray["diagram_File"])){
 				$splicedFileName=$parameterArray["diagram_File"];
+			}
+			if(isset($parameterArray["filelink"])){
 				$fileName=$parameterArray["filelink"];
-				$fileType=$parameterArray["type"];
+			}
+			if(isset($parameterArray["type"])){
+				$gFileType=$parameterArray["Type"];
+			}
+			if(isset($parameterArray["gFilelink"])){
 				$gFileName=$parameterArray["gFilelink"];
+			}
+			if(isset($parameterArray["gType"])){
 				$gFileType=$parameterArray["gType"];
+			}
 			
 			// for fetching file content
 			if(isset($fileName)){

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -81,7 +81,9 @@
 		$splicedFileName = substr($variantParams, strpos($variantParams, "diagram File&quot;:") + 25, ($end - $start));*/
 		$variantParams = str_replace('&quot;','"',$variantParams);
 		$parameterArray = json_decode($variantParams,true);
-		if(!empty($parameterArray) && !isset($parameterArray["variant"])){
+
+		//exception handling for default variants
+		if(!empty($parameterArray) && !isset($variantParams["variant"])){
 
 				$splicedFileName=$parameterArray["diagram_File"];
 				$fileName=$parameterArray["filelink"];

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -90,8 +90,12 @@ function returnedDugga(data)
             // getting the error checker allowed or not
             document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
             // Getting the instructions to the side of the dugga -currently using filelink which is wrong
-            window.parent.getInstructions(param.filelink);
-            window.parent.getInstructions(param.gFilelink);
+            if(param.filelink != undefined){
+                window.parent.getInstructions(param.filelink);
+            }
+            if(param.gFilelink != undefined){
+                window.parent.getInstructions(param.gFilelink);
+            }
         }
         else{
             var diagramType={ER:true,UML:true};


### PR DESCRIPTION
Added some exception handlings so it won't try to fetch any files for default variants. This wouldn't have been a problem on the production, I suspect, but proved difficult for testing. Now when opening any dugga regardless of variant parameters, it should not give an error for undefined variables.