### PR TITLE
Deleted .git from regex

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -562,7 +562,7 @@ function setActiveCodes() {
 const regex = {
 	coursename: /^[A-ZÅÄÖa-zåäö]+( ?(- ?)?[A-ZÅÄÖa-zåäö]+)*$/,
 	coursecode: /^[a-zA-Z]{2}\d{3}[a-zA-Z]{1}$/,
-	courseGitURL: /^(https?:\/\/)?(github)(\.com\/)([\w-]*)\/([\w-]*)\/*?$/
+	courseGitURL: /^(https?:\/\/)?(github)(\.com\/)([\w-]*\/)([\w-]+)$/
 };
 
 //Validates single element against regular expression returning true if valid and false if invalid

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -562,7 +562,7 @@ function setActiveCodes() {
 const regex = {
 	coursename: /^[A-ZÅÄÖa-zåäö]+( ?(- ?)?[A-ZÅÄÖa-zåäö]+)*$/,
 	coursecode: /^[a-zA-Z]{2}\d{3}[a-zA-Z]{1}$/,
-	courseGitURL: /^(https?:\/\/)?(github)(\.com)([/\w \.-]*)*\/?$/
+	courseGitURL: /^(https?:\/\/)?(github)(\.com\/)([\w-]*)\/([\w-]*)\/*?$/
 };
 
 //Validates single element against regular expression returning true if valid and false if invalid

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -562,7 +562,7 @@ function setActiveCodes() {
 const regex = {
 	coursename: /^[A-ZÅÄÖa-zåäö]+( ?(- ?)?[A-ZÅÄÖa-zåäö]+)*$/,
 	coursecode: /^[a-zA-Z]{2}\d{3}[a-zA-Z]{1}$/,
-	courseGitURL: /^(https?:\/\/)?(github)(\.com)([/\w \.-]*)*\/?(\.git)$/
+	courseGitURL: /^(https?:\/\/)?(github)(\.com)([/\w \.-]*)*\/?$/
 };
 
 //Validates single element against regular expression returning true if valid and false if invalid


### PR DESCRIPTION
Issue #13281 
Removed the ".git" part from the regex on the git input fields. Test this by entering for example "https://github.com/HGustavs/Webbprogrammering-Examples" into the input field on both create and edit course. 

![image](https://user-images.githubusercontent.com/102578908/232481860-e4086f33-ef46-42d5-95b7-837cd0b1e1f9.png)

( Co-creator @c21rebja )