### PR TITLE
Mobile view for larger mobile devices.

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -892,7 +892,7 @@ p {
   font-size: 10px;
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
   #swimlaneSVG text {
       font-size: 14px;
   }
@@ -1549,7 +1549,7 @@ div .navButt:hover {
   cursor: pointer;
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
         #div2 {
         top: 80px;
         }
@@ -5203,7 +5203,8 @@ only screen and (max-device-width: 1085px) {
 }
 
 @media only screen and (max-width: 800px),
-only screen and (max-device-width: 800px) {
+only screen and (max-device-width: 800px),
+only screen and (orientation:portrait){
   #addElement {
     display: none;
   }

--- a/Shared/css/template1.css
+++ b/Shared/css/template1.css
@@ -18,7 +18,7 @@
     }
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait){
 #box1wrapper{
     position: absolute;
     left: 0px;

--- a/Shared/css/template2.css
+++ b/Shared/css/template2.css
@@ -16,7 +16,7 @@
     height: 100%;
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
     #box1wrapper{
          overflow: hidden;
         position: absolute;

--- a/Shared/css/template3.css
+++ b/Shared/css/template3.css
@@ -24,7 +24,7 @@
     height: 100%;  
   }
   
-  @media only screen and (max-width: 800px) {
+  @media only screen and (max-width: 800px), only screen and (orientation:portrait) {
       #box1wrapper {
           overflow: hidden;
           position: absolute;

--- a/Shared/css/template4.css
+++ b/Shared/css/template4.css
@@ -25,7 +25,7 @@
 }
 
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
     #box1wrapper{
      overflow: hidden;
     position: absolute;

--- a/Shared/css/template5.css
+++ b/Shared/css/template5.css
@@ -33,7 +33,7 @@
 }
 
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
     #box1wrapper{
      overflow: hidden;
     position: absolute;

--- a/Shared/css/template6.css
+++ b/Shared/css/template6.css
@@ -32,7 +32,7 @@
     height: 100%;
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
     #box1wrapper{
      overflow: hidden;
     position: absolute;

--- a/Shared/css/template7.css
+++ b/Shared/css/template7.css
@@ -33,7 +33,7 @@
     width: 100%;
     height: 100%;
 }
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
 
     #box1wrapper{
      overflow: hidden;

--- a/Shared/css/template8.css
+++ b/Shared/css/template8.css
@@ -24,7 +24,7 @@
     height: 100%;
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
 
     #box1wrapper{
      overflow: hidden;

--- a/Shared/css/template9.css
+++ b/Shared/css/template9.css
@@ -50,7 +50,7 @@
     height: 100%;
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
 
     #box1wrapper{
      overflow: hidden;


### PR DESCRIPTION
Larger mobile devices such as an ipad är will now be in mobile view.
Added a clease where the orientation is portrait.
(portrait meaning the widht(px) of the screen is smaller than the height(px) of the screen.)

For testing:
1: Press ctrl+shift+i
2: Press ctrl+shift+m
(might be different for apple users)
3:Change your view to the ipad air(Or any large device where the widht of the screen is smaller than the height.).
![image](https://user-images.githubusercontent.com/102600690/169292049-2d938ea1-8883-495b-ab3f-a998ebc5bd9d.png)
4: Enter an example.
![image](https://user-images.githubusercontent.com/102600690/169292319-5e20b94c-589e-48c4-863d-ff6eef888e81.png)
5: The example should be shown in mobile view(Where the boxes are all stacked ontop of eachother).