### PR TITLE
Changed style of drag and drop bacckground image

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -596,6 +596,6 @@ body {
 
 .highlight{
     background-image: url(../icons/draganddropBlack.png);
-    object-fit: cover;
-    background-size: 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
 }

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -1028,6 +1028,6 @@
 
 .highlight{
     background-image: url(../icons/draganddrop.png);
-    object-fit: cover;
-    background-size: 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
 }


### PR DESCRIPTION
For testing:
1. Go into `javascript exammple 3`
2. scroll to bottom of left codebox (there should be somme empty space!)
3. Login as a teacher
4. Hover a file over any code box
5. The drag and drop background should stretch to fit the box!