### PR TITLE
Icons not saved in options.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6281,34 +6281,39 @@ function generateContextProperties()
             //iterate trough all icons associated with IE. add these icons to the drop down
             //if the line in context has one of these lines in the starting position, just like for UML, it is automatically selected
             Object.keys(IELineIcons).forEach(icon => {
-                //this only really covers WEAK, since the rest have a inconsistent naming scheme, like ONE_MANY; its also reffered to as 1-M
-                //This means we have to manually check these and others like them
-                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //icon can be ZERO_MANY while start icon can be 0-M.
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers ZERO_ONE not being equal to 0-1
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-1") && (icon == "ZERO_ONE")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers ONE not being equal to 1
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "1") && (icon == "ONE")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers FORCEDONE not being equal to 1!
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "1!") && (icon == "FORCEDONE")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers ONE_MANY not being equal to 1-M
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "1-M") && (icon == "ONE_MANY")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers MANY not being equal to M
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "M") && (icon == "MANY")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                if (contextLine[0].startIcon != undefined) {
+                    //this only really covers WEAK, since the rest have a inconsistent naming scheme, like ONE_MANY; its also reffered to as 1-M
+                    //This means we have to manually check these and others like them
+                    if (contextLine[0].startIcon.toUpperCase() == icon){
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //icon can be ZERO_MANY while start icon can be 0-M.
+                    else if ((contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers ZERO_ONE not being equal to 0-1
+                    else if ((contextLine[0].startIcon.toUpperCase() == "0-1") && (icon == "ZERO_ONE")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers ONE not being equal to 1
+                    else if ((contextLine[0].startIcon.toUpperCase() == "1") && (icon == "ONE")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers FORCEDONE not being equal to 1!
+                    else if ((contextLine[0].startIcon.toUpperCase() == "1!") && (icon == "FORCEDONE")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers ONE_MANY not being equal to 1-M
+                    else if ((contextLine[0].startIcon.toUpperCase() == "1-M") && (icon == "ONE_MANY")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers MANY not being equal to M
+                    else if ((contextLine[0].startIcon.toUpperCase() == "M") && (icon == "MANY")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    else {
+                        str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                    }
                 }
                 else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6262,7 +6262,7 @@ function generateContextProperties()
             }
             str += `</option>`; */
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                console.log(contextLine[0].startIcon.length);
+                console.log(contextLine[0].startIcon.options.length);
             }
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6316,6 +6316,10 @@ function generateContextProperties()
                 }
                 else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                    console.log("IE else icon is " + icon);
+                }
+                if (contextLine[0].startIcon != undefined) {
+                    console.log("IE else startIcon is " + contextLine[0].startIcon);
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6273,9 +6273,9 @@ function generateContextProperties()
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
-                    else {
-                        str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
-                    }
+                }
+                else {
+                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 }
             });
             //iterate trough all icons associated with IE. add these icons to the drop down

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6316,6 +6316,9 @@ function generateContextProperties()
                     console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
                 }
                 //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
                 /* else if (condition) {
                     
                 } */

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6318,9 +6318,10 @@ function generateContextProperties()
                 else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                 }
-                else if (condition) {
+                //
+                /* else if (condition) {
                     
-                }
+                } */
                 else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
                     console.log("IE else icon is " + icon);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6318,9 +6318,9 @@ function generateContextProperties()
                     console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
                 }
                 //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
-                else if (condition) {
+                /* else if (condition) {
                     
-                }
+                } */
                 else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
                     console.log("IE else icon is " + icon);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6252,7 +6252,7 @@ function generateContextProperties()
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             //str  += `<option value=''>None</option>`;
             //if the line has a start icon, the drop down will show it 
-            str  += `<option `;
+            /* str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 let contextStartIcon = contextLine[0].startIcon;
                 str += `value=`+contextStartIcon+`">`+contextStartIcon;
@@ -6260,8 +6260,8 @@ function generateContextProperties()
             } else {
                 str += `value=''>None`;
             }
-            str += `</option>`;
-            /* if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
+            str += `</option>`; */
+            if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
                 if (document.getElementById("lineStartIcon")) {
                     let startIconDropDown = document.getElementById("lineStartIcon");
@@ -6276,7 +6276,7 @@ function generateContextProperties()
                     }
                     console.log(document.getElementById("lineStartIcon").options.length);
                 }
-            } */
+            }
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6266,7 +6266,7 @@ function generateContextProperties()
                 if (document.getElementById("lineStartIcon")) {
                     let startIconDropDown = document.getElementById("lineStartIcon");
                     for (let i = 0; i < startIconDropDown.options.length; i++) {
-                        startIconDropDown.options[i].value;
+                        console.log(startIconDropDown.options[i].value);
                     }
                     console.log(document.getElementById("lineStartIcon").options.length);
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6285,6 +6285,8 @@ function generateContextProperties()
                 }else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 }
+                console.log("icon is " + icon);
+                console.log("startIcon is " + contextLine[0].startIcon);
             });
             Object.keys(IELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6273,6 +6273,9 @@ function generateContextProperties()
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
+                    else {
+                        str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    }
                 }
                 else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6283,20 +6283,18 @@ function generateContextProperties()
                 //this covers Triangle and Arrow.
                 //TODO i assume the weird icons are IE
                 //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                if (contextLine[0].startIcon != undefined) {
-                    if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                        console.log("icon is " + icon);
-                        console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
-                    }
-                    //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
-                    //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
-                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                    }
-                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                    }
+                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    console.log("icon is " + icon);
+                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
+                }
+                //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
+                //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                }
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                 }
                 //else, its not matching and the option is just added to the dropdown normally.
                 else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6262,7 +6262,7 @@ function generateContextProperties()
                 } */
                 //fixed Triangle=/=TRIANGLE with toUpperCase()
                 //check if there even is a starticon first
