### PR TITLE
Fixed multiple variables generating error alerts when opening diagram dugga #12458

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -98,8 +98,6 @@
 				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents("../courses/global/"."$fileName");
 				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
-				echo $fileName;
-				exit();
 			}
 
 			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $fileName != "UNK"){

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -100,7 +100,7 @@
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
 			}
 
-			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $fileName != "UNK" && $fileName != ""){
+			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $gfileName != "UNK" && $gfileName != ""){
 				if(file_exists("../courses/global/"."$gFileName"))						$information = file_get_contents("../courses/global/"."$gFileName");
 				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents("../courses/".$cid."/"."$gFileName");
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
@@ -125,7 +125,7 @@
 
 	if($fileContent === "UNK")															$fileContent = "NO_FILE_FETCHED";
 
-    // if the used is redirected from 
+    // if the used is redirected from the validateHash.php page, a hash will be set and the latest "diagramSave.json" file should be loaded. 
 	if(isset($_GET['hash']) && $_GET['hash'] != "UNK"){
 		$tempDir = strval(dirname(__DIR__, 2))."/submissions/{$cid}/{$vers}/{$quizid}/{$_SESSION['hash']}/";
 		$latest = time() - (365 * 24 * 60 * 60);

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -95,15 +95,15 @@
 
 			// for fetching file content
 			if(isset($fileName) && $fileName != "." && $fileName != ".." && $fileName != "UNK" && $fileName != ""){
-				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents(__DIR__."../courses/global/"."$fileName");
-				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents(__DIR__."../courses/".$cid."/"."$fileName");
-				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents(__DIR__."../courses/".$cid."/"."$vers"."/"."$fileName");
+				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents("../courses/global/"."$fileName");
+				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
 			}
 
 			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $fileName != "UNK" && $fileName != ""){
-				if(file_exists("../courses/global/"."$gFileName"))						$information = file_get_contents(__DIR__."../courses/global/"."$gFileName");
-				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents(__DIR__."../courses/".$cid."/"."$gFileName");
-				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents(__DIR__."../courses/".$cid."/"."$vers"."/"."$gFileName");
+				if(file_exists("../courses/global/"."$gFileName"))						$information = file_get_contents("../courses/global/"."$gFileName");
+				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents("../courses/".$cid."/"."$gFileName");
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
 			}
 
 			$pattern = '/\s*/m';
@@ -157,10 +157,10 @@
 	}
 	
   // for fetching file content
-	if(file_exists("../courses/global/"."$fileName" && $fileName != ""))									$instructions = file_get_contents("../courses/global/"."$fileName");
+	if(file_exists("../courses/global/"."$fileName" && $fileName != ""))								$instructions = file_get_contents("../courses/global/"."$fileName");
 	else if(file_exists("../courses/".$cid."/"."$fileName") && $fileName != "")							$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
 	else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName") && $fileName != "")				$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
-	if($instructions === "UNK")															$instructions = "NO_FILE_FETCHED";
+	if($instructions === "UNK")																			$instructions = "NO_FILE_FETCHED";
 	
 	$pattern = '/\s*/m';
   	$replace = '';

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -117,13 +117,13 @@
 	}
 	$response->closeCursor();
 
