### PR TITLE
"General information" and/or "Instructions" only show if a file is available #12476

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -361,7 +361,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 				if(<?php echo json_encode($finalArray);?>[index][2]==fileName){
 					document.getElementById("assignment_discrb").innerHTML =<?php echo json_encode($finalArray);?>[index][3];
 
-					// Checks if index[3] i.e. the instructions file is empty
+					// Checks if index[3] i.e. the "Instruction file" is empty in edit dugga --> diagram dugga
 					if(<?php echo json_encode($finalArray);?>[index][3]=='') {
 						document.getElementById("container__left").style.display="none";
 					}
@@ -369,7 +369,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 				if(<?php echo json_encode($finalArray);?>[index][5]==fileName){
 					document.getElementById("diagram_instructions").innerHTML =<?php echo json_encode($finalArray);?>[index][6];
 
-					// Checks if index[3] i.e. the instructions file is empty
+					// Checks if index[6] i.e. the "General information file" is empty in edit dugga --> diagram dugga
 					if(<?php echo json_encode($finalArray);?>[index][6]=='') {
 						document.getElementById("instructionsContainer").style.display="none";
 					}

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -368,6 +368,11 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 				}
 				if(<?php echo json_encode($finalArray);?>[index][5]==fileName){
 					document.getElementById("diagram_instructions").innerHTML =<?php echo json_encode($finalArray);?>[index][6];
+
+					// Checks if index[3] i.e. the instructions file is empty
+					if(<?php echo json_encode($finalArray);?>[index][6]=='') {
+						document.getElementById("instructionsContainer").style.display="none";
+					}
 				}	
 			}
 		}			

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -361,7 +361,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 				if(<?php echo json_encode($finalArray);?>[index][2]==fileName){
 					document.getElementById("assignment_discrb").innerHTML =<?php echo json_encode($finalArray);?>[index][3];
 
-					// Checks if index[3] i.e. the "Instruction file" is empty in edit dugga --> diagram dugga
+					// Checks if index[3] i.e. the "Instruction file" is empty 
 					if(<?php echo json_encode($finalArray);?>[index][3]=='') {
 						document.getElementById("container__left").style.display="none";
 					}
@@ -369,7 +369,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 				if(<?php echo json_encode($finalArray);?>[index][5]==fileName){
 					document.getElementById("diagram_instructions").innerHTML =<?php echo json_encode($finalArray);?>[index][6];
 
-					// Checks if index[6] i.e. the "General information file" is empty in edit dugga --> diagram dugga
+					// Checks if index[6] i.e. the "General information file" is empty 
 					if(<?php echo json_encode($finalArray);?>[index][6]=='') {
 						document.getElementById("instructionsContainer").style.display="none";
 					}

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -360,10 +360,15 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 			for (let index = 0; index < <?php echo json_encode($finalArray);?>.length; index++) {
 				if(<?php echo json_encode($finalArray);?>[index][2]==fileName){
 					document.getElementById("assignment_discrb").innerHTML =<?php echo json_encode($finalArray);?>[index][3];
+
+					// Checks if index[3] i.e. the instructions file is empty
+					if(<?php echo json_encode($finalArray);?>[index][3]=='') {
+						document.getElementById("container__left").style.display="none";
+					}
 				}
 				if(<?php echo json_encode($finalArray);?>[index][5]==fileName){
 					document.getElementById("diagram_instructions").innerHTML =<?php echo json_encode($finalArray);?>[index][6];
-				}
+				}	
 			}
 		}			
 	}

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -110,7 +110,7 @@
                 <div id="feedbackTable" style="margin-top: -3px;"></div>
             </div>
         </div>
-        <div class='instructions-container'>
+        <div id="instructionsContainer" class='instructions-container'>
             <div class='instructions-button' onclick='toggleInstructions(this)'>
                 <h3>General information</h3>
             </div>

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -69,39 +69,34 @@
         }
     </style>
     <script>
-        $(document).ready(function() {
-            $("#close_open").click(function() {
-                if ($("#pvalue").val() == "0") {
-                    // hides description when open
-                    $("#assignment_discrb").css('visibility', 'hidden');
-                    $("#container__left").animate({
-                        width: "10px"
-                    }, "slow");
-                    $("#close_open").css({
-                        'display': 'fixed',
-                        'left': '7px',
-                        'transform': 'scaleX(-1)',
-                        'transition': '0.55s ease-in-out'
-                    });
-                    $("#pvalue").val("1");
-                } else {
-                    // opens description when closed
-                    $("#container__left").animate({
-                        width: "300px"
-                    }, "slow");
-                    $("#assignment_discrb").css('visibility', 'visible');
-                    $("#close_open").css({
-                        'display': 'block',
-                        'transform': 'scaleX(1)',
-                        'left': '272px'
-                    });
-                    $("#pvalue").val("0");
-                }
-
-
-            });
-
-        });
+        function openCloseDescription() { 
+            if ($("#pvalue").val() == "0") {
+                // hides description when open
+                $("#assignment_discrb").css('visibility', 'hidden');
+                $("#container__left").animate({
+                    width: "10px"
+                }, "slow");
+                $("#close_open").css({
+                    'display': 'fixed',
+                    'left': '7px',
+                    'transform': 'scaleX(-1)',
+                    'transition': '0.55s ease-in-out'
+                });
+                $("#pvalue").val("1");
+            } else {
+                // opens description when closed
+                $("#container__left").animate({
+                    width: "300px"
+                }, "slow");
+                $("#assignment_discrb").css('visibility', 'visible');
+                $("#close_open").css({
+                    'display': 'block',
+                    'transform': 'scaleX(1)',
+                    'left': '272px'
+                });
+                $("#pvalue").val("0");
+            }
+        }
     </script>
 </head>
 
