### PR TITLE
Students no longer have access to error check when logged out through keyboard #12525

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -757,7 +757,6 @@ const keybinds = {
         TOGGLE_KEYBINDLIST: {key: "F1", ctrl: false},
         TOGGLE_REPLAY_MODE: {key: "r", ctrl: false},
         TOGGLE_ER_TABLE: {key: "e", ctrl: false},
-        TOGGLE_ERROR_CHECK:  {key: "h", ctrl: false},
 };
 
 /** 
@@ -1516,7 +1515,6 @@ document.addEventListener('keyup', function (e)
         if(isKeybindValid(e, keybinds.CENTER_CAMERA)) centerCamera();
         if(isKeybindValid(e, keybinds.TOGGLE_REPLAY_MODE)) toggleReplay();
         if(isKeybindValid(e, keybinds.TOGGLE_ER_TABLE)) toggleErTable();
-        if(isKeybindValid(e, keybinds.TOGGLE_ERROR_CHECK)) toggleErrorCheck();
 
         if (isKeybindValid(e, keybinds.COPY)){
             // Remove the preivous copy-paste data from localstorage.

--- a/DuggaSys/diagramkeybinds.md
+++ b/DuggaSys/diagramkeybinds.md
@@ -45,7 +45,3 @@
 
 ## ER-Table
 - Toggles between ER-table functionality when an ER-element is selected and option panel is open = "E"
-
-
-## Error check
-- Performs error checking if an error is present = "H"


### PR DESCRIPTION
Removed the keybind for the error check functionality so that logged out students don't always have access to it unless purposely given to them, as it is mainly reserved for teachers.

### To test:

1. Go to diagram dugga
2. **Log out** if not already done so
3. Press the _Ssn_ attribute 
4. Open Option panel
5. Change the variant from candidate to _weakKey_ and press save.
6. Press "h" on your keyboard and make sure that the boxes don't turn red.
7. Log in (teacher mode)
8. Repeat steps 3-6 and make sure that the boxes turn red.