### PR TITLE
The dropdowns for filelink and gfilelink does not change to the selected variant when changed before. #12610 

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -490,12 +490,14 @@ function selectVariant(vid, el) {
 
   				if(result == "type"){
   					document.getElementById('type').value = obj[result];
+					  updateInstructions();
   				}
   				else if(result == "filelink"){
   					document.getElementById('filelink').value = obj[result];
   				}
 				  if(result == "gType"){
 					document.getElementById('gType').value = obj[result];
+					updateInformation();
 				}
 				else if(result == "gFilelink"){
 					document.getElementById('gFilelink').value = obj[result];


### PR DESCRIPTION
Put updateInstuction and Updateinfromation in setVariant to get info from left field. It now works as intended.