### PR TITLE
Lines between UMLEntities #12481

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5777,8 +5777,8 @@ function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, su
         }
     }
 
-    // Check so the elements does not have the same kind, exception for the "ERAttr" kind.
-    if (fromElement.kind !== toElement.kind || fromElement.kind === "ERAttr" ) {
+    // Check so the elements does not have the same kind, exception for the "ERAttr" and "UMLEntity" kind.
+    if (fromElement.kind !== toElement.kind || fromElement.kind === "ERAttr" || fromElement.kind === "UMLEntity") {
 
         // Filter the existing lines and gets the number of existing lines
         var numOfExistingLines = lines.filter(function (line) {


### PR DESCRIPTION
Added exception so lines can be drawn between two UMLEntities.

To Test: Try to draw lines between two UMLEntities - This should be possible. 
Also try to draw lines between other elements of the same kind - This should not be possible, except for ERAttributes.