### PR TITLE
You can now copy only important code

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -399,7 +399,11 @@ function returned(data)
 	// Add all drop zones
 	if (retData['writeaccess'] == "w") {
 		initFileDropZones();
-	}	
+	} else {
+		$('.codebox').each(function() {
+			$(this).find('*').addClass('unselectable');
+		});
+	}
 
 	var ranges = getBlockRanges(allBlocks);
 	for (var i = 0; i < Object.keys(ranges).length; i++) {
@@ -4698,44 +4702,30 @@ function addHtmlLineBreak(inString) {
 function copyCodeToClipboard(boxid) {
 	var box = document.getElementById("box" + boxid);
 	var code = box.getElementsByClassName("normtextwrapper")[0];
+	var lines = "";
 
-	var impo = code.getElementsByClassName("impo"); // Add code to just copy impo code
+	// Get important lines based on code window
+	var impo = code.getElementsByClassName("impo"); 
 
-	// Select the code
-	var selection = window.getSelection();
-	
-	if (selectionRange != null && selectionRange.toString() != "") {
-		// Copy selected code
-		selection.removeAllRanges();
-		selection.addRange(selectionRange);
-	} else if (impo.length > 0) {
-		// Copy impo code if no selection is made
-		selection.removeAllRanges();
+	// Check if a teacher is logged in
+	if (retData['writeaccess'] != "w") {
+		// Add Code to just copy impo code
 		for(i = 0; i<impo.length;i++){
-			var range = document.createRange();
-			range.selectNode(impo[i]);
-			selection.addRange(range);
+			lines += impo[i].innerText  + "\n";
 		}
 	} else {
-		// Retain previous clipboard if no code is selected and there is no impo code
-		return;
+		for(i = 0; i<code.childNodes.length;i++){
+			lines += code.childNodes[i].innerText  + "\n";
+		}
 	}
-	
-	if (navigator.clipboard) {
-		// Write selection to clipboard
-		navigator.clipboard.writeText(selection).catch(function (err) {
-			// Display errors as a warning
-			console.warn("Error occurred.", err);
-		});
+
+	// Now using clipboard api, but fals back to execCommand incase it's not supported
+	if (navigator.clipboard){
+		navigator.clipboard.writeText(lines);
 	} else {
-		// If clipboard API is not available
-		document.execCommand("Copy");
-		console.warn("Depricated feature \'documnet.execCommand()\' was used");
+		var dummy = $('<input>').val(lines).appendTo('body').select();
+		document.execCommand("Copy")
 	}
-
-	selection.removeAllRanges();
-	selectionRange = "";
-
 
 	// Notification animation
 	$("#notificationbox" + boxid).css("display", "flex").css("overflow", "hidden").hide().fadeIn("fast", function () {

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -4723,8 +4723,9 @@ function copyCodeToClipboard(boxid) {
 	if (navigator.clipboard){
 		navigator.clipboard.writeText(lines);
 	} else {
-		var dummy = $('<input>').val(lines).appendTo('body').select();
+		var dummy = $('<textarea>').val(lines).appendTo('body').select();
 		document.execCommand("Copy")
+		dummy.remove();
 	}
 
 	// Notification animation

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8991,3 +8991,11 @@ select{
   border-radius: 5px;
 }
 /* END */
+
+.unselectable {
+  -moz-user-select: none;  
+  -webkit-user-select: none;  
+  -ms-user-select: none;  
+  -o-user-select: none;  
+  user-select: none;
+}


### PR DESCRIPTION
Lines are now copied using another function instead, as the old version did not work well when selecting specific elements in a class. 