-                if (contextLine[0].startIcon != undefined){
+                /* if (contextLine[0].startIcon != undefined){
                     console.log("icon is " + icon);
                     console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
                     //check if its white or black diamond since these wont be caught otherwise
@@ -6276,6 +6276,11 @@ function generateContextProperties()
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                     //str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                }else {
+                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                } */
+                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                 }else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6293,25 +6293,25 @@ function generateContextProperties()
                 }
             });
             str += `</select>`;
+            if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
+                //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
+                if (document.getElementById("lineStartIcon")) {
+                    let startIconDropDown = document.getElementById("lineStartIcon");
+                    let contextStartIcon = contextLine[0].startIcon;
+                    //iterate through the whole dropdown until the value matches the icon.
+                    //then set that option to be selected.
+                    for (let i = 0; i < startIconDropDown.options.length; i++) {
+                        console.log(startIconDropDown.options[i].value);
+                        if (contextStartIcon == startIconDropDown.options[i].value) {
+                            contextStartIcon.options[i].selected = true;
+                        }
+                    }
+                    console.log(document.getElementById("lineStartIcon").options.length);
+                }
+            }
         }
         str+=`<br><br><input type="submit" class='saveButton' value="Save" onclick="changeLineProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
         //if the line has a start icon, the drop down will show it 
-        if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-            //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
-            if (document.getElementById("lineStartIcon")) {
-                let startIconDropDown = document.getElementById("lineStartIcon");
-                let contextStartIcon = contextLine[0].startIcon;
-                //iterate through the whole dropdown until the value matches the icon.
-                //then set that option to be selected.
-                for (let i = 0; i < startIconDropDown.options.length; i++) {
-                    console.log(startIconDropDown.options[i].value);
-                    if (contextStartIcon == startIconDropDown.options[i].value) {
-                        contextStartIcon.options[i].selected = true;
-                    }
-                }
-                console.log(document.getElementById("lineStartIcon").options.length);
-            }
-        }
       }
 
       //If more than one element is selected

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6281,11 +6281,14 @@ function generateContextProperties()
                 } */
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    console.log("icon is " + icon);
+                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
                 }else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    console.log("icon is " + icon);
+                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
                 }
-                console.log("icon is " + icon);
-                console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
+                
                 /* for (let i = 0; i < contextLine.length; i++) {
                     console.log("startIcon iteration is " + contextLine[i].startIcon);
                 } */

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6313,11 +6313,6 @@ function generateContextProperties()
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             Object.keys(UMLLineIcons).forEach(icon => {
-                /* if (contextLine[0].endIcon != undefined && contextLine[0].endIcon == icon){
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                }else {
-                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
-                } */
                 //this covers Triangle and Arrow.
                 //If the lines in context happen to be matching something in the drop down, it is set as selected.
                 if (contextLine[0].endIcon != undefined && contextLine[0].endIcon.toUpperCase() == icon){
@@ -6337,11 +6332,6 @@ function generateContextProperties()
                 }
             });
             Object.keys(IELineIcons).forEach(icon => {
-                /* if (contextLine[0].endIcon != undefined && contextLine[0].endIcon == icon){
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }else {
-                    str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
-                } */
                 //this only really covers WEAK, since the rest have a inconsistent naming scheme, like ONE_MANY; its also reffered to as 1-M
                 //This means we have to manually check these and others like them
                 if (contextLine[0].endIcon != undefined && contextLine[0].endIcon.toUpperCase() == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6255,8 +6255,25 @@ function generateContextProperties()
                 //TODO icon and contextLine[0].startIcon will never be the same:
                 //staricon can, for example, be Triangle, while icon is TRIANGLE
                 //whats worse is that starticon can be White_Diamond while icon is WHITEDIAMOND
-                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
+                /* if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                }else {
+                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                } */
+                //fixed Triangle=/=TRIANGLE with toUpperCase
+                //check if there even is a starticon first
+                if (contextLine[0].startIcon != undefined){
+                    //check if its white or black diamond since these wont be caught otherwise
+                    if ((contextLine[0].startIcon == "White_Diamond") && icon == "WHITEDIAMOND") {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    else if ((contextLine[0].startIcon == "Black_Diamond") && icon == "BLACKDIAMOND") {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    else if (toUpperCase(contextLine[0].startIcon) == icon) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    //str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                 }else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6311,13 +6311,13 @@ function generateContextProperties()
             
             Object.keys(IELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined) {
-                    if (contextLine[0].startIcon.toUpperCase() == icon){
+                    if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                         str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                         console.log("IE icon is " + icon);
                         console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
                     }
                     //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
-                    else if ((contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
+                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
                         str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                     }
                     /* else if (condition) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6248,38 +6248,12 @@ function generateContextProperties()
             if(contextLine[0].endLabel && contextLine[0].endLabel != "") str += `value="${contextLine[0].endLabel}"`;
             str += `/>`;
         }
+        //TODO this code can be refactored to avoid the reuse of if (contextLine[0].startIcon != undefined... in every if statement
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             //iterate through all the icons assicoated with UML, like Arrow or Black Diamond and add them to the drop down as options
             Object.keys(UMLLineIcons).forEach(icon => {
-                //TODO icon and contextLine[0].startIcon will never be the same:
-                //staricon can, for example, be Triangle, while icon is TRIANGLE
-                //whats worse is that starticon can be White_Diamond while icon is WHITEDIAMOND
-                /* if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                }else {
-                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
-                } */
-                //fixed Triangle=/=TRIANGLE with toUpperCase()
-                //check if there even is a starticon first
-                /* if (contextLine[0].startIcon != undefined){
-                    console.log("icon is " + icon);
-                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
-                    //check if its white or black diamond since these wont be caught otherwise
-                    if ((contextLine[0].startIcon == "White_Diamond") && icon == "WHITEDIAMOND") {
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                    }
-                    else if ((contextLine[0].startIcon == "Black_Diamond") && icon == "BLACKDIAMOND") {
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                    }
-                    else if (contextLine[0].startIcon.toUpperCase() == icon) {
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                    }
-                    //str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                }else {
-                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
-                } */
                 //this covers Triangle and Arrow.
                 //If the lines in context happen to be matching something in the drop down, it is set as selected.
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
@@ -6300,22 +6274,17 @@ function generateContextProperties()
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 }
             });
-            /* Object.keys(IELineIcons).forEach(icon => {
-                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }else {
-                    str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
-                }
-            }); */
-            
+            //iterate trough all icons associated with IE. add these icons to the drop down
+            //if the line in context has one of these lines in the starting position, just like for UML, it is automatically selected
             Object.keys(IELineIcons).forEach(icon => {
                 //this only really covers WEAK, since the rest have a inconsistent naming scheme, like ONE_MANY; its also reffered to as 1-M
+                //This means we have to manually check these and others like them
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                     console.log("IE icon is " + icon);
                     console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
                 }
-                //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
+                //icon can be ZERO_MANY while start icon can be 0-M.
                 else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6272,10 +6272,10 @@ function generateContextProperties()
                     else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
-                }
-                //else, its not matching and the option is just added to the dropdown normally.
-                else {
-                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    //else, its not matching and the option is just added to the dropdown normally.
+                    else {
+                        str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    }
                 }
             });
             //iterate trough all icons associated with IE. add these icons to the drop down

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6260,7 +6260,7 @@ function generateContextProperties()
                 }else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 } */
-                //fixed Triangle=/=TRIANGLE with toUpperCase
+                //fixed Triangle=/=TRIANGLE with toUpperCase()
                 //check if there even is a starticon first
                 if (contextLine[0].startIcon != undefined){
                     //check if its white or black diamond since these wont be caught otherwise
@@ -6270,7 +6270,7 @@ function generateContextProperties()
                     else if ((contextLine[0].startIcon == "Black_Diamond") && icon == "BLACKDIAMOND") {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
-                    else if (toUpperCase(contextLine[0].startIcon) == icon) {
+                    else if (contextLine[0].startIcon.toUpperCase() == icon) {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                     //str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6284,17 +6284,17 @@ function generateContextProperties()
                 //TODO i assume the weird icons are IE
                 //If the lines in context happen to be matching something in the drop down, it is set as selected.
                 if (contextLine[0].startIcon != undefined) {
-                    if (contextLine[0].startIcon.toUpperCase() == icon){
+                    if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                         console.log("icon is " + icon);
                         console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
                     }
                     //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
                     //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
-                    else if ((contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
-                    else if ((contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6264,7 +6264,7 @@ function generateContextProperties()
                 //check if there even is a starticon first
                 if (contextLine[0].startIcon != undefined){
                     console.log("icon is " + icon);
-                    console.log("startIcon is " + contextLine[0].startIcon);
+                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
                     //check if its white or black diamond since these wont be caught otherwise
                     if ((contextLine[0].startIcon == "White_Diamond") && icon == "WHITEDIAMOND") {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6280,13 +6280,21 @@ function generateContextProperties()
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 } */
                 //this covers Triangle and Arrow.
-                //TODO add for Black and white diamond.
                 //TODO i assume the weird icons are IE
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     console.log("icon is " + icon);
                     console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
-                }else {
+                }
+                //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
+                //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
+                else if ((contextLine[0].startIcon != undefined) && (contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                }
+                else if ((contextLine[0].startIcon != undefined) && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                }
+                else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                     /* console.log("icon is " + icon);
                     console.log("startIcon is " + contextLine[0].startIcon.toUpperCase()); */

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6255,7 +6255,7 @@ function generateContextProperties()
             str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 let contextStartIcon = contextLine[0].startIcon;
-                str += `value=`+contextStartIcon+`">'contextStartIcon`;
+                str += `value=`+contextStartIcon+`">'`+contextStartIcon;
                 console.log(contextLine[0].startIcon);
             } else {
                 str += `value=''>None`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6252,14 +6252,14 @@ function generateContextProperties()
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             //str  += `<option value=''>None</option>`;
             //if the line has a start icon, the drop down will show it 
-            str  += `<option value='`;
+            str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                str += `"${contextLine[0].startIcon}"`;
+                str += `value="${contextLine[0].endLabel}">None`;
                 console.log(contextLine[0].startIcon);
             } else {
-                str += `'>None</option>`;
+                str += `value=''>None`;
             }
