### PR TITLE
Lines draw correctly from IE-inheritance #12851

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7823,7 +7823,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'IERelation') {
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element ie-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh/2}px;`;
       
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -7834,16 +7834,16 @@ function drawElement(element, ghosted = false)
         str += `'>`;
       
         //svg for inheritance symbol
-        str += `<svg width='${boxw}' height='${boxh}' style='transform:rotate(180deg);  stroke-width:${linew};'>`;
+        str += `<svg width='${boxw}' height='${boxh}' style='transform:rotate(180deg); margin-top:${-(boxw/2)};  stroke-width:${linew};'>`;
 
         //Overlapping inheritance
         if (element.state == 'overlapping') {
-                str+= `<circle cx="${(boxw/2)}" cy="100;" r="${(boxw/2.08)}" stroke="black";'/> 
+                str+= `<circle cx="${(boxw/2)}" cy="0;" r="${(boxw/2.08)}" stroke="black";'/> 
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />`
         }
         // Disjoint inheritance
         else {
-            str+= `<circle cx="${(boxw/2)}" cy="100;" r="${(boxw/2.08)}" stroke="black";'/>
+            str+= `<circle cx="${(boxw/2)}" cy="0;" r="${(boxw/2.08)}" stroke="black";'/>
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />
                 <line x1="${boxw/1.6}" y1="${boxw/2.9}" x2="${boxw/2.6}" y2="${boxw/12.7}" stroke="black" />
                 <line x1="${boxw/2.6}" y1="${boxw/2.87}" x2="${boxw/1.6}" y2="${boxw/12.7}" stroke="black" />`


### PR DESCRIPTION
- #12851

Lines now draw correctly from IE-inheritance.

How to test:
1. Place an IE-entity on the diagram
2. Place and IE-inheritance on the diagram
3. Draw a line between them, manke sure there isn't any space between the line and entity.
4. The fact that the inheritance turns black when drawing a line between ie-entities will be fixed in another issue.

<img width="240" alt="lines" src="https://user-images.githubusercontent.com/81613484/169804989-2e30a807-bd48-4fec-ad7b-ffd2e1836321.png">

