### PR TITLE
G3 2022 w7 #000001

### DIFF
--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -530,11 +530,39 @@ foreach($queryz->fetchAll(PDO::FETCH_ASSOC) as $row){
 	$userCourse[$row['cid']] = $row['access'];
 }
 
-//Delete Courses that have been marked as deleted.
+//Delete course matterial from courses that have been marked as deleted.
 $deleted = 3;
-$query = $pdo->prepare("DELETE FROM course WHERE visibility=:deleted;");
+$query = $pdo->prepare("DELETE codeexample FROM course,codeexample WHERE course.visibility=:deleted AND codeexample.cid = course.cid;");
 $query->bindParam(':deleted', $deleted);
+ if(!$query->execute()) {
+	$error=$query->errorInfo();
+	$debug="Error reading courses\n".$error[2];
+} 
 
+$query = $pdo->prepare("DELETE listentries FROM course,listentries WHERE course.visibility=:deleted AND listentries.cid = course.cid;");
+$query->bindParam(':deleted', $deleted);
+ if(!$query->execute()) {
+	$error=$query->errorInfo();
+	$debug="Error reading courses\n".$error[2];
+} 
+
+$query = $pdo->prepare("DELETE quiz FROM course,quiz WHERE course.visibility=:deleted AND quiz.cid = course.cid;");
+$query->bindParam(':deleted', $deleted);
+ if(!$query->execute()) {
+	$error=$query->errorInfo();
+	$debug="Error reading courses\n".$error[2];
+} 
+
+$query = $pdo->prepare("DELETE vers FROM course,vers WHERE course.visibility=:deleted AND vers.cid = course.cid;");
+$query->bindParam(':deleted', $deleted);
+ if(!$query->execute()) {
+	$error=$query->errorInfo();
+	$debug="Error reading courses\n".$error[2];
+} 
+
+//Delete Courses that have been marked as deleted.
+$query = $pdo->prepare("DELETE course FROM course WHERE visibility=:deleted;");
+$query->bindParam(':deleted', $deleted);
 if(!$query->execute()) {
 	$error=$query->errorInfo();
 	$debug="Error reading courses\n".$error[2];

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -530,6 +530,16 @@ foreach($queryz->fetchAll(PDO::FETCH_ASSOC) as $row){
 	$userCourse[$row['cid']] = $row['access'];
 }
 
+//Delete Courses that have been marked as deleted.
+$deleted = 3;
+$query = $pdo->prepare("DELETE FROM course WHERE visibility=:deleted;");
+$query->bindParam(':deleted', $deleted);
+
+if(!$query->execute()) {
+	$error=$query->errorInfo();
+	$debug="Error reading courses\n".$error[2];
+}
+
 
 $query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion FROM course ORDER BY coursename");
 
@@ -552,29 +562,29 @@ if(!$query->execute()) {
 					if ($userCourse[$row['cid']] == "W") $writeAccess = true;
 			}
 			if ($isSuperUserVar ||
-					$row['visibility']==1 ||
-					($row['visibility']==2 && (isset ($userCourse[$row['cid']] ))) ||
-					($row['visibility']==0 && $writeAccess)){
-					$isRegisteredToCourse = false;
-					foreach($userRegCourses as $userRegCourse){
-							if($userRegCourse == $row['cid']){
-								$isRegisteredToCourse = true;
-								break;
-							}
-						}
-					array_push(
-						$entries,
-						array(
-							'cid' => $row['cid'],
-							'coursename' => $row['coursename'],
-							'coursecode' => $row['coursecode'],
-							'visibility' => $row['visibility'],
-							'activeversion' => $row['activeversion'],
-							'activeedversion' => $row['activeedversion'],
-							'registered' => $isRegisteredToCourse
-							)
-						);
+			$row['visibility']==1 ||
+			($row['visibility']==2 && (isset ($userCourse[$row['cid']] ))) ||
+			($row['visibility']==0 && $writeAccess)){
+				$isRegisteredToCourse = false;
+				foreach($userRegCourses as $userRegCourse){
+					if($userRegCourse == $row['cid']){
+						$isRegisteredToCourse = true;
+						break;
+					}
 				}
+				array_push(
+					$entries,
+					array(
+						'cid' => $row['cid'],
+						'coursename' => $row['coursename'],
+						'coursecode' => $row['coursecode'],
+						'visibility' => $row['visibility'],
+						'activeversion' => $row['activeversion'],
+						'activeedversion' => $row['activeedversion'],
+						'registered' => $isRegisteredToCourse
+						)
+					);
+			}
 		}
 }
 


### PR DESCRIPTION
@a20vicad If you press the cog wheel next to a course on the main page (courseed.php) and mark visibility as deleted the course will now be scrubbed from memory and removed from the main page. All duggas, code examples, etc will also be scrubbed from memory if they belonged to that course. Because of the amount of information and work (including grades) that can be deleted very easily with three mousse clicks this seams kind of dangerous. Especially since every logged in user currently has editing privileges on courses. But the customers did specify that they wanted everything to be quick and easy for the user.

To test switch to my branch and  make a course in the main page then delete it whit the method above.

Warning I had a lot off memory leak problems when implementing this. Currently I "think" all problems are resolved. But be aware that this has been a big issue. 