### PR TITLE
The error check field gets hidden

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4369,10 +4369,10 @@ function toggleErrorCheck(){
  */
 function hideErrorCheck(show){
     if(show == true){
-        document.getElementById("errorCheckToggle").style.display = "flex";
+        document.getElementById("errorCheckField").style.display = "flex";
     }
     else{
-        document.getElementById("errorCheckToggle").style.display = "none";
+        document.getElementById("errorCheckField").style.display = "none";
     }
 }
 function setA4SizeFactor(e){

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -258,7 +258,7 @@
                 </span>
             </div>
         </fieldset>     
-        <fieldset>
+        <fieldset id = "errorCheckField">
         <legend>Check</legend>
             <div id="errorCheckToggle" class="diagramIcons" onclick="toggleErrorCheck()">
                 <img src="../Shared/icons/diagram_errorCheck.svg"/>


### PR DESCRIPTION
The error check field gets hidden when error checking is turned of. #12409 

Instructions for testing:
1) Click "Demo-Course"
2) Click "Diagram Dugga"
3) Turn off error checking with a teacher through dugga variants
4) Check if the error checking field disappears when error checking is turned off.