### PR TITLE
Changed redirect when loading dugga via hash so nav-bar still shows #12495

### DIFF
--- a/sh/index.php
+++ b/sh/index.php
@@ -71,9 +71,9 @@ function GetAssignment ($hash){
 		$_SESSION["submission-password-$cid-$vers-$did-$moment"]=$hashpwd;
 		$_SESSION["submission-variant-$cid-$vers-$did-$moment"]=$variant;	
 		$_SESSION["hash"]=$hash;
-		echo "../DuggaSys/showDugga.php?coursename={$coursename}&courseid={$cid}&cid={$cid}&coursevers={$vers}&did={$did}&moment={$moment}&deadline={$deadline}&hash={$hash}&embed<br>";
+		echo "../DuggaSys/showDugga.php?coursename={$coursename}&courseid={$cid}&cid={$cid}&coursevers={$vers}&did={$did}&moment={$moment}&deadline={$deadline}&hash={$hash}<br>";
 		echo "|$hash|$hashpwd|<br>";
-		header("Location: ../DuggaSys/showDugga.php?coursename={$coursename}&courseid={$cid}&cid={$cid}&coursevers={$vers}&did={$did}&moment={$moment}&deadline={$deadline}&hash={$hash}&embed");
+		header("Location: ../DuggaSys/showDugga.php?coursename={$coursename}&courseid={$cid}&cid={$cid}&coursevers={$vers}&did={$did}&moment={$moment}&deadline={$deadline}&hash={$hash}");
 		exit();	
 	}else{
 		$_SESSION['checkhash']=$hash;


### PR DESCRIPTION
#12495 

Removed &embed from header in index.php which determined url. Now simply redirects to page normally. 