### PR TITLE
Fixed consistent darkmode background color #12386

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -276,7 +276,7 @@
 
 .normtext {
     color: #fff;
-    background-color: #2c2c2c;
+    background-color: var(--color-background);
     white-space:nowrap;
 }
 


### PR DESCRIPTION
The background color in darkmode for codeviewer text and textwrapper are now the same shade.

Testing:
1) Enter Webbprogrammering
2) Open any code example
3) Enter darkmode
The codeviewer should look like this:
![image](https://user-images.githubusercontent.com/102609651/168026995-bc4c0961-d51a-4c5b-976c-0e9d0d2a7067.png)

And not like this:
![image](https://user-images.githubusercontent.com/102599780/167841430-8715d973-5bde-46a1-a402-7cc6617597f7.png)
