### PR TITLE
Fixed saving changes made in the edit window #12687

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -266,6 +266,8 @@ function returned(data)
 		var boxcontent = retData['box'][i][2];
 		var boxwordlist = retData['box'][i][3];
 		var boxfilename = retData['box'][i][5];
+		var boxfilepath = retData['box'][i][7];
+		var boxfilekind = retData['box'][i][8];
 		var boxmenuheight = 0;
 
 		// don't create templatebox if it already exists
@@ -279,7 +281,7 @@ function returned(data)
 			boxtypeCodebox.removeAttribute("contenteditable");
 			boxtypeCodebox.classList.remove("descbox");
 			boxtypeCodebox.classList.add("codebox");
-			createboxmenu(contentid, boxid, boxtype);
+			createboxmenu(contentid, boxid, boxtype, boxfilepath, boxfilename, boxfilekind);
 
 			// Make room for the menu by setting padding-top equal to height of menubox
 			// Without this fix the code box is placed at same height as the menu, obstructing first lines of the code
@@ -335,7 +337,7 @@ function returned(data)
 			/* Assign Content */
 			$("#" + contentid).html(desc);
 			$("#" + contentid).css("margin-top", boxmenuheight);
-			createboxmenu(contentid, boxid, boxtype);
+			createboxmenu(contentid, boxid, boxtype, boxfilepath, boxfilename, boxfilekind);
 
 			// set font size
 			$("#box" + boxid).css("font-size", retData['box'][boxid - 1][6] + "px");
