### PR TITLE
G3 2023 v2 issue#13262

### DIFF
--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -5,27 +5,37 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>
-
-	<script>
-
-		// const regexp = /^<a-href=\"(.*?)\/commit\//;
-		// var link = .querySelectorAll('.f6 a');
-		// for(let i = 0; i<link.length; i++) {
-		// 	if(i.match(regexp)) {
-		// 		console.log(link[i]);
-		// 	}
-		// }
-
-	</script>
 </head>
 <body>
 	<?php 
-	  // print_r();
-		// Get the contents of the HTML page
-		echo $html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
-	?>
+		// Used to display errors on screen since PHP doesn't do that automatically.
+		ini_set('display_errors', 1);
+		ini_set('display_startup_errors', 1);
+		error_reporting(E_ALL);
 
-	
+		$html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
+		$dom = new DomDocument;
+		$dom->preserveWhiteSpace = FALSE;
+		
+		// Because of how dom works with html, this is necessary to not fill the screen with errors - the page still prints
+		libxml_use_internal_errors(true); 
+		$dom->loadHTML($html);
+		libxml_use_internal_errors(false);
+
+		//$orgUrl = "HGustavs/LenaSYS/commit"; // temporary until we get the actual url needed
+		$regex = "/^(.*?)\/commit\//";
+
+		// Go through the document
+		$links = $dom->getElementsByTagName('a');
+		foreach ($links as $link) {
+			$value = $link->getAttribute("href");
+			if(preg_match($regex, $value)) {
+				echo "<p>".$value."</p>"; // Print the link if it matches the regex
+			}
+		}
+
+		//print_r($dom);
+	?>
 
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -19,7 +19,7 @@
 		// Fails to load latest commit unless clearing cache on reload
 		$page = file_get_contents("https://github.com/HGustavs/LenaSYS"); 
 
-		echo print_r($page.getElementById("spoof-warning"));
+		echo print_r($page);
 	?>
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -26,7 +26,7 @@
 
 		$xpath = new DOMXPath($dom);
 
-		$resource = $xpath->query("//div/a[@class='link--secondary']");
+		$resource = $xpath->query("//div/a[@class='link--secondary']")->item(0);
 
 		echo $resource->textContent;
 

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -24,15 +24,16 @@
 		// $dom->preserveWhiteSpace = FALSE;
 		// $dom->loadHTML($html);
 
-		 $divs = $html->getElementsByTagName('div');
-        foreach ($divs as $div) {
-					echo "hej";
-		 			if($div->attribute('class')=='Box'){
-		 				echo "Attribute '$div'";
 
-					 }
+		//  $divs = $html->getElementsByTagName('div');
+    //     foreach ($divs as $div) {
+		// 			echo "hej";
+		//  			if($div->attribute('class')=='Box'){
+		//  				echo "Attribute '$div'";
+
+		// 			 }
 					
-       }
+    //    }
 
 				// getElementByClassName('Box');
 				// 	if($div->nodeName == 'a'){

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -29,7 +29,7 @@
 
 		echo "<script>";
 		echo "const regexp = /^<a-href=\"(.*?)\/commit\//;";
-		echo "var link = ".$html.".querySelectorAll('.f6 a');";
+		echo "var link = document.querySelectorAll('.f6 a');";
 		echo "for(let i = 0; i<link.length; i++){";
 		echo "if(i.match(regexp)){";
 		echo "console.log(link[i]);";

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -10,6 +10,7 @@
 		//var url = 'https://github.com/HGustavs/LenaSYS';
 		//var urledit = url.replace('.git', ''); //remove ending
 
+
 			
 	</script>
 </head>
@@ -28,7 +29,7 @@
 
 		echo " 
 			<script>