-            str += `/>`;
+            str += `</option>`;
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6263,6 +6263,8 @@ function generateContextProperties()
                 //fixed Triangle=/=TRIANGLE with toUpperCase()
                 //check if there even is a starticon first
                 if (contextLine[0].startIcon != undefined){
+                    console.log("icon is " + icon);
+                    console.log("startIcon is " + contextLine[0].startIcon);
                     //check if its white or black diamond since these wont be caught otherwise
                     if ((contextLine[0].startIcon == "White_Diamond") && icon == "WHITEDIAMOND") {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6251,35 +6251,10 @@ function generateContextProperties()
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
-            
-            /* str  += `<option `;
-            if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                let contextStartIcon = contextLine[0].startIcon;
-                str += `value=`+contextStartIcon+`">`+contextStartIcon;
-                console.log(contextLine[0].startIcon);
-            } else {
-                str += `value=''>None`;
-            }
-            str += `</option>`; */
-            //if the line has a start icon, the drop down will show it 
-            /* if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
-                if (document.getElementById("lineStartIcon")) {
-                    let startIconDropDown = document.getElementById("lineStartIcon");
-                    let contextStartIcon = contextLine[0].startIcon;
-                    //iterate through the whole dropdown until the value matches the icon.
-                    //then set that option to be selected.
-                    for (let i = 0; i < startIconDropDown.options.length; i++) {
-                        console.log(startIconDropDown.options[i].value);
-                        if (contextStartIcon == startIconDropDown.options[i].value) {
-                            contextStartIcon.options[i].selected = true;
-                        }
-                    }
-                    console.log(document.getElementById("lineStartIcon").options.length);
-                }
-            } */
-            
             Object.keys(UMLLineIcons).forEach(icon => {
+                //TODO icon and contextLine[0].startIcon will never be the same:
+                //staricon can, for example, be Triangle, while icon is TRIANGLE
+                //whats worse is that starticon can be White_Diamond while icon is WHITEDIAMOND
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                 }else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6323,10 +6323,10 @@ function generateContextProperties()
                     /* else if (condition) {
                         
                     } */
-                    else {
-                        str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
-                        console.log("IE else icon is " + icon);
-                    }
+                }
+                else {
+                    str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                    console.log("IE else icon is " + icon);
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6266,10 +6266,10 @@ function generateContextProperties()
                     }
                     //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
                     //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
-                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                    else if ((contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
-                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                    else if ((contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6252,7 +6252,7 @@ function generateContextProperties()
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             //str  += `<option value=''>None</option>`;
             //if the line has a start icon, the drop down will show it 
-            str  += `<option `;
+            /* str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 let contextStartIcon = contextLine[0].startIcon;
                 str += `value=`+contextStartIcon+`">`+contextStartIcon;
@@ -6260,7 +6260,7 @@ function generateContextProperties()
             } else {
                 str += `value=''>None`;
             }
-            str += `</option>`;
+            str += `</option>`; */
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6262,7 +6262,9 @@ function generateContextProperties()
             }
             str += `</option>`; */
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                console.log(contextLine[0].startIcon.options.length);
+                let startIconDropDown = documnet.getElementById("lineStartIcon");
+                console.log(startIconDropDown.options.length);
+                console.log(startIconDropDown.length);
             }
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6255,6 +6255,7 @@ function generateContextProperties()
             str  += `<option value='`;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 str += `"${contextLine[0].startIcon}"`;
+                console.log(contextLine[0].startIcon);
             } else {
                 str += `'>None</option>`;
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6248,15 +6248,12 @@ function generateContextProperties()
             if(contextLine[0].endLabel && contextLine[0].endLabel != "") str += `value="${contextLine[0].endLabel}"`;
             str += `/>`;
         }
-        //TODO this code can be refactored to avoid the reuse of if (contextLine[0].startIcon != undefined... in every if statement
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             //iterate through all the icons assicoated with UML, like Arrow or Black Diamond and add them to the drop down as options
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined) {
-                    
-                
                     //this covers Triangle and Arrow.
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
                     if (contextLine[0].startIcon.toUpperCase() == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6254,7 +6254,8 @@ function generateContextProperties()
             //if the line has a start icon, the drop down will show it 
             str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                str += `value="${contextLine[0].endLabel}">${contextLine[0].endLabel}`;
+                let contextStartIcon = contextLine[0].startIcon;
+                str += `value=`+contextStartIcon+`">'contextStartIcon`;
                 console.log(contextLine[0].startIcon);
             } else {
                 str += `value=''>None`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6285,10 +6285,10 @@ function generateContextProperties()
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 }
                 console.log("icon is " + icon);
-                console.log("startIcon is " + contextLine[0].startIcon);
-                for (let i = 0; i < contextLine.length; i++) {
+                console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
+                /* for (let i = 0; i < contextLine.length; i++) {
                     console.log("startIcon iteration is " + contextLine[i].startIcon);
-                }
+                } */
             });
             Object.keys(IELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6262,12 +6262,14 @@ function generateContextProperties()
             }
             str += `</option>`; */
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                //let startIconDropDown = document.getElementById("lineStartIcon");
+                //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
                 if (document.getElementById("lineStartIcon")) {
-                    
+                    let startIconDropDown = document.getElementById("lineStartIcon");
+                    for (let i = 0; i < startIconDropDown.options.length; i++) {
+                        startIconDropDown.options[i].value;
+                    }
                     console.log(document.getElementById("lineStartIcon").options.length);
                 }
-                //console.log(startIconDropDown.length);
             }
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6311,13 +6311,13 @@ function generateContextProperties()
             
             Object.keys(IELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined) {
-                    if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
+                    if (contextLine[0].startIcon.toUpperCase() == icon){
                         str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                         console.log("IE icon is " + icon);
                         console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
                     }
                     //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
-                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
+                    else if ((contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
                         str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                     }
                     /* else if (condition) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6263,7 +6263,10 @@ function generateContextProperties()
             str += `</option>`; */
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 //let startIconDropDown = document.getElementById("lineStartIcon");
-                console.log(document.getElementById("lineStartIcon").options.length);
+                if (document.getElementById("lineStartIcon")) {
+                    
+                    console.log(document.getElementById("lineStartIcon").options.length);
+                }
                 //console.log(startIconDropDown.length);
             }
             Object.keys(UMLLineIcons).forEach(icon => {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6322,18 +6322,23 @@ function generateContextProperties()
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             Object.keys(UMLLineIcons).forEach(icon => {
-                //this covers Triangle and Arrow.
-                //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                if (contextLine[0].endIcon != undefined && contextLine[0].endIcon.toUpperCase() == icon){
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                }
-                //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
-                //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
-                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                }
-                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                if (contextLine[0].endIcon != undefined) {
+                    //this covers Triangle and Arrow.
+                    //If the lines in context happen to be matching something in the drop down, it is set as selected.
+                    if (contextLine[0].endIcon != undefined && contextLine[0].endIcon.toUpperCase() == icon){
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
+                    //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
+                    else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    else {
+                        str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    }
                 }
                 //else, its not matching and the option is just added to the dropdown normally.
                 else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6254,20 +6254,24 @@ function generateContextProperties()
             str  += `<option value=''>None</option>`;
             //iterate through all the icons assicoated with UML, like Arrow or Black Diamond and add them to the drop down as options
             Object.keys(UMLLineIcons).forEach(icon => {
-                //this covers Triangle and Arrow.
-                //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                    console.log("icon is " + icon);
-                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
-                }
-                //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
-                //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                }
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                if (contextLine[0].startIcon != undefined) {
+                    
+                
+                    //this covers Triangle and Arrow.
+                    //If the lines in context happen to be matching something in the drop down, it is set as selected.
+                    if (contextLine[0].startIcon.toUpperCase() == icon){
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                        console.log("icon is " + icon);
+                        console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
+                    }
+                    //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
+                    //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
+                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
                 }
                 //else, its not matching and the option is just added to the dropdown normally.
                 else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6255,7 +6255,7 @@ function generateContextProperties()
             str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 let contextStartIcon = contextLine[0].startIcon;
-                str += `value=`+contextStartIcon+`">'`+contextStartIcon;
+                str += `value=`+contextStartIcon+`">`+contextStartIcon;
                 console.log(contextLine[0].startIcon);
             } else {
                 str += `value=''>None`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6250,7 +6250,7 @@ function generateContextProperties()
         }
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
-            str  += `<option value=''>None</option>`;
+            //str  += `<option value=''>None</option>`;
             //if the line has a start icon, the drop down will show it 
             str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6254,7 +6254,7 @@ function generateContextProperties()
             //if the line has a start icon, the drop down will show it 
             str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                str += `value="${contextLine[0].endLabel}">None`;
+                str += `value="${contextLine[0].endLabel}">${contextLine[0].endLabel}`;
                 console.log(contextLine[0].startIcon);
             } else {
                 str += `value=''>None`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6265,8 +6265,14 @@ function generateContextProperties()
                 //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
                 if (document.getElementById("lineStartIcon")) {
                     let startIconDropDown = document.getElementById("lineStartIcon");
+                    let contextStartIcon = contextLine[0].startIcon;
+                    //iterate through the whole dropdown until the value matches the icon.
+                    //then set that option to be selected.
                     for (let i = 0; i < startIconDropDown.options.length; i++) {
                         console.log(startIconDropDown.options[i].value);
+                        if (contextStartIcon == startIconDropDown.options[i].value) {
+                            contextStartIcon.options[i].selected = true;
+                        }
                     }
                     console.log(document.getElementById("lineStartIcon").options.length);
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6262,9 +6262,9 @@ function generateContextProperties()
             }
             str += `</option>`; */
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                let startIconDropDown = document.getElementById("lineStartIcon");
-                console.log(startIconDropDown.options.length);
-                console.log(startIconDropDown.length);
+                //let startIconDropDown = document.getElementById("lineStartIcon");
+                console.log(document.getElementById("lineStartIcon").options.length);
+                //console.log(startIconDropDown.length);
             }
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6251,6 +6251,7 @@ function generateContextProperties()
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
+            //iterate through all the icons assicoated with UML, like Arrow or Black Diamond and add them to the drop down as options
             Object.keys(UMLLineIcons).forEach(icon => {
                 //TODO icon and contextLine[0].startIcon will never be the same:
                 //staricon can, for example, be Triangle, while icon is TRIANGLE
@@ -6281,6 +6282,7 @@ function generateContextProperties()
                 } */
                 //this covers Triangle and Arrow.
                 //TODO i assume the weird icons are IE
+                //If the lines in context happen to be matching something in the drop down, it is set as selected.
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     console.log("icon is " + icon);
@@ -6296,13 +6298,7 @@ function generateContextProperties()
                 }
                 else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
-                    /* console.log("icon is " + icon);
-                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase()); */
                 }
-                
-                /* for (let i = 0; i < contextLine.length; i++) {
-                    console.log("startIcon iteration is " + contextLine[i].startIcon);
-                } */
             });
             Object.keys(IELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6281,7 +6281,6 @@ function generateContextProperties()
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 } */
                 //this covers Triangle and Arrow.
-                //TODO i assume the weird icons are IE
                 //If the lines in context happen to be matching something in the drop down, it is set as selected.
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
@@ -6310,23 +6309,21 @@ function generateContextProperties()
             }); */
             
             Object.keys(IELineIcons).forEach(icon => {
-                if (contextLine[0].startIcon != undefined) {
-                    if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
-                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                        console.log("IE icon is " + icon);
-                        console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
-                    }
-                    //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
-                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
-                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                    }
-                    /* else if (condition) {
-                        
-                    } */
-                    else {
-                        str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
-                        console.log("IE else icon is " + icon);
-                    }
+                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    console.log("IE icon is " + icon);
+                    console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
+                }
+                //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                else if (condition) {
+                    
+                }
+                else {
+                    str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                    console.log("IE else icon is " + icon);
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6310,21 +6310,23 @@ function generateContextProperties()
             }); */
             
             Object.keys(IELineIcons).forEach(icon => {
-                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                    console.log("IE icon is " + icon);
-                    console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
-                }
-                //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
-                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                /* else if (condition) {
-                    
-                } */
-                else {
-                    str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
-                    console.log("IE else icon is " + icon);
+                if (contextLine[0].startIcon != undefined) {
+                    if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                        console.log("IE icon is " + icon);
+                        console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
+                    }
+                    //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
+                    else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    /* else if (condition) {
+                        
+                    } */
+                    else {
+                        str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                        console.log("IE else icon is " + icon);
+                    }
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6279,6 +6279,9 @@ function generateContextProperties()
                 }else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 } */
