### PR TITLE
Fix relative deadline when there is no course start date

### DIFF
--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -217,7 +217,7 @@ if(checklogin()){
 						$debug="Error reading quiz\n".$error[2];
 				}else{
 						foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-								$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
+								$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
 								$ruery->bindParam(':oldid', $row['id']);
 								$ruery->bindParam(':newvers', $versid);
 								if(!$ruery->execute()) {


### PR DESCRIPTION
This mainly fixes how the deadlines is displayed if there's no course start date.

Instead of trying to display a specific date it will display which day, week or month from the course start date.
So it would say "Course week 3, 15:00" if there's no course week.

I also fixed some of my own code, bugfixes with the datepicker and new functions to display everything needed.
I understand that when creating a new course version there is no way of getting around the validation to create a course without a start date. This is, however, made upon request from the original issue thread and acts as a fail-safe in case. We don't want the page to break if this accidentally happens in the future.

I test this myself by going into demo courses, add a new course and then manually delete the course start date in the database.

Steps for testing:
- First pick a course that contains some duggas
- Change the relative deadline value for some of them (it doesn't matter if absolute deadline is used or not)
- Add new course with the big + button at the top the screen.
- Picking version ID as 12345 and copy from the course that include the dugga with relative deadlines, the rest can be randomly chosen to pass validation
![image](https://user-images.githubusercontent.com/82010032/169752050-05c62e52-b29b-40d9-8f5b-12c4ae575ba0.png)
- Press create and then open up any way of altering the database. If you use XAMPP or similar software then you open the control panel and click on shell or mysql admin page
![image](https://user-images.githubusercontent.com/82010032/169752377-5d76effe-2622-4097-82bc-656043e5a920.png)
- Then you login to the database normally with this command ``mysql -u root -p`` or ``mysql -u root password``
- You should now be able to pass regular SQL queries to the database so first we select the database you named when you ran the install.php page most recently. example: ``use lena_db;`` where "lena_db" you change to the name you picked.
- Now run this to remove the course start date: ``update vers set startdate = null where vers = 12345;``
![image](https://user-images.githubusercontent.com/82010032/169753172-9079df02-8f78-4fa4-8e2b-6e86805ed90f.png)
- If you want to make sure the startdate is null you can now run ``select * from vers where vers = 12345;``
![image](https://user-images.githubusercontent.com/82010032/169753423-5772f8b7-5099-418d-8fa5-5455c42991af.png)
- OR you could go back to the course you created and refresh the page, press the cogwheel at the top of the page and the startdate should now display "yyyy-mm-dd"

After this you should be able to see that the relative deadlines you changed in the first step should now show as "Course day/week/month, X" instead of a date. Note that the empty spaces indicate both relative and absolute deadline being null. This is as intended and should not carry over to next course copy once you've picked a relative deadline for each dugga one time.

![image](https://user-images.githubusercontent.com/82010032/169753881-67616047-7b09-4c25-832d-1baba0c87505.png)

Furthermore, the validation inside the coghweel menu of each dugga should not let you pick a deadline. Instead it should prompt you to use relative deadlines because there is no course start date.

![image](https://user-images.githubusercontent.com/82010032/169754034-7a657b79-5c67-43f8-b4bf-f6aa8b706502.png)
