### PR TITLE
Made repo unique in database

### DIFF
--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -252,7 +252,7 @@ $sql2 = '
     repoURL VARCHAR(255), 
     repoFileType VARCHAR(50), 
     repoDownloadURL VARCHAR(255), 
-    repoSHA VARCHAR(255), 
+    repoSHA VARCHAR(255) UNIQUE, 
     repoPath VARCHAR(255) 
 	);
 '; 


### PR DESCRIPTION
Modified the database to make repoSHA  unique to avoid duplicated inserts.

Check in server cmd by using "cd /var/www/html/root/G3/students/e21krida/githubMetadata" then "sqlite3 metadata2.db" and finally "select repoName from gitRepos ;"

Now there should only be one repo with the files instead of multiple repos with the same files