### PR TITLE
Greyed out zooming buttons when no longer clickable. 

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2807,15 +2807,23 @@ function zoomText(boxid, increment)
 	}
 	
 	else { 
-	
-		var zoomButton = document.querySelector('#box'+boxid+'wrapper #zoomIn');
 		
-		zoomButton.style.opacity = "0.4";
-		zoomButton.style.pointerEvents = "none";
-	
+		if(increment < 0) {
+			var zoomButton = document.querySelector('#box'+boxid+'wrapper #zoomOut');
+			zoomButton.style.opacity = "0.4";
+			zoomButton.style.pointerEvents = "none";
+		}
+		
+		else if (increment > 0) {
+			var zoomButton = document.querySelector('#box'+boxid+'wrapper #zoomIn');
+			zoomButton.style.opacity = "0.4";
+			zoomButton.style.pointerEvents = "none";
+			
+		}
+		
 	}
-	
 }
+	
 
 //-----------------------------------------------------------------------------
 // resetText: Resets the text size to the default value. (9px)

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2843,12 +2843,10 @@ function resetText(boxid)
 }
 
 function enableZoomButton(zoomButton){
-	zoomButton.style.opacity = "1";
 	zoomButton.style.cssText = "";
 }
 
 function disableZoomButton(zoomButton){
-	console.log(zoomButton.style);
 	zoomButton.style.opacity = "0.4";
 	zoomButton.style.pointerEvents = "none";
 }

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2797,31 +2797,20 @@ function zoomText(boxid, increment)
 
 	var fontSize = parseInt(document.getElementById("box" + boxid).style.fontSize);
 	
+	var zoomOutButton = document.querySelector('#box'+boxid+'wrapper #zoomOut');
+	var zoomInButton = document.querySelector('#box'+boxid+'wrapper #zoomIn');
 
-	if (increment > 0 && fontSize < upperLimit || increment < 0 && fontSize > lowerLimit){
+
+	if (increment > 0 && fontSize - increment < upperLimit || increment < 0 && fontSize + increment > lowerLimit){
 
 		fontSize = fontSize + increment; 
-
 		document.getElementById("box" + boxid).style.fontSize = fontSize + "px";
-	
+		
+		enableZoomButton(zoomInButton);
+		enableZoomButton(zoomOutButton);
+
 	}
-	
-	else { 
-		
-		if(increment < 0) {
-			var zoomButton = document.querySelector('#box'+boxid+'wrapper #zoomOut');
-			zoomButton.style.opacity = "0.4";
-			zoomButton.style.pointerEvents = "none";
-		}
-		
-		else if (increment > 0) {
-			var zoomButton = document.querySelector('#box'+boxid+'wrapper #zoomIn');
-			zoomButton.style.opacity = "0.4";
-			zoomButton.style.pointerEvents = "none";
-			
-		}
-		
-	}
+
 }
 	
 
@@ -2830,9 +2819,25 @@ function zoomText(boxid, increment)
 //-----------------------------------------------------------------------------
 function resetText(boxid)
 {
+	var zoomButton = document.querySelector('#box'+boxid+'wrapper #zoomOut');
+	var zoomInButton = document.querySelector('#box'+boxid+'wrapper #zoomIn');
+	
+	enableZoomButton(zoomButton);
+	enableZoomButton(zoomInButton);
+	
+	document.getElementById("box" + boxid).style.fontSize = "9px";
 
-document.getElementById("box" + boxid).style.fontSize = "9px";
+}
 
+function enableZoomButton(zoomButton){
+	zoomButton.style.opacity = "1";
+	zoomButton.style.cssText = "";
+}
+
+function disableZoomButton(zoomButton){
+	console.log(zoomButton.style);
+	zoomButton.style.opacity = "0.4";
+	zoomButton.style.pointerEvents = "none";
 }
 
 //-----------------------------------------------------------------------------

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1069,9 +1069,9 @@ function createboxmenu(contentid, boxid, type) {
 		}
 
 		// Add zoom in, zoom out and reset buttons.
-		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' title='Zoom in' onclick='zoomText(" + boxid + ", 3);'><img src='../Shared/icons/MaxButton.svg' /></div>";
-		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' title='Zoom out' onclick='zoomText(" + boxid + ", -3);'><img src='../Shared/icons/MinButton.svg' /></div>";
-		str += "<div id='resetBoxes'><td class='butto2 resetbtn' title='Reset zoom' onclick='resetText(" + boxid + ");'><img src='../Shared/icons/ResetButton.svg' /></div>";
+		str += "<div id='maximizeBoxes'><td class='butto2 maximizebtn' id='zoomIn' title='Zoom in' onclick='zoomText(" + boxid + ", 3);'><img src='../Shared/icons/MaxButton.svg' /></div>";
+		str += "<div id='minimizeBoxes'><td class='butto2 minimizebtn' id='zoomOut' title='Zoom out' onclick='zoomText(" + boxid + ", -3);'><img src='../Shared/icons/MinButton.svg' /></div>";
+		str += "<div id='resetBoxes'><td class='butto2 resetbtn' id='resetZoom' title='Reset zoom' onclick='resetText(" + boxid + ");'><img src='../Shared/icons/ResetButton.svg' /></div>";
     
 
 		// Show the copy to clipboard button for code views only
@@ -2797,11 +2797,21 @@ function zoomText(boxid, increment)
 
 	var fontSize = parseInt(document.getElementById("box" + boxid).style.fontSize);
 	
+
 	if (increment > 0 && fontSize < upperLimit || increment < 0 && fontSize > lowerLimit){
 
 		fontSize = fontSize + increment; 
 
 		document.getElementById("box" + boxid).style.fontSize = fontSize + "px";
+	
+	}
+	
+	else { 
+	
+		var zoomButton = document.querySelector('#box'+boxid+'wrapper #zoomIn');
+		
+		zoomButton.style.opacity = "0.4";
+		zoomButton.style.pointerEvents = "none";
 	
 	}
 	

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2810,7 +2810,20 @@ function zoomText(boxid, increment)
 		enableZoomButton(zoomOutButton);
 
 	}
-
+	
+	//Disable zoom buttons on last click
+	else if(increment < 0) {
+			fontSize = fontSize + increment; 
+			document.getElementById("box" + boxid).style.fontSize = fontSize + "px";
+			disableZoomButton(zoomOutButton);
+	}
+		
+	else if (increment > 0) {
+			fontSize = fontSize + increment; 
+			document.getElementById("box" + boxid).style.fontSize = fontSize + "px";
+			disableZoomButton(zoomInButton);
+	}
+	
 }
 	
 


### PR DESCRIPTION
The appearance of the zooming buttons now behave intuitive.

The Zoom In & zoom out buttons now grey out when they are no longer clickable. 
Pressing the opposite button of a greyed out one will make the other clickable. 

The reset button will make both buttons press-able again.

![Buttons legend](https://user-images.githubusercontent.com/102584401/168251566-ea87e80f-1c9b-4216-b2b5-622f03d46549.png)

**This issue can be tested by:**

1. Open a code example, preferably one with files ready.
        e.g Webbprogrammering -> JavaScript Example 2.

2. Pressing the zoom in button will make the text larger up until the max font size has been reached.
3. Whenever the max font size has been reached the zoom in button now gets greyed out.
4. Press the opposite zoom button, Zoom in button is now clickable.
5. Max zoom again.
6. Press reset button and the button gets clickable again.
7. Repeat steps 2-6 for the Zoom out button.

