### PR TITLE
G3 2023 v1 issue#13068

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -568,8 +568,8 @@ function elementIsValid(element) {
 	const messageElement = element.parentNode.nextElementSibling; //The dialog to show validation messages in
 	//Standard styling for a failed validation that will be changed if element passes validation
 	//element.style.backgroundColor = "#f57";
-	element.classList.toggle("bg-color-change-invalid");
-	//element.classList.remove("bg-color-change");
+	element.classList.add("bg-color-change-invalid");
+	element.classList.remove("bg-color-change");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
 
@@ -588,8 +588,8 @@ function elementIsValid(element) {
 		}
 
 		//Setting the style of the element represent being valid and not show
-		//element.classList.add("bg-color-change");
-		element.classList.toggle("bg-color-change-invalid");
+		element.classList.add("bg-color-change");
+		element.classList.remove("bg-color-change-invalid");
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();
 		//messageElement.style.display = "none";

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -601,6 +601,7 @@ function elementIsValid(element) {
 		element.removeAttribute("style");
 		element.value = "";
 		//messageElement.style.display = "none";
+		element.classList.remove("bg-color-change-invalid");
 		return false;
 	}
 

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -568,8 +568,8 @@ function elementIsValid(element) {
 	const messageElement = element.parentNode.nextElementSibling; //The dialog to show validation messages in
 	//Standard styling for a failed validation that will be changed if element passes validation
 	//element.style.backgroundColor = "#f57";
-	element.classList.add("bg-color-change-invalid");
-	element.classList.remove("bg-color-change");
+	//element.classList.add("bg-color-change-invalid");
+	//element.classList.remove("bg-color-change");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
 
@@ -600,6 +600,8 @@ function elementIsValid(element) {
 		element.removeAttribute("style");
 		element.value = "";
 		//messageElement.style.display = "none";
+		element.classList.add("bg-color-change-invalid");
+		element.classList.remove("bg-color-change");
 		return false;
 	}
 

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -586,7 +586,7 @@ function elementIsValid(element) {
 		}
 
 		//Setting the style of the element represent being valid and not show
-		//element.style.backgroundColor = "#ffff";
+		element.style.backgroundColor = "transparent";
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();
 		//messageElement.style.display = "none";

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -567,7 +567,9 @@ const regex = {
 function elementIsValid(element) {
 	const messageElement = element.parentNode.nextElementSibling; //The dialog to show validation messages in
 	//Standard styling for a failed validation that will be changed if element passes validation
-	element.style.backgroundColor = "#f57";
+	//element.style.backgroundColor = "#f57";
+	element.classList.add("bg-color-change-invalid");
+	element.classList.remove("bg-color-change");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
 
@@ -586,7 +588,8 @@ function elementIsValid(element) {
 		}
 
 		//Setting the style of the element represent being valid and not show
-		element.style.backgroundColor = "transparent";
+		element.classList.add("bg-color-change");
+		element.classList.remove("bg-color-change-invalid");
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();
 		//messageElement.style.display = "none";

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -568,7 +568,7 @@ function elementIsValid(element) {
 	const messageElement = element.parentNode.nextElementSibling; //The dialog to show validation messages in
 	//Standard styling for a failed validation that will be changed if element passes validation
 	//element.style.backgroundColor = "#f57";
-	element.classList.add("bg-color-change-invalid");
+	element.setAttribute("class", "bg-color-change-invalid");
 	// element.classList.remove("bg-color-change");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
@@ -590,7 +590,8 @@ function elementIsValid(element) {
 		//Setting the style of the element represent being valid and not show
 		//element.style.backgroundColor = "#fff";
 		// element.classList.add("bg-color-change");
-		element.classList.remove("bg-color-change-invalid");
+		//element.classList.remove("bg-color-change-invalid");
+		element.setAttribute("class", "bg-color-change");
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();
 		//messageElement.style.display = "none";

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -586,7 +586,7 @@ function elementIsValid(element) {
 		}
 
 		//Setting the style of the element represent being valid and not show
-		element.style.backgroundColor = "#ffff";
+		//element.style.backgroundColor = "#ffff";
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();
 		//messageElement.style.display = "none";

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -567,8 +567,8 @@ const regex = {
 function elementIsValid(element) {
 	const messageElement = element.parentNode.nextElementSibling; //The dialog to show validation messages in
 	//Standard styling for a failed validation that will be changed if element passes validation
-	//element.style.backgroundColor = "#f57";
-	element.setAttribute("class", "bg-color-change-invalid");
+	element.style.backgroundColor = "#f57";
+	//element.setAttribute("class", "bg-color-change-invalid");
 	// element.classList.remove("bg-color-change");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
@@ -588,10 +588,9 @@ function elementIsValid(element) {
 		}
 
 		//Setting the style of the element represent being valid and not show
-		//element.style.backgroundColor = "#fff";
+		element.style.backgroundColor = "#fff";
 		// element.classList.add("bg-color-change");
 		//element.classList.remove("bg-color-change-invalid");
-		element.setAttribute("class", "bg-color-change");
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();
 		//messageElement.style.display = "none";

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -568,8 +568,8 @@ function elementIsValid(element) {
 	const messageElement = element.parentNode.nextElementSibling; //The dialog to show validation messages in
 	//Standard styling for a failed validation that will be changed if element passes validation
 	//element.style.backgroundColor = "#f57";
-	//element.classList.add("bg-color-change-invalid");
-	//element.classList.remove("bg-color-change");
+	element.classList.add("bg-color-change-invalid");
+	element.classList.remove("bg-color-change");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
 
@@ -600,8 +600,6 @@ function elementIsValid(element) {
 		element.removeAttribute("style");
 		element.value = "";
 		//messageElement.style.display = "none";
-		element.classList.add("bg-color-change-invalid");
-		element.classList.remove("bg-color-change");
 		return false;
 	}
 

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -569,7 +569,7 @@ function elementIsValid(element) {
 	//Standard styling for a failed validation that will be changed if element passes validation
 	//element.style.backgroundColor = "#f57";
 	element.classList.add("bg-color-change-invalid");
-	element.classList.remove("bg-color-change");
+	// element.classList.remove("bg-color-change");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
 
@@ -588,7 +588,8 @@ function elementIsValid(element) {
 		}
 
 		//Setting the style of the element represent being valid and not show
-		element.classList.add("bg-color-change");
+		//element.style.backgroundColor = "#fff";
+		// element.classList.add("bg-color-change");
 		element.classList.remove("bg-color-change-invalid");
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -567,9 +567,9 @@ const regex = {
 function elementIsValid(element) {
 	const messageElement = element.parentNode.nextElementSibling; //The dialog to show validation messages in
 	//Standard styling for a failed validation that will be changed if element passes validation
-	element.style.backgroundColor = "#f57";
+	//element.style.backgroundColor = "#f57";
 	//element.setAttribute("class", "bg-color-change-invalid");
-	// element.classList.remove("bg-color-change");
+	element.classList.add("bg-color-change-invalid");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
 
@@ -588,9 +588,9 @@ function elementIsValid(element) {
 		}
 
 		//Setting the style of the element represent being valid and not show
-		element.style.backgroundColor = "#fff";
+		//element.style.backgroundColor = "#fff";
 		// element.classList.add("bg-color-change");
-		//element.classList.remove("bg-color-change-invalid");
+		element.classList.remove("bg-color-change-invalid");
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();
 		//messageElement.style.display = "none";

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -568,8 +568,8 @@ function elementIsValid(element) {
 	const messageElement = element.parentNode.nextElementSibling; //The dialog to show validation messages in
 	//Standard styling for a failed validation that will be changed if element passes validation
 	//element.style.backgroundColor = "#f57";
-	element.classList.add("bg-color-change-invalid");
-	element.classList.remove("bg-color-change");
+	element.classList.toggle("bg-color-change-invalid");
+	//element.classList.remove("bg-color-change");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
 
@@ -588,8 +588,8 @@ function elementIsValid(element) {
 		}
 
 		//Setting the style of the element represent being valid and not show
-		element.classList.add("bg-color-change");
-		element.classList.remove("bg-color-change-invalid");
+		//element.classList.add("bg-color-change");
+		element.classList.toggle("bg-color-change-invalid");
 		element.style.borderColor = "#383";
 		$(messageElement.firstChild).fadeOut();
 		//messageElement.style.display = "none";

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -80,13 +80,13 @@ if(isset($_SESSION['uid'])){
     			<input type='hidden' id='cid' value='Toddler' />
     			<div class='inputwrapper'>
 					<span>Course Name:</span>
-					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate bg-color-change' type='text' id='ncoursename' name='coursename' placeholder='Course Name' />
+					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate' type='text' id='ncoursename' name='coursename' placeholder='Course Name' />
 				</div>
 				<div class="formDialog" style="display: block;left:50px; top:-8px;"><span id="courseNameError" style="display: none; left:0px;" class="formDialogText">Only letters. Dash allowed in between words</span></div>
 				<p id="dialog4" class="validationDialog">Only letters. Dash allowed in between words</p>
     			<div class='inputwrapper'>
 					<span>Course code:</span>
-					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate bg-color-change' type='text' id='ncoursecode' name='coursecode' placeholder='Course Code' />
+					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate' type='text' id='ncoursecode' name='coursecode' placeholder='Course Code' />
 				</div>
 				<div class="formDialog" style="display: block; left:50px; top:0px;"><span id="courseCodeError" style="display: none; left:0px;" class="formDialogText">2 Letters, 3 digits, 1 letter</span></div>
 				<p id="dialog3" class="validationDialog">2 Letters, 3 digits, 1 letter</p>

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -95,7 +95,7 @@ if(isset($_SESSION['uid'])){
 				<div style="padding:5px;">
 					<div class="inputwrapper">
 						<span style="padding-right: 10px;">GitHub URL:</span>
-						<input onkeyup="validateGitInput('ncoursegit-url')" class="textinput" type="text" id="ncoursegit-url" name="coursegit-url" placeholder="https://github.com/..."/>
+						<input oninput="validateGitInput('ncoursegit-url')" class="textinput" type="text" id="ncoursegit-url" name="coursegit-url" placeholder="https://github.com/..."/>
 					</div>
 				</div>
     		<div style='padding:5px;'>

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -80,13 +80,13 @@ if(isset($_SESSION['uid'])){
     			<input type='hidden' id='cid' value='Toddler' />
     			<div class='inputwrapper'>
 					<span>Course Name:</span>
-					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate' type='text' id='ncoursename' name='coursename' placeholder='Course Name' />
+					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate bg-color-change' type='text' id='ncoursename' name='coursename' placeholder='Course Name' />
 				</div>
 				<div class="formDialog" style="display: block;left:50px; top:-8px;"><span id="courseNameError" style="display: none; left:0px;" class="formDialogText">Only letters. Dash allowed in between words</span></div>
 				<p id="dialog4" class="validationDialog">Only letters. Dash allowed in between words</p>
     			<div class='inputwrapper'>
 					<span>Course code:</span>
-					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate' type='text' id='ncoursecode' name='coursecode' placeholder='Course Code' />
+					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate bg-color-change' type='text' id='ncoursecode' name='coursecode' placeholder='Course Code' />
 				</div>
 				<div class="formDialog" style="display: block; left:50px; top:0px;"><span id="courseCodeError" style="display: none; left:0px;" class="formDialogText">2 Letters, 3 digits, 1 letter</span></div>
 				<p id="dialog3" class="validationDialog">2 Letters, 3 digits, 1 letter</p>

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -64,14 +64,6 @@
 	background-color: var(--color-background);
 }
 
-/* Used to reset the background color of input fields */
-.bg-color-change {
-    background-color: var(--color-background);
-}
-.bg-color-change-invalid{
-    background-color: #f57;
-}
-
 #picktemplate{
 	position: absolute;
 	top: 0px;

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -69,7 +69,7 @@
     background-color: var(--color-background);
 }
 .bg-color-change-invalid{
-    background-color: "#f57";
+    background-color: #f57;
 }
 
 #picktemplate{

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -64,6 +64,14 @@
 	background-color: var(--color-background);
 }
 
+/* Used to reset the background color of input fields */
+.bg-color-change {
+    background-color: var(--color-background);
+}
+.bg-color-change-invalid{
+    background-color: "#f57";
+}
+
 #picktemplate{
 	position: absolute;
 	top: 0px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2216,14 +2216,6 @@ input.inactive-button {
 #editCourse #visib{
   margin-right: 0px;
 }
-/* Used to reset the background color of input fields */
-.bg-color-change {
-  background-color: var(--color-background);
-}
-.bg-color-change-invalid{
-  background-color: #f57;
-}
-
 
 #impwords,
 #impword {
@@ -2692,6 +2684,11 @@ label.login-label {
   border-radius: 0px;
   box-sizing: border-box;
   opacity: 0.8;
+}
+
+/* Used to reset the background color of input fields */
+.bg-color-change-invalid{
+  background-color: #f57;
 }
 
 input.option {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2216,6 +2216,13 @@ input.inactive-button {
 #editCourse #visib{
   margin-right: 0px;
 }
+/* Used to reset the background color of input fields */
+.bg-color-change {
+  background-color: var(--color-background);
+}
+.bg-color-change-invalid{
+  background-color: "#f57";
+}
 
 
 #impwords,

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2221,7 +2221,7 @@ input.inactive-button {
   background-color: var(--color-background);
 }
 .bg-color-change-invalid{
-  background-color: "#f57";
+  background-color: #f57;
 }
 
 


### PR DESCRIPTION
"Stop it from changing text color when creating a new course #13068"

Changed so that the input boxes turn red using classes instead of just setting the style specifically for that element. This makes it possible to use it on all inputs, no matter which theme is currently active. We tested this on the create course form, but it should work just as well on the others.

![image](https://user-images.githubusercontent.com/102578746/230375586-1279236c-fdb1-4ebf-b42d-59f6b1fe4176.png)
