### PR TITLE
Fix windows new lines in the codeviewer #12777

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1482,6 +1482,12 @@ function tokenize(instring, inprefix, insuffix) {
 	currentCharacter = instring.charAt(i);
 	while (currentCharacter) { // currentCharacter == first character in each word
 		from = i;
+		// \r\n is used as a new line character in Windows \r and \n both represent a new line character in Unix and Mac OS
+		if (currentCharacter == '\r' && instring.charAt(i + 1) == '\n') {
+			i++
+			currentCharacter = instring.charAt(i);
+		}
+
 		if (currentCharacter <= ' ') { // White space and carriage return
 			if((currentCharacter=='\n')||(currentCharacter=='\r')||(currentCharacter =='')){
 				maketoken('newline',"",i,i,row);


### PR DESCRIPTION
Windows new line characters (\r\n) in course files are no longer represented as double new lines in the codeviewer (\r and \n).

Testing:
1) Enter Webbprogrammering
2) Open JavaScript Example 1
Before:
![image](https://user-images.githubusercontent.com/102609651/169532608-174b242f-064b-4f5f-bb0c-18ca94cf0731.png)
After:
![image](https://user-images.githubusercontent.com/102609651/169532636-779714e3-8f02-4c41-b845-ab49570ebdca.png)
