### PR TITLE
removed unnecessary css code to make #NewTabLink follow light and dar…

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -43,25 +43,11 @@
         --color-red-hover: #ce3d3d;
     }
 
-    #dorf {
+    #dorf, #NewTabLink, .whiteIcon, .iconColorInDarkMode {
         cursor: pointer;
         filter: invert(80%);
         -webkit-filter: invert(80%);
     }
-    #NewTabLink{
-        cursor: pointer; 
-    }
-    .code #NewTabLink{
-        filter: invert(80%);
-        -webkit-filter: invert(80%);   
-    }
-    .whiteIcon {
-        cursor: pointer;
-        filter: invert(80%);
-        -webkit-filter: invert(80%);
-    }
-
-
       
 #div2{
 	background-color: #2c2c2c;
@@ -522,12 +508,6 @@ body {
   background-color: var(--color-background);
   color:white;
   border: 2px solid var(--color-border);
-}
-
-.iconColorInDarkMode{
-    cursor: pointer;
-    filter: invert(80%);
-    -webkit-filter: invert(80%);
 }
 
 #statisticsSwimlanes{

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -841,19 +841,12 @@ p {
   background-color: var(--color-primary)/*var(--color-primary-light)*/;
 }
 
-#Sectionlist .section #NewTabLink {
-  filter: invert(100%);
-  -webkit-filter: invert(100%);  
-} 
-
+/* Turn the icons white */
 #Sectionlist .section #dorf {
+  cursor: pointer;
    filter: invert(100%);
   -webkit-filter: invert(100%);
 }
-.code #NewTabLink{
-  filter: invert(100%);
-  -webkit-filter: invert(100%);
-} 
 
 #Sectionlist .header {
   color: var(--color-text-header);
@@ -926,10 +919,6 @@ p {
 }
 
 /*Swimlane styling Ends*/
-
-#dorf {
-  cursor: pointer;
-}
 
 /*Styling for indented tabs*/
 .tabs0, .tabsnull{
@@ -3228,9 +3217,10 @@ div.submit-button:disabled {
 }
 
 #plorf,
-#dorf {
+#dorf, #NewTabLink {
   display: block;
   margin: auto;
+  /* Makes the icons purple */
   filter: invert(32%) sepia(42%) saturate(444%) hue-rotate(230deg) brightness(88%) contrast(96%);
 }
 
@@ -8862,13 +8852,6 @@ border: none !important;
   height: 32px;
   vertical-align: middle;
   padding: 0px 5px;
-}
-
-#NewTabLink{
-  cursor: pointer;
-  filter: invert(32%) sepia(42%) saturate(444%) hue-rotate(230deg) brightness(88%) contrast(96%);
-  display: block;
-  margin: auto; 
 }
 
 .iconColorInDarkMode{

--- a/Shared/icons/link-icon.svg
+++ b/Shared/icons/link-icon.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
 </svg>


### PR DESCRIPTION
Simplipied the complexity by reusing css code and changing the color set in the original svg file.

Testing:
1. Log in as teacher (stei: password)
2. Go to course Webbprogrammering
3. Check that the link-icon is purple in light mode ( and that it's continously white / light gray-ish in dark mode)

Before (in light mode)
![image](https://user-images.githubusercontent.com/81631818/169242465-9f4ed1d0-65c5-4eef-b986-7075acf4f46d.png)
After (in light mode)
![image](https://user-images.githubusercontent.com/81631818/169242592-ea69285d-e72c-4c9a-afbe-b15a66f564cb.png)

Should look like this in dark mode
![image](https://user-images.githubusercontent.com/81631818/169242931-c228628f-9ba3-41ec-a2bc-fdcf9cd7b925.png)