+                //this covers Triangle and Arrow.
+                //TODO add for Black and white diamond.
+                //TODO i assume the weird icons are IE
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     console.log("icon is " + icon);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6281,8 +6281,6 @@ function generateContextProperties()
                 //This means we have to manually check these and others like them
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                    console.log("IE icon is " + icon);
-                    console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
                 }
                 //icon can be ZERO_MANY while start icon can be 0-M.
                 else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
@@ -6310,22 +6308,70 @@ function generateContextProperties()
                 }
                 else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
-                    console.log("IE else icon is " + icon);
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             Object.keys(UMLLineIcons).forEach(icon => {
-                if (contextLine[0].endIcon != undefined && contextLine[0].endIcon == icon){
+                /* if (contextLine[0].endIcon != undefined && contextLine[0].endIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                 }else {
+                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                } */
+                //this covers Triangle and Arrow.
+                //If the lines in context happen to be matching something in the drop down, it is set as selected.
+                if (contextLine[0].endIcon != undefined && contextLine[0].endIcon.toUpperCase() == icon){
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                }
+                //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
+                //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
+                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                }
+                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                }
+                //else, its not matching and the option is just added to the dropdown normally.
+                else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 }
             });
             Object.keys(IELineIcons).forEach(icon => {
-                if (contextLine[0].endIcon != undefined && contextLine[0].endIcon == icon){
+                /* if (contextLine[0].endIcon != undefined && contextLine[0].endIcon == icon){
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                 }else {
+                    str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                } */
+                //this only really covers WEAK, since the rest have a inconsistent naming scheme, like ONE_MANY; its also reffered to as 1-M
+                //This means we have to manually check these and others like them
+                if (contextLine[0].endIcon != undefined && contextLine[0].endIcon.toUpperCase() == icon){
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //icon can be ZERO_MANY while start icon can be 0-M.
+                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers ZERO_ONE not being equal to 0-1
+                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "0-1") && (icon == "ZERO_ONE")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers ONE not being equal to 1
+                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "1") && (icon == "ONE")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers FORCEDONE not being equal to 1!
+                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "1!") && (icon == "FORCEDONE")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers ONE_MANY not being equal to 1-M
+                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "1-M") && (icon == "ONE_MANY")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers MANY not being equal to M
+                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "M") && (icon == "MANY")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
                 }
             });

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6261,7 +6261,9 @@ function generateContextProperties()
                 str += `value=''>None`;
             }
             str += `</option>`; */
