### PR TITLE
Fixed so you can add picture into the markdown file.

### DIFF
--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -382,7 +382,7 @@ function markdownBlock(inString)
     inString = inString.replace(/\-{3,}/g, '<hr>');
 
     // External img src !!!
-    // |||src,thumbnail width in px,full size width in px|||
+    // %%%src,thumbnail width in px,full size width in px%%%
     // Markdown image zoom rollover: All images are normally shown as a thumbnail but when rollover original image size will appear
     inString = inString.replace(/\%{3}(.*?\S),(.*?\S),(.*?\S)\%{3}$/g, '<img class="imgzoom" src="$1" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
     inString = inString.replace(/\%{3}(.*?\S)\%{3}$/g, '<img class="imgzoom" src="{$1}" /><br>');

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -382,12 +382,13 @@ function markdownBlock(inString)
     inString = inString.replace(/\-{3,}/g, '<hr>');
 
     // External img src !!!
-    // %%%src,thumbnail width in px,full size width in px%%%
     // Markdown image zoom rollover: All images are normally shown as a thumbnail but when rollover original image size will appear
-    inString = inString.replace(/\%{3}(.*?\S),(.*?\S),(.*?\S)\%{3}$/g, '<img class="imgzoom" src="$1" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
-    inString = inString.replace(/\%{3}(.*?\S)\%{3}$/g, '<img class="imgzoom" src="{$1}" /><br>');
-    inString = inString.replace(/\%{3}(.*?\S),(.*?\S),(.*?\S)\%{3}/g, '<img class="imgzoom" src="{$1}" onmouseover="originalImg(this, $2)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
-    inString = inString.replace(/\%{3}(.*?\S)\%{3}/g, '<img class="imgzoom" src="{$1}" />');
+    //OLD img tag: '<img class="imgzoom" src="$2" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
+    //This regex is the same as github when you upload image. The upload is now ![alt-text](IMGURL) and alt-text can be empty
+    inString = inString.replace(/\!\[(.*?)\]\((.*?\S)\)/g, '<img class="imgzoom" src="$2" /><br>');
+    //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$2}" /><br>');
+    //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" onmouseover="originalImg(this, $2)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
+    //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" />');
 
     // Hyperlink !!!
     // !!!url,text to show!!!
@@ -591,7 +592,7 @@ function setCarotPosition(){
 }
 function externalImg(){
     this.setCarotPosition();
-    var finText = txtarea.value.substring(0,start) + '%%%' + 'img here, thumbnail in width px here,  full width here' + sel + '%%%' + txtarea.value.substring(end);
+    var finText = txtarea.value.substring(0,start) + '![Alt-text]' + '(IMG URL' + sel + ')' + txtarea.value.substring(end);
     txtarea.value = finText;
     txtarea.focus();
     txtarea.selectionEnd = end +11;

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -384,9 +384,9 @@ function markdownBlock(inString)
     // External img src !!!
     // Markdown image zoom rollover: All images are normally shown as a thumbnail but when rollover original image size will appear
     inString = inString.replace(/\|{3}(.*?\S),(.*?\S),(.*?\S)\|{3}$/g, '<img class="imgzoom" src="$1" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
-    inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$2}" /><br>');
-    inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" onmouseover="originalImg(this, $2)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
-    inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" />');
+    inString = inString.replace(/\|{3}(.*?\S),(.*?\S),(.*?\S)\|{3}$/g, '<img class="imgzoom" src="{$2}" /><br>');
+    inString = inString.replace(/\|{3}(.*?\S),(.*?\S),(.*?\S)\|{3}$/g, '<img class="imgzoom" src="{$1}" onmouseover="originalImg(this, $2)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
+    inString = inString.replace(/\|{3}(.*?\S),(.*?\S),(.*?\S)\|{3}$/g, '<img class="imgzoom" src="{$1}" />');
 
     // EXTERNAL img src AS GITHUB !!!
     //This regex is the same as github when you upload image. The upload is now ![alt-text](IMGURL) and alt-text can be empty

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -385,7 +385,7 @@ function markdownBlock(inString)
     // Markdown image zoom rollover: All images are normally shown as a thumbnail but when rollover original image size will appear
     //OLD img tag: '<img class="imgzoom" src="$2" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
     //This regex is the same as github when you upload image. The upload is now ![alt-text](IMGURL) and alt-text can be empty
-    inString = inString.replace(/\!\[(.*?)\]\((.*?\S)\)/g, '<img class="imgzoom" src="$2" /><br>');
+    inString = inString.replace(/\!\[(.*?)\]\((.*?\S)\)/g, '<img class="imgzoom" alt="$1" src="$2" /><br>');
     //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$2}" /><br>');
     //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" onmouseover="originalImg(this, $2)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
     //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" />');

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -384,10 +384,10 @@ function markdownBlock(inString)
     // External img src !!!
     // |||src,thumbnail width in px,full size width in px|||
     // Markdown image zoom rollover: All images are normally shown as a thumbnail but when rollover original image size will appear
-    inString = inString.replace(/\|{3}(.*?\S),(.*?\S),(.*?\S)\|{3}$/g, '<img class="imgzoom" src="$1" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
-    inString = inString.replace(/\|{3}(.*?\S)\|{3}$/g, '<img class="imgzoom" src="$1" /><br>');
-    inString = inString.replace(/\|{3}(.*?\S),(.*?\S),(.*?\S)\|{3}/g, '<img class="imgzoom" src="$1" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
-    inString = inString.replace(/\|{3}(.*?\S)\|{3}/g, '<img class="imgzoom" src="$1" />');
+    inString = inString.replace(/\%{3}(.*?\S),(.*?\S),(.*?\S)\%{3}$/g, '<img class="imgzoom" src="$1" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
+    inString = inString.replace(/\%{3}(.*?\S)\%{3}$/g, '<img class="imgzoom" src="{$1}" /><br>');
+    inString = inString.replace(/\%{3}(.*?\S),(.*?\S),(.*?\S)\%{3}/g, '<img class="imgzoom" src="{$1}" onmouseover="originalImg(this, $2)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
+    inString = inString.replace(/\%{3}(.*?\S)\%{3}/g, '<img class="imgzoom" src="{$1}" />');
 
     // Hyperlink !!!
     // !!!url,text to show!!!
@@ -591,7 +591,7 @@ function setCarotPosition(){
 }
 function externalImg(){
     this.setCarotPosition();
-    var finText = txtarea.value.substring(0,start) + '|||' + 'img here, thumbnail in width px here,  full width here' + sel + '|||' + txtarea.value.substring(end);
+    var finText = txtarea.value.substring(0,start) + '%%%' + 'img here, thumbnail in width px here,  full width here' + sel + '%%%' + txtarea.value.substring(end);
     txtarea.value = finText;
     txtarea.focus();
     txtarea.selectionEnd = end +11;

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -383,13 +383,15 @@ function markdownBlock(inString)
 
     // External img src !!!
     // Markdown image zoom rollover: All images are normally shown as a thumbnail but when rollover original image size will appear
-    //OLD img tag: '<img class="imgzoom" src="$2" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
+    inString = inString.replace(/\|{3}(.*?\S),(.*?\S),(.*?\S)\|{3}$/g, '<img class="imgzoom" src="$1" onmouseover="originalImg(this, $3)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" /><br>');
+    inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$2}" /><br>');
+    inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" onmouseover="originalImg(this, $2)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
+    inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" />');
+
+    // EXTERNAL img src AS GITHUB !!!
     //This regex is the same as github when you upload image. The upload is now ![alt-text](IMGURL) and alt-text can be empty
     inString = inString.replace(/\!\[(.*?)\]\((.*?\S)\)/g, '<img class="imgzoom" alt="$1" src="$2" /><br>');
-    //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$2}" /><br>');
-    //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" onmouseover="originalImg(this, $2)" onmouseout="thumbnailImg(this, $2)" width="$2px" style="border: 3px solid #614875;" />');
-    //inString = inString.replace(/\!\[(.*?\S)\]\((.*?\S)\)/g, '<img class="imgzoom" src="{$1}" />');
-
+    
     // Hyperlink !!!
     // !!!url,text to show!!!
     inString = inString.replace(/\!{3}(.*?\S),(.*?\S)\!{3}/g, '<a href="$1" target="_blank">$2</a>');


### PR DESCRIPTION
You can now add an image to a md file with %%% image url, thumbnail size, full size %%%.

Can test it on my server version: https://cms.webug.se/root/G3/students/b21leowa/LenaSYS/DuggaSys/courseed.php

<img width="818" alt="image" src="https://user-images.githubusercontent.com/102594255/230323360-7e127827-fdbc-4a12-a1bc-ea4248c608d6.png">


This pull request will also fix issue  #13082.