### PR TITLE
made the code lines numbers background inherit from .codeborder

### DIFF
--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -217,7 +217,6 @@
     padding-left: 4px;
     padding-right: 6px;
     width: 22px;
-	background-color: #614875;
 	font-family: Hack,'Ubuntu Mono',"Andale Mono", AndaleMono, monospace;
     -moz-user-select: none;
     -webkit-user-select: none;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8518,7 +8518,7 @@ span[id$="examples"]:hover{
   left:0px;
   margin: 0px !important;
   padding: 5px 0px 0px 0px !important;
-  background-color: #614875;
+  background-color: var(--color-primary);
   text-align: right;
   /* Width of .no and .impo */
   width: 32px !important;
@@ -8529,8 +8529,7 @@ span[id$="examples"]:hover{
   color: #D8D8D8;
   padding-left: 4px;
   padding-right: 6px;
-  width: 22px;    
-  background-color: #614875;
+  width: 22px;
   font-family: Hack,'Ubuntu Mono',"Andale Mono", AndaleMono, monospace;
   line-height: 21px; /* Workaround! Should be dynamically set according to selected font-size in code example. This works for font-size 16px. */
   -moz-user-select: none;


### PR DESCRIPTION
Made the code lines numbers background inherit from `.codeborder` through removing redundant css line.

Testing (follow the same steps both for light and dark mode:
1. Go to course Webbprogrammering
2. Click any of the code examples
3. Open inspect and click the select tool
![image](https://user-images.githubusercontent.com/81631818/169041832-2b64a44c-0f22-437d-bd13-5854b58cef53.png)
4. Select the code bar 
![image](https://user-images.githubusercontent.com/81631818/169042045-2f7970fc-d35e-4c58-ba9b-b53aff9777fd.png)
5. Find the class `codeborder` in inspect
![image](https://user-images.githubusercontent.com/81631818/169042277-25ee7694-6932-4397-b6b9-0a75425c340f.png)
6. Change color of class codeborder to any color

Before:
- before changing color
![image](https://user-images.githubusercontent.com/81631818/169040397-61092a01-bed4-4c8e-98b6-cc49978c3547.png)

- after changing color
![image](https://user-images.githubusercontent.com/81631818/169040621-a115001c-2c10-49d4-a668-fb6ced2bf146.png)

After: All lines should get the color chosen except the ones that were marked with another color since before
- before changing color
![image](https://user-images.githubusercontent.com/81631818/169040200-25c74eaa-1d3e-4cbd-b888-e70d8cd1598b.png)

- after changing color
![image](https://user-images.githubusercontent.com/81631818/169039196-34c16730-5389-4b6a-9a8e-497160be79e1.png)
