### PR TITLE
Lines only between state chart elements #13216

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7305,7 +7305,7 @@ function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, su
     }
 
     // Prevent a line to be drawn between UML- and ER-elements.
-    if (fromElement.type != toElement.type && fromElement.type != "UML_STATE") {
+    if (fromElement.type != toElement.type) {
         displayMessage(messageTypes.ERROR, `Not possible to draw lines between: ${fromElement.type}- and ${toElement.type}-elements`);
         return;
     }


### PR DESCRIPTION
Removed a condition from if-statement in function addLine(). The condition caused the program to ignore the "type to type" check if _fromElement_ was of type UML_STATE.