-            console.log(contextLine[0].startIcon.length);
+            if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
+                console.log(contextLine[0].startIcon.length);
+            }
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6261,7 +6261,7 @@ function generateContextProperties()
                 str += `value=''>None`;
             }
             str += `</option>`; */
-            console.log(startIcon.length);
+            console.log(contextLine[0].startIcon.length);
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6296,14 +6296,25 @@ function generateContextProperties()
                 else if ((contextLine[0].startIcon != undefined) && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                 }
+                //else, its not matching and the option is just added to the dropdown normally.
                 else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
                 }
             });
-            Object.keys(IELineIcons).forEach(icon => {
+            /* Object.keys(IELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                 }else {
+                    str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                }
+            }); */
+            Object.keys(IELineIcons).forEach(icon => {
+                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    console.log("IE icon is " + icon);
+                    console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
+                }
+                else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
                 }
             });

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6309,6 +6309,7 @@ function generateContextProperties()
             }); */
             
             Object.keys(IELineIcons).forEach(icon => {
+                //this only really covers WEAK, since the rest have a inconsistent naming scheme, like ONE_MANY; its also reffered to as 1-M
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                     console.log("IE icon is " + icon);
@@ -6318,10 +6319,26 @@ function generateContextProperties()
                 else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                 }
-                //
-                /* else if (condition) {
-                    
-                } */
+                //this covers ZERO_ONE not being equal to 0-1
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "0-1") && (icon == "ZERO_ONE")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers ONE not being equal to 1
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "1") && (icon == "ONE")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers FORCEDONE not being equal to 1!
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "1!") && (icon == "FORCEDONE")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers ONE_MANY not being equal to 1-M
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "1-M") && (icon == "ONE_MANY")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
+                //this covers MANY not being equal to M
+                else if (contextLine[0].startIcon != undefined && (contextLine[0].startIcon.toUpperCase() == "M") && (icon == "MANY")) {
+                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                }
                 else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
                     console.log("IE else icon is " + icon);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6323,10 +6323,10 @@ function generateContextProperties()
                     /* else if (condition) {
                         
                     } */