-	if($splicedFileName != "UNK" && isset($splicedFileName)){
+	if($splicedFileName != "UNK" && isset($splicedFileName) && $splicedFileName != "." && $splicedFileName != ".." && $splicedFileName != ""){
 		if(file_exists("../courses/global/"."$splicedFileName"))						$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
 		else if(file_exists("../courses/".$cid."/"."$splicedFileName"))					$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
 		else if(file_exists("../courses/".$cid."/"."$vers"."/"."$splicedFileName"))		$fileContent = file_get_contents("../courses/".$cid."/"."$vers"."/"."$splicedFileName");
 	}
 
-	if($fileContent === "UNK")															$fileContent = "NO_FILE_FETCHED";
+	if($fileContent === "UNK" || $fileContent === "")															$fileContent = "NO_FILE_FETCHED";
 
     // if the used is redirected from the validateHash.php page, a hash will be set and the latest "diagramSave.json" file should be loaded. 
 	if(isset($_GET['hash']) && $_GET['hash'] != "UNK"){

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -82,36 +82,57 @@
 		$variantParams = str_replace('&quot;','"',$variantParams);
 		$parameterArray = json_decode($variantParams,true);
 		if(!empty($parameterArray)){
-			$splicedFileName=$parameterArray["diagram_File"];
-			$fileName=$parameterArray["filelink"];
-			$fileType=$parameterArray["type"];
-			$gFileName=$parameterArray["gFilelink"];
-			$gFileType=$parameterArray["gType"];
+			if(isset($parameterArray['diagram_File'])
+			{
+				$splicedFileName=$parameterArray["diagram_File"];
+			})
+			if(isset($parameterArray['filelink']))
+			{
+				$fileName=$parameterArray["filelink"];
+			}
+			if(isset($parameterArray['filelink']))
+			{
+				$fileType=$parameterArray["type"];
+			}
+			if(isset($parameterArray['gFilelink']))
+			{
+				$gFileName=$parameterArray["gFilelink"];
+			}
+			if(isset($parameterArray['gType']))
+			{
+				$gFileType=$parameterArray["gType"];
+			}
 			// for fetching file content
-			if(file_exists("../courses/global/"."$fileName"))
+			if($fileName != "." && $fileName != "..")
 			{
-				$instructions = file_get_contents("../courses/global/"."$fileName");
-			}
-			else if(file_exists("../courses/".$cid."/"."$fileName"))
-			{
-				$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
-			}
-			else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))
-			{
-				$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+				if(file_exists("../courses/global/"."$fileName"))
+				{
+					$instructions = file_get_contents("../courses/global/"."$fileName");
+				}
+				else if(file_exists("../courses/".$cid."/"."$fileName"))
+				{
+					$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
+				}
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))
+				{
+					$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+				}
 			}
 
-			if(file_exists("../courses/global/"."$gFileName"))
+			if($gFileName != "." && $gFileName != "..")
 			{
-				$information = file_get_contents("../courses/global/"."$gFileName");
-			}
-			else if(file_exists("../courses/".$cid."/"."$gFileName"))
-			{
-				$information = file_get_contents("../courses/".$cid."/"."$gFileName");
-			}
-			else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))
-			{
-				$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
+				if(file_exists("../courses/global/"."$gFileName"))
+				{
+					$information = file_get_contents("../courses/global/"."$gFileName");
+				}
+				else if(file_exists("../courses/".$cid."/"."$gFileName"))
+				{
+					$information = file_get_contents("../courses/".$cid."/"."$gFileName");
+				}
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))
+				{
+					$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
+				}
 			}
 			//
 			$pattern = '/\s*/m';

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -100,7 +100,7 @@
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
 			}
 
