### PR TITLE
Added resizing support for browsers other than chrome. And added a function for hiding the text in boxes.

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -3952,13 +3952,14 @@ function resizeBoxes(parent, templateId)
 	{
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
-				remaining = ($(parent).width()) - $('#box1wrapper').width();
+				remaining = ($(parent).width()) - $('#box1wrapper').width();	
+				//box wrapper 2 widht = widht of screen - box wrapper 1 widht. ( this means the screen is always filled.) (box1wrapper + box2wrapper = div2 widht.)
+				document.querySelector('#box2wrapper').style.width = remaining + "px";
+
+				//Check if any descriptions needs to be hidden/shown
 				for(i = 1; i <= retData["numbox"];i++){
 					toggleTitleDescription(i);
-				}	
-				//box wrapper 2 and 3 widht = widht of screen - box wrapper 1 widht. ( this means the screen is always filled.) (box1wrapper + box2wrapper = screen widht.)
-				document.querySelector('#box2wrapper').style.width = remaining + "px";
-						
+				}						
 			},		
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -3982,12 +3983,13 @@ function resizeBoxes(parent, templateId)
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box1wrapper').width();
+				document.querySelector('#box2wrapper').style.width = remaining + "px";
+				document.querySelector('#box3wrapper').style.width = remaining + "px";	
+
+				//Check if any descriptions needs to be hidden/shown
 				for(i = 1; i <= retData["numbox"];i++){
 					toggleTitleDescription(i);
-				}	
-				//box wrapper 2 and 3 widht = widht of screen - box wrapper 1 widht. ( this means the screen is always filled.) (box1wrapper + box2wrapper = screen widht.)
-				document.querySelector('#box2wrapper').style.width = remaining + "px";
-				document.querySelector('#box3wrapper').style.width = remaining + "px";				
+				}				
 			},		
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -4009,22 +4011,22 @@ function resizeBoxes(parent, templateId)
 	if(templateId == 4){
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
-				remaining = ($(parent).width()) - $('#box1wrapper').width();
-				remainingHeight = ($(parent).height()) - $('#box1wrapper').height();
-				//Handles east resizing START.
-				for(i = 1; i <= retData["numbox"];i++){
-					toggleTitleDescription(i);
-				}	
 				//Blocking widht resizing if the width of the boxes has not changed.
 				if($('#box1wrapper').width()+ $('#box2wrapper').width() != $(parent).width()){
+					//East resizing
+					remaining = ($(parent).width()) - $('#box1wrapper').width();
 					$('#box2wrapper').css('width', remaining + "px");
-				}
-				//Handles east resizing END.
-				//Handles south resizing START.
-				$('#box2wrapper').css('height', $('#box1wrapper').height() + "px");
-				$('#box3wrapper').css('height', remainingHeight + "px");
-				//Handles south resizing END.
-						
+
+					//Check if any descriptions needs to be hidden/shown
+					for(i = 1; i <= retData["numbox"];i++){
+						toggleTitleDescription(i);
+					}	
+				}else{
+					//South resizing
+					remainingHeight = ($(parent).height()) - $('#box1wrapper').height();
+					$('#box2wrapper').css('height', $('#box1wrapper').height() + "px");
+					$('#box3wrapper').css('height', remainingHeight + "px");
+				}		
 			},		
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -4050,24 +4052,24 @@ function resizeBoxes(parent, templateId)
 	if(templateId == 5){
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
-				//Handles east resizing START.
-				remaining = ($(parent).width()) - $('#box1wrapper').width();
-				remainingHeight = ($(parent).height()) - $('#box1wrapper').height();
-				for(i = 1; i <= retData["numbox"];i++){
-					toggleTitleDescription(i);
-				}	
+
 				//Blocking widht resizing if the width of the boxes has not changed.
 				if($('#box1wrapper').width()+ $('#box2wrapper').width() != $(parent).width()){
+					//East resizing
+					remaining = ($(parent).width()) - $('#box1wrapper').width();
 					$('#box2wrapper').css('width', remaining + "px");
-				}
-				
-				//Handles east resizing END.
 
-				//Handles south resizing START.
-				$('#box2wrapper').css('height', $('#box1wrapper').height() + "px");
-				$('#box3wrapper').css('height', remainingHeight + "px");
-				$('#box4wrapper').css('height', remainingHeight + "px");
-				//Handles south resizing END.						
+					//Check if any descriptions needs to be hidden/shown
+					for(i = 1; i <= retData["numbox"];i++){
+						toggleTitleDescription(i);
+					}	
+				}else{
+					//South resizing
+					remainingHeight = ($(parent).height()) - $('#box1wrapper').height();
+					$('#box2wrapper').css('height', $('#box1wrapper').height() + "px");
+					$('#box3wrapper').css('height', remainingHeight + "px");
+					$('#box4wrapper').css('height', remainingHeight + "px");
+				}					
 			},		
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -4090,14 +4092,15 @@ function resizeBoxes(parent, templateId)
 		});
 		$('#box3wrapper').resizable({
 			resize: function( event, ui ) {
-				remaining = ($(parent).width()) - $('#box3wrapper').width();
-				for(i = 1; i <= retData["numbox"];i++){
-					toggleTitleDescription(i);
-				}	
+				remaining = ($(parent).width()) - $('#box3wrapper').width();	
 				$('#box1wrapper').css('width', $('#box3wrapper').width());
 				$('#box2wrapper').css('width', remaining + "px");
 				$('#box4wrapper').css('width', remaining + "px");
 
+				//Check if any descriptions needs to be hidden/shown
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}
 			},
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -4110,12 +4113,14 @@ function resizeBoxes(parent, templateId)
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box1wrapper').width();
+				$('#box2wrapper').css('width', remaining + "px");
+				$('#box3wrapper').css('width', remaining + "px");
+				$('#box4wrapper').css('width', remaining + "px");	
+				
+				//Check if any descriptions needs to be hidden/shown
 				for(i = 1; i <= retData["numbox"];i++){
 					toggleTitleDescription(i);
 				}	
-				$('#box2wrapper').css('width', remaining + "px");
-				$('#box3wrapper').css('width', remaining + "px");
-				$('#box4wrapper').css('width', remaining + "px");						
 			},		
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -4169,19 +4174,20 @@ function resizeBoxes(parent, templateId)
 	if(templateId == 7){
 		$('#box2wrapper').resizable({
 			resize: function( event, ui ) {
-				//Handles east resizing START.
-				remaining = ($(parent).width()) - $('#box2wrapper').width();
-				for(i = 1; i <= retData["numbox"];i++){
-					toggleTitleDescription(i);
-				}	
-
 				//Blocking widht resizing if the width of the boxes has not changed.
 				if($('#box1wrapper').width()+ $('#box2wrapper').width() != $(parent).width()){
+					//East resizing
+					remaining = ($(parent).width()) - $('#box2wrapper').width();
 					$('#box1wrapper').css('width', remaining + "px");
-
 					$('#box3wrapper').css('width', $('#box2wrapper').width() + "px");
 					$('#box4wrapper').css('width', $('#box2wrapper').width() + "px");
+
+					//Check if any descriptions needs to be hidden/shown
+					for(i = 1; i <= retData["numbox"];i++){
+						toggleTitleDescription(i);
+					}
 				}else{
+					//South resizing
 					resizeAmount = $(parent).height() - $('#box2wrapper').height() - $('#box3wrapper').height() - $('#box4wrapper').height();
 					if($('#box3wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
 						$('#box4wrapper').css('height', ($('#box4wrapper').height() + resizeAmount) + "px");
@@ -4193,8 +4199,7 @@ function resizeBoxes(parent, templateId)
 						$('#box3wrapper').css('height', ($('#box3wrapper').height() + (resizeAmount)/2) + "px");
 						$('#box4wrapper').css('height', ($('#box4wrapper').height() + (resizeAmount)/2) + "px");
 					}
-				}
-				//Handles east resizing END.
+				}					
 			},
 			handles:"s, e",
 			maxHeight: ($(parent).height()*0.70),
@@ -4205,18 +4210,21 @@ function resizeBoxes(parent, templateId)
 		});
 		$('#box3wrapper').resizable({
 			resize: function( event, ui ) {
-				//Handles east resizing START.
-				remaining = ($(parent).width()) - $('#box3wrapper').width();
-				for(i = 1; i <= retData["numbox"];i++){
-					toggleTitleDescription(i);
-				}	
-				//Blocking widht resizing if the width of the boxes has not changed.
-				if($('#box1wrapper').width()+ $('#box3wrapper').width() != $(parent).width()){				
-					$('#box1wrapper').css('width', remaining + "px");
 
+				//Blocking widht resizing if the width of the boxes has not changed.
+				if($('#box1wrapper').width()+ $('#box3wrapper').width() != $(parent).width()){
+					//East resizing	
+					remaining = ($(parent).width()) - $('#box3wrapper').width();			
+					$('#box1wrapper').css('width', remaining + "px");
 					$('#box2wrapper').css('width', $('#box3wrapper').width() + "px");
 					$('#box4wrapper').css('width', $('#box3wrapper').width() + "px");
+
+					//Check if any descriptions needs to be hidden/shown
+					for(i = 1; i <= retData["numbox"];i++){
+						toggleTitleDescription(i);
+					}
 				}else{
+					//South resizing
 					resizeAmount = $(parent).height() - $('#box2wrapper').height() - $('#box3wrapper').height() - $('#box4wrapper').height();
 					if($('#box2wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
 						$('#box4wrapper').css('height', ($('#box4wrapper').height() + resizeAmount) + "px");
@@ -4229,12 +4237,6 @@ function resizeBoxes(parent, templateId)
 						$('#box4wrapper').css('height', ($('#box4wrapper').height() + (resizeAmount)/2) + "px");
 					}	
 				}
-				//Handles east resizing END.
-				//Handles south resizing START.
-				//Blocking height resizing if the height of the boxes has not changed. The +1 is due to rounding errors.
-
-				
-				//Handles south resizing END.
 			},
 			handles: "s, e",
 			maxHeight: ($(parent).height()*0.70),
@@ -4246,16 +4248,15 @@ function resizeBoxes(parent, templateId)
 		});
 		$('#box4wrapper').resizable({
 			resize: function( event, ui ) {
-				//Handles east resizing START.
-				remaining = ($(parent).width()) - $('#box4wrapper').width();
-				for(i = 1; i <= retData["numbox"];i++){
-					toggleTitleDescription(i);
-				}	
+				remaining = ($(parent).width()) - $('#box4wrapper').width();	
 				$('#box1wrapper').css('width', remaining + "px");
-
 				$('#box2wrapper').css('width', $('#box4wrapper').width() + "px");
 				$('#box3wrapper').css('width', $('#box4wrapper').width() + "px");
-				//Handles east resizing END.
+
+				//Check if any descriptions needs to be hidden/shown
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}				
 			},
 			handles: "e",
 			maxHeight: ($(parent).width()*0.85),
@@ -4266,20 +4267,22 @@ function resizeBoxes(parent, templateId)
 	if(templateId == 8){
 		$('#box2wrapper').resizable({
 			resize: function( event, ui ) {
-				remaining = ($(parent).width()) - $('#box2wrapper').width();
-				remainingHeight = ($(parent).height()) - $('#box2wrapper').height();
-				//Handles east resizing START.
-				for(i = 1; i <= retData["numbox"];i++){
-					toggleTitleDescription(i);
-				}	
 				//Blocking widht resizing if the width of the boxes has not changed.
 				if($('#box1wrapper').width()+ $('#box2wrapper').width() != $(parent).width()){
+					//East resizing
+					remaining = ($(parent).width()) - $('#box2wrapper').width();
 					$('#box1wrapper').css('width', remaining + "px");
 					$('#box3wrapper').css('width', $('#box2wrapper').width() + "px");
+
+					//Check if any descriptions needs to be hidden/shown
+					for(i = 1; i <= retData["numbox"];i++){
+						toggleTitleDescription(i);
+					}
 				}else{
+					//South resizing
+					remainingHeight = ($(parent).height()) - $('#box2wrapper').height();
 					$('#box3wrapper').css('height', remainingHeight + "px");
 				}				
-				//Handles east resizing END.
 			},
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -4292,11 +4295,13 @@ function resizeBoxes(parent, templateId)
 		$('#box3wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box3wrapper').width();
+				$('#box1wrapper').css('width', remaining + "px");
+				$('#box2wrapper').css('width', $('#box3wrapper').width() + "px");
+
+				//Check if any descriptions needs to be hidden/shown
 				for(i = 1; i <= retData["numbox"];i++){
 					toggleTitleDescription(i);
 				}	
-				$('#box1wrapper').css('width', remaining + "px");
-				$('#box2wrapper').css('width', $('#box3wrapper').width() + "px");
 			},
 			handles: "e",
 			maxWidth: ($(parent).width()*0.85),
@@ -4307,14 +4312,16 @@ function resizeBoxes(parent, templateId)
 	if(templateId == 9){
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
-				remaining = ($(parent).width()) - $('#box1wrapper').width();
-				for(i = 1; i <= retData["numbox"];i++){
-					toggleTitleDescription(i);
-				}	
+				remaining = ($(parent).width()) - $('#box1wrapper').width();	
 				$('#box2wrapper').css('width', remaining + "px");
 				$('#box3wrapper').css('width', remaining + "px");
 				$('#box4wrapper').css('width', remaining + "px");
 				$('#box5wrapper').css('width', remaining + "px");
+
+				//Check if any descriptions needs to be hidden/shown
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}				
 			},
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -3953,28 +3953,9 @@ function resizeBoxes(parent, templateId)
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box1wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					//hide box 2 title
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-	
-				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-				}
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
 				//box wrapper 2 and 3 widht = widht of screen - box wrapper 1 widht. ( this means the screen is always filled.) (box1wrapper + box2wrapper = screen widht.)
 				document.querySelector('#box2wrapper').style.width = remaining + "px";
 						
@@ -3984,62 +3965,29 @@ function resizeBoxes(parent, templateId)
 			handles: "e",
 			containment: parent
 		});
-		$('#box2wrapper').resizable({
-			disabled: true
-		});
 	}
 	if(templateId == 2){
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).height()) - $('#box1wrapper').height();
 				document.querySelector('#box2wrapper').style.height = remaining + "px";		
