### PR TITLE
Fixed popover buttons not being clickable

### DIFF
--- a/DuggaSys/templates/bit-dugga.html
+++ b/DuggaSys/templates/bit-dugga.html
@@ -61,7 +61,7 @@
 		</tr>
 </table>
 
-<div id="pop" class="popover arrow-topr" style='position:absolute;display:none;z-index:2000'>
+<div id="pop" class="popover arrow-topr" style='top:-35px;display:none;z-index:2000'>
 		<table width="100%" height="100%" style='border-collapse: separate;'>
 				<tr>
 						<td class='hexbutt' onclick="setval('0');">0</td>

--- a/DuggaSys/templates/color-dugga.html
+++ b/DuggaSys/templates/color-dugga.html
@@ -45,7 +45,7 @@
 		</tr>
 </table>
 
-<div id="pop" class="popover arrow-topr" style='position:absolute;display:none;z-index:2000'>
+<div id="pop" class="popover arrow-topr" style='top:-35px;display:none;z-index:2000'>
 		<table width="100%" height="100%" style='border-collapse: separate;'>
 				<tr>
 						<td class='hexbutt' onclick="setval('0');">0</td>

--- a/DuggaSys/templates/dugga1.html
+++ b/DuggaSys/templates/dugga1.html
@@ -66,7 +66,7 @@
 		</tr>
 </table>
 
-<div id="pop" class="popover arrow-topr" style='position:absolute;display:none;'>
+<div id="pop" class="popover arrow-topr" style='top:-35px;display:none;'>
 		<table width="100%" height="100%" style='border-collapse: separate;'>
 				<tr>
 						<td class='hexbutt' onclick="setval('0');">0</td>

--- a/DuggaSys/templates/duggaTest.html
+++ b/DuggaSys/templates/duggaTest.html
@@ -58,7 +58,7 @@
 		</tr>
 </table>
 
-<div id="pop" class="popover arrow-topr" style='position:absolute;display:none;'>
+<div id="pop" class="popover arrow-topr" style='top:-35px;display:none;'>
 		<table width="100%" height="100%" style='border-collapse: separate;'>
 				<tr>
 						<td class='hexbutt' onclick="setval('0');">0</td>


### PR DESCRIPTION
Made the popover the same as the version used for dugga2. This fixes the issue of certain buttons being unclickable because the submitButtonTable was over them.