### PR TITLE
Added block from logging in when git_user is pending or revoked

### DIFF
--- a/DuggaSys/contribution_loginbox.js
+++ b/DuggaSys/contribution_loginbox.js
@@ -85,9 +85,9 @@ function contribution_showLoginPopup()
 
 function returned_git_user_login(data)
 {
-  if(data)
+  if(data['success'])
     window.location.reload(true);  // TODO should I just reload the page here perhaps? 
-  else
+  else if(data['status'] == "wrong pass")
   {
     displayAlertText("#UserExistslogin_message", "Invalid password <br />");
 
@@ -102,6 +102,33 @@ function returned_git_user_login(data)
         displayAlertText("#UserExistslogin_message", "");
       }, 2000);
 
+
+    }, 2000);
+  }
+  else if(data['status'] == "revoked")
+  {
+    displayAlertText("#UserExistslogin_message", "User revoked <br />");
+
+    $("#UserExistslogin_password").addClass("loginFail");
+
+    setTimeout(function()
+    {
+      $("#UserExistslogin_password").removeClass("loginFail");
+      displayAlertText("#UserExistslogin_message", "");
+
+
+    }, 2000);
+  }
+  else if(data['status'] == "pending")
+  {
+    displayAlertText("#UserExistslogin_message", "User pending <br />");
+
+    $("#UserExistslogin_password").addClass("loginFail");
+
+    setTimeout(function()
+    {
+      $("#UserExistslogin_password").removeClass("loginFail");
+      displayAlertText("#UserExistslogin_message", "");
 
     }, 2000);
   }

--- a/DuggaSys/contribution_loginbox_service.php
+++ b/DuggaSys/contribution_loginbox_service.php
@@ -14,6 +14,10 @@ include_once "../Shared/basic.php";
 pdoConnect();
 session_start();
 
+$git_pending = 101;
+$git_revoked = 102;
+$git_accepted = 0;
+
 $debug="NONE!";
 
 //This uses an hardcoded path to a database file containing all Github data and run all funtions on that data. No other connection to a database at the moment.
@@ -214,9 +218,7 @@ else if(strcmp($opt,"requestGitUserCreation") == 0)
 
 			  At this point we have done the server side check and we can create a pending user creation from here
         	 */
-			$git_pending = 101;
-			$git_revoked = 102;
-			$git_accepted = 103;
+			
 		
 			$temp_null_str = "NULL";
 			
@@ -300,10 +302,10 @@ else if(strcmp($opt,"requestContributionUserLogin") == 0)
 	}
 
 
-	if($gituser != "UNK" && $status != "super")
+	if($gituser != "UNK" && $status != "super") // we are either a git_user or not a user at all
 	{
 		// retrieve a user with the same name
-		$query = $pdo->prepare("SELECT git_uid,username,password FROM git_user WHERE username=:username LIMIT 1");
+		$query = $pdo->prepare("SELECT git_uid,username,password,status_account FROM git_user WHERE username=:username LIMIT 1");
 		$query->bindParam(':username',$gituser);
 
 		if(!$query->execute()) // execute and check for errors
@@ -318,25 +320,69 @@ else if(strcmp($opt,"requestContributionUserLogin") == 0)
 			
 			if(password_verify($gitpass, $row['password'])) // entered gitpass matched hashed password
 			{
-				$_SESSION['git_uid'] = $row['git_uid'];
-        		$_SESSION["git_loginname"]=$row['username'];
-				$_SESSION["git_passwd"]=$row['password'];
-                echo json_encode(array(
-                    "returnMethod" => getOP('return'),
-                    "debug" => $debug,
-                    "returnData" => json_encode(true)
-                ));			
+                $status_account_int = (int)$row['status_account'];
+                if($status_account_int == $git_pending)
+                {
+                   /* $_SESSION['git_uid'] = $row['git_uid'];
+                    $_SESSION["git_loginname"]=$row['username'];
+                    $_SESSION["git_passwd"]=$row['password']; */
+
+
+                    echo json_encode(array(
+                        "returnMethod" => getOP('return'),
+                        "debug" => $debug,
+                        "returnData" => json_encode(array(
+                            "success" => false,
+                            "status" => "pending",
+                            "debug" => $debug
+                        )
+                    )));
+                }
+                else if($status_account_int == $git_revoked)
+                {
+                    echo json_encode(array(
+                        "returnMethod" => getOP('return'),
+                        "debug" => $debug,
+                        "returnData" => json_encode(array(
+                            "success" => false,
+                            "status" => "revoked",
+                            "debug" => $debug
+                        )
+                    )));
+                }
+                else if($status_account_int == $git_accepted)
+                {
+                    $_SESSION['git_uid'] = $row['git_uid'];
+                    $_SESSION["git_loginname"]=$row['username'];
+                    $_SESSION["git_passwd"]=$row['password'];
+
+                    echo json_encode(array(
+                        "returnMethod" => getOP('return'),
+                        "debug" => $debug,
+                        "returnData" => json_encode(array(
+                            "success" => true,
+                            "status" => "accepted",
+                            "debug" => $debug
+                        )
+                    )));
+
+                }			
             }
 			else // wrong password entered
 			{
+
                 echo json_encode(array(
                     "returnMethod" => getOP('return'),
                     "debug" => $debug,
-                    "returnData" => json_encode(false)
-                ));
+                    "returnData" => json_encode(array(
+                        "success" => false,
+                        "status" => "wrong pass",
+                        "debug" => $debug
+                    )
+                )));
+
 			}
 		}
-
 
 	}
 	else if($status == "super") // user exists on the lenasys database login with this instead of the git database
@@ -346,16 +392,27 @@ else if(strcmp($opt,"requestContributionUserLogin") == 0)
             echo json_encode(array(
                 "returnMethod" => getOP('return'),
                 "debug" => $debug,
-                "returnData" => json_encode(true)
-            ));
+                "returnData" => json_encode(array(
+                    "success" => true,
+                    "status" => "super",
+                    "debug" => $debug
+                )
+            )));
+
 		}
 		else
 		{
             echo json_encode(array(
                 "returnMethod" => getOP('return'),
                 "debug" => $debug,
-                "returnData" => json_encode(false)
-            ));
+                "returnData" => json_encode(array(
+                    "success" => false,
+                    "status" => "wrong pass",
+                    "debug" => $debug
+                )
+            )));
+
+
 		}
 	}
 	else // logout the git
@@ -373,9 +430,12 @@ else if(strcmp($opt,"requestContributionUserLogin") == 0)
         echo json_encode(array(
             "returnMethod" => getOP('return'),
             "debug" => $debug,
-            "returnData" => json_encode(true)
-        ));
-	
+            "returnData" => json_encode(array(
+                "success" => true,
+                "status" => "logged out",
+                "debug" => $debug
+            )
+        )));
 	}
 }
 


### PR DESCRIPTION
Added so you are blocked from logging in when you are pending or revoked.
relates to issue https://github.com/HGustavs/LenaSYS/issues/12503

when status_Account is 101
![image](https://user-images.githubusercontent.com/102584289/168587666-412799d8-fede-4bbc-bbdf-446707c3cd8a.png)


when status_Account is 102
![image](https://user-images.githubusercontent.com/102584289/168587967-64371a6e-96b6-4988-9641-33b567ce20d9.png)

------------------------------Testing----------------------------------
Make sure you cant login with a pending/revoked user, test by manually changing account_status to 101 and or 102 in git_user table
