### PR TITLE
Added mobile support for copy button #12442

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -45,6 +45,7 @@ var template8maximizebuttonpressed = false;
 var sectionData; // Variable that stores all the data that is sent from Section, which contains the ordering of the code examples.
 var codeExamples = []; // Array that contains all code examples in the same order that was assigned in Section before pressing one of the examples.
 var currentPos; // Variable for the current position that determines where in the list of code examples you are.
+var selectionRange; // Variable that stores range of selected text.
 
 
 /********************************************************************************
@@ -4943,15 +4944,38 @@ function copyCodeToClipboard(boxid) {
 	// Select the code
 	var selection = window.getSelection();
 	
-	// Add Code to just copy impo code
-	for(i = 0; i<impo.length;i++){
-		var range = document.createRange();
-		range.selectNode(impo[i]);
-		selection.addRange(range);
+	if (selectionRange != null && selectionRange.toString() != "") {
+		// Copy selected code
+		selection.removeAllRanges();
+		selection.addRange(selectionRange);
+	} else if (impo.length > 0) {
+		// Copy impo code if no selection is made
+		selection.removeAllRanges();
+		for(i = 0; i<impo.length;i++){
+			var range = document.createRange();
+			range.selectNode(impo[i]);
+			selection.addRange(range);
+		}
+	} else {
+		// Retain previous clipboard if no code is selected and there is no impo code
+		return;
 	}
 	
-	document.execCommand("Copy");
+	if (navigator.clipboard) {
+		// Write selection to clipboard
+		navigator.clipboard.writeText(selection).catch(function (err) {
+			// Display errors as a warning
+			console.warn("Error occurred.", err);
+		});
+	} else {
+		// If clipboard API is not available
+		document.execCommand("Copy");
+		console.warn("Depricated feature \'documnet.execCommand()\' was used");
+	}
+
 	selection.removeAllRanges();
+	selectionRange = "";
+
 
 	// Notification animation
 	$("#notificationbox" + boxid).css("display", "flex").css("overflow", "hidden").hide().fadeIn("fast", function () {
@@ -4961,6 +4985,14 @@ function copyCodeToClipboard(boxid) {
 	});
 }
 
+// Selectionchange EventListener
+document.addEventListener('selectionchange', function () {
+	// 0.5 second delay to update selectionRange (Needed for copyCodeToClipboard() to work on mobile)
+	setTimeout(function () {
+		if (window.getSelection().rangeCount > 0)
+			selectionRange = window.getSelection().getRangeAt(0);
+	}, 500);
+  });
 
 // Detects clicks
 $(document).mousedown(function (e) {


### PR DESCRIPTION
Added a 0.5 second delay to the selectioncahnge event because when mobile users have selected code and press the cody button their selection is deselected before the copy command is executed. With the slight delay that will not be a problem. Also added clipboard  API support to replace depricated method execCommand().

Testing:
1) Login as a teacher account (username: stei password: password)
2) Enter Webbprogrammering
3) Open JavaScript Example 1
4) Select a code paragraph and click the "Copy to clipboard" button. The selected code should have been copied to the clipboard
5)  Click the "Copy to clipboard" button with no selection. If there are rows marked as "important" that should be copied, if not, the clipboard should be unchanged.
6) Now also test this on a mobile device (Not mobile view on your desktop). This should work the same on both iOS and Android.