### PR TITLE
G3 2022 w7 #12092

### DIFF
--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -194,7 +194,7 @@ if(checklogin()){
 						$debug="Error reading quiz\n".$error[2];
 				}else{
 						foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-								$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
+								$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
 								$ruery->bindParam(':oldid', $row['id']);
 								$ruery->bindParam(':newvers', $versid);
 								if(!$ruery->execute()) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -179,17 +179,17 @@ function toggleHamburger() {
 // selectItem: Prepare item editing dialog after cog-wheel has been clicked
 //----------------------------------------------------------------------------------
 
-function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, highscoremode, comments, grptype, deadline, relativedeadline, tabs, feedbackenabled, feedbackquestion) {
+function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, highscoremode, comments, grptype, deadline, relativeDeadline, tabs, feedbackenabled, feedbackquestion) {
 
   // Variables for the different options and values for the deadlne time dropdown meny.
   var hourArrOptions=["00","01","02","03","04","05","06","07","08","09","10","11","12","13","14","15","16","17","18","19","20","21","22","23"];
   var hourArrValue=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23];
   var minuteArrOptions=["00","05","10","15","20","25","30","35","40","45","50","55"];
   var minuteArrValue=[0,5,10,15,20,25,30,35,40,45,50,55];
-  var weekArrOptions=["1","2","3","4","5","6","7","8","9","10","11","12"];
-  var weekArrValue=[1,2,3,4,5,6,7,8,9,10,11,12];
-  var weekdayArrOptions=["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
-  var weekdayArrValue=[1,2,3,4,5,6,7];
+  var amountArrOptions=["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23", "24"];
+  var amountArrValue=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24];
+  var typeArrOptions=["Days", "Weeks", "Months"];
+  var typeArrValue=[1,2,3];
 
   nameSet = false;
   if (entryname == "undefined") entryname = "New Header";
@@ -224,14 +224,24 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
     $("#deadlineminutes").html(makeoptions(deadline.substr(14,2),minuteArrOptions,minuteArrValue));
     $("#setDeadlineValue").val(deadline.substr(0,10));
   }
