### PR TITLE
Height of logged in button is  now 30px in mobile view. 

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1438,6 +1438,12 @@ div .navButt:hover {
   overflow: hidden;
 }
 
+@media screen and (max-width:480px) {
+  .loginbutton-nav {
+    height: 30px;
+    }
+  }
+
 @media screen and (max-width:400px){
     .hamburger{
         display: flex;


### PR DESCRIPTION
Height of logged in button is 30px in mobile view instead of 50px.

**For Testing:**
1. Be logged in and enter mobile view. 
2. Check whether the height of the login button is larger than the height of the nav bar.
It should look like this:
![image](https://user-images.githubusercontent.com/102605031/168246655-3e6a797e-1d4f-4325-938f-f7ad506709bf.png)