### PR TITLE
Child attributes of primary/candidate key are now underlined as one key object

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4869,9 +4869,9 @@ function generateErTableString()
                     //Not array
                     if (!Array.isArray(allEntityList[i][j])) {
                         if (allEntityList[i][j].state == 'normal') {
-                            //currentString += `${allEntityList[i][j].name}, `;
+                            //If parent attribute is a primary or candidate key, it'll be added as underlined
                             if(getParentElementOfID(allEntityList[i][j].id) != undefined && getParentElementOfID(allEntityList[i][j].id).kind == 'ERAttr'){
-                                if(getParentElementOfID(allEntityList[i][j].id).state == 'primary' || getParentElementOfID(allEntityList[i][j].id.state == 'candidate')){
+                                if(getParentElementOfID(allEntityList[i][j].id).state == 'primary' || getParentElementOfID(allEntityList[i][j].id).state == 'candidate'){
                                     currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][j].name}</span>, `;
                                 }
                                 else{

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4869,7 +4869,18 @@ function generateErTableString()
                     //Not array
                     if (!Array.isArray(allEntityList[i][j])) {
                         if (allEntityList[i][j].state == 'normal') {
-                            currentString += `${allEntityList[i][j].name}, `;
+                            //currentString += `${allEntityList[i][j].name}, `;
+                            if(getParentElementOfID(allEntityList[i][j].id) != undefined && getParentElementOfID(allEntityList[i][j].id).kind == 'ERAttr'){
+                                if(getParentElementOfID(allEntityList[i][j].id).state == 'primary' || getParentElementOfID(allEntityList[i][j].id.state == 'candidate')){
+                                    currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][j].name}</span>, `;
+                                }
+                                else{
+                                    currentString += `${allEntityList[i][j].name}, `;
+                                }
+                            }
+                            else{
+                                currentString += `${allEntityList[i][j].name}, `;
+                            }
                         }
                     }
                 }
@@ -5021,10 +5032,6 @@ function generateErTableString()
     var stri = "";
     for (var i = 0; i < stringList.length; i++) {
         stri += new String(stringList[i] + "\n\n");
-    }
-
-    for (var i = 0; i < data.length; i++){
-        
     }
     return stri;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4888,7 +4888,7 @@ function generateErTableString()
                     //Not array
                     if (!Array.isArray(allEntityList[i][j])) {
                         if (allEntityList[i][j].state == 'normal') {
-                            if(!hasChildElement(allEntityList[i][j].id)){
+                            if(allEntityList[i][j].newKeyName == undefined){
                                 currentString += `${allEntityList[i][j].name}, `;
                             }
                         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3830,7 +3830,7 @@ function hasChildElement(ID){
         if(lines[i].fromID == ID){
             for (var j = 0; j < data.length; j++){
                 if(lines[i].toID == data[j].id){
-                    return data[j];
+                    return true;
                 }
             }
         }
@@ -3972,9 +3972,18 @@ function generateErTableString()
                             // looking if the parent attribute is in the parentAttributeList 
                             if(findIndex(parentAttribeList,currentEntityAttrList[j].id) == -1){
                                 parentAttribeList.push(currentEntityAttrList[j]);
+                                currentEntityAttrList[j].newKeyName = "";
+                            }
+                            if(currentEntityAttrList[j].newKeyName == ""){
+                                currentEntityAttrList[j].newKeyName += attrList[k].name;
+                            }
+                            else{
+                                currentEntityAttrList[j].newKeyName += " "+attrList[k].name;
+                            }
+                            if(currentEntityAttrList[j].state != 'primary' && currentEntityAttrList[j].state != 'candidate'){
+                                currentRow.push(attrList[k]);
                             }
                             currentEntityAttrList.push(attrList[k]);
-                            currentRow.push(attrList[k]);
                             idList.push(attrList[k].id);
                         }
                     }   
@@ -3983,9 +3992,9 @@ function generateErTableString()
         }
 
         //removes all attributes in parent attribute list from current entity attribute list
-        for (let index = 0; index < parentAttribeList.length; index++) {
-            currentRow.splice(findIndex(currentRow,parentAttribeList[index].id),1);
-        }
+        //for (let index = 0; index < parentAttribeList.length; index++) {
+        //    currentRow.splice(findIndex(currentRow,parentAttribeList[index].id),1);
+        //}
         //Push list with entity at index 0 followed by its attributes
         ERAttributeData.push(currentRow);
     }
