### PR TITLE
Fixed "open in new tab" error

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1560,10 +1560,8 @@ function returnedSection(data) {
           //Generate new tab link
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-            str += `<div class="newTabCanvasLink" tabIndex="0">`;
-            str += `<img style='width:16px;' alt='canvasLink icon' id='NewTabLink' title='Open link in new tab' class='' 
+            str += `<img style='width:16px;' class="newTabCanvasLink" tabIndex="0" alt='canvasLink icon' id='NewTabLink' title='Open link in new tab' class='' 
             src='../Shared/icons/link-icon.svg' onclick='openCanvasLink(this);'>`;
-            str += `</div>`;
             str += "</td>";
 
           // Generate Canvas Link Button


### PR DESCRIPTION
How to test:
1. Login as superuser
2. Choose demo course
3. Click on this icon
<img width="937" alt="image" src="https://user-images.githubusercontent.com/81676918/169766103-7fbeec49-af5e-47a7-b42e-be9691abff96.png">
4. Does the tab open in another tab? If it works, the issue is resolved. You can also try to tab to the icon and check if it also open in a new tab, it should work in both way