### PR TITLE
Fixed course lable icons #12412

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -971,6 +971,8 @@ function returnedSection(data) {
       // Hide FAB / Menu
       document.getElementById("FABStatic").style.display = "None";
       document.getElementById("FABStatic2").style.display = "None";
+      // remove course-label margin
+      document.getElementById("course-label").style.marginRight = "10px";
     }
 
     // Hide som elements if to narrow

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -167,7 +167,7 @@
 		
 			<!-- end hide button -->
 			
-			<div style='flex-grow:1'>
+			<div id='course-label' style='flex-grow:1'>
 					<span id='course-coursename' class='nowrap ellipsis' >UNK</span>
 					<span id='course-coursecode' style='margin-right:10px;'>UNK</span>
 					<span id='course-versname' class='courseVersionField'>UNK</span>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5170,9 +5170,6 @@ only screen and (max-device-width: 800px) {
   #addElement {
     display: none;
   }
-  #hideElement{
-    display: block;
-  }
   .maximizebtn, .minimizebtn, .resetbtn, .copybutton, .editbtn {
     height: 35px;
   }
@@ -5651,12 +5648,6 @@ only screen and (max-device-width: 480px) {
   #searchbar button#searchbutton{
     padding: 8px 10px 5px 10px;
   }
-
-  #hideElement{
-    width: 20px;
-    height: 20px;
-  }
-
 }
 @media only screen and (max-width: 390px),
 only screen and (max-device-width: 390px) {
@@ -5672,19 +5663,6 @@ only screen and (max-device-width: 390px) {
     visibility: visible;
     opacity: 1;
 
-  }
-
-  #hideElement{
-    width: 20px;
-    height: 20px;
-  }
-
-}
-
-@media only screen and (max-width: 320px),
-only screen and (max-device-width: 320px) {
-  #Sectionlist .course {
-    font-size: 12px;
   }
 }
 
@@ -6715,6 +6693,24 @@ only screen and (max-device-width: 320px) {
     display:none !important;
   }
 
+  #showElements {
+    margin-right: 10px !important;
+  }
+
+  #course-label {
+    min-width: 135px;
+    margin-right: 150px;
+  }
+}
+@media only screen and (max-width: 430px),
+only screen and (max-device-width: 430px) {
+  #course-label {
+    font-size: 12px;
+    margin-right: 25px;
+  }
+  #showElements, #hideElement {
+    display: none;
+  }
 }
 
 #Courselist div.fixed-action-button a:hover {


### PR DESCRIPTION
Course lable icons and text adjust to screen width to fit the content on the screen (icons in the nav header are fixed in pull request #12524)

Testing:
1) Enter Testing-Course (Demo-course does not work on this branch)
2) Resize the screen width
The course label should not break when resizing the window width.
3) Login as teacher acount stei and resize the screen width
The navbar should not break when resizing the window width.