-				const regexp = /<a-href=\"(.*?)\/commit\/;
+				const regexp = /^<a-href=\"(.*?)\/commit\//;
 				var link = ".$html.".querySelectorAll('a');
 				for(let i = 0; i<link.lenght; i++){
 					if(i.match(regexp)){

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -9,7 +9,6 @@
 			// Get url from db/courseGitURL instead of hardcoding
 			var url = 'https://github.com/HGustavs/LenaSYS.git';
 			var urledit = url.replace('.git', ''); //remove ending
-			console.log(fetch(urledit));
 
 			
 		</script>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -1,23 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-		<script>
-			// Get url from db/courseGitURL instead of hardcoding
-			var url = 'https://github.com/HGustavs/LenaSYS';
-			var urledit = url.replace('.git', ''); //remove ending
+  <meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Document</title>
+	<script>
+		// Get url from db/courseGitURL instead of hardcoding
+		//var url = 'https://github.com/HGustavs/LenaSYS';
+		//var urledit = url.replace('.git', ''); //remove ending
 
 			
-		</script>
+	</script>
 </head>
 <body>
-    <?php 
-        echo $page = file_get_contents("https://github.com/HGustavs/LenaSYS");
+	<?php 
 
-        echo print_r($page);
-    ?>
+		// Fails to load latest commit unless clearing cache on reload
+		$page = file_get_contents("https://github.com/HGustavs/LenaSYS"); 
+
+		echo print_r($page.getElementById("spoof-warning"));
+	?>
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+		<script>
+			// Get url from db/courseGitURL instead of hardcoding
+			var url = 'https://github.com/HGustavs/LenaSYS.git';
+			var urledit = url.replace('.git', ''); //remove ending
+			console.log(fetch(urledit));
+
+			
+		</script>
+</head>
+<body>
+    <?php 
+        
+    ?>
+</body>
+</html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -7,15 +7,14 @@
 	<title>Document</title>
 
 	<script>
-		var page = '<?php $html; ?>';
 
-		const regexp = /^<a-href=\"(.*?)\/commit\//;
-		var link = page.querySelectorAll('.f6 a');
-		for(let i = 0; i<link.length; i++) {
-			if(i.match(regexp)) {
-				console.log(link[i]);
-			}
-		}
+		// const regexp = /^<a-href=\"(.*?)\/commit\//;
+		// var link = .querySelectorAll('.f6 a');
+		// for(let i = 0; i<link.length; i++) {
+		// 	if(i.match(regexp)) {
+		// 		console.log(link[i]);
+		// 	}
+		// }
 
 	</script>
 </head>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -17,26 +17,28 @@
 <body>
 	<?php 
 	  // print_r();
-
 		// Get the contents of the HTML page
 		$html = file_get_contents('https://github.com/HGustavs/LenaSYS'); // Fails to load latest commit unless clearing cache on reload
-		
-		// Parse the HTML with DOM document 
+	?>
+		<!-- // Parse the HTML with DOM document 
 		// $dom = new DomDocument;
  		// $dom->preserveWhiteSpace = FALSE;
-		// $dom->loadHTML($html);
+		// $dom->loadHTML($html); -->
+
+	<script>
+		var page = '<?php echo $html; ?>';
+
+		const regexp = /^<a-href=\"(.*?)\/commit\//;
+		var link = page.querySelectorAll('.f6 a');
+		for(let i = 0; i<link.length; i++) {
+			if(i.match(regexp)) {
+				console.log(link[i]);
+			}
+		}
+	</script>
 
 
-		echo "<script>";
-		echo "const regexp = /^<a-href=\"(.*?)\/commit\//;";
-		echo "var link = document.querySelectorAll('.f6 a');";
-		echo "for(let i = 0; i<link.length; i++){";
-		echo "if(i.match(regexp)){";
-		echo "console.log(link[i]);";
-		echo "}}</script>";
-
-
-		//  $divs = $html->getElementsByTagName('div');
+		<!-- //  $divs = $html->getElementsByTagName('div');
     //     foreach ($divs as $div) {
 		// 			echo "hej";
 		//  			if($div->attribute('class')=='Box'){
@@ -53,7 +55,7 @@
 				// 		echo print_r($link->nodeValue);
 				// 	 }
 
-		// echo print_r($dom);
-	?>
+		// echo print_r($dom); -->
+
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -11,7 +11,7 @@
 	<?php 
 	  // print_r();
 		// Get the contents of the HTML page
-		$html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
+		echo $html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
 	?>
 
 	<script>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -27,17 +27,13 @@
 		// $dom->loadHTML($html);
 
 
-		echo " 
-			<script>
-				const regexp = /^<a-href=\"(.*?)\/commit\//;
-				var link = ".$html.".querySelectorAll('a');
-				for(let i = 0; i<link.lenght; i++){
-					if(i.match(regexp)){
-						console.log(link[i]);
-					}
-				}
-			</script> 
-		";
+		echo "<script>";
+		echo "const regexp = /^<a-href=\"(.*?)\/commit\//;";
+		echo "var link = ".$html.".querySelectorAll('a');";
+		echo "for(let i = 0; i<link.lenght; i++){";
+		echo "if(i.match(regexp)){";
+		echo "console.log(link[i]);";
+		echo "}}</script>";
 
 
 		//  $divs = $html->getElementsByTagName('div');

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -24,13 +24,15 @@
 		$dom->preserveWhiteSpace = FALSE;
 		$dom->loadHTML($html);
 
-		$xpath = new DOMXPath($dom);
+		$divs = $dom->getElementsByClassName('Box');
+        foreach ($divs as $div) {
+           if($div->nodeName == 'a'){
+						$link = $div->getAttribute('href');
+						echo print_r($link->nodeValue);
+					 }
+        }
 
-		$resource = $xpath->query("//div/a[@class='link--secondary']")->item(0);
-
-		echo $resource->textContent;
-
-		echo print_r($resource);
+		//echo print_r();
 	?>
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -7,7 +7,7 @@
     <title>Document</title>
 		<script>
 			// Get url from db/courseGitURL instead of hardcoding
-			var url = 'https://github.com/HGustavs/LenaSYS.git';
+			var url = 'https://github.com/HGustavs/LenaSYS';
 			var urledit = url.replace('.git', ''); //remove ending
 
 			
@@ -15,7 +15,9 @@
 </head>
 <body>
     <?php 
-        
+        echo $page = file_get_contents("https://github.com/HGustavs/LenaSYS");
+
+        echo print_r($page);
     ?>
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -20,19 +20,19 @@
 		$html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
 		
 		// Parse the HTML with DOM document 
-		$dom = new DomDocument;
-		$dom->preserveWhiteSpace = FALSE;
-		$dom->loadHTML($html);
+		// $dom = new DomDocument;
+		// $dom->preserveWhiteSpace = FALSE;
+		// $dom->loadHTML($html);
 
-		// $divs = $dom->getElementsByTagName('div');
-    //     foreach ($divs as $div) {
-		// 			echo "hej";
-		// 			if($div->attribute('class')=='Box'){
-		// 				echo "Attribute '$div'";
+		 $divs = $html->getElementsByTagName('div');
+        foreach ($divs as $div) {
+					echo "hej";
+		 			if($div->attribute('class')=='Box'){
+		 				echo "Attribute '$div'";
 
-					// }
+					 }
 					
-        // }
+       }
 
 				// getElementByClassName('Box');
 				// 	if($div->nodeName == 'a'){
@@ -41,7 +41,7 @@
 				// 		echo print_r($link->nodeValue);
 				// 	 }
 
-		echo print_r($dom);
+		// echo print_r($dom);
 	?>
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -29,7 +29,7 @@
 
 		echo "<script>";
 		echo "const regexp = /^<a-href=\"(.*?)\/commit\//;";
-		echo "var link = ".$html.".querySelectorAll('a');";
+		echo "var link = ".$html.".querySelectorAll('.f6 a');";
 		echo "for(let i = 0; i<link.length; i++){";
 		echo "if(i.match(regexp)){";
 		echo "console.log(link[i]);";

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -6,16 +6,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>
 
-</head>
-<body>
-	<?php 
-	  // print_r();
-		// Get the contents of the HTML page
-		echo $html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
-	?>
-
 	<script>
-		var page = '<?php echo $html; ?>';
+		var page = '<?php $html; ?>';
 
 		const regexp = /^<a-href=\"(.*?)\/commit\//;
 		var link = page.querySelectorAll('.f6 a');
@@ -26,6 +18,15 @@
 		}
 
 	</script>
+</head>
+<body>
+	<?php 
+	  // print_r();
+		// Get the contents of the HTML page
+		echo $html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
+	?>
+
+	
 
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -16,10 +16,21 @@
 <body>
 	<?php 
 
-		// Fails to load latest commit unless clearing cache on reload
-		$page = file_get_contents("https://github.com/HGustavs/LenaSYS"); 
+		// Get the contents of the HTML page
+		$html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
+		
+		// Parse the HTML with DOM document 
+		$dom = new DomDocument;
+		$dom->preserveWhiteSpace = FALSE;
+		$dom->loadHTML($html);
 
-		echo print_r($page);
+		$xpath = new DOMXPath($dom);
+
+		$resource = $xpath->query("//div/a[@class='link--secondary']");
+
+		echo $resource->textContent;
+
+		echo print_r($resource);
 	?>
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -15,14 +15,26 @@
 </head>
 <body>
 	<?php 
+	  // print_r();
 
 		// Get the contents of the HTML page
-		$html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
+		$html = file_get_contents('https://github.com/HGustavs/LenaSYS'); // Fails to load latest commit unless clearing cache on reload
 		
 		// Parse the HTML with DOM document 
 		// $dom = new DomDocument;
-		// $dom->preserveWhiteSpace = FALSE;
+ 		// $dom->preserveWhiteSpace = FALSE;
 		// $dom->loadHTML($html);
+
+
+		echo "
+			<script>
+				var link = ".$html.".querySelectorAll('.Box a');
+				for(let i = 0; i < link.lenght; i++){
+					console.log(link[i]);
+				}
+			</script>
+		
+		";
 
 
 		//  $divs = $html->getElementsByTagName('div');

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -26,6 +26,7 @@
 
 		$divs = $dom->getElementsByTagName('div');
         foreach ($divs as $div) {
+					echo "hej";
 					if($div->attribute('class')=='Box'){
 						echo "Attribute '$div'";
 

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -5,14 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>
-	<script>
-		// Get url from db/courseGitURL instead of hardcoding
-		//var url = 'https://github.com/HGustavs/LenaSYS';
-		//var urledit = url.replace('.git', ''); //remove ending
 
-
-			
-	</script>
 </head>
 <body>
 	<?php 
@@ -20,10 +13,6 @@
 		// Get the contents of the HTML page
 		$html = file_get_contents('https://github.com/HGustavs/LenaSYS'); // Fails to load latest commit unless clearing cache on reload
 	?>
-		<!-- // Parse the HTML with DOM document 
-		// $dom = new DomDocument;
- 		// $dom->preserveWhiteSpace = FALSE;
-		// $dom->loadHTML($html); -->
 
 	<script>
 		var page = '<?php echo $html; ?>';
@@ -35,27 +24,8 @@
 				console.log(link[i]);
 			}
 		}
+		
 	</script>
-
-
-		<!-- //  $divs = $html->getElementsByTagName('div');
-    //     foreach ($divs as $div) {
-		// 			echo "hej";
-		//  			if($div->attribute('class')=='Box'){
-		//  				echo "Attribute '$div'";
-
-		// 			 }
-					
-    //    }
-
-				// getElementByClassName('Box');
-				// 	if($div->nodeName == 'a'){
-
-				// 		$link = $div->getAttribute('href');
-				// 		echo print_r($link->nodeValue);
-				// 	 }
-
-		// echo print_r($dom); -->
 
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -24,15 +24,15 @@
 		$dom->preserveWhiteSpace = FALSE;
 		$dom->loadHTML($html);
 
-		$divs = $dom->getElementsByTagName('div');
-        foreach ($divs as $div) {
-					echo "hej";
-					if($div->attribute('class')=='Box'){
-						echo "Attribute '$div'";
+		// $divs = $dom->getElementsByTagName('div');
+    //     foreach ($divs as $div) {
+		// 			echo "hej";
+		// 			if($div->attribute('class')=='Box'){
+		// 				echo "Attribute '$div'";
 
-					}
+					// }
 					
-        }
+        // }
 
 				// getElementByClassName('Box');
 				// 	if($div->nodeName == 'a'){
@@ -41,7 +41,7 @@
 				// 		echo print_r($link->nodeValue);
 				// 	 }
 
-		//echo print_r();
+		echo print_r($dom);
 	?>
 </body>
 </html>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -26,14 +26,16 @@
 		// $dom->loadHTML($html);
 
 
-		echo "
+		echo " 
 			<script>
-				var link = ".$html.".querySelectorAll('.Box a');
-				for(let i = 0; i < link.lenght; i++){
-					console.log(link[i]);
+				const regexp = /<a-href=\"(.*?)\/commit\/;
+				var link = ".$html.".querySelectorAll('a');
+				for(let i = 0; i<link.lenght; i++){
+					if(i.match(regexp)){
+						console.log(link[i]);
+					}
 				}
-			</script>
-		
+			</script> 
 		";
 
 

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -11,7 +11,7 @@
 	<?php 
 	  // print_r();
 		// Get the contents of the HTML page
-		$html = file_get_contents('https://github.com/HGustavs/LenaSYS'); // Fails to load latest commit unless clearing cache on reload
+		$html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
 	?>
 
 	<script>
@@ -24,7 +24,7 @@
 				console.log(link[i]);
 			}
 		}