-                }
-                else {
-                    str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
-                    console.log("IE else icon is " + icon);
+                    else {
+                        str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                        console.log("IE else icon is " + icon);
+                    }
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6285,8 +6285,8 @@ function generateContextProperties()
                     console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
                 }else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
-                    console.log("icon is " + icon);
-                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
+                    /* console.log("icon is " + icon);
+                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase()); */
                 }
                 
                 /* for (let i = 0; i < contextLine.length; i++) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6250,8 +6250,8 @@ function generateContextProperties()
         }
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
-            //str  += `<option value=''>None</option>`;
-            //if the line has a start icon, the drop down will show it 
+            str  += `<option value=''>None</option>`;
+            
             /* str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 let contextStartIcon = contextLine[0].startIcon;
@@ -6261,22 +6261,7 @@ function generateContextProperties()
                 str += `value=''>None`;
             }
             str += `</option>`; */
-            if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
-                if (document.getElementById("lineStartIcon")) {
-                    let startIconDropDown = document.getElementById("lineStartIcon");
-                    let contextStartIcon = contextLine[0].startIcon;
-                    //iterate through the whole dropdown until the value matches the icon.
-                    //then set that option to be selected.
-                    for (let i = 0; i < startIconDropDown.options.length; i++) {
-                        console.log(startIconDropDown.options[i].value);
-                        if (contextStartIcon == startIconDropDown.options[i].value) {
-                            contextStartIcon.options[i].selected = true;
-                        }
-                    }
-                    console.log(document.getElementById("lineStartIcon").options.length);
-                }
-            }
+            
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
@@ -6310,6 +6295,23 @@ function generateContextProperties()
             str += `</select>`;
         }
         str+=`<br><br><input type="submit" class='saveButton' value="Save" onclick="changeLineProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
+        //if the line has a start icon, the drop down will show it 
+        if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
+            //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
+            if (document.getElementById("lineStartIcon")) {
+                let startIconDropDown = document.getElementById("lineStartIcon");
+                let contextStartIcon = contextLine[0].startIcon;
+                //iterate through the whole dropdown until the value matches the icon.
+                //then set that option to be selected.
+                for (let i = 0; i < startIconDropDown.options.length; i++) {
+                    console.log(startIconDropDown.options[i].value);
+                    if (contextStartIcon == startIconDropDown.options[i].value) {
+                        contextStartIcon.options[i].selected = true;
+                    }
+                }
+                console.log(document.getElementById("lineStartIcon").options.length);
+            }
+        }
       }
 
       //If more than one element is selected

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6283,18 +6283,20 @@ function generateContextProperties()
                 //this covers Triangle and Arrow.
                 //TODO i assume the weird icons are IE
                 //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                    console.log("icon is " + icon);
-                    console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
-                }
-                //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
-                //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
-                else if ((contextLine[0].startIcon != undefined) && (contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                }
-                else if ((contextLine[0].startIcon != undefined) && (contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
-                    str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                if (contextLine[0].startIcon != undefined) {
+                    if (contextLine[0].startIcon.toUpperCase() == icon){
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                        console.log("icon is " + icon);
+                        console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
+                    }
+                    //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
+                    //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
+                    else if ((contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    else if ((contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
                 }
                 //else, its not matching and the option is just added to the dropdown normally.
                 else {
@@ -6308,18 +6310,20 @@ function generateContextProperties()
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
                 }
             }); */
+            
             Object.keys(IELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon.toUpperCase() == icon){
                     str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
                     console.log("IE icon is " + icon);
                     console.log("IE startIcon is " + contextLine[0].startIcon.toUpperCase());
                 }
+                //icon can be ZERO_MANY while start icon can be 0-M. This means we have to manually check these and others like them
+                else if (condition) {
+                    
+                }
                 else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
                     console.log("IE else icon is " + icon);
-                }
-                if (contextLine[0].startIcon != undefined) {
-                    console.log("IE else startIcon is " + contextLine[0].startIcon);
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6262,7 +6262,7 @@ function generateContextProperties()
             }
             str += `</option>`; */
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                let startIconDropDown = documnet.getElementById("lineStartIcon");
+                let startIconDropDown = document.getElementById("lineStartIcon");
                 console.log(startIconDropDown.options.length);
                 console.log(startIconDropDown.length);
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6252,7 +6252,7 @@ function generateContextProperties()
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             //if the line has a start icon, the drop down will show it 
-            /* str  += `<option `;
+            str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 let contextStartIcon = contextLine[0].startIcon;
                 str += `value=`+contextStartIcon+`">`+contextStartIcon;
