### PR TITLE
Fixed so that the instructions-panel follows the standard #12408

### DIFF
--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -17,7 +17,7 @@
             width:100%;
             display:inline-block;
             position:relative;
-            padding:3px 10px;
+            padding:3px 26px;
             box-sizing: border-box;
             -webkit-box-sizing: border-box;
             -moz-box-sizing: border-box;
@@ -40,19 +40,21 @@
             width: 300px;
             height: 800px;
             overflow: auto;
-            margin: 0px;
+            margin-left: 0px;
             border: 1px solid #ccc;
         }
         
         #close_open {
             width: 23px;
             position: absolute;
-            top: 520px;
-            left: 272px;
+            top: 420px;
+            /*left: 274px;*/
             border-top: 14px solid transparent;
             border-bottom: 14px solid transparent;
             border-right: 14px solid #d4d2d2;
             margin-left:10px;
+            transform: scaleX(-1);
+            right:-56px;
         }
         
         #close_open:hover {
@@ -65,35 +67,67 @@
             flex: 1;
             display: flex;
             justify-content: space-around;
-            margin-left:10px;
+            margin-left:0px;
         }
+
+        #close_open_border {
+            position: absolute;
+            background-color: #ccc;
+            width:20px;
+            height:800px;
+            /*top:180px;*/
+           /* left: 321px;*/
+        }
+
+       #close_open_border:hover {
+            cursor: pointer;
+        }
+
+        #instructions_arrow_border {
+            position: absolute;
+            top:180px;
+        }
+
     </style>
     <script>
         $(document).ready(function() {
-            $("#close_open").click(function() {
+            $('#instructions_arrow_border').click(function() {
                 if ($("#pvalue").val() == "0") {
-                    // hides description when open
-                    $("#assignment_discrb").css('visibility', 'hidden');
+                    // closed mode
+                    $("#assignment_discrb").css('display', 'none');
                     $("#container__left").animate({
                         width: "10px"
                     }, "slow");
-                    $("#close_open").css({
+                    $("#instructions_arrow_border").css({
                         'display': 'fixed',
-                        'left': '7px',
-                        'transform': 'scaleX(-1)',
-                        'transition': '0.55s ease-in-out'
+                        'left': '20px',
+                        'transition': '0.55s ease-in-out',
+                    });
+                    $("#diagram-iframe").css({
+                        'margin-left':'10px'
+                    });
+                    $(".canvas_right").css({
+                        'margin-left':'10px'
                     });
                     $("#pvalue").val("1");
                 } else {
-                    // opens description when closed
+                    // open mode
                     $("#container__left").animate({
                         width: "300px"
                     }, "slow");
-                    $("#assignment_discrb").css('visibility', 'visible');
-                    $("#close_open").css({
+
+                    $("#assignment_discrb").css('display', 'block');
+
+                    $("#instructions_arrow_border").css({
+                        'position':'absolute',
                         'display': 'block',
-                        'transform': 'scaleX(1)',
-                        'left': '272px'
+                        //'left': '276px'
+                    });
+                    $("#diagram-iframe").css({
+                        'margin-left':'0px'
+                    });
+                    $(".canvas_right").css({
+                        'margin-left':'0px'
                     });
                     $("#pvalue").val("0");
                 }
@@ -133,7 +167,7 @@
             <input type="hidden" id="pvalue" value="0" />
             <div class="assignment_left" id="container__left" style="overflow: auto;">
                 <div id="container_header"><h3>Instructions</h3></div>
-                <div class="assignment_discrb" id="assignment_discrb" cellpadding="0" cellspacing="0" style=" visibility: visible; color: rgb(0, 0, 0); padding: 4px; ">
+                <div class="assignment_discrb" id="assignment_discrb" cellpadding="0" cellspacing="0" style=" visibility: visible; color: rgb(0, 0, 0); padding: 12px; ">
                     <h2 style="margin-left: 14px;">Modellering</h2>
                     <p style="margin-left: 14px;">Modellera nedanstående uppgifter i notationerna ER och UML.</p>
                     <ol type="1">
@@ -151,14 +185,15 @@
                         </li><br>
                     </ol>
                 </div>
-                <div id="close_open">
-
+                <div id="instructions_arrow_border">
+                    <div id="close_open_border"></div>
+                    <div id="close_open"></div>
                 </div>
             </div>
             <div id="container" class="canvas_right">
 
 
-                <iframe onclick="canSaveController()" id="diagram-iframe" height="800px" width="100%" style="pointer-events:auto;margin-left: 10px;" src="
+                <iframe onclick="canSaveController()" id="diagram-iframe" height="800px" width="100%" style="pointer-events:auto;" src="
                                     ./diagram.php" title="Diagram"></iframe>
 
 

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -49,7 +49,6 @@
             width: 23px;
             position: absolute;
             top: 220px;
-            /*left: 274px;*/
             border-top: 14px solid transparent;
             border-bottom: 14px solid transparent;
             border-right: 14px solid #d4d2d2;
@@ -78,7 +77,6 @@
             width:20px;
             height:803px;
             top:-180px;
-           /* left: 321px;*/
         }
 
        #close_open_border:hover {
@@ -95,7 +93,7 @@
         $(document).ready(function() {
             $('#instructions_arrow_border').click(function() {
                 if ($("#pvalue").val() == "0") {
-                    // closed mode
+                    // Closed mode
                     $("#assignment_discrb").css('display', 'none');
                     $("#container__left").animate({
                         width: "10px"
@@ -104,12 +102,14 @@
                     $("#diagram-iframe").css({
                         'margin-left':'12px'
                     });
+
                     $(".canvas_right").css({
                         'margin-left':'12px'
                     });
+
                     $("#pvalue").val("1");
                 } else {
-                    // open mode
+                    // Open mode
                     $("#container__left").animate({
                         width: "300px"
                     }, "slow");
@@ -117,22 +117,20 @@
                     $("#assignment_discrb").css('display', 'block');
 
                     $("#instructions_arrow_border").css({
-                        //'position':'absolute',
                         'display': 'block',
-                        //'left': '276px'
                     });
+
                     $("#diagram-iframe").css({
                         'margin-left':'0px'
                     });
+
                     $(".canvas_right").css({
                         'margin-left':'0px'
                     });
+
                     $("#pvalue").val("0");
                 }
-
-
             });
-
         });
     </script>
 </head>

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -48,13 +48,13 @@
         #close_open {
             width: 23px;
             position: absolute;
-            top: 220px;
+            top: 370px;
             border-top: 14px solid transparent;
             border-bottom: 14px solid transparent;
             border-right: 14px solid #d4d2d2;
             margin-left:10px;
             transform: scaleX(-1);
-            right:-56px;
+            right:-37px;
         }
         
         #close_open:hover {
@@ -188,8 +188,9 @@
                     </ol>
                 </div>
                 <div id="instructions_arrow_border">
-                    <div id="close_open_border" class="instruction-border"></div>
-                    <div id="close_open" class="instruction-border"></div>
+                    <div id="close_open_border" class="instruction-border">
+                        <div id="close_open" class="instruction-border"></div>
+                    </div>
                 </div>
             </div>
             <div id="container" class="canvas_right">

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -81,12 +81,18 @@
 
        #close_open_border:hover {
             cursor: pointer;
+            background-color: #8e8e8e;
         }
 
         #instructions_arrow_border {
             position: absolute;
             top:180px;
         }
+
+/*         .instruction-border::after, #instructions_arrow_border::after, #close_open_border::after, #close_open::after {
+            cursor: pointer;
+            background-color: #8e8e8e;
+        } */
 
     </style>
     <script>
@@ -182,8 +188,8 @@
                     </ol>
                 </div>
                 <div id="instructions_arrow_border">
-                    <div id="close_open_border"></div>
-                    <div id="close_open"></div>
+                    <div id="close_open_border" class="instruction-border"></div>
+                    <div id="close_open" class="instruction-border"></div>
                 </div>
             </div>
             <div id="container" class="canvas_right">

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -10,10 +10,11 @@
             height: 50.1rem;
             width: 100%;
             justify-content: space-between;
+            position: relative;
         }
 
         #container_header{
-            background-color: #ccc;
+            background-color: #d4d2d2;
             width:100%;
             display:inline-block;
             position:relative;
@@ -47,7 +48,7 @@
         #close_open {
             width: 23px;
             position: absolute;
-            top: 420px;
+            top: 220px;
             /*left: 274px;*/
             border-top: 14px solid transparent;
             border-bottom: 14px solid transparent;
@@ -61,6 +62,7 @@
             border-top: 14px solid transparent;
             border-bottom: 14px solid transparent;
             border-right: 14px solid #8e8e8e;
+            cursor: pointer;
         }
         
         .canvas_right {
@@ -71,11 +73,11 @@
         }
 
         #close_open_border {
-            position: absolute;
-            background-color: #ccc;
+           position: absolute;
+            background-color: #d4d2d2;
             width:20px;
-            height:800px;
-            /*top:180px;*/
+            height:803px;
+            top:-180px;
            /* left: 321px;*/
         }
 
@@ -98,16 +100,12 @@
                     $("#container__left").animate({
                         width: "10px"
                     }, "slow");
-                    $("#instructions_arrow_border").css({
-                        'display': 'fixed',
-                        'left': '20px',
-                        'transition': '0.55s ease-in-out',
-                    });
+
                     $("#diagram-iframe").css({
-                        'margin-left':'10px'
+                        'margin-left':'12px'
                     });
                     $(".canvas_right").css({
-                        'margin-left':'10px'
+                        'margin-left':'12px'
                     });
                     $("#pvalue").val("1");
                 } else {
@@ -119,7 +117,7 @@
                     $("#assignment_discrb").css('display', 'block');
 
                     $("#instructions_arrow_border").css({
-                        'position':'absolute',
+                        //'position':'absolute',
                         'display': 'block',
                         //'left': '276px'
                     });

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -14,7 +14,7 @@
         }
 
         #container_header{
-            background-color: #d4d2d2;
+            background-color: #ccc;
             width:100%;
             display:inline-block;
             position:relative;
@@ -45,25 +45,6 @@
             border: 1px solid #ccc;
         }
         
-        #close_open {
-            width: 23px;
-            position: absolute;
-            top: 370px;
-            border-top: 14px solid transparent;
-            border-bottom: 14px solid transparent;
-            border-right: 14px solid #d4d2d2;
-            margin-left:10px;
-            transform: scaleX(-1);
-            right:-37px;
-        }
-        
-        #close_open:hover {
-            border-top: 14px solid transparent;
-            border-bottom: 14px solid transparent;
-            border-right: 14px solid #8e8e8e;
-            cursor: pointer;
-        }
-        
         .canvas_right {
             flex: 1;
             display: flex;
@@ -72,32 +53,40 @@
         }
 
         #close_open_border {
-           position: absolute;
-            background-color: #d4d2d2;
+            position: absolute;
+            background-color: #ccc;
             width:20px;
             height:803px;
-            top:-180px;
-        }
-
-       #close_open_border:hover {
+            top:0px;
             cursor: pointer;
