### PR TITLE
ools/functionalities not visible on smaller screens #12693

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -274,7 +274,20 @@
     border-right: solid black 1px;
     background-color: var(--color-primary);
     z-index: 1000;
+    overflow-y: auto;
+    
 }
+/* Hides the  scrollbar for Chrome, Safari and Opera */
+#diagram-toolbar::-webkit-scrollbar {
+    display: none;
+}
+
+/* Hides the  scrollbar for IE, Edge and Firefox */
+#diagram-toolbar {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+
 #diagram-toolbar>fieldset {
     padding: 2px;
     border-color: var(--color-primary-hover);


### PR DESCRIPTION
You can now scroll the the toolbar with middle mouse, so if you are on a smaller screen you get access to all items.

Test: click on diagram and scroll the toolbar with middle mouse.
