### PR TITLE
Refresh screen breaks UML-Class #12669

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2637,7 +2637,7 @@ function saveProperties()
                 //Update the attribute array
                 arrElementFunc = formatArr;
                 element[propName] = arrElementFunc;
-                propsChanged.attributes = arrElementFunc;
+                propsChanged.functions = arrElementFunc;
                 break;
 
             default:


### PR DESCRIPTION
This was probably just a typo that created a lot of problems. To test this you should create a UML-Class; add some attribute and functions; use the undo and redo tool; save and load a diagram, with and without history; refresh the page. If the UML-Class remain the same without any odd behaviour your golden.