### PR TITLE
Made text white for ER-table when in darkmode, Issue#13257

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1133,4 +1133,8 @@ border-left: 14px solid var(--color-sectioned-table-hi);
     background-color: #121212;
     accent-color: #434343;
 }
+
+#ERTable {
+    color:white;
+}
 /*/ END /*/


### PR DESCRIPTION
When you toggle ER-table (can be accessed through key "E") on an ER element the text appears as white when in darkmode. 