### PR TITLE
Fixed so that the keybinding is visible in the tooltip #12584

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -316,7 +316,7 @@
         <div id="options-pane-button" onclick="toggleOptionsPane();"><span id='optmarker'>&#9660;Options</span>
             <span id="tooltip-OPTIONS" class="toolTipText"><b>Show Option Panel</b><br>
                 <p>Enable/disable the Option Panel</p><br>
-                <p class="key_tooltip">Keybinding:</p>
+                <p id="tooltip-OPTIONS" class="key_tooltip">Keybinding:</p>
             </span>
         </div>
         <div id ="fieldsetBox">


### PR DESCRIPTION
- #12584
- Fixed so that the keybinding: "O" shows in the tooltip for the options panel

### Before:

<img width="163" alt="optionbefore" src="https://user-images.githubusercontent.com/81613484/168760804-0d2a1154-1372-4f2f-8868-d71de177d956.png">


### After: 

<img width="161" alt="option after" src="https://user-images.githubusercontent.com/81613484/168760831-ea6e38e0-e6c7-4749-aaad-8d5920b9a275.png">

