### PR TITLE
fixed bug so that the color selector closes simultaneously as the option panel #12580b

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5105,6 +5105,7 @@ function toggleOptionsPane()
 {
     if (document.getElementById("options-pane").className == "show-options-pane") {
         document.getElementById('optmarker').innerHTML = "&#9660;Options";
+        document.getElementById("BGColorMenu").style.visibility = "hidden";
         document.getElementById("options-pane").className = "hide-options-pane";
     } else {
         document.getElementById('optmarker').innerHTML = "&#x1f4a9;Options";


### PR DESCRIPTION
### This pull request contains:
- #12580 
- Added code so that color selector dosen't remain open and closes simulatenously as options panel
- Make sure you're on branch 12580b, don't forget the "b"!


### How to test:
***Make sure you're on branch #12580b, don't forget the "b"!***
1. Select an entity in the diagram
2. Open the options panel
3. Press the color selection option (do not press a color)
4. Close the option panel 
5. Make sure that the color selector closes as well.

<img width="492" alt="option" src="https://user-images.githubusercontent.com/81613484/168754540-c44f6e20-c700-4b3a-ab1d-574c5d6e129c.png">
 