### PR TITLE
Added a check to make sure that only tables with footers will have the sum/average row

### DIFF
--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -234,6 +234,7 @@ function SortableTable(param)
     this.updateCell = getparam(param.updateCellCallback,null);
 		this.hasMagicHeadings = getparam(param.hasMagicHeadings,false);
     this.hasCounter = getparam(param.hasCounterColumn,false);
+    this.hasFooter = getparam(param.hasFooter, false);
 
 		// Prepare head and order with columns from rowsum list
 		for(let i=0;i<rowsumList.length;i++){
@@ -468,35 +469,36 @@ function SortableTable(param)
       str += "<tfoot class='bottomBorderColor'>";
       str += "<tr class='changeColorInDarkModeTable' style='font-style:italic;'>";
 
-      /* Empty row - Doesn't appear to be used for anything?
-      if(this.hasCounter) {
+      if(this.hasFooter) {
+        if(this.hasCounter) {
           str += "<td>&nbsp;</td>";
           mhvstr += "<td>&nbsp;</td>";
-      }
-      for(var columnOrderIdx=0;columnOrderIdx<columnOrder.length;columnOrderIdx++){
+        }
+        for(var columnOrderIdx=0;columnOrderIdx<columnOrder.length;columnOrderIdx++){
           if (columnfilter[columnOrderIdx] !== null) {
-              if (typeof(sumContent[columnOrder[columnOrderIdx]])!=='undefined') {
-                  if(columnOrder[columnOrderIdx]== 'rank'){
-                    str += "<td style='whitespace:nowrap;'>"+sumContent[columnOrder[columnOrderIdx]].toFixed(2)+"</td>";
-                  }else{
-                    str += "<td style='whitespace:nowrap;'>"+sumContent[columnOrder[columnOrderIdx]]+"</td>";
-                  }
-                  if (columnOrderIdx < freezePaneIndex) {
-                      mhvstr += "<td style='whitespace:nowrap;'>"+sumContent[columnOrder[columnOrderIdx]]+"</td>";                  
-                  }
+            if (typeof(sumContent[columnOrder[columnOrderIdx]])!=='undefined') {
+              if(columnOrder[columnOrderIdx]== 'rank'){
+                str += "<td style='whitespace:nowrap;'>"+sumContent[columnOrder[columnOrderIdx]].toFixed(2)+"</td>";
               }else{
-                if(columnOrder[columnOrderIdx]== 'kind'){
-                    str += "<td>Sum/Average</td>";
-                }else {
-                    str += "<td>&nbsp;</td>";
+                str += "<td style='whitespace:nowrap;'>"+sumContent[columnOrder[columnOrderIdx]]+"</td>";
+              }
+              if (columnOrderIdx < freezePaneIndex) {
+                mhvstr += "<td style='whitespace:nowrap;'>"+sumContent[columnOrder[columnOrderIdx]]+"</td>";                  
+              }
+            }else{
+              if(columnOrder[columnOrderIdx]== 'kind'){
+                str += "<td>Sum/Average</td>";
+              }else {
+                str += "<td>&nbsp;</td>";
                 if (columnOrderIdx < freezePaneIndex) {
-                    mhvstr += "<td>&nbsp;</td>";
-                  }
+                  mhvstr += "<td>&nbsp;</td>";
                 }
-              }          
+              }
+            }          
           }
+        }
       }
-      */
+      
       str+= "</tr></tfoot>";
       mhvstr+= "</tr></tfoot>";
     	str += "</table>";

--- a/Shared/SortableTableLibrary/sortableTable.js
+++ b/Shared/SortableTableLibrary/sortableTable.js
@@ -468,6 +468,7 @@ function SortableTable(param)
       str += "<tfoot class='bottomBorderColor'>";
       str += "<tr class='changeColorInDarkModeTable' style='font-style:italic;'>";
 
+      /* Empty row - Doesn't appear to be used for anything?
       if(this.hasCounter) {
           str += "<td>&nbsp;</td>";
           mhvstr += "<td>&nbsp;</td>";
@@ -495,7 +496,7 @@ function SortableTable(param)
               }          
           }
       }
-
+      */
       str+= "</tr></tfoot>";
       mhvstr+= "</tr></tfoot>";
     	str += "</table>";


### PR DESCRIPTION
The sum/average row was rarely used and often appeared as a blank white row. This is now removed from most tables except those that explicitly set the hasFooter variable to true, such as the result table in contribution. Other tables may need to be updated if they wish to use this feature.

To test:
1. Go to duggaed/resulted/fileed
2. Confirm that the table does not have an empty row on the bottom
3. Go to contribution
4. Confirm that the top-most table (above the weekly bar chart) has a bottom row for average/sum.

Note that the table on the bottom of the contribution page has values summed up on the bottom row, but does not make use of the footer. This was the case before my changes as well and it may need to be updated to be in line with the other tables.