-  if(relativedeadline !== undefined) {
-    var splitdeadline = relativedeadline.split(":");
-    // relativedeadline -> week:weekday:hour:minute
+  if(relativeDeadline !== undefined) {
+    var splitdeadline = relativeDeadline.split(":");
+    // relativeDeadline = amount:type:hour:minute
     $("#relativedeadlinehours").html(makeoptions(splitdeadline[2],hourArrOptions,hourArrValue));
     $("#relativedeadlineminutes").html(makeoptions(splitdeadline[3],minuteArrOptions,minuteArrValue));
 
-    $("#relativedeadlineweeks").html(makeoptions(splitdeadline[0],weekArrOptions,weekArrValue ));
-    $("#relativedeadlineweekdays").html(makeoptions(splitdeadline[1],weekdayArrOptions,weekdayArrValue));
+    $("#relativedeadlineamount").html(makeoptions(splitdeadline[0],amountArrOptions,amountArrValue ));
+    $("#relativedeadlinetype").html(makeoptions(splitdeadline[1],typeArrOptions,typeArrValue));
+
+    if (relativeDeadline !== "null") {
+      if (calculateRelativeDeadline(relativeDeadline).getTime() !== new Date(deadline).getTime()) {
+        checkDeadlineCheckbox($("#absolutedeadlinecheck"), true);
+      } else {
+        checkDeadlineCheckbox($("#absolutedeadlinecheck"), false);
+      }
+    } else {
+      checkDeadlineCheckbox($("#absolutedeadlinecheck"), true);
+    }
   }
   var groups = [];
   for (var key in retdata['groups']) {
@@ -302,6 +312,65 @@ function selectItem(lid, entryname, kind, evisible, elink, moment, gradesys, hig
     $('#inputwrapper-Feedback').css("display","none");
     $( "#fdbck" ).prop( "checked", false );
   }
+}
+
+// Handles the logic behind the checkbox for absolute deadline
+function checkDeadlineCheckbox(e, check) {
+
+  if (check !== undefined) e.checked = check;
+
+  if (e.checked) {
+    $("#absolutedeadlinecheck").prop("checked", true);
+    $("#setDeadlineValue").prop("disabled", false);
+    $("#deadlineminutes").prop("disabled", false);
+    $("#deadlinehours").prop("disabled", false);
+  } else {
+    $("#absolutedeadlinecheck").prop("checked", false);
+    $("#setDeadlineValue").prop("disabled", true);
+    $("#deadlineminutes").prop("disabled", true);
+    $("#deadlinehours").prop("disabled", true);
+  }
+}
+
+// Calculates the relative deadline string into a real date relative to the course startdate
+function calculateRelativeDeadline(rDeadline) {
+  // rDeadline = [amount, type, hour, minute]
+  if(rDeadline === null ){
+    rDeadline = "1:1:0:0";
+  } 
+  rDeadlineArr = rDeadline.split(":");
+  var daysToAdd;
+  switch (rDeadlineArr[1]) {
+    case "1":
+      var daysToAdd = parseInt(rDeadlineArr[0]);
+      break;
+    case "2":
+      var daysToAdd = parseInt(rDeadlineArr[0]) * 7;
+      break;
+    case "3":
+      var daysToAdd = parseInt(rDeadlineArr[0]) * 30;
+      break;
+    default:
+      var daysToAdd = parseInt(rDeadlineArr[0]);
+      break;
+  }
+  if (retdata['startdate'] === "UNK") {
+    console.log("Course has no startdate, deadlines set to 2015-01-01");
+    return new Date("2015-01-01 00:00:00");
+  }
+  var newDeadline = new Date(retdata['startdate']);
+  newDeadline.setDate(newDeadline.getDate() + daysToAdd);
+  newDeadline.setHours(parseInt(rDeadlineArr[2]));
+  newDeadline.setMinutes(parseInt(rDeadlineArr[3]));
+  return newDeadline;
+}
+// Takes a date object and returns it as a string as deadlines are stored in the database
+function convertDateToDeadline(date) {
+  var rDeadlineArr = date.toLocaleDateString().split("/");
+  rDeadlineArr[0] = rDeadlineArr[0].length < 2 ? "0" + rDeadlineArr[0] : rDeadlineArr[0];
+  rDeadlineArr[1] = rDeadlineArr[1].length < 2 ? "0" + rDeadlineArr[1] : rDeadlineArr[1];
+  var newDeadline = rDeadlineArr[2] + "-" + rDeadlineArr[0]+ "-" + rDeadlineArr[1] + " " + date.toString().split(" ")[4];
+  return newDeadline;
 }
 
 //---------------------------------------------------------------------------------------------
@@ -601,8 +670,12 @@ function prepareItem() {
   param.comments = $("#comments").val();
   param.grptype = $("#grptype").val();
   param.deadline = $("#setDeadlineValue").val()+" "+$("#deadlinehours").val()+":"+$("#deadlineminutes").val();
-  param.relativedeadline = $("#relativedeadlineweeks").val()+":"+$("#relativedeadlineweekdays").val()+":"+$("#relativedeadlinehours").val()+":"+$("#relativedeadlineminutes").val();
+  param.relativedeadline = $("#relativedeadlineamount").val()+":"+$("#relativedeadlinetype").val()+":"+$("#relativedeadlinehours").val()+":"+$("#relativedeadlineminutes").val();
 
+  // If absolute deadline is not checked, always use relative deadline
+  if (!$('#absolutedeadlinecheck').prop('checked')) {
+    param.deadline = convertDateToDeadline(calculateRelativeDeadline(param.relativedeadline));
+  }
   if ($('#fdbck').prop('checked')){
     param.feedback = 1;
     param.feedbackquestion = $("#fdbckque").val();
@@ -997,6 +1070,7 @@ function returnedSection(data) {
       for (i = 0; i < data['entries'].length; i++) {
         var item = data['entries'][i];
         var deadline = item['deadline'];
+        var rDeadline = item['relativedeadline'];
         var released = item['release'];
 
         // Separating sections into different classes
@@ -1275,7 +1349,10 @@ function returnedSection(data) {
 
         str += "</td>";
         
-
+        // If the deadline is null the relative deadline should be used
+        if (itemKind === 3 && deadline === null){
+          deadline = convertDateToDeadline(calculateRelativeDeadline(rDeadline));
+        }
         // Add generic td for deadlines if one exists
         if ((itemKind === 3) && (deadline !== null || deadline === "undefined")) {
           var dl = deadline.split(" ");
@@ -2851,6 +2928,16 @@ function validateDate2(ddate, dialogid) {
   // Correct the fetched dates from database
   startdate.setMonth(startdate.getMonth() - 1);
   enddate.setMonth(enddate.getMonth() - 1);
+
+   // If absolute deadline is not being used
+   if (!$("#absolutedeadlinecheck").is(":checked")) {
+    ddate.style.borderWidth = "0px";
+    x.style.display = "none";
+    window.bool8 = true;
+
+    return true;
+
+  }
 
   // If deadline is between start date and end date
   if (startdate <= deadline && enddate >= deadline) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1388,6 +1388,8 @@ function returnedSection(data) {
 
             // If minute and hour contains nothing but 0 we dont show it
             if (!/^[0]+$/.test(new String(rDeadlineArr[2] + rDeadlineArr[3]))) {
+              rDeadlineArr[2] = rDeadlineArr[2].length == 1 ? "0" + rDeadlineArr[2] : rDeadlineArr[2];
+              rDeadlineArr[3] = rDeadlineArr[3].length == 1 ? "0" + rDeadlineArr[3] : rDeadlineArr[3];
               str += ", " + rDeadlineArr[2] + ":"+ rDeadlineArr[3]
             }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -337,7 +337,11 @@ function calculateRelativeDeadline(rDeadline) {
   // rDeadline = [amount, type, hour, minute]
   if(rDeadline === null ){
     rDeadline = "1:1:0:0";
-  } 
+  }
+  if (typeof rDeadline === "undefined") {
+    rDeadline =  $("#relativedeadlineamount").val() + ":" + $("#relativedeadlinetype").val() + ":" + $("#relativedeadlineminutes").val() + ":" + $("#relativedeadlinehours").val();
+    console.log("sets the deadline to " + rDeadline);
+  }
   rDeadlineArr = rDeadline.split(":");
   var daysToAdd;
   switch (rDeadlineArr[1]) {
@@ -2901,12 +2905,14 @@ function validateDate(startDate, endDate, dialogID) {
 
 function showCourseDate(ddate, dialogid){
   var isCorrect = validateDate2(ddate,dialogid);
-  var startdate = new Date(retdata['startdate']);;
-  var enddate = new Date(retdata['enddate']);
-  var startdate = new String(startdate.getFullYear()+ "-" + startdate.getMonth() + "-" + startdate.getDate());
-  var enddate = new String(enddate.getFullYear()+ "-" + ("0" + enddate.getMonth()).slice(-2) + "-" + ("0" + enddate.getDate()).slice(-2));
-  document.getElementById("dialog8").innerHTML =
-  "The date has to be between " + startdate + " and " + enddate;
+  var startdate = convertDateToDeadline(new Date(retdata['startdate'])).split(" ")[0];
+  var enddate = convertDateToDeadline(new Date(retdata['enddate'])).split(" ")[0];
+
+  if (!$("#absolutedeadlinecheck").is(":checked")) {
+    $("#dialog8").html("The relative deadline will be set to " + convertDateToDeadline(calculateRelativeDeadline()));
+  } else {
+    $("#dialog8").html("The date has to be between " + startdate + " and " + enddate);
+  }
   return isCorrect;
 }
 
@@ -2925,14 +2931,10 @@ function validateDate2(ddate, dialogid) {
   var startdate = new Date(retdata['startdate']);
   var enddate = new Date(retdata['enddate']);
 
-  // Correct the fetched dates from database
-  startdate.setMonth(startdate.getMonth() - 1);
-  enddate.setMonth(enddate.getMonth() - 1);
-
    // If absolute deadline is not being used
    if (!$("#absolutedeadlinecheck").is(":checked")) {
     ddate.style.borderWidth = "0px";
-    x.style.display = "none";
+    x.style.display = "block";
     window.bool8 = true;
 
     return true;

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1372,15 +1372,24 @@ function returnedSection(data) {
           // We prioritize absolute deadline and we dont want absolute deadlines if there's no startdate for course
           if ((deadline !== null && deadline !== "undefined") && retdata['startdate'] !== null) {
             deadline = convertDateToDeadline(new Date(deadline));
-            str += deadline.split(" ")[0];
-            if (!/^[0:]+$/.test(deadline.split(" ")[1])) {
-              str += " "+deadline.split(" ")[1].split(":")[0]+":"+deadline.split(" ")[1].split(":")[1];
+            deadlineArr = deadline.split(" ");
+            str += deadlineArr[0];
+
+            // If minute and hour contains nothing but 0 we dont show it
+            if (!/^[0:]+$/.test(deadlineArr[1])) {
+              str += " "+deadlineArr[1].split(":")[0]+":"+deadlineArr[1].split(":")[1];
             }
+
             // If there is only a relative deadline we display it instead
           } else if (rDeadline !== null && rDeadline !== "undefined") {
             rDeadlineArr = rDeadline.split(":");
             rDeadlineArr[1] = rDeadlineArr[1] == 1 ? "Day" : (rDeadlineArr[1] == 2 ? "Week" : "Month");
-            str += "Course " + rDeadlineArr[1] + " " + rDeadlineArr[0] + ", " + rDeadlineArr[2] + ":" + rDeadlineArr[3];
+            str += "Course " + rDeadlineArr[1] + " " + rDeadlineArr[0];
+
+            // If minute and hour contains nothing but 0 we dont show it
+            if (!/^[0]+$/.test(new String(rDeadlineArr[2] + rDeadlineArr[3]))) {
+              str += ", " + rDeadlineArr[2] + ":"+ rDeadlineArr[3]
+            }
 
           }
           str += "</div></td>";

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -261,17 +261,18 @@
 							<legend><h3>Deadline</h3></legend>
 							<span>Absolute</span>
 							<span style='float:right'>
-								<input onchange="quickValidateForm('editSection', 'saveBtn');" class='textinput' type='date' id='setDeadlineValue' value='' />
+								<input onchange="showCourseDate('setDeadlineValue','dialog8')" class='textinput' type='date' id='setDeadlineValue' value='' />
 								<select style='width:55px;' id='deadlineminutes'></select>
 								<select style='width:55px;' id='deadlinehours'></select>
+								<input type='checkbox' id='absolutedeadlinecheck' style='margin:3px 5px; height:20px' onclick='checkDeadlineCheckbox(this)'/>
 							</span>
 							<br />
 							<span title="Relative deadline that relates to the start of the course instead of a set date">Relative</span>
 							<span style='float:right'>
-								<select style='width:140px;' id='relativedeadlineweekdays'title="Weekday"></select>
-								<select style='width:55px;' id='relativedeadlineweeks' title="Course Week"></select>
-								<select style='width:55px;' id='relativedeadlineminutes'title="Minute"></select>
-								<select style='width:55px;' id='relativedeadlinehours' title="Hour"></select>
+								<select style='width:140px;' id='relativedeadlinetype'></select>
+								<select style='width:55px;' id='relativedeadlineamount'></select>
+								<select style='width:55px;' id='relativedeadlineminutes'></select>
+								<select style='width:55px;' id='relativedeadlinehours'></select>
 							</span>
 							<span style='float:left'>
 								<p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;max-height:20px;">Deadline has to be between start date and end date</p>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -275,7 +275,7 @@
 								<select style='width:55px;' id='relativedeadlinehours'></select>
 							</span>
 							<span style='float:left'>
-								<p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;max-height:20px;">Deadline has to be between start date and end date</p>
+								<p id="dialog8" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Deadline has to be between start date and end date</p>
 							</span>
 					</div>
 					<div id='inputwrapper-tabs' class='inputwrapper'><span>Tabs:</span><select id='tabs' ></select></div>


### PR DESCRIPTION
## Relative Deadlines

The relative deadline calculates a deadline from the course start up until the amount of time you pick. So if the course starts at 2020-05-01 and you pick 2 weeks as the relative deadline then this dugga will have its deadline set to 2020-05-01 plus 14 days. This is, in general, what relative deadlines do.

The relative deadlines are chosen through the menu that appears when you press the cogwheel(logged in as a teacher) on a dugga or quiz. You'll then have the option to choose a time, a amount, and a type to store in the database for this particular dugga.

- Time = Hour and minute of the day
- Amount = Amount of the type
- Type = Days, Weeks or Months

Currently, what happens behind the scenes is that you'll have the option to choose absolute deadlines(as it was before) if you want by ticking a checkbox next to the absolute deadline date picker as the picture below shows. Doing this, this will then override the relative deadline. The relative deadline will still be stored and saved but the absolute deadline will be used as it was prior to the implementation of relative deadlines.

![image](https://user-images.githubusercontent.com/82010032/166444226-1ee6354b-4fc4-42fa-b8b2-af45130c81cb.png)

When the site loads, a check will be made whether the relative deadline and the absolute deadline are the same or not. If they are the same, the websites assume that the relative should be used and shows a unchecked absolute deadline. If these two dates differ, then it will show as the above picture show. When a teacher then clicks save, the website will check whether the absolute deadline checkbox is checked, if it isn't then it will override the deadline datepicker date with the previously calculated relative deadline and then store that data in the database. This way, we can assure ourselves with the fact that relative deadlines will never cause any issue with how the deadlines are being used in any other part of the website. All we're essentially doing is changing what deadline should be stored prior to storing it. This also gives the flexibility for relative deadlines to be stored in a json format as a string and retrieved and read after the fetching has happened, so we could potentially store many other variables to do with relative deadlines that has not to do with a date. 

Keep in mind that currently, all relative deadlines will be NULL once you re-install the database and I choose to automatically pick absolute deadline if the relative deadline is NULL and therefore when you click on the cogwheel for the first time for each dugga, it will always pick absolute deadline. Reasoning behind this is that I didn't want to disrupt any ongoing deadlines by overriding the current deadline. Once you uncheck the absolute deadline checkbox and save it, it should pick the relative deadline over the absolute one.

If we're ever storing deadlines outside of the sectioned.js file then maybe there would be some issues but as far as I've seen, there is no ajax requests besides the one I've been working with that handles deadlines and that one only points to sectionedservice.php which is the file that handles all SQL requests to the database.

Just to emphasize:
These changes *do not* interfere with the current logic with comparing absolute deadline validation for it being within the course dates or not. 

They *do not* interfere with how the deadlines are being stored in the database.

They *do not* interfere with how the deadline are being handled subsequent any deadline being fetched from the database.

### Tests
In order to test this, I would simply play around with deadlines and see which one is being picked after saving a dugga.
Here's a few tests that can be made:

**Remember to re-install the DB by running install.php if you didn't do that since last merge.**

- Open any dugga through the cogwheel menu and change the relative deadline. Press save and open again(can be done without refreshing the site) and check whether your change persisted or not.
- Open any dugga through the cogwheel menu and change both relative and absolute deadline by checking the absolute checkbox. Then proceed to save and open the same dugga again to see whether the absolute deadline checkbox is checked or not and if the dates are the dates you previously picked.
- Open any dugga through the cogwheel menu and do the same as the previous step but this time before saving uncheck the absolute deadline checkbox and then check again whether the absolute or relative is being used. The one being used will be the one displayed to the left of the cogwheel menu button. The picture below shows where this is.
![image](https://user-images.githubusercontent.com/82010032/166445895-edf79536-63e7-47e6-bae6-f6c6d5debddb.png)

I'm sure there are many other ways to test this, but this is the simple way or figuring out whether the data is being stored *and* if it's being displayed correctly.

### Added from last pull request

Added functionality to show the correct deadline if the startdate for the course is null. Should now prioritize displaying absolute deadlines when possible and should choose relative deadlines if there's no startdate. This still means that relative deadlines will be displayed if those are chosen to be the default deadline(checkbox for absolute deadlines not checked).

### Known issues
- When copying a course the old absolute deadlines will still be prioritized
- There is no "preview text" yet as requested in the original issue request
- The absolute deadlines checkbox positioning behaves strange on smaller devices