-			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $gfileName != "UNK" && $gfileName != ""){
+			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $gFileName != "UNK" && $gFileName != ""){
 				if(file_exists("../courses/global/"."$gFileName"))						$information = file_get_contents("../courses/global/"."$gFileName");
 				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents("../courses/".$cid."/"."$gFileName");
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -55,7 +55,7 @@
 
 	#vars for handling fetching of diagram variant file name
 	$variantParams = "UNK";
-	$filePath ="";
+	$filePath ="UNK";
 	$finalArray = array();
 	$fileContent="UNK";
 	$splicedFileName = "UNK";
@@ -65,8 +65,8 @@
 	$json = "UNK";
 	$fileName = "UNK";
 	$gFileName = "UNK";
-	$instructions = "";
-	$information = "";
+	$instructions = "UNK";
+	$information = "UNK";
 	
 	#create request to database and execute it
 	$response = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid AND disabled = 0;");
@@ -94,13 +94,13 @@
 																				else	$gFileType = "UNK";
 
 			// for fetching file content
-			if(isset($fileName) && $fileName != "." && $fileName != ".." && $fileName != "UNK"){
+			if(isset($fileName) && $fileName != "." && $fileName != ".." && $fileName != "UNK" && $fileName != ""){
 				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents(__DIR__."../courses/global/"."$fileName");
 				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents(__DIR__."../courses/".$cid."/"."$fileName");
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents(__DIR__."../courses/".$cid."/"."$vers"."/"."$fileName");
 			}
 
-			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $fileName != "UNK"){
+			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $fileName != "UNK" && $fileName != ""){
 				if(file_exists("../courses/global/"."$gFileName"))						$information = file_get_contents(__DIR__."../courses/global/"."$gFileName");
 				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents(__DIR__."../courses/".$cid."/"."$gFileName");
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents(__DIR__."../courses/".$cid."/"."$vers"."/"."$gFileName");
@@ -117,7 +117,7 @@
 	}
 	$response->closeCursor();
 
-	if($splicedFileName != "UNK" && isset($splicedFileName)){
+	if($splicedFileName != "UNK" && isset($splicedFileName && $splicedFileName != "")){
 		if(file_exists("../courses/global/"."$splicedFileName"))						$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
 		else if(file_exists("../courses/".$cid."/"."$splicedFileName"))					$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
 		else if(file_exists("../courses/".$cid."/"."$vers"."/"."$splicedFileName"))		$fileContent = file_get_contents("../courses/".$cid."/"."$vers"."/"."$splicedFileName");

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -117,7 +117,7 @@
 	}
 	$response->closeCursor();
 
-	if($splicedFileName != "UNK" && isset($splicedFileName && $splicedFileName != "")){
+	if($splicedFileName != "UNK" && isset($splicedFileName)){
 		if(file_exists("../courses/global/"."$splicedFileName"))						$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
 		else if(file_exists("../courses/".$cid."/"."$splicedFileName"))					$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
 		else if(file_exists("../courses/".$cid."/"."$vers"."/"."$splicedFileName"))		$fileContent = file_get_contents("../courses/".$cid."/"."$vers"."/"."$splicedFileName");

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -72,6 +72,7 @@
 	$response = $pdo->prepare("SELECT param as jparam FROM variant LEFT JOIN quiz ON quiz.id = variant.quizID WHERE quizID = $quizid AND quiz.cid = $cid AND disabled = 0;");
 	$response->execute();
 	$i=0;
+
 	#loop through responses, fetch param column in variant table, splice string to extract file name, then close request.
 	foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
 	{
@@ -82,22 +83,26 @@
 		$variantParams = str_replace('&quot;','"',$variantParams);
 		$parameterArray = json_decode($variantParams,true);
 		if(!empty($parameterArray)){
-			if		(isset($parameterArray['diagram_File'])) 							$splicedFileName=$parameterArray["diagram_File"];
-			else 	$splicedFileName = "UNK";
-			if		(isset($parameterArray['filelink']))								$fileName=$parameterArray["filelink"];
-			else	$fileName = "UNK";
+			if(isset($parameterArray['diagram_File'])) 									$splicedFileName=$parameterArray["diagram_File"];
+																				else 	$splicedFileName = "UNK";
+			if(isset($parameterArray['filelink']))										$fileName=$parameterArray["filelink"];
+																				else	$fileName = "UNK";
 			if(isset($parameterArray['type']))											$fileType=$parameterArray["type"];
-			else	$fileType = "UNK";
+																				else	$fileType = "UNK";
 			if(isset($parameterArray['gFilelink']))										$gFileName=$parameterArray["gFilelink"];
-			else	$gFileName = "UNK";
+																				else	$gFileName = "UNK";
 			if(isset($parameterArray['gType']))											$gFileType=$parameterArray["gType"];
-			else	$gFileType = "UNK";
-
+																				else	$gFileType = "UNK";
+			print_r($parameterArray);
+			exit();
 			// for fetching file content
 			if(isset($fileName) && $fileName != "." && $fileName != ".." && $fileName != "UNK"){
+
 				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents("../courses/global/"."$fileName");
 				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+				echo $fileName;
+				exit();
 			}
 
 			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $fileName != "UNK"){
@@ -117,7 +122,7 @@
 	}
 	$response->closeCursor();
 
-	if($splicedFileName != "UNK" && $splicedFileName != ""){
+	if($splicedFileName != "UNK" && isset($splicedFileName)){
 		if(file_exists("../courses/global/"."$splicedFileName"))						$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
 		else if(file_exists("../courses/".$cid."/"."$splicedFileName"))					$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
 		else if(file_exists("../courses/".$cid."/"."$vers"."/"."$splicedFileName"))		$fileContent = file_get_contents("../courses/".$cid."/"."$vers"."/"."$splicedFileName");

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -82,28 +82,37 @@
 		$variantParams = str_replace('&quot;','"',$variantParams);
 		$parameterArray = json_decode($variantParams,true);
 		if(!empty($parameterArray)){
-			if(isset($parameterArray['diagram_File'])
-			{
+			if(isset($parameterArray['diagram_File'])){
 				$splicedFileName=$parameterArray["diagram_File"];
-			})
-			if(isset($parameterArray['filelink']))
-			{
-				$fileName=$parameterArray["filelink"];
+			}else{
+				$splicedFileName = "UNK";
 			}
 			if(isset($parameterArray['filelink']))
 			{
+				$fileName=$parameterArray["filelink"];
+			}else{
+				$fileName = "UNK";
+			}
+			if(isset($parameterArray['type']))
+			{
 				$fileType=$parameterArray["type"];
+			}else{
+				$fileType = "UNK";
 			}
 			if(isset($parameterArray['gFilelink']))
 			{
 				$gFileName=$parameterArray["gFilelink"];
+			}else{
+				$gFileName = "UNK";
 			}
 			if(isset($parameterArray['gType']))
 			{
 				$gFileType=$parameterArray["gType"];
+			}else{
+				$gFileType = "UNK";
 			}
 			// for fetching file content
-			if($fileName != "." && $fileName != "..")
+			if($fileName != "." && $fileName != ".." && $fileName != "UNK")
 			{
 				if(file_exists("../courses/global/"."$fileName"))
 				{
@@ -119,7 +128,7 @@
 				}
 			}
 
-			if($gFileName != "." && $gFileName != "..")
+			if($gFileName != "." && $gFileName != ".." && $fileName != "UNK")
 			{
 				if(file_exists("../courses/global/"."$gFileName"))
 				{

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -82,66 +82,28 @@
 		$variantParams = str_replace('&quot;','"',$variantParams);
 		$parameterArray = json_decode($variantParams,true);
 		if(!empty($parameterArray)){
-			if(isset($parameterArray['diagram_File'])){
-				$splicedFileName=$parameterArray["diagram_File"];
-			}else{
-				$splicedFileName = "UNK";
-			}
-			if(isset($parameterArray['filelink']))
-			{
-				$fileName=$parameterArray["filelink"];
-			}else{
-				$fileName = "UNK";
-			}
-			if(isset($parameterArray['type']))
-			{
-				$fileType=$parameterArray["type"];
-			}else{
-				$fileType = "UNK";
-			}
-			if(isset($parameterArray['gFilelink']))
-			{
-				$gFileName=$parameterArray["gFilelink"];
-			}else{
-				$gFileName = "UNK";
-			}
-			if(isset($parameterArray['gType']))
-			{
-				$gFileType=$parameterArray["gType"];
-			}else{
-				$gFileType = "UNK";
-			}
+			if		(isset($parameterArray['diagram_File'])) 							$splicedFileName=$parameterArray["diagram_File"];
+			else 	$splicedFileName = "UNK";
+			if		(isset($parameterArray['filelink']))								$fileName=$parameterArray["filelink"];
+			else	$fileName = "UNK";
+			if(isset($parameterArray['type']))											$fileType=$parameterArray["type"];
+			else	$fileType = "UNK";
+			if(isset($parameterArray['gFilelink']))										$gFileName=$parameterArray["gFilelink"];
+			else	$gFileName = "UNK";
+			if(isset($parameterArray['gType']))											$gFileType=$parameterArray["gType"];
+			else	$gFileType = "UNK";
+
 			// for fetching file content
-			if($fileName != "." && $fileName != ".." && $fileName != "UNK")
-			{
-				if(file_exists("../courses/global/"."$fileName"))
-				{
-					$instructions = file_get_contents("../courses/global/"."$fileName");
-				}
-				else if(file_exists("../courses/".$cid."/"."$fileName"))
-				{
-					$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
-				}
-				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))
-				{
-					$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
-				}
+			if(isset($fileName) && $fileName != "." && $fileName != ".." && $fileName != "UNK"){
+				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents("../courses/global/"."$fileName");
+				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
 			}
 
-			if($gFileName != "." && $gFileName != ".." && $fileName != "UNK")
-			{
-				if(file_exists("../courses/global/"."$gFileName"))
-				{
-					$information = file_get_contents("../courses/global/"."$gFileName");
-				}
-				else if(file_exists("../courses/".$cid."/"."$gFileName"))
-				{
-					$information = file_get_contents("../courses/".$cid."/"."$gFileName");
-				}
-				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))
-				{
-					$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
-				}
+			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $fileName != "UNK"){
+				if(file_exists("../courses/global/"."$gFileName"))						$information = file_get_contents("../courses/global/"."$gFileName");
+				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents("../courses/".$cid."/"."$gFileName");
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
 			}
 			//
 			$pattern = '/\s*/m';
@@ -156,45 +118,28 @@
 	$response->closeCursor();
 
 	if($splicedFileName != "UNK" && $splicedFileName != ""){
-		if(file_exists("../courses/global/"."$splicedFileName"))
-		{
-			$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
-		}
-		else if(file_exists("../courses/".$cid."/"."$splicedFileName"))
-		{
-			$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
-		}
-		else if(file_exists("../courses/".$cid."/"."$vers"."/"."$splicedFileName"))
-		{
-			$fileContent = file_get_contents("../courses/".$cid."/"."$vers"."/"."$splicedFileName");
-		}
+		if(file_exists("../courses/global/"."$splicedFileName"))						$fileContent = file_get_contents("../courses/global/"."$splicedFileName");
+		else if(file_exists("../courses/".$cid."/"."$splicedFileName"))					$fileContent = file_get_contents("../courses/".$cid."/"."$splicedFileName");
+		else if(file_exists("../courses/".$cid."/"."$vers"."/"."$splicedFileName"))		$fileContent = file_get_contents("../courses/".$cid."/"."$vers"."/"."$splicedFileName");
 	}
 
-	if($fileContent === "UNK")
-	{
-		$fileContent = "NO_FILE_FETCHED";
-	}
+	if($fileContent === "UNK")															$fileContent = "NO_FILE_FETCHED";
 
     // if the used is redirected from 
-	if(isset($_GET['hash']) && $_GET['hash'] != "UNK")
-	{
+	if(isset($_GET['hash']) && $_GET['hash'] != "UNK"){
 		$tempDir = strval(dirname(__DIR__, 2))."/submissions/{$cid}/{$vers}/{$quizid}/{$_SESSION['hash']}/";
 		$latest = time() - (365 * 24 * 60 * 60);
 		$current = "diagramSave1.json";	 
 
-		if(is_dir($tempDir))
-		{
+		if(is_dir($tempDir)){
 			//try and catch for using test data
 			try{
-				foreach(new DirectoryIterator($tempDir) as $file)
-				{
+				foreach(new DirectoryIterator($tempDir) as $file){
 					$ctime = $file->getCTime();    // Time file was created
 					$fname = $file->GetFileName (); // File name
 
-					if($fname != "." && $fname != "..")
-					{
-						if( $ctime > $latest )
-						{
+					if($fname != "." && $fname != ".."){
+						if( $ctime > $latest ){
 							$latest = $ctime;
 							$current = $fname;
 						}
@@ -212,22 +157,11 @@
 	}
 	
   // for fetching file content
-	if(file_exists("../courses/global/"."$fileName"))
-	{
-		$instructions = file_get_contents("../courses/global/"."$fileName");
-	}
-	else if(file_exists("../courses/".$cid."/"."$fileName"))
-	{
-		$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
-	}
-	else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))
-	{
-		$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
-	}
-	if($instructions === "UNK")
-	{
-		$instructions = "NO_FILE_FETCHED";
-	}
+	if(file_exists("../courses/global/"."$fileName"))									$instructions = file_get_contents("../courses/global/"."$fileName");
+	else if(file_exists("../courses/".$cid."/"."$fileName"))							$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
+	else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))				$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+	if($instructions === "UNK")															$instructions = "NO_FILE_FETCHED";
+	
 	$pattern = '/\s*/m';
   	$replace = '';
 	$instructions = preg_replace( $pattern, $replace,$instructions);

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -157,9 +157,9 @@
 	}
 	
   // for fetching file content
-	if(file_exists("../courses/global/"."$fileName"))									$instructions = file_get_contents("../courses/global/"."$fileName");
-	else if(file_exists("../courses/".$cid."/"."$fileName"))							$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
-	else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))				$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+	if(file_exists("../courses/global/"."$fileName" && $fileName != ""))									$instructions = file_get_contents("../courses/global/"."$fileName");
+	else if(file_exists("../courses/".$cid."/"."$fileName") && $fileName != "")							$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
+	else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName") && $fileName != "")				$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
 	if($instructions === "UNK")															$instructions = "NO_FILE_FETCHED";
 	
 	$pattern = '/\s*/m';

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -95,15 +95,15 @@
 
 			// for fetching file content
 			if(isset($fileName) && $fileName != "." && $fileName != ".." && $fileName != "UNK"){
-				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents("../courses/global/"."$fileName");
-				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
-				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
+				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents(__DIR__."../courses/global/"."$fileName");
+				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents(__DIR__."../courses/".$cid."/"."$fileName");
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents(__DIR__."../courses/".$cid."/"."$vers"."/"."$fileName");
 			}
 
 			if(isset($gFileName) && $gFileName != "." && $gFileName != ".." && $fileName != "UNK"){
-				if(file_exists("../courses/global/"."$gFileName"))						$information = file_get_contents("../courses/global/"."$gFileName");
-				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents("../courses/".$cid."/"."$gFileName");
-				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
+				if(file_exists("../courses/global/"."$gFileName"))						$information = file_get_contents(__DIR__."../courses/global/"."$gFileName");
+				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents(__DIR__."../courses/".$cid."/"."$gFileName");
+				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents(__DIR__."../courses/".$cid."/"."$vers"."/"."$gFileName");
 			}
 
 			$pattern = '/\s*/m';

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -74,8 +74,7 @@
 	$i=0;
 
 	#loop through responses, fetch param column in variant table, splice string to extract file name, then close request.
-	foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row)
-	{
+	foreach($response->fetchAll(PDO::FETCH_ASSOC) as $row){
 		$variantParams=$row['jparam'];
 		/* $start = strpos($variantParams, "diagram File&quot;:&quot;") + 25; Old way to get the filename
 		$end = strpos($variantParams, "&quot;:&quot;&quot;,&quot;diagram_type") - 176;
@@ -93,11 +92,9 @@
 																				else	$gFileName = "UNK";
 			if(isset($parameterArray['gType']))											$gFileType=$parameterArray["gType"];
 																				else	$gFileType = "UNK";
-			print_r($parameterArray);
-			exit();
+
 			// for fetching file content
 			if(isset($fileName) && $fileName != "." && $fileName != ".." && $fileName != "UNK"){
-
 				if(file_exists("../courses/global/"."$fileName"))						$instructions = file_get_contents("../courses/global/"."$fileName");
 				else if(file_exists("../courses/".$cid."/"."$fileName"))				$instructions = file_get_contents("../courses/".$cid."/"."$fileName");
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$fileName"))	$instructions = file_get_contents("../courses/".$cid."/"."$vers"."/"."$fileName");
@@ -110,12 +107,12 @@
 				else if(file_exists("../courses/".$cid."/"."$gFileName"))				$information = file_get_contents("../courses/".$cid."/"."$gFileName");
 				else if(file_exists("../courses/".$cid."/"."$vers"."/"."$gFileName"))	$information = file_get_contents("../courses/".$cid."/"."$vers"."/"."$gFileName");
 			}
-			//
+
 			$pattern = '/\s*/m';
 			$replace = '';
 			$instructions = preg_replace( $pattern, $replace,$instructions);
 			$information = preg_replace( $pattern, $replace,$information);
-			//
+
 			$finalArray[$i]=([$splicedFileName,$fileType,$fileName,$instructions, $gFileType, $gFileName, $information]);
 			$i++;
 		}

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -95,7 +95,9 @@ function returnedDugga(data)
                 window.parent.getInstructions(param.filelink);
             }
             if(param.gFilelink != undefined)
-            window.parent.getInstructions(param.gFilelink);
+            {
+                window.parent.getInstructions(param.gFilelink);
+            }
         }
         else{
             var diagramType={ER:true,UML:true};

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -90,7 +90,11 @@ function returnedDugga(data)
             // getting the error checker allowed or not
             document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
             // Getting the instructions to the side of the dugga -currently using filelink which is wrong
-            window.parent.getInstructions(param.filelink);
+            if(param.filelink != undefined)
+            {
+                window.parent.getInstructions(param.filelink);
+            }
+            if(param.gFilelink != undefined)
             window.parent.getInstructions(param.gFilelink);
         }
         else{


### PR DESCRIPTION
Added proper error handling for variables regarding fetching of diagram .json files, instruction files and general error information. By adding any type of variant to a diagram dugga, there should be no error message popup, and if the .json file is undeclared, should load in the standard demo-data as a diagram.

To Test:
1. open diagram dugga.

Note: To completely test, all combinations of variant params should be checked. However, this would take a long time and could instead be done with two tests, one where each field contains something, and one where all fields are empty.