### PR TITLE
Instruction and General information files are now visible

### DIFF
--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -594,13 +594,9 @@ function updateVariantTitle(number) {
 
 // Opens the variant editor.
 function showVariantEditor() {
-
+	AJAXService("GET", { cid: querystring['courseid'], coursevers: querystring['coursevers'] }, "FILE");
 	//check if the selected dugga is a diagram dugga
 	if(globalData['entries'][globalVariant].quizFile == "diagram_dugga"){
-		/*For now it only fetches the files when it's a diagram dugga. 
-		This might change in the future if other duggor should have
-		additional files as parameters*/
-		AJAXService("GET", { cid: querystring['courseid'], coursevers: querystring['coursevers'] }, "FILE");
 		$("#selectBox").css("display", "flex");
 		$("#typeCheckbox").css("display", "flex");
 		$("#errorCheck").css("display", "flex");


### PR DESCRIPTION
Issue #12456 was present again in merge 8, the files weren't loaded into the dropdown box.
Ajax call was only made if the dugga was of diagram type, now its done when opening the variant editor.

![bild](https://user-images.githubusercontent.com/37794783/169493999-188cc81e-b33f-4d5b-95e4-d564b50b3ef6.png)