@@ -4852,13 +4861,23 @@ function generateErTableString()
                 // Print only primary keys if at least one is present
                 if (existPrimary) {
                     if (allEntityList[i][1][j].state == 'primary') {
-                        currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][1][j].name}</span>, `;
+                        if(allEntityList[i][1][j].newKeyName != undefined){
+                            currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][1][j].newKeyName}</span>, `;
+                        }
+                        else{
+                            currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][1][j].name}</span>, `;
+                        }
                     }
                 }
                 //Print only candidate keys if no primary keys are present
                 if (!existPrimary) {
                     if (allEntityList[i][1][j].state == 'candidate') {
-                        currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][1][j].name}</span>, `;
+                        if(allEntityList[i][1][j].newKeyName != undefined){
+                            currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][1][j].newKeyName}</span>, `;
+                        }
+                        else{
+                            currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][1][j].name}</span>, `;
+                        }
                     }
                 }
             }
@@ -4869,16 +4888,7 @@ function generateErTableString()
                     //Not array
                     if (!Array.isArray(allEntityList[i][j])) {
                         if (allEntityList[i][j].state == 'normal') {
-                            //If parent attribute is a primary or candidate key, it'll be added as underlined
-                            if(getParentElementOfID(allEntityList[i][j].id) != undefined && getParentElementOfID(allEntityList[i][j].id).kind == 'ERAttr'){
-                                if(getParentElementOfID(allEntityList[i][j].id).state == 'primary' || getParentElementOfID(allEntityList[i][j].id).state == 'candidate'){
-                                    currentString += `<span style='text-decoration: underline black solid 2px;'>${allEntityList[i][j].name}</span>, `;
-                                }
-                                else{
-                                    currentString += `${allEntityList[i][j].name}, `;
-                                }
-                            }
-                            else{
+                            if(!hasChildElement(allEntityList[i][j].id)){
                                 currentString += `${allEntityList[i][j].name}, `;
                             }
                         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3804,6 +3804,40 @@ function toggleErTable()
     }
     generateContextProperties();
 }
+
+/**
+ * @description Fetches the parent element of the current element ID
+ * @returns The parent element object
+ */
+ function getParentElementOfID(ID){
+    for (var i = 0; i < lines.length; i++){
+        if(lines[i].toID == ID){
+            for (var j = 0; j < data.length; j++){
+                if(lines[i].fromID == data[j].id){
+                    return data[j];
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @description checks the element ID and determines if it has child elements
+ * @returns true or false
+ */
+function hasChildElement(ID){
+    for (var i = 0; i < lines.length; i++){
+        if(lines[i].fromID == ID){
+            for (var j = 0; j < data.length; j++){
+                if(lines[i].toID == data[j].id){
+                    return data[j];
+                }
+            }
+        }
+    }
+    return false;
+}
+
 /**
  * @description Generates the string which holds the ER table for the current ER-model/ER-diagram.
  * @returns Current ER table in the form of a string.
@@ -4987,6 +5021,10 @@ function generateErTableString()
     var stri = "";
     for (var i = 0; i < stringList.length; i++) {
         stri += new String(stringList[i] + "\n\n");
+    }
+
+    for (var i = 0; i < data.length; i++){
+        
     }
     return stri;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3806,39 +3806,6 @@ function toggleErTable()
 }
 
 /**
- * @description Fetches the parent element of the current element ID
- * @returns The parent element object
- */
- function getParentElementOfID(ID){
-    for (var i = 0; i < lines.length; i++){
-        if(lines[i].toID == ID){
-            for (var j = 0; j < data.length; j++){
-                if(lines[i].fromID == data[j].id){
-                    return data[j];
-                }
-            }
-        }
-    }
-}
-
-/**
- * @description checks the element ID and determines if it has child elements
- * @returns true or false
- */
-function hasChildElement(ID){
-    for (var i = 0; i < lines.length; i++){
-        if(lines[i].fromID == ID){
-            for (var j = 0; j < data.length; j++){
-                if(lines[i].toID == data[j].id){
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-/**
  * @description Generates the string which holds the ER table for the current ER-model/ER-diagram.
  * @returns Current ER table in the form of a string.
  */
@@ -3990,11 +3957,6 @@ function generateErTableString()
                 }
             }
         }
-
-        //removes all attributes in parent attribute list from current entity attribute list
-        //for (let index = 0; index < parentAttribeList.length; index++) {
-        //    currentRow.splice(findIndex(currentRow,parentAttribeList[index].id),1);
-        //}
         //Push list with entity at index 0 followed by its attributes
         ERAttributeData.push(currentRow);
     }


### PR DESCRIPTION
If an attribute that's a primary or candidate key has child attributes, they're now printed as one underlined key object

![bild](https://user-images.githubusercontent.com/37794783/169301987-a19d292f-87c8-4dbe-8ff8-5f4ee131adef.png)

You can test this by having a primary or candidate attribute have child attributes, they should then be printed in the ER table as one key object. And if a primary and candidate exist, the candidate and its child attributes will not be printed at all