### PR TITLE
Fixed template dropdown menus and fixed fatal error #9552

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -94,6 +94,7 @@ function fillBurger() {
 
 function returned(data) 
 {
+	allBlocks = [];
 	retData = data;
 	sectionData = JSON.parse(localStorage.getItem("ls-section-data"));
 	// User can choose template if no template has been chosen and the user has write access.
@@ -502,6 +503,8 @@ function initFileDropZones()
 {
 	for(i = 1; i <= retData["box"].length; i++) {
 		dropArea = document.getElementById("box" + i);
+		if (typeof(dropArea) == 'undefined' || dropArea == null)
+			continue;
 
 		['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => 
 			{
@@ -859,6 +862,7 @@ function changeDirectory(kind) {
 		wordlist.disabled = false;
 	} else if ($(kind).val() == "IFRAME") {
 		dir = retData['directory'][2];
+		wordlist.value = null;
 		wordlist.disabled = 'disabled';
 	} else if ($(kind).val() == "DOCUMENT") {
 		dir = retData['directory'][1];
@@ -874,7 +878,7 @@ function changeDirectory(kind) {
 			str += "<option selected='selected' value='" + dir[i].filename.replace(/'/g, '&apos;') + "'>" + dir[i].filename + "</option>";
 		} 
 		else if (dir[i].filename == "---===######===---"){
-			str += "<option disabled hidden value='" + dir[i].filename.replace(/'/g, '&apos;') + "'>" + dir[i].filename + "</option>"
+			str += "<option selected hidden value='" + dir[i].filename.replace(/'/g, '&apos;') + "'>" + dir[i].filename + "</option>"
 		}
 		else {
 			str += "<option value='" + dir[i].filename.replace(/'/g, '&apos;') + "'>" + dir[i].filename + "</option>";
@@ -2443,7 +2447,15 @@ function changetemplate(templateno)
 	}
 	templateOptions.innerHTML = str;
 	for (var i = 0; i < boxes; i++) {
-		changeDirectory(document.querySelector('#boxcontent_' + i));
+		if (i < retData['box'].length) {
+			var select = templateOptions.querySelectorAll(".templateSelect");
+			select[0 + i * 3].value = retData['box'][i][1];
+			changeDirectory(document.querySelector('#boxcontent_' + i));
+			select[1 + i * 3].value = retData['box'][i][5];
+			select[2 + i * 3].value = retData['box'][i][3];
+		} else {
+			changeDirectory(document.querySelector('#boxcontent_' + i));
+		}
 	}
 }
 
@@ -2508,6 +2520,8 @@ function closeEditExample() {
 //----------------------------------------------------------------------------------
 
 function openTemplateWindow() {
+	if (retData != null)
+		changetemplate(String(retData['templateid']));
 	document.getElementById("chooseTemplateContainer").style.display = "flex";
 }
 


### PR DESCRIPTION
The dropdown menus in change template are auto filled with current information from boxes in the example.
When changing template new boxes are created in the database and already existing boxes are updated with new data.

Testing:
1) Login as a teacher account (username: stei password: password)
2) Enter Webbprogrammering
3) Open JavaScript Example 1
4) Click Choose Template
5) The window should display this:
![image](https://user-images.githubusercontent.com/102609651/169823749-23a94722-d23e-4cc8-b31e-eba65b3f2dd5.png)
6) Choose a new template and edit the information to this:
![image](https://user-images.githubusercontent.com/102609651/169824247-dd0a8744-ad3a-4596-a837-500e9a58e787.png)
7) Clicking save should update the code example with the new template and infromation:
![image](https://user-images.githubusercontent.com/102609651/169824496-549ce418-d93f-4230-814e-76ee004447f6.png)
8) Create a new code example in Webbprogrammering
9) Open the new code example, choosing a template and saving should still work.
![image](https://user-images.githubusercontent.com/102609651/169824968-ad369ef4-7946-4909-ab12-0b669188fdca.png)
![image](https://user-images.githubusercontent.com/102609651/169824980-a2c6c9aa-7f18-45f5-b215-f7c3d6cbba4d.png)