-		
+
 	</script>
 
 </body>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -24,13 +24,21 @@
 		$dom->preserveWhiteSpace = FALSE;
 		$dom->loadHTML($html);
 
-		$divs = $dom->getElementsByClassName('Box');
+		$divs = $dom->getElementsByTagName('div');
         foreach ($divs as $div) {
-           if($div->nodeName == 'a'){
-						$link = $div->getAttribute('href');
-						echo print_r($link->nodeValue);
-					 }
+					if($div->attribute('class')=='Box'){
+						echo "Attribute '$div'";
+
+					}
+					
         }
+
+				// getElementByClassName('Box');
+				// 	if($div->nodeName == 'a'){
+
+				// 		$link = $div->getAttribute('href');
+				// 		echo print_r($link->nodeValue);
+				// 	 }
 
 		//echo print_r();
 	?>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -30,7 +30,7 @@
 		echo "<script>";
 		echo "const regexp = /^<a-href=\"(.*?)\/commit\//;";
 		echo "var link = ".$html.".querySelectorAll('a');";
-		echo "for(let i = 0; i<link.lenght; i++){";
+		echo "for(let i = 0; i<link.length; i++){";
 		echo "if(i.match(regexp)){";
 		echo "console.log(link[i]);";
 		echo "}}</script>";

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -1,41 +1,35 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Document</title>
-</head>
-<body>
-	<?php 
-		// Used to display errors on screen since PHP doesn't do that automatically.
-		ini_set('display_errors', 1);
-		ini_set('display_startup_errors', 1);
-		error_reporting(E_ALL);
+<?php 
+	// Used to display errors on screen since PHP doesn't do that automatically.
+	ini_set('display_errors', 1);
+	ini_set('display_startup_errors', 1);
+	error_reporting(E_ALL);
 
