### PR TITLE
G1 2023 v0 #12957

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6612,7 +6612,7 @@ function setElementColors(clickedCircleID)
                 //element.id.style.color = "#000000";
             }*/
         }
-        console.log("'bout to save I think");
+        console.log("'bout to save I think ", elementIDs);
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(elementIDs, { fill: color }),
         StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     } else if (menu.id == "StrokeColorMenu") {  // If stroke button was pressed

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6602,6 +6602,7 @@ function setElementColors(clickedCircleID)
         var color = colors[index];
         for (var i = 0; i < context.length; i++) {
             context[i].fill = color;
+            elementIDs.push(context[i].id);
             /*
             // Change font color to white for contrast, doesn't work for whatever reason but will maybe provide a hint for someone who might want to try to solve it.
             if (clickedCircleID == "BGColorCircle9" || clickedCircleID == "BGColorCircle6") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6613,7 +6613,6 @@ function setElementColors(clickedCircleID)
                 //element.id.style.color = "#000000";
             }*/
         }
-        console.log("'bout to save I think ", elementIDs);
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(elementIDs, { fill: color }),
         StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     } else if (menu.id == "StrokeColorMenu") {  // If stroke button was pressed

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6151,9 +6151,9 @@ function generateContextProperties()
             str += `<div style="white">Color</div>`;
             str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
                `<span id="BGColorMenu" class="colorMenu"></span></button>`;
-          }
-          str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();generateContextProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
         }
+        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();generateContextProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
+      }
 
       // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.
       if (contextLine.length == 1 && context.length == 0) {
@@ -6612,6 +6612,7 @@ function setElementColors(clickedCircleID)
                 //element.id.style.color = "#000000";
             }*/
         }
+        console.log("'bout to save I think");
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(elementIDs, { fill: color }),
         StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     } else if (menu.id == "StrokeColorMenu") {  // If stroke button was pressed


### PR DESCRIPTION
color-changing events have been added into the undo-redo-structure, a single line was missing for this. Beware this interacts with another bug meaning the first two events performed will be undone as one so when testing perform more than two changes and perform color-changes after those first two as well.