### PR TITLE
made code lines inherit background color from .box

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -114,7 +114,7 @@
     font-family: Arial,Sans-Serif;
     font-size: 14px;
     outline: 0 none;
-    background-color: #2c2c2c;
+    background-color: var(--color-background);
     color: #FFF;
 }
 
@@ -248,7 +248,7 @@
 
 .normtext {
     color: #fff;
-    background-color: var(--color-background);
+    background-color: transparent;
     white-space:nowrap;
 }
 
@@ -385,12 +385,12 @@
 
 .codebox{
   font-family:Hack;
-  background-color: var(--color-background);
+  /* Inherits background-color from .box */
 }
 
 .descbox{
-	background-color: var(--color-background);
 	color: #fff;
+    /* Inherits background-color from .box */
 }
 
 /* BOXMENU STYLING START */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8558,7 +8558,7 @@ span[id$="examples"]:hover{
 
 .normtext {
   color: #000;
-  background-color: #F2F2F2;
+  background-color: transparent;
   white-space:nowrap;
   font-family: Hack,'Ubuntu Mono',"Andale Mono", AndaleMono, monospace;
 }


### PR DESCRIPTION
Code lines should inherit color from .box since the background should follow if the background color changes. Solved by setting background-color: transparent and through removad or redundant css code lines.

Testing (repeat the same teps for light and dark theme):
1. Go to course Webbprogrammering
2. Open inspect
3. Click the select tool
![image](https://user-images.githubusercontent.com/81631818/169033465-887c11cd-6c4d-4a19-8b85-fb2bb2b0301c.png)
4. Select a code line 
![image](https://user-images.githubusercontent.com/81631818/169033671-0dc18594-c625-45a3-b268-f00cb9b38d3e.png)
5. Find element .box in the css style
![image](https://user-images.githubusercontent.com/81631818/169033949-ba6519a3-d281-4c13-bb90-ec5d04500088.png)
6. Change the background color to any color

Before: not all elements were affected by the color change.
![image](https://user-images.githubusercontent.com/81631818/169034636-6d44fad5-c73b-42e1-819e-2d1c8c6b2224.png)

After: every codeviewer element (description and code)  on the page shuold get the the same background color.
![image](https://user-images.githubusercontent.com/81631818/169034203-e58c8b29-8a02-4771-be31-cbdd171c75bd.png)