### PR TITLE
Added highlighting to enter press

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2092,6 +2092,19 @@ $(window).keyup(function (event) {
     if (saveButtonDisplay == 'block' && editSectionDisplay == 'flex') {
       //I don't know who did this but this call is not necessory
       updateItem();
+      //Add class to element so it will be highlighted.
+      setTimeout(function(){
+        var element = document.getElementById('I'+updatedLidsection).firstChild;
+        if(element.tagName == 'DIV') {
+        element = element.firstChild;
+        element.classList.add("highlightChange");
+        }else if (element.tagName == 'A'){
+          document.getElementById('I'+updatedLidsection).classList.add("highlightChange");
+        }else if (element.tagName == 'SPAN'){
+          document.getElementById('I'+updatedLidsection).firstChild.classList.add("highlightChange");
+        }
+      },200);
+
     } else if (submitButtonDisplay == 'block' && editSectionDisplay == 'flex') {
       newItem();
       showSaveButton();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2091,7 +2091,7 @@ $(window).keyup(function (event) {
     var errorMissingMaterialDisplay = ($('#noMaterialConfirmBox').css('display'));
     if (saveButtonDisplay == 'block' && editSectionDisplay == 'flex') {
       //I don't know who did this but this call is not necessory
-      // updateItem();
+      updateItem();
     } else if (submitButtonDisplay == 'block' && editSectionDisplay == 'flex') {
       newItem();
       showSaveButton();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1500,7 +1500,7 @@ function returnedSection(data) {
 
 
           str += "<img alt='settings icon'  tabIndex='0' id='dorf' title='Settings' class='settingIconTab' src='../Shared/icons/Cogwheel.svg' ";
-          str += " onclick='selectItem(" + makeparams([item['lid'], item['entryname'],
+          str += " onclick='setActiveLid("+item['lid']+");selectItem(" + makeparams([item['lid'], item['entryname'],
           item['kind'], item['visible'], item['link'], momentexists, item['gradesys'],
           item['highscoremode'], item['comments'], item['grptype'], item['deadline'], item['relativedeadline'],
           item['tabs'], item['feedbackenabled'], item['feedbackquestion']]) + "), clearHideItemList();' />";

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -2774,7 +2774,10 @@ $(document).on('keydown', function(e) {
 			
 		}
 		else if (box[0].classList.contains("settingIconTab")){
-			box[0].click();
+			setTimeout(function(){
+				box[0].click();
+			  },200);
+			
         }
 		else if(box[0].classList.contains("checkboxIconTab")){
 			box[0].click();


### PR DESCRIPTION
Fixed an issue that prevented the edit box from showing up when pressing tab to navigate to the cog wheel and then pressing enter on the selected item. 

There is now also highlighting when pressing enter to save the new changes made whilst editing a section on sectioned.php. 

To test this simply go in to any course(Logged in) and press the cog wheel. Then you need to edit the name. Press enter and watch if the "edited section" is highlighted. 