### PR TITLE
Deleted listentries from sectioned will now change the "visibile-attribute" instead of deleting the item. 

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -685,16 +685,17 @@ function deleteItem(item_lid = null) {
    }, 60000);
 }
 
-// Permanently delete elements
-function deleteAll()
+// Permanently delete elements. Update: This function now calls DELETED in sectionserviced.php instead of DEL
+function deleteAll(item)
 {
   for(var i = delArr.length-1; i >= 0; --i){
-    AJAXService("DEL", {
+    AJAXService("DELETED", {
       lid: delArr.pop()
     }, "SECTION");
   }
   $("#editSection").css("display", "none");
   document.querySelector("#undoButton").style.display = "none";
+  item.style.display = "none";
 }
 
 // Cancel deletion
@@ -706,34 +707,6 @@ function cancelDelete() {
   }
   location.reload();
 }
-
-// Set all "deleted" items as hidden
-// Used when refreshing the table
-function hideDeleted()
-{
-  for(var i = 0; i < delArr.length; ++i){
-    document.getElementById("lid" + delArr[i]).style.display = "none";
-  }
-}
-
-//             Work in progress
-//-----------------------------------------//
-function createDeletedItemsFrame(){
-  var iFrame = document.createElement("frame");
-  iFrame.setAttribute("src", "http://google.com/");
-  iFrame.style.width = "500px";
-  iFrame.style.width = "500px";
-  document.body.appendChild(iFrame); 
-}
-
-function getDeletedItems(){
-
-}
-
-function loadDeletedItems(){
-
-}
-//-------------------------------------------//
 
 //----------------------------------------------------------------------------------
 // hideMarkedItems: Hides Item from Section List

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -709,6 +709,12 @@ function cancelDelete() {
 }
 
 //----------------------------------------------------------------------------------
+// getDeletedItems: Used to retrieve deleted list entries
+//----------------------------------------------------------------------------------
+function getDeletedListEntries(){
+ var deletedEntries = document.write('<?php echo getDeletedEntries("DISPLAYDELETED"); ');
+}
+//----------------------------------------------------------------------------------
 // hideMarkedItems: Hides Item from Section List
 //----------------------------------------------------------------------------------
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -716,6 +716,25 @@ function hideDeleted()
   }
 }
 
+//             Work in progress
+//-----------------------------------------//
+function createDeletedItemsFrame(){
+  var iFrame = document.createElement("frame");
+  iFrame.setAttribute("src", "http://google.com/");
+  iFrame.style.width = "500px";
+  iFrame.style.width = "500px";
+  document.body.appendChild(iFrame); 
+}
+
+function getDeletedItems(){
+
+}
+
+function loadDeletedItems(){
+
+}
+//-------------------------------------------//
+
 //----------------------------------------------------------------------------------
 // hideMarkedItems: Hides Item from Section List
 //----------------------------------------------------------------------------------

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -198,27 +198,9 @@ if($gradesys=="UNK") $gradesys=0;
 
 					if(!$query->execute()) {
 						if($query->errorInfo()[0] == 23000) {
-							$debug = "The item could not be deleted because of a foreign key constraint.";
+							$debug = "foreign key constraint.";
 						} else {
-							$debug = "The item could not be deleted.";
-						}
-					}
-				}
-
-				//This will enable fetching every listentry with visibility DELETED and will enable restoring deleted items
-				if(strcmp($opt,"DISPLAYDELETED")===0) {
-					$query = $pdo->prepare("SELECT * FROM listentries WHERE visible = '3'");
-					$query -> execute();
-					$result = $query -> fetchAll();
-					foreach( $result as $row ) {
-    					echo $row["listentries"];
-						}
-
-					if(!$query->execute()) {
-						if($query->errorInfo()[0] == 23000) {
-							$debug = "The item could not be deleted because of a foreign key constraint.";
-						} else {
-							$debug = "The item could not be deleted.";
+							$debug = "Error.";
 						}
 					}
 				}
@@ -939,6 +921,31 @@ if($gradesys=="UNK") $gradesys=0;
 		  "feedbackquestion" => $feedbackquestion,
 		  "avgfeedbackscore" => $avgfeedbackscore
 		);
+
+				function getDeletedEntries($opt){
+					
+					pdoConnect();
+					session_start();
+					//This will enable fetching every listentry with visibility DELETED and will enable restoring deleted items
+				if(strcmp($opt,"DISPLAYDELETED")===0) {
+					$resultArray = array();
+					$query = $pdo->prepare("SELECT * FROM listentries WHERE visible = '3'");
+					$query -> execute();
+					$result = $query -> fetchAll();
+					
+					foreach( $result as $row ) {
+    					$resultArray = array($row);
+						}
+						return $resultArray;
+					if(!$query->execute()) {
+						if($query->errorInfo()[0] == 23000) {
+							$debug = "foreign key constraint.";
+						} else {
+							$debug = "Error.";
+						}
+					}
+				}
+			}
 
 		echo json_encode($array);
 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -190,7 +190,40 @@ if($gradesys=="UNK") $gradesys=0;
 						}
 					}
 
-				} else if(strcmp($opt,"NEW")===0) {
+				}
+				//This will change the visibility of a listentry to deleted instead of deleting the item from the database. This will enable restoring deleted items.
+				if(strcmp($opt,"DELETED")===0) {
+					$query = $pdo->prepare("UPDATE listentries SET visible = '3' WHERE lid=:lid");
+					$query->bindParam(':lid', $sectid);
+
+					if(!$query->execute()) {
+						if($query->errorInfo()[0] == 23000) {
+							$debug = "The item could not be deleted because of a foreign key constraint.";
+						} else {
+							$debug = "The item could not be deleted.";
+						}
+					}
+				}
+
+				//This will enable fetching every listentry with visibility DELETED and will enable restoring deleted items
+				if(strcmp($opt,"DISPLAYDELETED")===0) {
+					$query = $pdo->prepare("SELECT * FROM listentries WHERE visible = '3'");
+					$query -> execute();
+					$result = $query -> fetchAll();
+					foreach( $result as $row ) {
+    					echo $row["listentries"];
+						}
+
+					if(!$query->execute()) {
+						if($query->errorInfo()[0] == 23000) {
+							$debug = "The item could not be deleted because of a foreign key constraint.";
+						} else {
+							$debug = "The item could not be deleted.";
+						}
+					}
+				}
+				
+				else if(strcmp($opt,"NEW")===0) {
 
 					// Insert a new code example and update variables accordingly.
 					if($link==-1) {


### PR DESCRIPTION
Upon deleting listentries from sectioned listentries will now change the attrubute "visible" to 3(deleted) instead of deleting the row from the database. Functions to retrieve rows with visible 3 is created. This is the groundwork  to enable restoration of deleted items from sectioned.php.

**For testing:**
1. Enter webbprogrammering.
2. Delete a example.
3. Check if the "visible"-attribute has changed from 1 to 3 in the database.