@@ -6260,8 +6260,8 @@ function generateContextProperties()
             } else {
                 str += `value=''>None`;
             }
-            str += `</option>`; */
-            if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
+            str += `</option>`;
+            /* if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
                 //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
                 if (document.getElementById("lineStartIcon")) {
                     let startIconDropDown = document.getElementById("lineStartIcon");
@@ -6276,7 +6276,7 @@ function generateContextProperties()
                     }
                     console.log(document.getElementById("lineStartIcon").options.length);
                 }
-            }
+            } */
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6262,6 +6262,9 @@ function generateContextProperties()
                 }
                 console.log("icon is " + icon);
                 console.log("startIcon is " + contextLine[0].startIcon);
+                for (let i = 0; i < contextLine.length; i++) {
+                    console.log("startIcon iteration is " + contextLine[i].startIcon);
+                }
             });
             Object.keys(IELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6250,7 +6250,7 @@ function generateContextProperties()
         }
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
-            //str  += `<option value=''>None</option>`;
+            str  += `<option value=''>None</option>`;
             //if the line has a start icon, the drop down will show it 
             /* str  += `<option `;
             if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
@@ -6261,6 +6261,7 @@ function generateContextProperties()
                 str += `value=''>None`;
             }
             str += `</option>`; */
+            console.log(startIcon.length);
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
                     str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6261,6 +6261,23 @@ function generateContextProperties()
                 str += `value=''>None`;
             }
             str += `</option>`; */
