### PR TITLE
Fixed that inheritance turned black by mistake when using line tool.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8328,12 +8328,12 @@ function drawElement(element, ghosted = false)
 
         //Overlapping inheritance
         if (element.state == 'overlapping') {
-                str+= `<circle cx="${(boxw/2)}" cy="0;" r="${(boxw/2.08)}" stroke="black";'/> 
+                str+= `<circle cx="${(boxw/2)}" cy="0;" r="${(boxw/2.08)}" fill="white"; stroke="black";'/> 
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />`
         }
         // Disjoint inheritance
         else {
-            str+= `<circle cx="${(boxw/2)}" cy="0;" r="${(boxw/2.08)}" stroke="black";'/>
+            str+= `<circle cx="${(boxw/2)}" cy="0;" r="${(boxw/2.08)}" fill="white"; stroke="black";'/>
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />
                 <line x1="${boxw/1.6}" y1="${boxw/2.9}" x2="${boxw/2.6}" y2="${boxw/12.7}" stroke="black" />
                 <line x1="${boxw/2.6}" y1="${boxw/2.87}" x2="${boxw/1.6}" y2="${boxw/12.7}" stroke="black" />`

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7838,12 +7838,12 @@ function drawElement(element, ghosted = false)
 
         //Overlapping inheritance
         if (element.state == 'overlapping') {
-                str+= `<circle cx="${(boxw/2)}" cy="100;" r="${(boxw/2.08)}" stroke="black";'/> 
+                str+= `<circle cx="${(boxw/2)}" cy="100;" r="${(boxw/2.08)}" fill="white"; stroke="black";'/> 
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />`
         }
         // Disjoint inheritance
         else {
-            str+= `<circle cx="${(boxw/2)}" cy="100;" r="${(boxw/2.08)}" stroke="black";'/>
+            str+= `<circle cx="${(boxw/2)}" cy="100;" r="${(boxw/2.08)}" fill="white"; stroke="black";'/>
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />
                 <line x1="${boxw/1.6}" y1="${boxw/2.9}" x2="${boxw/2.6}" y2="${boxw/12.7}" stroke="black" />
                 <line x1="${boxw/2.6}" y1="${boxw/2.87}" x2="${boxw/1.6}" y2="${boxw/12.7}" stroke="black" />`


### PR DESCRIPTION
**What has been done**
- Added white fill on inheritance symbol so that it doesn't turn black when using line tool.

**How to test**
Add two IE inheritance symbols on canvas + two EI entities.
Change one of the IE inheritance symbols to overlapping.
Then make a line between one entity and the inheritance symbol.
Make the test like this: 
![image](https://user-images.githubusercontent.com/81772705/169813690-76340577-b80a-4fab-b62d-e1721c0725b6.png)

Line connection issue solved in other branch. 