-            background-color: #8e8e8e;
         }
 
-        #instructions_arrow_border {
+        #close_open_border:after {
+            content: '';
             position: absolute;
-            top:180px;
+            left: 19px;
+            top:383px;
+            border-top: 14px solid transparent;
+            border-right: 0px solid transparent;
+            border-bottom: 14px solid transparent;
+            border-left: 14px solid #ccc;
         }
 
-/*         .instruction-border::after, #instructions_arrow_border::after, #close_open_border::after, #close_open::after {
-            cursor: pointer;
-            background-color: #8e8e8e;
-        } */
+        #close_open_border:hover:after {
+            border-top: 14px solid transparent;
+            border-right: 0px solid transparent;
+            border-bottom: 14px solid transparent;
+            border-left: 14px solid #8e8e8e;
+        }
 
+        #close_open_border:hover {
+            background-color:#8e8e8e;
+        }
+        
     </style>
     <script>
         $(document).ready(function() {
-            $('#instructions_arrow_border').click(function() {
+            $('#close_open_border').click(function() {
                 if ($("#pvalue").val() == "0") {
                     // Closed mode
                     $("#assignment_discrb").css('display', 'none');
@@ -121,10 +110,6 @@
                     }, "slow");
 
                     $("#assignment_discrb").css('display', 'block');
-
-                    $("#instructions_arrow_border").css({
-                        'display': 'block',
-                    });
 
                     $("#diagram-iframe").css({
                         'margin-left':'0px'
@@ -187,11 +172,7 @@
                         </li><br>
                     </ol>
                 </div>
-                <div id="instructions_arrow_border">
-                    <div id="close_open_border" class="instruction-border">
-                        <div id="close_open" class="instruction-border"></div>
-                    </div>
-                </div>
+                <div id="close_open_border"></div>
             </div>
             <div id="container" class="canvas_right">
 


### PR DESCRIPTION
- #12408
- In this pull request i changed the appearance of the instruction-panel so it follows the standard look as the "General information"-panel.


### Before, "Instructions"-arrow-panel not following the same standard as "General information": 
Open: <img width="282" alt="before1" src="https://user-images.githubusercontent.com/81613484/168049852-9534b126-9f1d-46da-b3b4-9cf995686e18.png"> Closed: <img width="151" alt="before2" src="https://user-images.githubusercontent.com/81613484/168049861-4f9e7a4b-a24b-4c2d-897f-26d66aa1524c.png">


### After, following same standard as "General information":
Open: <img width="189" alt="after1" src="https://user-images.githubusercontent.com/81613484/168049881-10a25dda-8e69-4b66-bbf6-e9e5b5053cf7.png"> Closed:  <img width="105" alt="after2" src="https://user-images.githubusercontent.com/81613484/168049891-7c415ac8-6302-437d-a6c0-ba4e4e9ec0a5.png">

### ("General information"-panel looks like this:)
<img width="960" alt="generalinfo" src="https://user-images.githubusercontent.com/81613484/168051219-5034be94-42b8-4574-a046-6ce813a1e2c6.png">


## To test:
- Make sure the description is hidden/visible after pressing anywhere on the border/arrow
- Make sure it looks alright when zooming in/out + when hiding the "General information" (i.e. make sure it follows the screen)