### PR TITLE
remoed extra bottom margin on plus button

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6760,7 +6760,6 @@ only screen and (max-device-width: 320px) {
   color: var(--color-primary);
   font-size: 30px;
   vertical-align: middle;
-  margin-bottom: 30px;
 }
 
 .fab-btn-lg:hover {


### PR DESCRIPTION
Testing:

1. Go to any course 
2. Log in as stei (password: password)
3. Open inspector
4. Click the "select element tool" in inspector
![image](https://user-images.githubusercontent.com/81631818/168558293-a6471a09-fef9-4d49-a443-3b97fab93c06.png)
5. Hover the yellow plus

Before it looked like this:
![image](https://user-images.githubusercontent.com/81631818/168558773-6eceaa87-6dfa-4263-921d-e46a334ff56a.png)


On this branch it should look like this:
![image](https://user-images.githubusercontent.com/81631818/168558131-6126ee99-093e-4e5a-811a-2af6e0e12884.png)
