### PR TITLE
Removed space in header.

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8300,6 +8300,9 @@ textarea#filecont {
   #hamburgerBox{
     display:none;
   }
+  #hamburgerIcon{
+    display:none;
+  }
 }
 
 #selectdir{


### PR DESCRIPTION
Removed space in header.

For testing: 

1. Log in as teacher
2. Enter course Webbprogrammering
3. Look at the header and the space between the course bar and the back button is no longer there. 
![image](https://user-images.githubusercontent.com/102584401/169049306-372c6cfa-6f5a-4b16-992e-7a7ba1eec34c.png)
5. Make the window smaller & the burger menu will appear with appropriate spacing. 