### PR TITLE
Colours not working properly for all elements. #12462

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8253,6 +8253,7 @@ function updateCSSForAllElements()
             var useDelta = (inContext && movingObject);
             var fillColor;
             var fontColor;
+            var weakKeyUnderline;
             if (data[i].isLocked) useDelta = false;
             updateElementDivCSS(element, elementDiv, useDelta);
             // Edge creation does not highlight selected elements
@@ -8270,7 +8271,6 @@ function updateCSSForAllElements()
                             fillColor.style.fill = `${element.fill}`;
                             fontColor.style.fill = `${"#000000"}`;
                         }
-                        
                     }
                 // Update Elements with double borders.
                 }else if(element.state == "weak" || element.state == "multiple"){
@@ -8289,10 +8289,14 @@ function updateCSSForAllElements()
                 }else{ // Update normal elements, and relations
                     fillColor = elementDiv.children[0].children[0];
                     fontColor = elementDiv.children[0];
+                    weakKeyUnderline = elementDiv.children[0].children[2];
                     // If more than one element is marked.
                     if(inContext && context.length > 1 || inContext && context.length > 0 && contextLine.length > 0){
                         fillColor.style.fill = `${"#927b9e"}`;
                         fontColor.style.fill = `${"#ffffff"}`;
+                        if(element.state == "weakKey") {
+                            weakKeyUnderline.style.stroke = `${"#ffffff"}`;
+                        }
                         // If UMLRelation is not marked.
                     } else if(element.kind == "UMLRelation"){
                         if(element.state == "overlapping"){
@@ -8303,6 +8307,9 @@ function updateCSSForAllElements()
                     }else{
                         fillColor.style.fill = `${element.fill}`;
                         fontColor.style.fill = `${"#000000"}`;
+                        if(element.state == "weakKey") {
+                            weakKeyUnderline.style.stroke = `${"#000000"}`;
+                        }
                     }
                 }
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -936,7 +936,7 @@ const strokewidth = 2.0;
 const baseline = 10;
 const avgcharwidth = 6; // <-- This variable is never used anywhere in this file. 
 const colors = ["#ffffff", "#c4e4fc", "#ffd4d4", "#fff4c2", "#c4f8bd", "#648fff", "#DC267F", "#FFB000", "#FE6100"];
-const strokeColors = ["#000000"];
+const strokeColors = ["#383737"];
 const selectedColor = "#A000DC";
 const multioffs = 3;
 // Zoom values for offsetting the mouse cursor positioning
@@ -1042,12 +1042,12 @@ var ghostLine = null;
  * @see constructElementOfType() For creating new elements with default values.
  */
 var defaults = {
-    EREntity: { name: "Entity", kind: "EREntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "ER", attributes: ['Attribute'], functions: ['Function'] },
-    ERRelation: { name: "Relation", kind: "ERRelation", fill: "#ffffff", stroke: "#000000", width: 60, height: 60, type: "ER" },
-    ERAttr: { name: "Attribute", kind: "ERAttr", fill: "#ffffff", stroke: "#000000", width: 90, height: 45, type: "ER", state: 'normal'},
-    Ghost: { name: "Ghost", kind: "ERAttr", fill: "#ffffff", stroke: "#000000", width: 5, height: 5, type: "ER" },
-    UMLEntity: {name: "Class", kind: "UMLEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "UML", attributes: ['Attribute'], functions: ['Function'] },     //<-- UML functionality
-    UMLRelation: {name: "Inheritance", kind: "UMLRelation", fill: "#ffffff", stroke: "#000000", width: 50, height: 50, type: "UML" }, //<-- UML functionality
+    EREntity: { name: "Entity", kind: "EREntity", fill: "#ffffff",  width: 200, height: 50, type: "ER", attributes: ['Attribute'], functions: ['Function'] },
+    ERRelation: { name: "Relation", kind: "ERRelation", fill: "#ffffff",  width: 60, height: 60, type: "ER" },
+    ERAttr: { name: "Attribute", kind: "ERAttr", fill: "#ffffff", width: 90, height: 45, type: "ER", state: 'normal'},
+    Ghost: { name: "Ghost", kind: "ERAttr", fill: "#ffffff",  width: 5, height: 5, type: "ER" },
+    UMLEntity: {name: "Class", kind: "UMLEntity", fill: "#ffffff", width: 200, height: 50, type: "UML", attributes: ['Attribute'], functions: ['Function'] },     //<-- UML functionality
+    UMLRelation: {name: "Inheritance", kind: "UMLRelation", fill: "#ffffff", width: 50, height: 50, type: "UML" }, //<-- UML functionality
 }
 var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
@@ -6595,7 +6595,7 @@ function drawElement(element, ghosted = false)
                             Q${boxw - linew},${linew} ${boxw - linew},${hboxh} 
                             Q${boxw - linew},${boxh - linew} ${hboxw},${boxh - linew} 
                             Q${linew},${boxh - linew} ${linew},${hboxh}" 
-                        stroke='${element.stroke}' fill='${element.fill}' ${dash} stroke-width='${linew} class="text" '/>
+                        stroke='${element.stroke}' fill='${element.fill}' ${dash} stroke-width='${linew}' class="text" />
                         
                         ${multi}
                         <text x='${xAnchor}' y='${hboxh}' `;
@@ -7916,7 +7916,7 @@ function checkElementError(element)
 function errorReset(elements)
 {
     for (var i = 0; i < elements.length; i++) {
-        elements[i].stroke = 'black';
+        elements[i].stroke = strokeColors;
     }
 }
 /**


### PR DESCRIPTION
 #12462

**What has been made**
- Fixed typo error which caused outer line on normal attributes and multivalued attribute to look thinner.
- Removed stroke from element values as the value is no longer in use. (Might cause programmers confusion in the future if it stayed).
- Changed black stroke colour to websafe dark colour. 
- Changed so that errorReset doesn't use by default a black, but instead gets stroke colour from the variable list.  
- Fixed so that the weak key also changes to white when multiple objects are selected. Also fixed so that it changes back when unselected. 

**How to test**
Open the diagram and make sure you have an attribute with a weak key. For example Name in image below:
<img src="https://user-images.githubusercontent.com/81772705/168249257-a24b1ffb-566b-4dd3-a5fd-7a661afaaed0.png" width="200"/>
Then select this attribute together with at least one more attribute. The dashed underline should change to white together with the text, then back to black when being unselected. 

Before and after for attribute stroke thickness.
<img src="https://user-images.githubusercontent.com/81772705/168249813-5dd2b701-f332-4d1b-af0e-d97a5a27ab63.png" width="300"/>      <img src="https://user-images.githubusercontent.com/81772705/168249677-37c86292-d937-408d-aada-4d5babca9eab.png" width="300"/>

