### PR TITLE
Revert "Made it so loading diagram from hash doesn't remove nav-bar"

### DIFF
--- a/sh/index.php
+++ b/sh/index.php
@@ -71,9 +71,9 @@ function GetAssignment ($hash){
 		$_SESSION["submission-password-$cid-$vers-$did-$moment"]=$hashpwd;
 		$_SESSION["submission-variant-$cid-$vers-$did-$moment"]=$variant;	
 		$_SESSION["hash"]=$hash;
-		echo "../DuggaSys/showDugga.php?coursename={$coursename}&courseid={$cid}&cid={$cid}&coursevers={$vers}&did={$did}&moment={$moment}&deadline={$deadline}&hash={$hash}<br>";
+		echo "../DuggaSys/showDugga.php?coursename={$coursename}&courseid={$cid}&cid={$cid}&coursevers={$vers}&did={$did}&moment={$moment}&deadline={$deadline}&hash={$hash}&embed<br>";
 		echo "|$hash|$hashpwd|<br>";
-		header("Location: ../DuggaSys/showDugga.php?coursename={$coursename}&courseid={$cid}&cid={$cid}&coursevers={$vers}&did={$did}&moment={$moment}&deadline={$deadline}&hash={$hash}");
+		header("Location: ../DuggaSys/showDugga.php?coursename={$coursename}&courseid={$cid}&cid={$cid}&coursevers={$vers}&did={$did}&moment={$moment}&deadline={$deadline}&hash={$hash}&embed");
 		exit();	
 	}else{
 		$_SESSION['checkhash']=$hash;


### PR DESCRIPTION
Reverts HGustavs/LenaSYS#12698
Do not work as intended, perhaps it is due to another problem with the hash that has arisen. To asure not getting more trouble with that earlier trouble this will be reverted. The image tells what happend after this merge when trying to load from hash. There were no 404 before this merge.
![image](https://user-images.githubusercontent.com/81630339/169290791-5e8e5f4d-f8fb-4d1f-88e6-45d3020f82f6.png)
