### PR TITLE
It's now possible to delete variants with assigned user answers #12638

### DIFF
--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -129,7 +129,7 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid) || has
 			$debug="Error updating user".$error[2];
 		}
 	}else if(strcmp($opt,"DELVARI")===0){
-		$query = $pdo->prepare("DELETE FROM useranswer WHERE variant=:vid;");
+		$query = $pdo->prepare("DELETE FROM userAnswer WHERE variant=:vid;");
 		$query->bindParam(':vid', $vid);
 
 		if(!$query->execute()) {

--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -129,6 +129,14 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid) || has
 			$debug="Error updating user".$error[2];
 		}
 	}else if(strcmp($opt,"DELVARI")===0){
+		$query = $pdo->prepare("DELETE FROM useranswer WHERE variant=:vid;");
+		$query->bindParam(':vid', $vid);
+
+		if(!$query->execute()) {
+			$error=$query->errorInfo();
+			$debug="Error updating user".$error[2];
+		}
+
 		$query = $pdo->prepare("DELETE FROM variant WHERE vid=:vid;");
 		$query->bindParam(':vid', $vid);
 


### PR DESCRIPTION
Made it so deleting a variant also deletes all stored user answers that correlates to said variant.