### PR TITLE
The disjoint "X" turns white in IE-inheritance when multiple IE-inheritances are selected #12855

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -10689,6 +10689,8 @@ function updateCSSForAllElements()
             var fillColor;
             var fontColor;
             var weakKeyUnderline;
+            var disjointLine1Color;
+            var disjointLine2Color;
             if (data[i].isLocked) useDelta = false;
             updateElementDivCSS(element, elementDiv, useDelta);
             // Edge creation does not highlight selected elements
@@ -10742,17 +10744,29 @@ function updateCSSForAllElements()
                     fillColor = elementDiv.children[0].children[0];
                     fontColor = elementDiv.children[0];
                     weakKeyUnderline = elementDiv.children[0].children[2];
+                    disjointLine1Color = elementDiv.children[0].children[2];
+                    disjointLine2Color = elementDiv.children[0].children[3];
                     // If more than one element is marked.
                     if(inContext && context.length > 1 || inContext && context.length > 0 && contextLine.length > 0){
                         fillColor.style.fill = `${"#927b9e"}`;
                         fontColor.style.fill = `${"#ffffff"}`;
                         if(element.state == "weakKey") {
                             weakKeyUnderline.style.stroke = `${"#ffffff"}`;
+                        } 
+                        else if(element.kind == "IERelation" && element.state != "overlapping") {
+                                disjointLine1Color.style.stroke = `${"#ffffff"}`;
+                                disjointLine2Color.style.stroke = `${"#ffffff"}`;
                         }
                         // If UMLRelation is not marked.
                     } else if(element.kind == "UMLRelation"){
                         if(element.state == "overlapping"){
                             fillColor.style.fill = `${"#000000"}`;
+                        }else{
+                            fillColor.style.fill = `${"#ffffff"}`;
+                        }
+                    } else if(element.kind == "IERelation"){
+                        if(element.state == "overlapping"){
+                            fillColor.style.fill = `${"#ffffff"}`;
                         }else{
                             fillColor.style.fill = `${"#ffffff"}`;
                         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8239,12 +8239,12 @@ function drawElement(element, ghosted = false)
         //svg for inheritance symbol
         str += `<svg width='${boxw}' height='${boxh}'>`;
 
-        //Disjoint inheritance
+        //Overlapping UML-inheritance
         if (element.state == 'overlapping') {
             str += `<polygon points='${linew},${boxh-linew} ${boxw/2},${linew} ${boxw-linew},${boxh-linew}' 
             style='fill:black;stroke:black;stroke-width:${linew};'/>`;
         }
-        //Overlapping inheritance
+        //Disjoint UML-inheritance
         else {
             str += `<polygon points='${linew},${boxh-linew} ${boxw/2},${linew} ${boxw-linew},${boxh-linew}' 
             style='fill:white;stroke:black;stroke-width:${linew};'/>`;
@@ -8326,12 +8326,12 @@ function drawElement(element, ghosted = false)
         //svg for inheritance symbol
         str += `<svg width='${boxw}' height='${boxh}' style='transform:rotate(180deg); margin-top:${-(boxw/2)};  stroke-width:${linew};'>`;
 
-        //Overlapping inheritance
+        // Overlapping IE-inheritance
         if (element.state == 'overlapping') {
                 str+= `<circle cx="${(boxw/2)}" cy="0;" r="${(boxw/2.08)}" stroke="black";'/> 
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />`
         }
-        // Disjoint inheritance
+        // Disjoint IE-inheritance
         else {
             str+= `<circle cx="${(boxw/2)}" cy="0;" r="${(boxw/2.08)}" stroke="black";'/>
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />
@@ -10752,7 +10752,7 @@ function updateCSSForAllElements()
                         fontColor.style.fill = `${"#ffffff"}`;
                         if(element.state == "weakKey") {
                             weakKeyUnderline.style.stroke = `${"#ffffff"}`;
-                        } 
+                        } // Turns the "X" white in disjoint IE-inheritance when multiple IE-inheritances are selected.
                         else if(element.kind == "IERelation" && element.state != "overlapping") {
                                 disjointLine1Color.style.stroke = `${"#ffffff"}`;
                                 disjointLine2Color.style.stroke = `${"#ffffff"}`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -10767,8 +10767,12 @@ function updateCSSForAllElements()
                     } else if(element.kind == "IERelation"){
                         if(element.state == "overlapping"){
                             fillColor.style.fill = `${"#ffffff"}`;
+                            disjointLine1Color.style.stroke = `${"#000000"}`;
+                            disjointLine2Color.style.stroke = `${"#000000"}`;
                         }else{
                             fillColor.style.fill = `${"#ffffff"}`;
+                            disjointLine1Color.style.stroke = `${"#000000"}`;
+                            disjointLine2Color.style.stroke = `${"#000000"}`;
                         }
                     } else{
                         fillColor.style.fill = `${element.fill}`;


### PR DESCRIPTION
- #12855 

How to test:
1. Place two or more disjoint IE-inheritances  (the one with the X in the middle).
2. Select them all
3. Make sure the "X" turns white.

<img width="132" alt="white" src="https://user-images.githubusercontent.com/81613484/169817884-29497923-5937-48f5-b775-e18b010e1b9a.png">

