### PR TITLE
Made the navheader table-layout fixed #12287

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -962,6 +962,9 @@ function returnedSection(data) {
       document.getElementById("HIDEStatic").style.display = "Block";
       // Show addElement Button
       document.getElementById("addElement").style.display = "Block";
+      
+      // Disable div used for table spacing in the navheader
+      document.getElementById("menuHook").style.display =  "none"
     } else {
       // Hide FAB / Menu
       document.getElementById("FABStatic").style.display = "None";

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -983,11 +983,16 @@
 
 
 
-@media only screen and (max-width: 480px) {
+@media only screen and (max-width: 520px) {
         #mobileNavHeading {
             font-size: 13px;
     }
-    .maximizebtn, .minimizebtn {
+    .maximizebtn, .minimizebtn, #templatebutton, #codeburger, #editbutton {
+        display: none;
+    }
+}
+@media only screen and (max-width: 440px) {
+    .navName {
         display: none;
     }
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1289,6 +1289,8 @@ header {
 
 header td {
   white-space: nowrap;
+  padding-left: 6px;
+  padding-right: 6px;
 }
 
 #scoreElement {
@@ -1322,6 +1324,7 @@ header td {
 }
 
 .navheader {
+  table-layout: fixed;
   height: 20px;
   margin-bottom: 10px;
   width: 100%;
@@ -1341,7 +1344,6 @@ header td {
 }
 
 .navButt img {
-  margin-left: 10px;
   vertical-align: middle;
   height: 32px;
 }
@@ -1492,11 +1494,6 @@ div .navButt:hover {
   width: 50px;
   vertical-align: middle;
   text-align: center;
-}
-@media only screen and (max-width: 342px) {
-  #loginbutton {
-    width: 35px;
-  }
 }
 
 #div2 {
@@ -5427,7 +5424,7 @@ only screen and (max-device-width: 380px) {
     display: block;
   }
 
- #homeIcon, #upIcon, #theme-toggle{
+ #home, #back, #theme-toggle{
     display: none;
   }
 }
@@ -5591,12 +5588,18 @@ only screen and (max-device-width: 530px) {
   /* Mobile resulted end */
 }
 
-@media only screen and (max-width: 480px),
-only screen and (max-device-width: 480px) {
+@media only screen and (max-width: 520px),
+only screen and (max-device-width: 520px) {
 
   table.navheader td.tests,
-  table.navheader td.results {
+  table.navheader td.results,
+  table.navheader td.editVers,
+  table.navheader td.newVers,
+  table.navheader td.files,
+  table.navheader td.coursePage,
+  table.navheader td.access {
     margin-right: 0px;
+    padding: 0px;
     width: 0px;
     -webkit-transition: margin-right 0.5s, width 0.5s;
     -moz-transition: margin-right 0.5s, width 0.5s;
@@ -8116,16 +8119,6 @@ textarea#filecont {
 
   table.navheader div.menuButton{
     margin-right: 0px;
-  }
-}
-
-@media only screen and (max-width: 339px) {
-  .navheader .course-dropdown{
-    height: 20px;
-    width: 120px;
-  }
-  .navName{
-    width: 0px;
   }
 }
 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -346,7 +346,7 @@
 					echo "<td class='navButt' id='playbutton' title='Open demo' onclick='Play(event);'><img src='../Shared/icons/play_button.svg' /></td>";
 					if(checklogin() && (isSuperUser($_SESSION['uid']) || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'st') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'sv') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'w'))) {
 						echo "<td class='navButt' id='templatebutton' title='Choose Template' onclick='openTemplateWindow();'><img src='../Shared/icons/choose_template.svg'  /></td>";
-						echo "<td class='navButt' onclick='displayEditExample();' title='Example Settings' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
+						echo "<td class='navButt' id='editbutton' onclick='displayEditExample();' title='Example Settings' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
 					  echo "<td class='navButt' id='fileedButton' onclick='' style='display:none;' title='File Download/Upload' ><img src='../Shared/icons/files_icon.svg' /></td>";
 					}
 					echo "<td class='navButt' id='codeBurger' onclick='showBurgerMenu();' title='Show box' ><img src='../Shared/icons/hotdog_button.svg' /></td>";


### PR DESCRIPTION
Gave navheader table a fixed table-layout to prevent the navbar to go outside the window. Quite a few problems occured when doing that shift that had to be taken care of.

Testing:
1) Enter Webbprogrammering
2) Open JavaScript Example 1
The navbar should not break when resizing the window width.
3) Login as teacher acount stei
The navbar should not break when resizing the window width.