### PR TITLE
Darktheme inputs text color and login form background color

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1082,3 +1082,7 @@ border-left: 14px solid var(--color-sectioned-table-hi);
    -webkit-text-decoration-color: var(--color-text-primary) !important;
     text-decoration-color: var(--color-text-primary) !important;
   }
+  
+  .textinput {
+    color:white;
+    }

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -200,10 +200,10 @@ function resetFields(){
 	$("#showsecurityquestion #answer").val("");
 
   //Changes the background color back to white
-	$("#loginBox #username").css("background-color", "rgb(255, 255, 255)");
-	$("#loginBox #password").css("background-color", "rgb(255, 255, 255)");
-	$("#newpassword #username").css("background-color", "rgb(255, 255, 255)");
-	$("#showsecurityquestion #answer").css("background-color", "rgb(255, 255, 255)");
+	//$("#loginBox #username").css("background-color", "rgb(255, 255, 255)");
+	//$("#loginBox #password").css("background-color", "rgb(255, 255, 255)");
+	//$("#newpassword #username").css("background-color", "rgb(255, 255, 255)");
+	//$("#showsecurityquestion #answer").css("background-color", "rgb(255, 255, 255)");
 
   //Hides error messages
   displayAlertText("#login #message", "");
@@ -1602,8 +1602,8 @@ function showLoginPopup()
 	$("#username").focus();
 
 	// Reset input box color
-	$("input#username").css("background-color", "rgba(255, 255, 255, 1)");
-	$("input#password").css("background-color", "rgba(255, 255, 255, 1)");
+	//$("input#username").css("background-color", "rgba(255, 255, 255, 1)");
+	//$("input#password").css("background-color", "rgba(255, 255, 255, 1)");
 
 	// Reset warning, if applicable
   displayAlertText("#login #message", "");


### PR DESCRIPTION
Solved why the input field text was black on black background. This fix ruined login form because it had inline css background color white so it was white text on white background. Therefore I commented out the inline css in dugga.js

Issue #13014 