+            //if the line has a start icon, the drop down will show it 
+            /* if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
+                //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
+                if (document.getElementById("lineStartIcon")) {
+                    let startIconDropDown = document.getElementById("lineStartIcon");
+                    let contextStartIcon = contextLine[0].startIcon;
+                    //iterate through the whole dropdown until the value matches the icon.
+                    //then set that option to be selected.
+                    for (let i = 0; i < startIconDropDown.options.length; i++) {
+                        console.log(startIconDropDown.options[i].value);
+                        if (contextStartIcon == startIconDropDown.options[i].value) {
+                            contextStartIcon.options[i].selected = true;
+                        }
+                    }
+                    console.log(document.getElementById("lineStartIcon").options.length);
+                }
+            } */
             
             Object.keys(UMLLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined && contextLine[0].startIcon == icon){
@@ -6293,25 +6310,8 @@ function generateContextProperties()
                 }
             });
             str += `</select>`;
-            if (contextLine[0].startIcon && contextLine[0].startIcon != "") {
-                //if the startIcon dropdown has been generated, set the value of it to match the start icon on the line. 
-                if (document.getElementById("lineStartIcon")) {
-                    let startIconDropDown = document.getElementById("lineStartIcon");
-                    let contextStartIcon = contextLine[0].startIcon;
-                    //iterate through the whole dropdown until the value matches the icon.
-                    //then set that option to be selected.
-                    for (let i = 0; i < startIconDropDown.options.length; i++) {
-                        console.log(startIconDropDown.options[i].value);
-                        if (contextStartIcon == startIconDropDown.options[i].value) {
-                            contextStartIcon.options[i].selected = true;
-                        }
-                    }
-                    console.log(document.getElementById("lineStartIcon").options.length);
-                }
-            }
         }
         str+=`<br><br><input type="submit" class='saveButton' value="Save" onclick="changeLineProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
-        //if the line has a start icon, the drop down will show it 
       }
 
       //If more than one element is selected

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6325,15 +6325,15 @@ function generateContextProperties()
                 if (contextLine[0].endIcon != undefined) {
                     //this covers Triangle and Arrow.
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                    if (contextLine[0].endIcon != undefined && contextLine[0].endIcon.toUpperCase() == icon){
+                    if (contextLine[0].endIcon.toUpperCase() == icon){
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                     //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
                     //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
-                    else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                    else if ((contextLine[0].endIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
-                    else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                    else if ((contextLine[0].endIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                     else {
@@ -6346,34 +6346,39 @@ function generateContextProperties()
                 }
             });
             Object.keys(IELineIcons).forEach(icon => {
-                //this only really covers WEAK, since the rest have a inconsistent naming scheme, like ONE_MANY; its also reffered to as 1-M
-                //This means we have to manually check these and others like them
-                if (contextLine[0].endIcon != undefined && contextLine[0].endIcon.toUpperCase() == icon){
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //icon can be ZERO_MANY while start icon can be 0-M.
-                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers ZERO_ONE not being equal to 0-1
-                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "0-1") && (icon == "ZERO_ONE")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers ONE not being equal to 1
-                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "1") && (icon == "ONE")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers FORCEDONE not being equal to 1!
-                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "1!") && (icon == "FORCEDONE")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers ONE_MANY not being equal to 1-M
-                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "1-M") && (icon == "ONE_MANY")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
-                }
-                //this covers MANY not being equal to M
-                else if (contextLine[0].endIcon != undefined && (contextLine[0].endIcon.toUpperCase() == "M") && (icon == "MANY")) {
-                    str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                if (contextLine[0].endIcon != undefined) {
+                    //this only really covers WEAK, since the rest have a inconsistent naming scheme, like ONE_MANY; its also reffered to as 1-M
+                    //This means we have to manually check these and others like them
+                    if (contextLine[0].endIcon.toUpperCase() == icon){
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //icon can be ZERO_MANY while start icon can be 0-M.
+                    else if ((contextLine[0].endIcon.toUpperCase() == "0-M") && (icon == "ZERO_MANY")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers ZERO_ONE not being equal to 0-1
+                    else if ((contextLine[0].endIcon.toUpperCase() == "0-1") && (icon == "ZERO_ONE")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers ONE not being equal to 1
+                    else if ((contextLine[0].endIcon.toUpperCase() == "1") && (icon == "ONE")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers FORCEDONE not being equal to 1!
+                    else if ((contextLine[0].endIcon.toUpperCase() == "1!") && (icon == "FORCEDONE")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers ONE_MANY not being equal to 1-M
+                    else if ((contextLine[0].endIcon.toUpperCase() == "1-M") && (icon == "ONE_MANY")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    //this covers MANY not being equal to M
+                    else if ((contextLine[0].endIcon.toUpperCase() == "M") && (icon == "MANY")) {
+                        str += `<option value='${IELineIcons[icon]}' selected>${IELineIcons[icon]}</option>`;
+                    }
+                    else {
+                        str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
+                    }
                 }
                 else {
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;


### PR DESCRIPTION
The previous author thought that icon could be used in an if case with startIcon/endIcon, this is not the case as there are several edge cases like icon being ZERO_ONE and startIcon / endIcon being 0-1. Or icon being WHITEDIAMOND while startIcon/endIcon are White_Diamond. Or icon being FORCEDONE and start/endicon being 1! 

This complete inconsistency of naming has made this issue very bothersome. The best way i found to solve it was to firstly use toUpperCase() on startIcon/endIcon, this solved certain icons like Arrow or Triangle. But the ones that could not be compared as easily I found it best to give them their own If statements; this does inherently lead to some bad smell and the possibilty for refactoring is massive. I strongly believe that if another issue comes up where the root of it lies in these inconsistent naming schemes; a new issue should be created for refactoring these to be consistent and, along side that, this solution should be refactored too.