-				console.log($('#box1wrapper').height());
 			},		
 			maxHeight: ($(parent).height()*0.85),
 			minHeight: ($(parent).height()*0.15),
 			handles: "s",
 			containment: parent	
 		});
-		$('#box2wrapper').resizable({
-			disabled: true
-		});	
 	}
 	if(templateId == 3){
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box1wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					//hide box 2 and 3 title
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-				}
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
 				//box wrapper 2 and 3 widht = widht of screen - box wrapper 1 widht. ( this means the screen is always filled.) (box1wrapper + box2wrapper = screen widht.)
 				document.querySelector('#box2wrapper').style.width = remaining + "px";
-				document.querySelector('#box3wrapper').style.width = remaining + "px";
-					
+				document.querySelector('#box3wrapper').style.width = remaining + "px";				
 			},		
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -4057,9 +4005,6 @@ function resizeBoxes(parent, templateId)
 		maxHeight: ($(parent).height()*0.85),
 		minHeight: ($(parent).height()*0.16)
 		});
-		$('#box3wrapper').resizable({
-			disabled: true
-		});
 	}
 	if(templateId == 4){
 		$('#box1wrapper').resizable({
@@ -4067,32 +4012,14 @@ function resizeBoxes(parent, templateId)
 				remaining = ($(parent).width()) - $('#box1wrapper').width();
 				remainingHeight = ($(parent).height()) - $('#box1wrapper').height();
 				//Handles east resizing START.
-				if((remaining/$(parent).width())*100 < 16){
-					//hide box 2 and 3 title
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-	
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
+				//Blocking widht resizing if the width of the boxes has not changed.
+				if($('#box1wrapper').width()+ $('#box2wrapper').width() != $(parent).width()){
+					$('#box2wrapper').css('width', remaining + "px");
 				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-				}
-				
-				$('#box2wrapper').css('width', remaining + "px");
 				//Handles east resizing END.
-
 				//Handles south resizing START.
 				$('#box2wrapper').css('height', $('#box1wrapper').height() + "px");
 				$('#box3wrapper').css('height', remainingHeight + "px");
@@ -4126,43 +4053,14 @@ function resizeBoxes(parent, templateId)
 				//Handles east resizing START.
 				remaining = ($(parent).width()) - $('#box1wrapper').width();
 				remainingHeight = ($(parent).height()) - $('#box1wrapper').height();
-				if((remaining/$(parent).width())*100 < 16){
-					//hide box 2 and 3 title
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-	
-					boxToHide = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
+				//Blocking widht resizing if the width of the boxes has not changed.
+				if($('#box1wrapper').width()+ $('#box2wrapper').width() != $(parent).width()){
+					$('#box2wrapper').css('width', remaining + "px");
 				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-				}
-				$('#box2wrapper').css('width', remaining + "px");
+				
 				//Handles east resizing END.
 
 				//Handles south resizing START.
@@ -4193,41 +4091,9 @@ function resizeBoxes(parent, templateId)
 		$('#box3wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box3wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-				}
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
 				$('#box1wrapper').css('width', $('#box3wrapper').width());
 				$('#box2wrapper').css('width', remaining + "px");
 				$('#box4wrapper').css('width', remaining + "px");
@@ -4244,43 +4110,9 @@ function resizeBoxes(parent, templateId)
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box1wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-	
-				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-				}
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
 				$('#box2wrapper').css('width', remaining + "px");
 				$('#box3wrapper').css('width', remaining + "px");
 				$('#box4wrapper').css('width', remaining + "px");						
@@ -4339,63 +4171,30 @@ function resizeBoxes(parent, templateId)
 			resize: function( event, ui ) {
 				//Handles east resizing START.
 				remaining = ($(parent).width()) - $('#box2wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');	
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
+
+				//Blocking widht resizing if the width of the boxes has not changed.
+				if($('#box1wrapper').width()+ $('#box2wrapper').width() != $(parent).width()){
+					$('#box1wrapper').css('width', remaining + "px");
+
+					$('#box3wrapper').css('width', $('#box2wrapper').width() + "px");
+					$('#box4wrapper').css('width', $('#box2wrapper').width() + "px");
+				}else{
+					resizeAmount = $(parent).height() - $('#box2wrapper').height() - $('#box3wrapper').height() - $('#box4wrapper').height();
+					if($('#box3wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
+						$('#box4wrapper').css('height', ($('#box4wrapper').height() + resizeAmount) + "px");
+					}
+					else if($('#box4wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
+						$('#box3wrapper').css('height', ($('#box3wrapper').height() + resizeAmount) + "px");
+					}
+					else{
+						$('#box3wrapper').css('height', ($('#box3wrapper').height() + (resizeAmount)/2) + "px");
+						$('#box4wrapper').css('height', ($('#box4wrapper').height() + (resizeAmount)/2) + "px");
+					}
 				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-				}		
-				$('#box1wrapper').css('width', remaining + "px");
-
-				$('#box3wrapper').css('width', $('#box2wrapper').width() + "px");
-				$('#box4wrapper').css('width', $('#box2wrapper').width() + "px");
 				//Handles east resizing END.
-				//Handles south resizing START.
-				resizeAmount = $(parent).height() - $('#box2wrapper').height() - $('#box3wrapper').height() - $('#box4wrapper').height();
-
-				if($('#box3wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
-					$('#box4wrapper').css('height', ($('#box4wrapper').height() + resizeAmount) + "px");
-					console.log('4');
-				}
-				else if($('#box4wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
-					$('#box3wrapper').css('height', ($('#box3wrapper').height() + resizeAmount) + "px");
-					console.log('3')
-				}
-				else{
-					$('#box3wrapper').css('height', ($('#box3wrapper').height() + (resizeAmount)/2) + "px");
-					$('#box4wrapper').css('height', ($('#box4wrapper').height() + (resizeAmount)/2) + "px");
-				}
-				//Handles south resizing END.
 			},
 			handles:"s, e",
 			maxHeight: ($(parent).height()*0.70),
@@ -4408,61 +4207,33 @@ function resizeBoxes(parent, templateId)
 			resize: function( event, ui ) {
 				//Handles east resizing START.
 				remaining = ($(parent).width()) - $('#box3wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');	
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
+				//Blocking widht resizing if the width of the boxes has not changed.
+				if($('#box1wrapper').width()+ $('#box3wrapper').width() != $(parent).width()){				
+					$('#box1wrapper').css('width', remaining + "px");
+
+					$('#box2wrapper').css('width', $('#box3wrapper').width() + "px");
+					$('#box4wrapper').css('width', $('#box3wrapper').width() + "px");
+				}else{
+					resizeAmount = $(parent).height() - $('#box2wrapper').height() - $('#box3wrapper').height() - $('#box4wrapper').height();
+					if($('#box2wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
+						$('#box4wrapper').css('height', ($('#box4wrapper').height() + resizeAmount) + "px");
+					}
+					else if($('#box4wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
+						$('#box2wrapper').css('height', ($('#box2wrapper').height() + resizeAmount) + "px");
+					}
+					else{
+						$('#box2wrapper').css('height', ($('#box2wrapper').height() + (resizeAmount)/2) + "px");
+						$('#box4wrapper').css('height', ($('#box4wrapper').height() + (resizeAmount)/2) + "px");
+					}	
 				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-				}
-				$('#box1wrapper').css('width', remaining + "px");
-
-				$('#box2wrapper').css('width', $('#box3wrapper').width() + "px");
-				$('#box4wrapper').css('width', $('#box3wrapper').width() + "px");
 				//Handles east resizing END.
 				//Handles south resizing START.
-				resizeAmount = $(parent).height() - $('#box2wrapper').height() - $('#box3wrapper').height() - $('#box4wrapper').height();
+				//Blocking height resizing if the height of the boxes has not changed. The +1 is due to rounding errors.
 
-				if($('#box2wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
-					$('#box4wrapper').css('height', ($('#box4wrapper').height() + resizeAmount) + "px");
-					console.log('4');
-				}
-				else if($('#box4wrapper').height() <= $(parent).height()*0.15 && resizeAmount < 0){
-					$('#box2wrapper').css('height', ($('#box2wrapper').height() + resizeAmount) + "px");
-					console.log('3')
-				}
-				else{
-					$('#box2wrapper').css('height', ($('#box2wrapper').height() + (resizeAmount)/2) + "px");
-					$('#box4wrapper').css('height', ($('#box4wrapper').height() + (resizeAmount)/2) + "px");
-				}
+				
 				//Handles south resizing END.
 			},
 			handles: "s, e",
@@ -4477,41 +4248,9 @@ function resizeBoxes(parent, templateId)
 			resize: function( event, ui ) {
 				//Handles east resizing START.
 				remaining = ($(parent).width()) - $('#box4wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');	
-				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-
-					boxToHide = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-				}
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
 				$('#box1wrapper').css('width', remaining + "px");
 
 				$('#box2wrapper').css('width', $('#box4wrapper').width() + "px");
@@ -4530,40 +4269,17 @@ function resizeBoxes(parent, templateId)
 				remaining = ($(parent).width()) - $('#box2wrapper').width();
 				remainingHeight = ($(parent).height()) - $('#box2wrapper').height();
 				//Handles east resizing START.
-				if((remaining/$(parent).width())*100 < 16){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-			
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-				}
-				$('#box1wrapper').css('width', remaining + "px");
-				$('#box3wrapper').css('width', $('#box2wrapper').width() + "px");
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
+				//Blocking widht resizing if the width of the boxes has not changed.
+				if($('#box1wrapper').width()+ $('#box2wrapper').width() != $(parent).width()){
+					$('#box1wrapper').css('width', remaining + "px");
+					$('#box3wrapper').css('width', $('#box2wrapper').width() + "px");
+				}else{
+					$('#box3wrapper').css('height', remainingHeight + "px");
+				}				
 				//Handles east resizing END.
-				//Handles south resizing START.
-				$('#box3wrapper').css('height', remainingHeight + "px");
-				//Handles south resizing END.
 			},
 			maxWidth: ($(parent).width()*0.85),
 			minWidth: ($(parent).width()*0.15),
@@ -4576,34 +4292,9 @@ function resizeBoxes(parent, templateId)
 		$('#box3wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box3wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-			
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-				}
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
 				$('#box1wrapper').css('width', remaining + "px");
 				$('#box2wrapper').css('width', $('#box3wrapper').width() + "px");
 			},
@@ -4617,47 +4308,9 @@ function resizeBoxes(parent, templateId)
 		$('#box1wrapper').resizable({
 			resize: function( event, ui ) {
 				remaining = ($(parent).width()) - $('#box1wrapper').width();
-				if((remaining/$(parent).width())*100 < 16){
-					boxToHide = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-					boxToHide = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-					boxToHide = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-					boxToHide = document.querySelector('#box5wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else if((remaining/$(parent).width())*100 > 84){
-					boxToHide = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToHide.classList.add('hidden');
-					boxToHide.classList.add('visuallyhidden');
-				}
-				else{
-					boxToShow = document.querySelector('#box1wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-					boxToShow = document.querySelector('#box2wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box3wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box4wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-
-					boxToShow = document.querySelector('#box5wrapper #boxtitlewrapper');
-					boxToShow.classList.remove('hidden');
-					boxToShow.classList.remove('visuallyhidden');
-	
-				}
+				for(i = 1; i <= retData["numbox"];i++){
+					toggleTitleDescription(i);
+				}	
 				$('#box2wrapper').css('width', remaining + "px");
 				$('#box3wrapper').css('width', remaining + "px");
 				$('#box4wrapper').css('width', remaining + "px");
@@ -5211,4 +4864,23 @@ function toggleTitleWrapper(targetBox, boxNum, boxW){
 	  });
 	}
 
+}
+//Toggles the description text one the boxes.
+function toggleTitleDescription(toCheck){
+	var box = document.querySelector('#box' + toCheck + 'wrapper #boxtitlewrapper');
+	var boxW = $('#box' + toCheck + 'wrapper').width()/$('#div2').width() * 100;
+	//Check if the widht(%) of the box is < 16
+	if(boxW <= 16){
+		box.classList.add('visuallyhidden');
+		box.addEventListener('transitionend', function(e) {
+			  box.classList.add('hidden');
+		}, {
+			  capture: false,
+			  once: true,
+			  passive: false
+		});
+	}else{
+		box.classList.remove('hidden');
+      	box.classList.remove('visuallyhidden');
+	}
 }

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -406,13 +406,6 @@ function returned(data)
 	hideMaximizeAndResetButton();
 
 	// Allows resizing of boxes on the page
-	//If firefox is the browser do not allow resizing. (firefox resizing is currently)
-	var userAgent = navigator.userAgent;
-
-	if(userAgent.match(/firefox|fxios/i)){
-		console.log('Resizing is broken in firefox');
-	}
-
 	resizeBoxes("#div2", retData["templateid"]);
 	var titles = [...document.querySelectorAll('[contenteditable="true"]')];
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1505,8 +1505,6 @@ div .navButt:hover {
   display: grid;
   justify-items: stretch;
   grid-gap: 0px;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-  grid-template-rows: 1fr 1fr 1fr 1fr 1fr 1fr;
   grid-template-areas: 
     'a a b b'
     'c c d d'


### PR DESCRIPTION
Resizing should now work for all browsers. 
For testing: 
1: Create a code example for each template.
![image](https://user-images.githubusercontent.com/102600690/168278791-82f24e84-bbb3-4d7c-a8ac-77650ddade5a.png)
2: Go into template 1 and pick template 1.
3: resizing should work as expecet in all browsers.
4: resizing the widht of a box to as small as it can be should hide the text.
![image](https://user-images.githubusercontent.com/102600690/168279029-00cd0635-1106-4749-838c-bed73f54964d.png)
5: Press the forward button and repeat for all templates.
![image](https://user-images.githubusercontent.com/102600690/168279157-dce4b29a-a8e9-454a-a27a-bb23bb8004c6.png)

Known bug: 
The initial resizing of the height of the stacked boxes in templates 6,7,9 is a bit "jumpy". 
This is due to a rounding error with the initial size of the boxes. Once the initial resizing of the box has occured there should not be a problem with resizing the boxes in that template.

