### PR TITLE
Diagram: Reset does not work (wrong function name in one place) #12749 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -10039,7 +10039,7 @@ function loadDiagramFromString(temp, shouldDisplayMessage = true)
 function resetDiagramAlert(){
     let refreshConfirm = confirm("Are you sure you want to reset to default state? All changes made to diagram will be lost");
     if(refreshConfirm){
-        refreshDiagram();
+        resetDiagram();
     }
     
 }


### PR DESCRIPTION
Quick fix (called an old function name (now updated)).

Test : Move element or add element, click the reset icon and after pressing ok, the diagram should now be in default position