### PR TITLE
G1 2023 v1 #13074 Add a button in the menu for placing statediagram states.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -737,7 +737,8 @@ const keybinds = {
         PLACE_UMLENTITY: {key: "6", ctrl: false},       //<-- UML functionality
         EDGE_CREATION: {key: "7", ctrl: false},
         PLACE_IEENTITY: {key: "8", ctrl: false},       //<-- IE functionality
-        IE_INHERITANCE: {key: "9", ctrl: false},  //<-- IE inheritance functionality
+        IE_INHERITANCE: { key: "9", ctrl: false },  //<-- IE inheritance functionality
+        PLACE_SDENTITY: { key: "1", ctrl: true },   //<-- SD functionality
         ZOOM_IN: {key: "+", ctrl: true, meta: true},
         ZOOM_OUT: {key: "-", ctrl: true, meta: true},
         ZOOM_RESET: {key: "0", ctrl: true, meta: true},
@@ -1833,6 +1834,14 @@ document.addEventListener('keyup', function (e)
         //Temp for IE entity
         if(isKeybindValid(e, keybinds.PLACE_IEENTITY)) {
             setElementPlacementType(elementTypes.IEEntity)
+            setMouseMode(mouseMode.PLACING_ELEMENT);
+        }
+        //======================================================
+
+        //=================================================== //<-- SD functionality
+        //Temp for SD entity
+        if (isKeybindValid(e, keybinds.PLACE_SDENTITY)) {
+            setElementPlacementType(elementTypes.SDEntity)
             setMouseMode(mouseMode.PLACING_ELEMENT);
         }
         //======================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1032,7 +1032,7 @@ var movingObject = false;
 var movingContainer = false;
 
 //setting the base values for the allowed diagramtypes
-var diagramType = {ER:false,UML:false,IE:false};
+var diagramType = {ER:false,UML:false,IE:false,SD:false};
 
 //Grid Settings
 var settings = {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1348,8 +1348,41 @@ function getData()
  * @description Used to determine the tools shown depending on diagram type.
  */
 function showDiagramTypes(){
+    //ER + UML + IE + SD
+    if (!!diagramType.ER && !!diagramType.UML && !!diagramType.IE && !!diagramType.SD) {
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");// UML Entity/CLass
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");// UML Inheritance
+        document.getElementById("elementPlacement6").classList.add("hiddenPlacementType");// IE Entity/CLass
+        document.getElementById("elementPlacement7").classList.add("hiddenPlacementType");// IE Inheritance
+        document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD Entity/State
+        document.getElementById("elementPlacement0").onmousedown = function () {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement4").onmousedown = function () {
+            holdPlacementButtonDown(4);
+        };
+        document.getElementById("elementPlacement6").onmousedown = function () {
+            holdPlacementButtonDown(6);
+        };
+        document.getElementById("elementPlacement8").onmousedown = function () {
+            holdPlacementButtonDown(8);
+        };
+        document.getElementById("elementPlacement1").onmousedown = function () {
+            holdPlacementButtonDown(1);
+        };
+        document.getElementById("elementPlacement5").onmousedown = function () {
+            holdPlacementButtonDown(5);
+        };
+        document.getElementById("elementPlacement7").onmousedown = function () {
+            holdPlacementButtonDown(7);
+        };
+    }
+
     //ER + UML + IE
-    if(!!diagramType.ER && !!diagramType.UML && !!diagramType.IE){
+    else if (!!diagramType.ER && !!diagramType.UML && !!diagramType.IE && !diagramType.SD) {
+        Array.from(document.getElementsByClassName("SDButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");// UML Entity/CLass
         document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");// UML Inheritance
         document.getElementById("elementPlacement6").classList.add("hiddenPlacementType");// IE Entity/CLass
@@ -1373,9 +1406,88 @@ function showDiagramTypes(){
             holdPlacementButtonDown(7);
         };
     }
-    // ER + UML
-    else if(!!diagramType.ER && !!diagramType.UML && !diagramType.IE){
+
+    //ER + UML + SD
+    else if (!!diagramType.ER && !!diagramType.UML && !diagramType.IE && !!diagramType.SD) {
         Array.from(document.getElementsByClassName("IEButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");// UML Entity/CLass
+        document.getElementById("elementPlacement5").classList.add("hiddenPlacementType");// UML Inheritance
+        document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD Entity/State
+        document.getElementById("elementPlacement0").onmousedown = function () {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement4").onmousedown = function () {
+            holdPlacementButtonDown(4);
+        };
+        document.getElementById("elementPlacement8").onmousedown = function () {
+            holdPlacementButtonDown(8);
+        };
+        document.getElementById("elementPlacement1").onmousedown = function () {
+            holdPlacementButtonDown(1);
+        };
+        document.getElementById("elementPlacement5").onmousedown = function () {
+            holdPlacementButtonDown(5);
+        };
+    }
+
+    //ER + IE + SD
+    else if (!!diagramType.ER && !diagramType.UML && !!diagramType.IE && !!diagramType.SD) {
+        Array.from(document.getElementsByClassName("UMLButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        document.getElementById("elementPlacement6").classList.add("hiddenPlacementType");// IE Entity/CLass
+        document.getElementById("elementPlacement7").classList.add("hiddenPlacementType");// IE Inheritance
+        document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD Entity/State
+        document.getElementById("elementPlacement0").onmousedown = function () {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement6").onmousedown = function () {
+            holdPlacementButtonDown(6);
+        };
+        document.getElementById("elementPlacement8").onmousedown = function () {
+            holdPlacementButtonDown(8);
+        };
+        document.getElementById("elementPlacement1").onmousedown = function () {
+            holdPlacementButtonDown(1);
+        };
+        document.getElementById("elementPlacement7").onmousedown = function () {
+            holdPlacementButtonDown(7);
+        };
+    }
+
+    //UML + IE + SD
+    else if (!diagramType.ER && !!diagramType.UML && !!diagramType.IE && !!diagramType.SD) {
+        Array.from(document.getElementsByClassName("ERButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        document.getElementById("elementPlacement6").classList.add("hiddenPlacementType");// IE Entity/CLass
+        document.getElementById("elementPlacement7").classList.add("hiddenPlacementType");// IE Inheritance
+        document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD Entity/State
+        document.getElementById("elementPlacement0").onmousedown = function () {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement4").onmousedown = function () {
+            holdPlacementButtonDown(4);
+        };
+        document.getElementById("elementPlacement8").onmousedown = function () {
+            holdPlacementButtonDown(8);
+        };
+        document.getElementById("elementPlacement1").onmousedown = function () {
+            holdPlacementButtonDown(1);
+        };
+        document.getElementById("elementPlacement5").onmousedown = function () {
+            holdPlacementButtonDown(5);
+        };
+    }
+    // ER+SD, UML+SD, IE+SD
+    // ER + UML
+    else if (!!diagramType.ER && !!diagramType.UML && !diagramType.IE && !diagramType.SD) {
+        Array.from(document.getElementsByClassName("IEButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        Array.from(document.getElementsByClassName("SDButton")).forEach(button => {
             button.classList.add("hiddenPlacementType");
         });
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");// UML Entity/CLass
@@ -1394,8 +1506,11 @@ function showDiagramTypes(){
         };
     }
     // ER + IE
-    else if(!!diagramType.ER && !diagramType.UML && !!diagramType.IE){
+    else if (!!diagramType.ER && !diagramType.UML && !!diagramType.IE && !diagramType.SD){
         Array.from(document.getElementsByClassName("UMLButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        Array.from(document.getElementsByClassName("SDButton")).forEach(button => {
             button.classList.add("hiddenPlacementType");
         });
         document.getElementById("elementPlacement6").classList.add("hiddenPlacementType");// IE Entity/CLass
@@ -1413,9 +1528,31 @@ function showDiagramTypes(){
             holdPlacementButtonDown(7);
         };
     }
+    // ER + SD
+    else if (!!diagramType.ER && !diagramType.UML && !diagramType.IE && !!diagramType.SD) {
+        Array.from(document.getElementsByClassName("IEButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        Array.from(document.getElementsByClassName("UMLButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD Entity/CLass
+        document.getElementById("elementPlacement0").onmousedown = function () {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement8").onmousedown = function () {
+            holdPlacementButtonDown(6);
+        };
+        document.getElementById("elementPlacement1").onmousedown = function () {
+            holdPlacementButtonDown(1);
+        };
+    }
     // UML + IE
-    else if(!diagramType.ER && !!diagramType.UML && !!diagramType.IE){
+    else if (!diagramType.ER && !!diagramType.UML && !!diagramType.IE && !diagramType.SD){
         Array.from(document.getElementsByClassName("ERButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        Array.from(document.getElementsByClassName("SDButton")).forEach(button => {
             button.classList.add("hiddenPlacementType");
         });
         document.getElementById("elementPlacement6").classList.add("hiddenPlacementType");// IE Entity/CLass
@@ -1431,6 +1568,44 @@ function showDiagramTypes(){
         };
         document.getElementById("elementPlacement7").onmousedown = function() {
             holdPlacementButtonDown(7);
+        };
+    }
+    // UML + SD
+    else if (!diagramType.ER && !!diagramType.UML && !diagramType.IE && !!diagramType.SD) {
+        Array.from(document.getElementsByClassName("ERButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        Array.from(document.getElementsByClassName("IEButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD Entity/CLass
+        document.getElementById("elementPlacement4").onmousedown = function () {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement8").onmousedown = function () {
+            holdPlacementButtonDown(6);
+        };
+        document.getElementById("elementPlacement5").onmousedown = function () {
+            holdPlacementButtonDown(1);
+        };
+    }
+    // IE + SD
+    else if (!diagramType.ER && !!diagramType.UML && !diagramType.IE && !!diagramType.SD) {
+        Array.from(document.getElementsByClassName("ERButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        Array.from(document.getElementsByClassName("UMLButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD Entity/CLass
+        document.getElementById("elementPlacement6").onmousedown = function () {
+            holdPlacementButtonDown(0);
+        };
+        document.getElementById("elementPlacement8").onmousedown = function () {
+            holdPlacementButtonDown(6);
+        };
+        document.getElementById("elementPlacement7").onmousedown = function () {
+            holdPlacementButtonDown(1);
         };
     }
     //ER
@@ -1457,6 +1632,17 @@ function showDiagramTypes(){
     }
     //IE
     else if (!diagramType.ER && !diagramType.UML && !!diagramType.IE){
+        Array.from(document.getElementsByClassName("ERButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        Array.from(document.getElementsByClassName("UMLButton")).forEach(button => {
+            button.classList.add("hiddenPlacementType");
+        });
+        document.getElementById("togglePlacementTypeButton6").classList.add("hiddenPlacementType");// IE Entity/CLass
+        document.getElementById("togglePlacementTypeButton7").classList.add("hiddenPlacementType");// IE Inheritance
+    }
+    //SD
+    else if (!diagramType.ER && !diagramType.UML && !diagramType.IE && !!diagramType.SD) {
         Array.from(document.getElementsByClassName("ERButton")).forEach(button => {
             button.classList.add("hiddenPlacementType");
         });

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -784,6 +784,7 @@ const elementTypes = {
     UMLRelation: 5, //<-- UML functionality
     IEEntity: 6,       //<-- IE functionality
     IERelation: 7, // IE inheritance functionality
+    SDState: 8,     //SD(State diagram) functionality
 };
 
 /**
@@ -797,7 +798,8 @@ const elementTypesNames = {
     Ghost: "Ghost",
     UMLEntity: "UMLEntity",
     IEEntity: "IEEntity",
-    IERelation: "IERelation"
+    IERelation: "IERelation",
+    SDState: "SDState"
 }
 
 /**
@@ -836,12 +838,13 @@ const attrState = {
 };
 
 /**
- * @description Available types of entity, ie ER, IE, UML This affect how the entity is drawn and which menu is displayed   //<-- UML functionality
+ * @description Available types of entity, ie ER, IE, UML and SD(state diagram) This affect how the entity is drawn and which menu is displayed   //<-- UML functionality
  */
 const entityType = {
     UML: "UML",
     ER: "ER",
     IE: "IE",
+    SD: "SD",
 };
 /**
  * @description Available types of the entity element. This will alter how the entity is drawn onto the screen.

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -332,7 +332,51 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
+                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                            <img src="../Shared/icons/diagram_IE_entity.svg"/>
+                            <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
+                                <p>Change to statediagram state</p>
+                            </span>
+                        </div>
                     </div>
+                </div><!--<-- UML functionality end -->
+                <div>
+                    <div id="elementPlacement6" class="StateButton diagramIcons toolbarMode" onclick='setElementPlacementType(6); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                        <img src="../Shared/icons/diagram_IE_entity.svg"/>
+                        <span class="toolTipText"><b>Statediagram state</b><br>
+                            <p>Add statediagram state to the diagram</p><br>
+                            <p id="tooltip-PLACE_IEENTITY" class="key_tooltip">Keybinding:</p>
+                        </span>
+                        <div id="togglePlacementTypeButton6" class="placementTypeIcon togglePlacementTypeButton">
+                            <img src="../Shared/icons/diagram_toolbar_arrow.svg"/>
+                        </div>
+                    </div>
+                    <div id="togglePlacementTypeBox6" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
+                        <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
+                            <img src="../Shared/icons/diagram_entity.svg"/>
+                            <span class="placementTypeToolTipText"><b>ER entity</b><br>
+                                <p>Change to ER entity</p>
+                            </span>
+                        </div>
+                        <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' >
+                            <img src="../Shared/icons/diagram_UML_entity.svg"/>
+                            <span class="placementTypeToolTipText"><b>UML class</b><br>
+                                <p>Change to UML class</p>
+                            </span>
+                        </div>
+                        <div class="IEButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' >
+                            <img src="../Shared/icons/diagram_IE_entity.svg"/>
+                            <span class="placementTypeToolTipText"><b>IE entity</b><br>
+                                <p>Change to IE entity</p>
+                            </span>
+                        </div>
+                    </div>
+                    <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                            <img src="../Shared/icons/diagram_IE_entity.svg"/>
+                            <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
+                                <p>Change to statediagram state</p>
+                            </span>
+                        </div>
                 </div><!--<-- UML functionality end -->
                 <div>
                     <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'> <!--<-- UML functionality -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -341,17 +341,17 @@
                     </div>
                 </div><!--<-- UML functionality end -->
                 <div>
-                    <div id="elementPlacement6" class="StateButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement8" class="StateButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_IE_entity.svg"/>
                         <span class="toolTipText"><b>Statediagram state</b><br>
                             <p>Add state diagram state to the diagram</p><br>
                             <p id="tooltip-PLACE_IEENTITY" class="key_tooltip">Keybinding:</p>
                         </span>
-                        <div id="togglePlacementTypeButton6" class="placementTypeIcon togglePlacementTypeButton">
+                        <div id="togglePlacementTypeButton8" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg"/>
                         </div>
                     </div>
-                    <div id="togglePlacementTypeBox6" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
+                    <div id="togglePlacementTypeBox8" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                         <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                             <img src="../Shared/icons/diagram_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>ER entity</b><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -370,13 +370,13 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                    </div>
-                    <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
                                 <p>Change to statediagram state</p>
                             </span>
-                        </div>
+                    </div>
+                    </div>
                 </div><!--<-- UML functionality end -->
                 <div>
                     <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'> <!--<-- UML functionality -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -258,8 +258,8 @@
                         </div>
                         <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
-                            <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
-                                <p>Change to statediagram state</p>
+                            <span class="placementTypeToolTipText"><b>State diagram state</b><br>
+                                <p>Change to state diagram state</p>
                             </span>
                         </div>
                     </div>
@@ -296,8 +296,8 @@
                         </div>
                         <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
-                            <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
-                                <p>Change to statediagram state</p>
+                            <span class="placementTypeToolTipText"><b>State diagram state</b><br>
+                                <p>Change to state diagram state</p>
                             </span>
                         </div>
                     </div>
@@ -334,8 +334,8 @@
                         </div>
                         <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
-                            <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
-                                <p>Change to statediagram state</p>
+                            <span class="placementTypeToolTipText"><b>State diagram state</b><br>
+                                <p>Change to state diagram state</p>
                             </span>
                         </div>
                     </div>
@@ -344,7 +344,7 @@
                     <div id="elementPlacement6" class="StateButton diagramIcons toolbarMode" onclick='setElementPlacementType(6); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_IE_entity.svg"/>
                         <span class="toolTipText"><b>Statediagram state</b><br>
-                            <p>Add statediagram state to the diagram</p><br>
+                            <p>Add state diagram state to the diagram</p><br>
                             <p id="tooltip-PLACE_IEENTITY" class="key_tooltip">Keybinding:</p>
                         </span>
                         <div id="togglePlacementTypeButton6" class="placementTypeIcon togglePlacementTypeButton">
@@ -373,7 +373,7 @@
                         <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
-                                <p>Change to statediagram state</p>
+                                <p>Change to state diagram state</p>
                             </span>
                     </div>
                     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -377,7 +377,7 @@
                             </span>
                     </div>
                     </div>
-                </div><!--<-- UML functionality end -->
+                </div><!--<-- Statediagram functionality end -->
                 <div>
                     <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"/>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -256,6 +256,12 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
+                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                            <img src="../Shared/icons/diagram_IE_entity.svg"/>
+                            <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
+                                <p>Change to statediagram state</p>
+                            </span>
+                        </div>
                     </div>
                 </div>
                 <div>
@@ -286,6 +292,12 @@
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                 <p>Change to IE entity</p>
+                            </span>
+                        </div>
+                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                            <img src="../Shared/icons/diagram_IE_entity.svg"/>
+                            <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
+                                <p>Change to statediagram state</p>
                             </span>
                         </div>
                     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -256,7 +256,7 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                 <p>Change to state diagram state</p>
@@ -294,7 +294,7 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                 <p>Change to state diagram state</p>
@@ -332,7 +332,7 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                 <p>Change to state diagram state</p>
@@ -341,7 +341,7 @@
                     </div>
                 </div><!--<-- UML functionality end -->
                 <div>
-                    <div id="elementPlacement8" class="StateButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement8" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_IE_entity.svg"/>
                         <span class="toolTipText"><b>Statediagram state</b><br>
                             <p>Add state diagram state to the diagram</p><br>
@@ -370,7 +370,7 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
                                 <p>Change to state diagram state</p>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -256,7 +256,7 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                 <p>Change to state diagram state</p>
@@ -294,7 +294,7 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                 <p>Change to state diagram state</p>
@@ -332,7 +332,7 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                 <p>Change to state diagram state</p>
@@ -341,7 +341,7 @@
                     </div>
                 </div><!--<-- UML functionality end -->
                 <div>
-                    <div id="elementPlacement6" class="StateButton diagramIcons toolbarMode" onclick='setElementPlacementType(6); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <div id="elementPlacement6" class="StateButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_IE_entity.svg"/>
                         <span class="toolTipText"><b>Statediagram state</b><br>
                             <p>Add state diagram state to the diagram</p><br>
@@ -370,7 +370,7 @@
                                 <p>Change to IE entity</p>
                             </span>
                         </div>
-                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                        <div class="StateButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
                             <img src="../Shared/icons/diagram_IE_entity.svg"/>
                             <span class="placementTypeToolTipText"><b>Statediagram state</b><br>
                                 <p>Change to state diagram state</p>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -343,7 +343,7 @@
                 <div>
                     <div id="elementPlacement8" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
                         <img src="../Shared/icons/diagram_IE_entity.svg"/>
-                        <span class="toolTipText"><b>Statediagram state</b><br>
+                        <span class="toolTipText"><b>State diagram state</b><br>
                             <p>Add state diagram state to the diagram</p><br>
                             <p id="tooltip-PLACE_IEENTITY" class="key_tooltip">Keybinding:</p>
                         </span>
@@ -377,7 +377,7 @@
                             </span>
                     </div>
                     </div>
-                </div><!--<-- Statediagram functionality end -->
+                </div><!--<-- State diagram functionality end -->
                 <div>
                     <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"/>


### PR DESCRIPTION
The button is now there, however it's sometimes there when it would usually be hidden by the system. Selecting it also in some cases doesn't allow you to swap back due to a bug. However all these things are caused by the backend not being implemented yet. Also the icon for a statediagram state is at this point the same as for IE-entity