@@ -120,12 +115,7 @@
                 <h3>General information</h3>
             </div>
             <div class="instructions-content" id="diagram_instructions">
-                <p style="margin-left: 4px;">Diagram-duggan går ut på att producera det diagrammet som beskrivs i beskrivningen.
-                </p>
-                <p style="margin-left: 4px;">Lägg till element med hjälp av att byta till respective läge och klicka på canvasen.
-                </p>
-                <!-- <p style="margin-left: 4px;"><strong>Uppgiftsbeskrivning:</strong></p>
-                <p style="margin-left: 4px;" id="assigment-instructions"></p> -->
+                
             </div>
         </div>
         <div class="container">
@@ -134,24 +124,9 @@
             <div class="assignment_left" id="container__left" style="overflow: auto;">
                 <div id="container_header"><h3>Instructions</h3></div>
                 <div class="assignment_discrb" id="assignment_discrb" cellpadding="0" cellspacing="0" style=" visibility: visible; color: rgb(0, 0, 0); padding: 4px; ">
-                    <h2 style="margin-left: 14px;">Modellering</h2>
-                    <p style="margin-left: 14px;">Modellera nedanstående uppgifter i notationerna ER och UML.</p>
-                    <ol type="1">
-                        <li>En person identifieras av ett personnummer och har ett namn.</li><br>
-                        <li>Lägg till så att personen också har ett efternamn samt att man kan härleda åldern med hjälp av personnumret.</li><br>
-                        <li>Lägg till så att personen kan ha många olika adresser.</li><br>
-                        <li>En bil identifieras av dess registreringsnummer och är av ett visst bilmärke. Bilen tillhör dessutom en viss typ, har en färg.</li><br>
-                        <li>Lägg till så att en person kan äga många bilar, men endast en bil kan ägas av en person. Vi vill inte lagra några egenskaper person, eftersom det anses onödigt, exempel namn, ålder, eller adress.</li><br>
-                        <li>En kaffekopp identifieras av en färg och har en viss storlek. En person identifieras av ett personnummer och äger en kaffekopp. En kaffekopp kan endast ägas av en person.</li><br>
-                        <li>En person har ett namn och personnummer och kan äta många maträtter från en buffé. Från buffén kan många personer äta. En maträtt hare en smak och identifieras av dess namn.</li><br>
-                        <li>Ett husdjur identifieras av dess namn och i kombination med personen som äger husdjuret. Personen har ett namn och ett personnummer.</li><br>
-                        <li>Lägg till så att ett husdjur också har en unik matskål. Matskålen identifieras av dess namn samt i kombination med husdjuret som äter ur matskålen.
-                        </li><br>
-                        <li>Lägg till så att ett husdjur kan ha en skötare. En skötare identifieras av ett anställningsnummer och har ett namn. En skötare kan ta hand om många husdjur.
-                        </li><br>
-                    </ol>
+                    
                 </div>
-                <div id="close_open">
+                <div id="close_open" onclick="openCloseDescription();">
 
                 </div>
             </div>


### PR DESCRIPTION
### This pull request contains:
- #12476
- "General information" and "Instructions-panel" are hidden if they are empty and there is no file to read from.

## How to test:
1. Log in as a teacher.
2. Go to "Edit dugga" and press the pen on diagram dugga.
3.  Create 4 new duggas:
     >a) One where both "File link" fields are empty on "Instruction file" and "General information file".
     >b) One where both "File link" fields are filled on "Instruction file" and "General information file" (just scribble anything).
     >c) One where only "Instruction file" "File link"-field is filled (again just write some characters).
     >d) One where only "General information" "File-link" field is filled (again just write some characters).
<img width="890" alt="editDugga" src="https://user-images.githubusercontent.com/81613484/168288407-6a877f25-af75-4069-a125-19a8a4c3247a.png">

4. Enable one at a time to test all four scenarios.
5.  When one of the duggas are enabled log out and go to diagram dugga as a student (logged out!!). Don't forget to refresh page.
      > Scenario a) Both "General information" and "Instructions" are hidden.
      > Scenario b) Both "General information" and "Instructions" are visible.
      > Scenario c) Only Instructions-panel is visible.
      > Scenario d) Only General information-panel is visible.

<img width="777" alt="abcd" src="https://user-images.githubusercontent.com/81613484/168293850-83c5acb2-b97d-420b-82ac-ea95b6a57b89.png">

