### PR TITLE
Relation attributes all types except keys

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9170,11 +9170,11 @@ function checkElementError(element)
                 }
             }
 
-            // Checking for non-normal attributes on relation
-            if (fElement.id == element.id && tElement.kind == "ERRelation" && fElement.state != "normal") {
+            // Checking for key attributes on relation
+            if (fElement.id == element.id && tElement.kind == "ERRelation" && (fElement.state == "primary" || fElement.state == "candidate" || fElement.state == "weakKey")) {
                 errorData.push(element);
             }
-            if (tElement.id == element.id && fElement.kind == "ERRelation" && tElement.state != "normal") {
+            if (tElement.id == element.id && fElement.kind == "ERRelation" && (tElement.state == "primary" || tElement.state == "candidate" || tElement.state == "weakKey")) {
                 errorData.push(element);
             }
 


### PR DESCRIPTION
ER Relation attributes can now have every type except key types. #12804 

Instructions for testing:
1) Click "Demo-Course"
2) Click "Diagram Dugga"
3) Change type of an attribute on a relation (non-keys: correct, keys: error)