### PR TITLE
Teacher can now select instruction and information files from a dropdown box

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -412,9 +412,15 @@ function returnedFile(data){
 		filearray[i] = JSON.parse(retdata['entries'][i].filename);
 	}
 	filteredarray = filearray.filter(x => x.extension === "json");
+	instrArray = filearray.filter(x => x.extension === $("#type").val());
 
-	//Not sure how the first parameter works yet, suspect it's to know which object is selected
 	$("#file").html(makeoptionsItem("AddEmptyField", filteredarray, 'filename','filename'));
+	$("#filelink").html(makeoptionsItem("AddEmptyField", instrArray, 'filename', 'filename'));
+}
+
+function updateInstructions(){
+	instrArray = filearray.filter(x => x.extension === $("#type").val());
+	$("#filelink").html(makeoptionsItem("AddEmptyField", instrArray, 'filename', 'filename'));
 }
 
 // Adds a submission row

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -413,14 +413,21 @@ function returnedFile(data){
 	}
 	filteredarray = filearray.filter(x => x.extension === "json");
 	instrArray = filearray.filter(x => x.extension === $("#type").val());
+	infArray = filearray.filter(x => x.extension === $("#gType").val());
 
 	$("#file").html(makeoptionsItem("AddEmptyField", filteredarray, 'filename','filename'));
 	$("#filelink").html(makeoptionsItem("AddEmptyField", instrArray, 'filename', 'filename'));
+	$("#gFilelink").html(makeoptionsItem("AddEmptyField", infArray, 'filename', 'filename'));
 }
 
 function updateInstructions(){
 	instrArray = filearray.filter(x => x.extension === $("#type").val());
 	$("#filelink").html(makeoptionsItem("AddEmptyField", instrArray, 'filename', 'filename'));
+}
+
+function updateInformation(){
+	infArray = filearray.filter(x => x.extension === $("#gType").val());
+	$("#gFilelink").html(makeoptionsItem("AddEmptyField", infArray, 'filename', 'filename'));
 }
 
 // Adds a submission row
@@ -497,7 +504,7 @@ function createJSONString(formData) {
 		"type":formData[0].value,
 		"filelink":formData[1].value,
 		"gType":formData[2].value,
-		"gFilelink":formData[3].value,
+		"gFilelink":$("#gFilelink option:selected").val(),
 		"diagram_File":$("#file option:selected").val(),
 		"diagram_type":{ER:document.getElementById("ER").checked,UML:document.getElementById("UML").checked}, //<-- UML functionality
 		"extraparam":$('#extraparam').val(),

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -175,12 +175,12 @@ session_start();
                     <fieldset style="width:90%;">
                       <legend>General information file</legend>
                       <div style="display:flex;flex-wrap:wrap;flex-direction:row;">
-                        <select name="gType" id="gType" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));">
+                        <select name="gType" id="gType" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray())), updateInformation();">
                           <option value="md">Markdown</option>
                           <option value="pdf">PDF</option>
                           <option value="html">HTML</option>
                         </select>
-                        <input id="gFilelink" type="text" name="gFilelink" style="flex:2;margin-left:5px;" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));">
+                        <select id="gFilelink" name="gFilelink" style="flex:2;margin-left:5px;" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"></select>
                       </div>
                     </fieldset>
                   </div>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -162,12 +162,12 @@ session_start();
                     <fieldset style="width:90%;">
                       <legend>Instruction file</legend>
                       <div style="display:flex;flex-wrap:wrap;flex-direction:row;">
-                        <select name="type" id="type" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));">
+                        <select name="type" id="type" style="flex:1" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray())), updateInstructions();">
                           <option value="md">Markdown</option>
                           <option value="pdf">PDF</option>
                           <option value="html">HTML</option>
                         </select>
-                        <input id="filelink" type="text" name="filelink" style="flex:2;margin-left:5px;" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));">
+                        <select id="filelink" name="filelink" style="flex:2;margin-left:5px;" onchange="$('#variantparameterText').val(createJSONString($('#jsonForm').serializeArray()));"></select>
                       </div>
                     </fieldset>
                   </div>


### PR DESCRIPTION
Instead of having to manually enter the filename, they can now select them from a dropdown based on whichever file extension they want
![bild](https://user-images.githubusercontent.com/37794783/168044449-f19ce0c4-1b71-4577-9003-9cd919f2e03c.png)
