### PR TITLE
Add darkmode switch to diagram.php in right sidemenu. Issue#13067

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3967,11 +3967,11 @@ function toggleDarkmode()
 	if(storedTheme) stylesheet.href = storedTheme;
 	
     if(stylesheet.href.includes('blackTheme')){
-        // if it's light -> go dark
+        // if it's dark -> go light
         stylesheet.href = "../Shared/css/style.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
     } else if(stylesheet.href.includes('style')) {
-        // if it's dark -> go light
+        // if it's light -> go dark
         stylesheet.href = "../Shared/css/blackTheme.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -745,6 +745,7 @@ const keybinds = {
         TOGGLE_GRID: {key: "g", ctrl: false},
         TOGGLE_RULER: {key: "t", ctrl: false},
         TOGGLE_SNAPGRID: {key: "s", ctrl: false},
+        TOGGLE_DARKMODE: {key: "d", ctrl: false},
         CENTER_CAMERA: {key:"home", ctrl: false},
         OPTIONS: {key: "o", ctrl: false},
         ENTER: {key: "enter", ctrl: false},
@@ -1652,6 +1653,7 @@ document.addEventListener('keyup', function (e)
         if(isKeybindValid(e, keybinds.TOGGLE_GRID)) toggleGrid();
         if(isKeybindValid(e, keybinds.TOGGLE_RULER)) toggleRuler();
         if(isKeybindValid(e, keybinds.TOGGLE_SNAPGRID)) toggleSnapToGrid();
+        if(isKeybindValid(e, keybinds.TOGGLE_DARKMODE)) toggleDarkmode();
         if(isKeybindValid(e, keybinds.OPTIONS)) toggleOptionsPane();
         if(isKeybindValid(e, keybinds.PASTE)) pasteClipboard(JSON.parse(localStorage.getItem('copiedElements') || "[]"), JSON.parse(localStorage.getItem('copiedLines') || "[]"));
         if(isKeybindValid(e, keybinds.CENTER_CAMERA)) centerCamera();
@@ -3953,6 +3955,37 @@ function toggleGrid()
         gridButton.style.backgroundColor ="#362049";
    }
 }
+
+/**
+ * @description Toggles the darkmode for svgbacklayer ON/OFF.
+ */
+function toggleDarkmode()
+{
+    const stylesheet = document.getElementById("themeBlack");
+    const storedTheme = localStorage.getItem('diagramTheme');
+
+	if(storedTheme) stylesheet.href = storedTheme;
+	
+    if(stylesheet.href.includes('blackTheme')){
+        // if it's light -> go dark
+        stylesheet.href = "../Shared/css/style.css";
+        localStorage.setItem('diagramTheme',stylesheet.href)
+    } else if(stylesheet.href.includes('style')) {
+        // if it's dark -> go light
+        stylesheet.href = "../Shared/css/blackTheme.css";
+        localStorage.setItem('diagramTheme',stylesheet.href)
+    }
+}
+
+/**
+ * @description When diagram page is loaded, check if preferred theme is stored in local storage.
+ */
+document.addEventListener("DOMContentLoaded", () => {
+    const stylesheet = document.getElementById("themeBlack");
+    if (!localStorage.getItem("diagramTheme")) return;
+
+    stylesheet.href = localStorage.getItem("diagramTheme");
+})
 
 /**
  * @description Toggles the replay-mode, shows replay-panel, hides unused elements

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -549,7 +549,7 @@
     
     <!-- Diagram grid -->
     <div id="svggrid" style="z-index:-11">
-        <svg id="svgbacklayer">
+        <svg id="svgbacklayer" class="svgbacklayer-background">
             <defs>
             <pattern id="grid" width="100" height="100" patternUnits="userSpaceOnUse">
 
@@ -586,7 +586,7 @@
                 <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
                 <button id="rulerToggle" class="saveButton" style="background-color:#362049;" onclick="toggleRuler()">Ruler</button><br><br>
                 <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">A4 template</button><br><br>
-                <button id="darkmodeToggle" class="saveButton" onclick="darkmodeToggle()">Darkmode</button><br><br>
+                <button id="darkmodeToggle" class="saveButton" onclick="toggleDarkmode()">Darkmode</button><br><br>
                 <div id="a4Options" style="display:flex;">
                     <button id="a4VerticalButton" style="display:none; width:76px; margin-right:45%;" onclick="toggleA4Vertical()">Vertical</button>
                     <button id="a4HorizontalButton" style="display:none;" onclick="toggleA4Horizontal()">Horizontal</button>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -586,12 +586,13 @@
                 <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
                 <button id="rulerToggle" class="saveButton" style="background-color:#362049;" onclick="toggleRuler()">Ruler</button><br><br>
                 <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">A4 template</button><br><br>
+                <button id="darkmodeToggle" class="saveButton" onclick="darkmodeToggle()">Darkmode</button><br><br>
                 <div id="a4Options" style="display:flex;">
                     <button id="a4VerticalButton" style="display:none; width:76px; margin-right:45%;" onclick="toggleA4Vertical()">Vertical</button>
                     <button id="a4HorizontalButton" style="display:none;" onclick="toggleA4Horizontal()">Horizontal</button>
                 </div>
             </fieldset>
-            <fieldset class='options-fieldset options-section' style='position: absolute; top: 33%;'>
+            <fieldset class='options-fieldset options-section' style='position: absolute; top: 35%; margin-top: 2%;'>
                 <legend>Export</legend>
                 <button class="saveButton" onclick="exportWithHistory();">With history</button><br><br>
                 <button class="saveButton" onclick="exportWithoutHistory();">Without history</button>

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1085,3 +1085,7 @@ border-left: 14px solid var(--color-sectioned-table-hi);
    -webkit-text-decoration-color: var(--color-text-primary) !important;
     text-decoration-color: var(--color-text-primary) !important;
   }
+
+.svgbacklayer-background {
+    background-color: var(--color-background);
+}

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9250,4 +9250,8 @@ margin:2px;
   font-size:18px;
 }
 
+.svgbacklayer-background {
+  background-color: var(--color-background);
+}
+
 /* END */


### PR DESCRIPTION
Added a darkmode button for the diagram in diagram dugga which can be accessed in the right sidemenu. Saves background color to local storage. Also possible to toggle darkmode with key "d".