@@ -349,7 +351,7 @@ function returned(data)
 			$("#" + contentid).css("margin-top", boxmenuheight);
 
 		} else if (boxtype === "IFRAME") {
-			createboxmenu(contentid, boxid, boxtype);
+			createboxmenu(contentid, boxid, boxtype, boxfilepath, boxfilename, boxfilekind);
 			
 			var boxtypeframebox = document.getElementById(contentid);
 			boxtypeframebox.classList.remove("codebox", "descbox");
@@ -385,7 +387,7 @@ function returned(data)
 
 		} else if (boxtype == "NOT DEFINED") {
 			if (retData['writeaccess'] == "w") {
-				createboxmenu(contentid, boxid, boxtype);
+				createboxmenu(contentid, boxid, boxtype, boxfilepath, boxfilename, boxfilekind);
 				// Make room for the menu by setting padding-top equals to height of menubox
 				if ($("#" + contentid + "menu").height() == null) {
 					boxmenuheight = 0;
@@ -1051,7 +1053,7 @@ function addTemplatebox(id) {
 //                Is called by returned(data) in codeviewer.js
 //----------------------------------------------------------------------------------
 
-function createboxmenu(contentid, boxid, type) {
+function createboxmenu(contentid, boxid, type, filepath, filename, filekind) {
 	if ($("#" + contentid + "menu").length == 0) {
 		var boxmenu = document.createElement("div");
 		$("#" + contentid + "wrapper").append(boxmenu);
@@ -1065,15 +1067,15 @@ function createboxmenu(contentid, boxid, type) {
 			if (type == "DOCUMENT") {
 				str += "<td class='butto2 editcontentbtn showdesktop codedropbutton' id='settings' title='Edit box settings' onclick='displayEditContent(" + boxid + ");' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
 				str += '<td id = "boxtitlewrapper" class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
-				str += "<div id='iframeBoxes'><td class='butto2 editbtn' onclick='showIframe(\""+boxid+"\",\""+kind +"\");'><img title='Edit file' class='markdownIcon' src='../Shared/icons/newMarkdown.svg'></div>";
+				str += `<div id='iframeBoxes'><td class='butto2 editbtn' onclick='showIframe("${filepath}", "${filename}", ${filekind});'><img title='Edit file' class='markdownIcon' src='../Shared/icons/newMarkdown.svg'></div>`;
 			} else if (type == "CODE") {
 				str += "<td class='butto2 editcontentbtn showdesktop codedropbutton' id='settings' title='Edit box settings' onclick='displayEditContent(" + boxid + ");' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
 				str += '<td id = "boxtitlewrapper" class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
-				str += "<div id='iframeBoxes'><td class='butto2 editbtn' onclick='showIframe(\""+boxid+"\",\""+kind +"\");'><img title='Edit file' class='markdownIcon' src='../Shared/icons/newMarkdown.svg'></div>";
+				str += `<div id='iframeBoxes'><td class='butto2 editbtn' onclick='showIframe("${filepath}", "${filename}", ${filekind});'><img title='Edit file' class='markdownIcon' src='../Shared/icons/newMarkdown.svg'></div>`;
 			} else if (type == "IFRAME") {
 				str += "<td class='butto2 editcontentbtn showdesktop codedropbutton' id='settings' title='Edit box settings' onclick='displayEditContent(" + boxid + ");' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
 				str += '<td id = "boxtitlewrapper" class="butto2 boxtitlewrap" title="Title"><span id="boxtitle2" class="boxtitleEditable" onblur="updateContent();">' + retData['box'][boxid - 1][4] + '</span></td>';
-				str += "<div id='iframeBoxes'><td class='butto2 editbtn' onclick='showIframe(\""+boxid+"\",\""+kind +"\");'><img title='Edit file' class='markdownIcon' src='../Shared/icons/newMarkdown.svg'></div>";
+				str += `<div id='iframeBoxes'><td class='butto2 editbtn' onclick='showIframe("${filepath}", "${filename}", ${filekind});'><img title='Edit file' class='markdownIcon' src='../Shared/icons/newMarkdown.svg'></div>`;
 			} else {
 				str += "<td class='butto2 showdesktop'>";
 				str += "<select class='chooseContentSelect' onchange='changeboxcontent(this.value,\"" + boxid + "\",\"" + contentid + "\");removeboxmenu(\"" + contentid + "menu\");'>";
@@ -4871,8 +4873,7 @@ function showBox(id) {
 }
 
 // Show preview winodow when clicking on "Edit file"
-function showIframe(boxid,kind) {
-	var fileName = retData['box'][boxid - 1][5]+'';
+function showIframe(path, name, kind) {
     
     // Fetch HTML text from fileed.php
     fetch('fileed.php').then(function (response) {
@@ -4893,11 +4894,15 @@ function showIframe(boxid,kind) {
 		previewWindow.classList.add("loginBox");
         previewWindow.style.display = "block";
         document.querySelector(".editFilePart").style.display = "none";
-        previewWindow.getElementsByTagName('div')[0].getElementsByTagName('div')[0].onclick = hideIframe;
+
+		// Clicking the save button will reload the example to display the new changes
+		previewWindow.querySelector(".save-button-md").addEventListener("click", function(){
+			location.reload();
+		});
         
         // Load the right file in to the preview window
         $.getScript("fileed.js", function(){
-            loadPreview(null, fileName, null);
+            loadPreview(path, name, kind);
         });
     }).catch(function (err) {
         // Display potential errors as a warning

--- a/DuggaSys/codeviewerService.php
+++ b/DuggaSys/codeviewerService.php
@@ -566,7 +566,7 @@
 					$content.="File: ".$filename." not found.";
 			}
 
-			array_push($box,array($row['boxid'],$boxContent,$content,$row['wordlistid'],$row['boxtitle'],$row['filename'], $row['fontsize']));
+			array_push($box,array($row['boxid'],$boxContent,$content,$row['wordlistid'],$row['boxtitle'],$row['filename'], $row['fontsize'], $file, $filekind));
 		}
 		$array = array(
 			'opt' => $opt,


### PR DESCRIPTION
The save button in the edit window saves changes made to the content in the file being edited.

Testing:
1) Login as a teacher account (username: stei password: password)
2) Enter Webbprogrammering
3) Open JavaScript Example 1
4) Click edit on the "JavaScript_Ex1.html" box
5) Make any change in the markdown
![image](https://user-images.githubusercontent.com/102609651/169321259-638ba1e8-cfd0-4708-ab28-97256029f4b3.png)
6) Click save
7) The changes made in the markdown should be displayed in the "JavaScript_Ex1.html" box
![image](https://user-images.githubusercontent.com/102609651/169320914-97a78e39-4883-4e11-8061-9f80f36e907d.png)
