### PR TITLE
Switch to from DELETED to DEL in sectionedservice.php

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -689,7 +689,7 @@ function deleteItem(item_lid = null) {
 function deleteAll(item)
 {
   for(var i = delArr.length-1; i >= 0; --i){
-    AJAXService("DELETED", {
+    AJAXService("DEL", {
       lid: delArr.pop()
     }, "SECTION");
   }


### PR DESCRIPTION
For some reason "DELETED" in sectionservice doesn't work. The code example won't stay hidden. Switched back to "DEL" so the code example permanently is removed from the db instead.

For testing:
Delete a in webbprogrammering.
wait 60 sek
The code example should now be deleted and not appear again.