### PR TITLE
Delay for tooltip instructions. Issue #12520.

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -354,6 +354,7 @@
 
 .diagramIcons:hover .toolTipText{
     visibility: visible;
+    transition-delay: 1200ms;
 }
 
 #tooltip-OPTIONS{

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -354,7 +354,7 @@
 
 .diagramIcons:hover .toolTipText{
     visibility: visible;
-    transition-delay: 1200ms;
+    transition-delay: 700ms;
 }
 
 #tooltip-OPTIONS{


### PR DESCRIPTION
Hover over some tool for more than 1200 ms to make the tooltip visible. Before this implementation the tooltip popped up instantly.