### PR TITLE
added an error catch

### DIFF
--- a/DuggaSys/diagramservice.php
+++ b/DuggaSys/diagramservice.php
@@ -112,7 +112,7 @@
         $array = array('debug' => $debug, 'weeks' => $weeks);
         echo json_encode($array);
     } catch (Exception $e) {
-        // Somehting went wrong
+        echo 'Message: ' .$e->getMessage();
     }
 
 


### PR DESCRIPTION
Checked diagram.php if there are function that can be moved to diagramservices.php but one was to fetch the data from diagram services and the other to get the error message. In diagramservices i added and error handler where it was missing. By using getMessage(); which returns the description of the error.