-		$html = file_get_contents("https://github.com/HGustavs/LenaSYS"); // Fails to load latest commit unless clearing cache on reload
-		$dom = new DomDocument;
-		$dom->preserveWhiteSpace = FALSE;
-		
-		// Because of how dom works with html, this is necessary to not fill the screen with errors - the page still prints
-		libxml_use_internal_errors(true); 
-		$dom->loadHTML($html);
-		libxml_use_internal_errors(false);
+	$url = "https://github.com/HGustavs/LenaSYS"; // TODO: This url should be the one you fetch from the database!
 
-		//$orgUrl = "HGustavs/LenaSYS/commit"; // temporary until we get the actual url needed
-		$regex = "/^(.*?)\/commit\//";
+	$html = file_get_contents($url);
+	$dom = new DomDocument;
+	$dom->preserveWhiteSpace = FALSE;
+	
+	// Because of how dom works with html, this is necessary to not fill the screen with errors - the page still prints
+	libxml_use_internal_errors(true); 
+	$dom->loadHTML($html);
+	libxml_use_internal_errors(false);
 
-		// Go through the document
-		$links = $dom->getElementsByTagName('a');
-		foreach ($links as $link) {
-			$value = $link->getAttribute("href");
-			if(preg_match($regex, $value)) {
-				echo "<p>".$value."</p>"; // Print the link if it matches the regex
-			}
+	/* TODO: This regex could be improved to take the explicit name of the user and repo,
+	* for example "/HGustavs/LenaSYS/commit/..."
+	* instead of just taking "/.../.../commit/...". */
+	$regex = "/^(.*?)\/commit\//";
+	
+	$links = $dom->getElementsByTagName('a');
+
+	foreach ($links as $link) {
+		$value = $link->getAttribute("href");
+		if(preg_match($regex, $value)) {
+			$href = $value; // Takes the first matching value and stores it in an array
+			break; //exits the loop since only the first match is necessary
 		}
+	}
 
-		//print_r($dom);
-	?>
-
-</body>
-</html>
+	$latestCommit = preg_replace($regex, "", $href);
+	print_r($latestCommit); // TODO: This is where we could store the value in the db, or similar
+?>


### PR DESCRIPTION
To reach the numbers representing the latest commit, we had to reach the link that it was connected to. This wasn't easy, since the element neither had classes or an id that made it easy to identify and reach. Becasue of this the easiset solution (that we could come up with) to reach the link was to use DomDocument. This is an extension and needed to be installed on the server for it to work properly. 

If the structure of the html on github had been better, we wouldn't have had to use DOM, but we found it necessary in order to resolve the issue.

When testing you should see several numbers, which respresent the lastest commit thas has been made. 

This have been implemented in the file recursivetesting -> getLatestCommit.php

( Co-creator - @c21rebja )