### PR TITLE
fixed indentation and matches with actual info

### DIFF
--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -2209,22 +2209,22 @@ function accountInformation(data){
     if(data[row][1]==101){  //pending account
       str+="<td class='accountRequestTable'>" + 'Pending'+ "</td>";
       str+="<td class='accountRequestTable'>";
-        str+= "<input type='button', id='accept"+data[row][0]+"', onclick='acceptAcc()', value='Accept'></input>" ;
-        str+= "<input type='button' ,id='deny"+data[row][0]+"', onclick='denyAcc()', value='Deny '></input>";
+        str+= "<input type='button', id='accept"+data[row][0]+"', onclick='acceptAcc()', value='Accept'></input><br>" ;
+        str+= "<input type='button' ,id='deny"+data[row][0]+"', onclick='denyAcc()', value='Deny '></input><br>";
         str+= "<input type='button' ,id='delete"+data[row][0]+"', onclick='deleteAcc()', value='Delete '></input>";
       str+= "</td>";
     }
     else if(data[row][1]==0){ //accepted account
       str+= "<td class='accountRequestTable'>" + 'Accepted'+ "</td>";
       str+= "<td class='accountRequestTable'>"; 
-        str+= "<input type='button' id='delete"+data[row][0]+"' onclick='deleteAcc()' value='Delete '></input>";
+        str+= "<input type='button' id='delete"+data[row][0]+"' onclick='deleteAcc()' value='Delete '></input> <br>";
         str+= "<input type='button' id=deny'"+data[row][0]+"' onclick='denyAcc()' value='Revoke '></input>"; 
       str+= "</td>";
     }
     else{ //if not accepted or pending its denied
       str+= "<td class='accountRequestTable'>" + 'Denied' + "</td>";
       str+= "<td class='accountRequestTable'>"; 
-        str+= "<input type='button' id='delete"+data[row][0]+"' onclick='deleteAcc()' value='Delete'></input>";
+        str+= "<input type='button' id='delete"+data[row][0]+"' onclick='deleteAcc()' value='Delete'></input><br>";
         str+= "<input type='button' id='accept"+data[row][0]+"' onclick='acceptAcc()' value='Accept'></input>"; 
       str+= "</td>";
     }
@@ -2255,9 +2255,9 @@ function placeSideBarInfo(data){
   str+= '<div id="accountRequests-pane-button" class="accountRequests-pane-button" onclick="toggleAccountRequestPane();"><span id="accountReqmarker" class="accountRequests-pane-span">Account requests</span></div>';
   str+= "<table class='accountRequestTable'style='width: 85%'  border='1'><br />";
 	str+= "<tr class='accountRequestTable' style=' background-color: #ffffff';>";
-  str+= "<th class='accountRequestTable'></th>";
-  str+= "<th class='accountRequestTable'>Name </th>";
-  str+= "<th class='accountRequestTable'>Status</th>";;
+  str+= "<th class='accountRequestTable'>Name</th>";
+  str+= "<th class='accountRequestTable'> Status</th>";
+  str+= "<th class='accountRequestTable'>Action</th>";;
   str+= "</tr>";
   str+=accountInformation(data);
 


### PR DESCRIPTION
indentation matches now with accounts

before:
![image](https://user-images.githubusercontent.com/102468604/169049504-8b2c3a36-f382-4d3b-90f3-1ba9a620b803.png)

after;
![image](https://user-images.githubusercontent.com/102468604/169049572-a192dde6-3769-44f5-9fc0-b119407d058b.png)


testing, 

check different accounts statuses. 

1) create account in contribution (proci works)
2) logg in to contribution as teacher (eg stei)
3) check account sidebar, make sure all match correctly
4) change new account _account_status_ (from 101 to 0 and 102) and notice button changes