### PR TITLE
Delay slider stuck while playing #13289

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4369,6 +4369,8 @@ function setReplayDelay(value)
     }
     settings.replay.delay = replayDelayMap[value];
     document.getElementById("replay-time-label").innerHTML = `Delay (${settings.replay.delay}s)`;
+    clearInterval(stateMachine.replayTimer);
+    stateMachine.replay();
 }
 /**
  * @description Changes the play/pause button and locks/unlocks the sliders in replay-mode

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -673,7 +673,8 @@ class StateMachine
         this.scrubHistory(tsIndexArr[cri]);
 
         var self = this;
-        this.replayTimer = setInterval(function() {
+        this.replayTimer = setInterval(function replayInterval() {
+            var startDelay = settings.replay.delay;
 
             cri++;
             var startStateIndex = tsIndexArr[cri];
@@ -692,7 +693,11 @@ class StateMachine
 
             for (var i = startStateIndex; i <= stopStateIndex; i++){
                 self.restoreState(self.historyLog[i]);
- 
+
+                if (settings.replay.delay != startDelay){
+                    clearInterval(self.replayTimer);
+                    self.replayTimer = setInterval(replayInterval, settings.replay.delay * 1000)
+                }
             }
 
             // Update diagram

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4377,7 +4377,6 @@ function setReplayRunning(state)
 
     if (state){
         button.innerHTML = '<div class="diagramIcons" onclick="clearInterval(stateMachine.replayTimer);setReplayRunning(false)"><img src="../Shared/icons/pause.svg"><span class="toolTipText" style="top: -80px;"><b>Pause</b><br><p>Pause history of changes made to the diagram</p><br></span></div>';
-        delaySlider.disabled = true;
         stateSlider.disabled = true;
     }else{
         button.innerHTML = '<div class="diagramIcons" onclick="stateMachine.replay()"><img src="../Shared/icons/Play.svg"><span class="toolTipText" style="top: -80px;"><b>Play</b><br><p>Play history of changes made to the diagram</p><br></span></div>';

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -696,7 +696,7 @@ class StateMachine
 
                 if (settings.replay.delay != startDelay){
                     clearInterval(self.replayTimer);
-                    self.replayTimer = setInterval(replayInterval, settings.replay.delay * 1000)
+                    this.replay();
                 }
             }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -673,8 +673,8 @@ class StateMachine
         this.scrubHistory(tsIndexArr[cri]);
 
         var self = this;
+        var startDelay = settings.replay.delay;
         this.replayTimer = setInterval(function replayInterval() {
-            var startDelay = settings.replay.delay;
 
             cri++;
             var startStateIndex = tsIndexArr[cri];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -693,11 +693,6 @@ class StateMachine
 
             for (var i = startStateIndex; i <= stopStateIndex; i++){
                 self.restoreState(self.historyLog[i]);
-
-                if (settings.replay.delay != startDelay){
-                    clearInterval(self.replayTimer);
-                    this.replay();
-                }
             }
 
             // Update diagram
@@ -711,6 +706,9 @@ class StateMachine
             if (tsIndexArr.length -1 == cri){
                 clearInterval(self.replayTimer);
                 setReplayRunning(false);
+            } else if (settings.replay.delay != startDelay) {
+                clearInterval(self.replayTimer);
+                this.replay();
             }
         }, settings.replay.delay * 1000)
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4387,7 +4387,6 @@ function setReplayRunning(state)
         stateSlider.disabled = true;
     }else{
         button.innerHTML = '<div class="diagramIcons" onclick="stateMachine.replay()"><img src="../Shared/icons/Play.svg"><span class="toolTipText" style="top: -80px;"><b>Play</b><br><p>Play history of changes made to the diagram</p><br></span></div>';
-        delaySlider.disabled = false;
         stateSlider.disabled = false;
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -693,6 +693,11 @@ class StateMachine
 
             for (var i = startStateIndex; i <= stopStateIndex; i++){
                 self.restoreState(self.historyLog[i]);
+
+                if (settings.replay.delay != startDelay){
+                    clearInterval(self.replayTimer);
+                    this.replay();
+                }
             }
 
             // Update diagram
@@ -706,9 +711,6 @@ class StateMachine
             if (tsIndexArr.length -1 == cri){
                 clearInterval(self.replayTimer);
                 setReplayRunning(false);
-            } else if (settings.replay.delay != startDelay) {
-                clearInterval(self.replayTimer);
-                this.replay();
             }
         }, settings.replay.delay * 1000)
 


### PR DESCRIPTION
In replay mode while playing a replay the delay slider that dictates how fast the replay should play can now be moved during replay and change the speed accordingly.