### PR TITLE
Added focus() to use tab function when you click and open cogwheel

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -203,6 +203,8 @@ function selectCourse(cid, coursename, coursecode, visi, vers, edvers)
 
 	// Show dialog
 	$("#editCourse").css("display", "flex");
+	// Get focus on the first input to use tab function
+	document.getElementById("coursename").focus();
 
 	//$("#overlay").css("display", "block");
 
@@ -279,6 +281,8 @@ function editSettings(){
 	}
 
 	popupContainer.style.display = "flex";
+	// Get focus on the motd to use tab function
+	document.getElementById("motd").focus();
 }
 
 function updateSettings() {

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -109,7 +109,7 @@ if(isset($_SESSION['uid'])){
     			<input type='hidden' id='cid' value='Toddler' />
     			<div class='inputwrapper'>
 					<span>Course Name:</span>
-					<input oninput="quickValidateForm('editCourse','saveCourse')" class='textinput validate' type='text' id='coursename' name='coursename' placeholder='Course Name' />
+					<input oninput="quickValidateForm('editCourse','saveCourse')"  class='textinput validate' type='text' id='coursename' name='coursename' placeholder='Course Name' />
 				</div>
 				<div class="formDialog" style="display: block; left:50px; top:-10px;"><span id="editcourseCodeError" style="display: none; left:0px;" class="formDialogText">Only letters. Dash allowed in between words</span></div>
 				<p id="dialog4" class="validationDialog">Only letters. Dash allowed in between words</p>

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -109,7 +109,7 @@ if(isset($_SESSION['uid'])){
     			<input type='hidden' id='cid' value='Toddler' />
     			<div class='inputwrapper'>
 					<span>Course Name:</span>
-					<input oninput="quickValidateForm('editCourse','saveCourse')"  class='textinput validate' type='text' id='coursename' name='coursename' placeholder='Course Name' />
+					<input oninput="quickValidateForm('editCourse','saveCourse')" class='textinput validate' type='text' id='coursename' name='coursename' placeholder='Course Name' />
 				</div>
 				<div class="formDialog" style="display: block; left:50px; top:-10px;"><span id="editcourseCodeError" style="display: none; left:0px;" class="formDialogText">Only letters. Dash allowed in between words</span></div>
 				<p id="dialog4" class="validationDialog">Only letters. Dash allowed in between words</p>


### PR DESCRIPTION
How to test:
1. Go to the first page 
2. click on the cogwheel beside the heading 
<img width="409" alt="image" src="https://user-images.githubusercontent.com/81676918/169533735-0f29cfe8-09fd-481e-b0ce-c59108bf8020.png">
3. Tab in the new view 
<img width="527" alt="image" src="https://user-images.githubusercontent.com/81676918/169533831-5a46275a-724d-4e44-8e27-4e085724f350.png">

4. Close the window and click on a cogwheel beside de courses 
<img width="220" alt="image" src="https://user-images.githubusercontent.com/81676918/169534015-449ab425-86ce-4a87-88f4-42707efc6a55.png">
5. Tab in the new view
<img width="551" alt="image" src="https://user-images.githubusercontent.com/81676918/169534080-5b256fa8-d105-4b73-9a72-cd7be29474fb.png">

The issue is solved if you can tab directly when you open the new view
