### PR TITLE
Changed the title for a more consistent look #12574

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5068,7 +5068,7 @@ function generateContextProperties()
               menuSet[i].classList.remove('options-fieldset-show');  
           }
 
-          str += `<div style="color: white">BG Color</div>`;
+          str += `<div style="color: white">Color</div>`;
           str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
               `<span id="BGColorMenu" class="colorMenu"></span></button>`;
       }


### PR DESCRIPTION
- #12574 
- The color selector had different titles when selecting one- vs multiple objects. Changed so that both titles now say "Color" to give it a more consistent look.

### To test:
1. Go to diagram dugga
2. Select one object 
3. Open the option panel, make sure the color alternatives title says _"Color"_.
4. Now select multiple objects and open the option panel, , make sure the color alternatives title says _"Color"_ instead of _"BG Color"_.

should **not** look like this:
![image](https://user-images.githubusercontent.com/81613484/168742640-b2eccd18-a806-424b-9e8d-65619d918a16.png)


