### PR TITLE
Changing properties on ER-Attribute does not work #13116

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2729,7 +2729,7 @@ function changeState()
 {
     const element =  context[0],
           oldType = element.type,
-          newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;;
+          newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;
 
     /* If the element has a new type and got lines, then it can't change type. */
     if (newType !== undefined && oldType != newType && elementHasLines(element)) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2729,10 +2729,10 @@ function changeState()
 {
     const element =  context[0],
           oldType = element.type,
-          newType = document.getElementById("typeSelect").value;
+          newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;;
 
     /* If the element has a new type and got lines, then it can't change type. */
-    if (oldType != newType && elementHasLines(element)) {
+    if (newType !== undefined && oldType != newType && elementHasLines(element)) {
         displayMessage("error", `
             Can't change type from \"${oldType}\" to \"${newType}\" as
             these types should not be able to connect with each other.`


### PR DESCRIPTION
Made it so that newType is assigned with optional values. If both "typeSelect" and "propertySelect" are null, newType is instead set to undefined. Solves issue #13116 

Changing color while editing an ER attribute will reset the name and variant to thier default values in the options-pane. Could potentially be an issue.