### PR TITLE
Fixed tab functions on the edit dugga table head and edit file table head to be able to sort the table

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -1134,11 +1134,11 @@ function renderSortOptionsDugga(col,status,colname) {
 		*/
 		if (col != "arrow" && col != "cogwheel" && col != "trashcan") {			//Disable sorting for pen, cog and trashcan icons
 			if (status ==- 1) {
-				str += `<span class='sortableHeading' onclick='myTable.toggleSortStatus(\"${col}\",0)'>${colname}</span>`;
+				str += `<span class='sortableHeading' tabindex='0' onclick='myTable.toggleSortStatus(\"${col}\",0)'>${colname}</span>`;
 			} else if (status == 0) {
-					str += `<span class='sortableHeading' onclick='myTable.toggleSortStatus(\"${col}\",1)'>${colname}<img class='sortingArrow' src='../Shared/icons/desc_white.svg'/></span>`;
+					str += `<span class='sortableHeading' tabindex='0' onclick='myTable.toggleSortStatus(\"${col}\",1)'>${colname}<img class='sortingArrow' src='../Shared/icons/desc_white.svg'/></span>`;
 			} else {
-					str += `<span class='sortableHeading' onclick='myTable.toggleSortStatus(\"${col}\",0)'>${colname}<img class='sortingArrow' src='../Shared/icons/asc_white.svg'/></span>`;
+					str += `<span class='sortableHeading' tabindex='0' onclick='myTable.toggleSortStatus(\"${col}\",0)'>${colname}<img class='sortingArrow' src='../Shared/icons/asc_white.svg'/></span>`;
 			}
 		}
 return str;

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -616,11 +616,11 @@ function renderSortOptions(col, status, colname) {
     str = "";
 
     if (status == -1) {
-        str += "<span class='sortableHeading' onclick='myTable.toggleSortStatus(\"" + col + "\",0)'>" + colname + "</span>";
+        str += "<span class='sortableHeading' tabindex='0' onclick='myTable.toggleSortStatus(\"" + col + "\",0)'>" + colname + "</span>";
     } else if (status == 0) {
-        str += "<span class='sortableHeading' onclick='myTable.toggleSortStatus(\"" + col + "\",1); sortFiles(true);'>" + colname + "<img class='sortingArrow' src='../Shared/icons/desc_white.svg'/></span>";
+        str += "<span class='sortableHeading' tabindex='0' onclick='myTable.toggleSortStatus(\"" + col + "\",1); sortFiles(true);'>" + colname + "<img class='sortingArrow' src='../Shared/icons/desc_white.svg'/></span>";
     } else {
-        str += "<span class='sortableHeading' onclick='myTable.toggleSortStatus(\"" + col + "\",0); sortFiles(false);'>" + colname + "<img class='sortingArrow' src='../Shared/icons/asc_white.svg'/></span>";
+        str += "<span class='sortableHeading' tabindex='0' onclick='myTable.toggleSortStatus(\"" + col + "\",0); sortFiles(false);'>" + colname + "<img class='sortingArrow' src='../Shared/icons/asc_white.svg'/></span>";
     }
     return str;
 }

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -2779,6 +2779,9 @@ $(document).on('keydown', function(e) {
 		else if(box[0].classList.contains("checkboxIconTab")){
 			box[0].click();
 		}
+		else if(box[0].classList.contains("sortableHeading")){
+			box[0].click();
+		}
 	}
 	else if(e.key === 'Escape'){
 		if ($('.fab-btn-list').is(':visible')) {


### PR DESCRIPTION
How to test
1. Login as a superuser
2. Click on demo course
3. Choose "show files" 
<img width="50" alt="image" src="https://user-images.githubusercontent.com/81676918/169480689-574c0f85-d614-4467-a128-45d8b22ca83f.png">
4. Try to tab and sort the table and check if it works
<img width="936" alt="image" src="https://user-images.githubusercontent.com/81676918/169480757-697d10b4-aa98-48a3-8b31-fe262fabce19.png">

5. Go back and choose 
<img width="36" alt="image" src="https://user-images.githubusercontent.com/81676918/169481065-708b9b97-5d7a-493b-a556-760fbfe42bb5.png">
6. Try to tab and sort the table and check if it works
<img width="952" alt="image" src="https://user-images.githubusercontent.com/81676918/169481152-a163dc3d-5a40-4346-8cf1-ab89d4a4f095.png">

If it works in both places, the issue will work

