### PR TITLE
 Lines between states should be possible to label #13081 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7882,6 +7882,21 @@ function drawLine(line, targetGhost = false)
                 }
                 var iconSizeStart=40;
                 break;
+            case UMLSTATELineIcons.ARROW:
+                if (line.ctype == 'TB') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy - 40 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                else if(line.ctype == 'BT'){
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy + 40 * zoomfact},${fx - 10 * zoomfact} ${fy + 20 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                else if (line.ctype == 'LR') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 20 * zoomfact} ${fy + 10 * zoomfact},${fx - 40 * zoomfact} ${fy},${fx - 20 * zoomfact} ${fy - 10 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                else if (line.ctype == 'RL') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 20 * zoomfact} ${fy + 10 * zoomfact},${fx + 40 * zoomfact} ${fy},${fx + 20 * zoomfact} ${fy - 10 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                var iconSizeStart=40;
+                break;
             default:
                 var iconSizeStart=0;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6700,15 +6700,15 @@ function generateContextProperties()
                 if (contextLine[0].startIcon != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
                     if (contextLine[0].startIcon == icon){
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                        str += `<option value='${UMLSTATELineIcons[icon]}' selected>${UMLSTATELineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
                     else {
-                        str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                        str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
                     }
                 }
                 else {
-                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
@@ -6717,15 +6717,15 @@ function generateContextProperties()
                 if (contextLine[0].endIcon != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
                     if (contextLine[0].endIcon == icon){
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                        str += `<option value='${UMLSTATELineIcons[icon]}' selected>${UMLSTATELineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
                     else {
-                        str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                        str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
                     }
                 }
                 else {
-                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
                 }
             });
             str += `</select>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6553,6 +6553,12 @@ function generateContextProperties()
             if(contextLine[0].endLabel && contextLine[0].endLabel != "") str += `value="${contextLine[0].endLabel}"`;
             str += `/>`;
         }
+        if (contextLine[0].type == 'UML_STATE') {
+            str += `<h3 style="margin-bottom: 0; margin-top: 5px">Label</h3>`;
+            str += `<input id="lineLabel" maxlength="50" type="text" placeholder="Label..."`;
+            if(contextLine[0].label && contextLine[0].label != "") str += `value="${contextLine[0].label}"`;
+            str += `/>`;
+        }
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6691,6 +6691,7 @@ function generateContextProperties()
             });
             str += `</select>`;
         }
+        //generate the dropdown for UML_STATE line icons.
         if (contextLine[0].type == 'UML_STATE') {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
@@ -6724,6 +6725,9 @@ function generateContextProperties()
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
+            Object.keys(UMLSTATELineIcons).forEach(icon => {
+                str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
+            });
             str += `</select>`;
         }
         str+=`<br><br><input type="submit" class='saveButton' value="Save" onclick="changeLineProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -852,7 +852,7 @@ const entityType = {
 
     SD: "SD",
 
-    //UML_STATE: "UML_STATE"
+    UML_STATE: "UML_STATE"
 
 };
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6540,7 +6540,7 @@ function generateContextProperties()
                 }
             }
         }
-        if (contextLine[0].type == 'UML') {
+        if ((contextLine[0].type == 'UML') || (contextLine[0].type == 'UML_STATE')) {
             str += `<h3 style="margin-bottom: 0; margin-top: 5px">Label</h3>`;
             str += `<input id="lineLabel" maxlength="50" type="text" placeholder="Label..."`;
             if(contextLine[0].label && contextLine[0].label != "") str += `value="${contextLine[0].label}"`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7884,16 +7884,16 @@ function drawLine(line, targetGhost = false)
                 break;
             case UMLSTATELineIcons.ARROW:
                 if (line.ctype == 'TB') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy - 40 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if(line.ctype == 'BT'){
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy + 40 * zoomfact},${fx - 10 * zoomfact} ${fy + 20 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 20 * zoomfact},${fx - 10 * zoomfact} ${fy + 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if (line.ctype == 'LR') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 20 * zoomfact} ${fy + 10 * zoomfact},${fx - 40 * zoomfact} ${fy},${fx - 20 * zoomfact} ${fy - 10 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 20 * zoomfact} ${fy + 10 * zoomfact},${fx - 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if (line.ctype == 'RL') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 20 * zoomfact} ${fy + 10 * zoomfact},${fx + 40 * zoomfact} ${fy},${fx + 20 * zoomfact} ${fy - 10 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 20 * zoomfact} ${fy + 10 * zoomfact},${fx + 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 var iconSizeStart=40;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -929,7 +929,7 @@ const lineCardinalitys = {
 /**
  * @description Available options of icons to display at the end of lines connecting two UML_STATE elements.
  */
- const SDSTATELineIcons = {//TODO: Replace with actual icons for the dropdown
+ const SDLineIcons = {//TODO: Replace with actual icons for the dropdown
     ARROW: "ARROW"
 };
 //#endregion ===================================================================================
@@ -6696,36 +6696,36 @@ function generateContextProperties()
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             //iterate through all the icons assicoated with UML_STATE, and add them to the drop down as options
-            Object.keys(SDSTATELineIcons).forEach(icon => {
+            Object.keys(SDLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
                     if (contextLine[0].startIcon == icon){
-                        str += `<option value='${SDSTATELineIcons[icon]}' selected>${SDSTATELineIcons[icon]}</option>`;
+                        str += `<option value='${SDLineIcons[icon]}' selected>${SDLineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
                     else {
-                        str += `<option value='${SDSTATELineIcons[icon]}'>${SDSTATELineIcons[icon]}</option>`;
+                        str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                     }
                 }
                 else {
-                    str += `<option value='${SDSTATELineIcons[icon]}'>${SDSTATELineIcons[icon]}</option>`;
+                    str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
-            Object.keys(SDSTATELineIcons).forEach(icon => {
+            Object.keys(SDLineIcons).forEach(icon => {
                 if (contextLine[0].endIcon != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
                     if (contextLine[0].endIcon == icon){
-                        str += `<option value='${SDSTATELineIcons[icon]}' selected>${SDSTATELineIcons[icon]}</option>`;
+                        str += `<option value='${SDLineIcons[icon]}' selected>${SDLineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
                     else {
-                        str += `<option value='${SDSTATELineIcons[icon]}'>${SDSTATELineIcons[icon]}</option>`;
+                        str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                     }
                 }
                 else {
-                    str += `<option value='${SDSTATELineIcons[icon]}'>${SDSTATELineIcons[icon]}</option>`;
+                    str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                 }
             });
             str += `</select>`;
@@ -7882,7 +7882,7 @@ function drawLine(line, targetGhost = false)
                 }
                 var iconSizeStart=40;
                 break;
-            case SDSTATELineIcons.ARROW:
+            case SDLineIcons.ARROW:
                 if (line.ctype == 'TB') {
                     str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
@@ -8102,7 +8102,7 @@ function drawLine(line, targetGhost = false)
                 }
                 var iconSizeEnd=40;
                 break;
-            case SDSTATELineIcons.ARROW:
+            case SDLineIcons.ARROW:
                 if (line.ctype == 'BT') {
                     str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${tx - 10 * zoomfact} ${ty - 20 * zoomfact},${tx} ${ty},${tx + 10 * zoomfact} ${ty - 20 * zoomfact},${tx - 10 * zoomfact} ${ty - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7610,10 +7610,20 @@ function drawLine(line, targetGhost = false)
         y2Offset = 0;
     }
 
-    if (felem.type != 'ER' || telem.type != 'ER') {
+    /* if (felem.type != 'ER' || telem.type != 'ER') {
         line.type = 'UML';
     } else {
         line.type = 'ER';
+    } */
+    //gives the lines the correct type based on the from and to element.
+    if ((felem.type == 'UML_STATE') || (telem.type == 'UML_STATE')) {
+        line.type = 'UML_STATE';
+    }
+    else if ((felem.type == 'ER') || (telem.type == 'ER')) {
+        line.type = 'ER';
+    }
+    else {
+        line.type = 'UML';
     }
 
     // If element is UML or IE (use straight line segments instead)

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8102,6 +8102,21 @@ function drawLine(line, targetGhost = false)
                 }
                 var iconSizeEnd=40;
                 break;
+            case UMLSTATELineIcons.ARROW:
+                if (line.ctype == 'TB') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                else if(line.ctype == 'BT'){
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 20 * zoomfact},${fx - 10 * zoomfact} ${fy + 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                else if (line.ctype == 'LR') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 20 * zoomfact} ${fy + 10 * zoomfact},${fx - 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                else if (line.ctype == 'RL') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 20 * zoomfact} ${fy + 10 * zoomfact},${fx + 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                var iconSizeStart=40;
+                break;    
             default:
                 var iconSizeEnd=0;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3178,7 +3178,7 @@ function changeLineProperties()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { label: label.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     }
     // UML line
-    if (line.type == 'UML') {
+    if ((line.type == 'UML') || (line.type == 'UML_STATE')) {
         // Start label, near side
         if(line.startLabel != startLabel.value){
             startLabel.value = startLabel.value.trim();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6695,22 +6695,11 @@ function generateContextProperties()
         if (contextLine[0].type == 'UML_STATE') {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
-            //iterate through all the icons assicoated with UML, like Arrow or Black Diamond and add them to the drop down as options
+            //iterate through all the icons assicoated with UML_STATE, and add them to the drop down as options
             Object.keys(UMLSTATELineIcons).forEach(icon => {
-                /* if (contextLine[0].startIcon != undefined) {
-                    //this covers Triangle and Arrow.
+                if (contextLine[0].startIcon != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                    if (contextLine[0].startIcon.toUpperCase() == icon){
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                        console.log("icon is " + icon);
-                        console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
-                    }
-                    //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
-                    //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
-                    else if ((contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
-                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
-                    }
-                    else if ((contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                    if (contextLine[0].startIcon == icon){
                         str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
@@ -6720,13 +6709,24 @@ function generateContextProperties()
                 }
                 else {
                     str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
-                } */
-                str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
+                }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             Object.keys(UMLSTATELineIcons).forEach(icon => {
-                str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
+                if (contextLine[0].endIcon != undefined) {
+                    //If the lines in context happen to be matching something in the drop down, it is set as selected.
+                    if (contextLine[0].endIcon == icon){
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    //else, its not matching and the option is just added to the dropdown normally.
+                    else {
+                        str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    }
+                }
+                else {
+                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                }
             });
             str += `</select>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7884,16 +7884,16 @@ function drawLine(line, targetGhost = false)
                 break;
             case UMLSTATELineIcons.ARROW:
                 if (line.ctype == 'TB') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 5 * zoomfact} ${fy - 20 * zoomfact},${fx - 5 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if(line.ctype == 'BT'){
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 20 * zoomfact},${fx - 10 * zoomfact} ${fy + 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 5 * zoomfact} ${fy + 20 * zoomfact},${fx - 5 * zoomfact} ${fy + 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if (line.ctype == 'LR') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 20 * zoomfact} ${fy + 10 * zoomfact},${fx - 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 10 * zoomfact} ${fy + 10 * zoomfact},${fx - 10 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if (line.ctype == 'RL') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 20 * zoomfact} ${fy + 10 * zoomfact},${fx + 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 10 * zoomfact},${fx + 10 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 var iconSizeStart=40;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6553,12 +6553,6 @@ function generateContextProperties()
             if(contextLine[0].endLabel && contextLine[0].endLabel != "") str += `value="${contextLine[0].endLabel}"`;
             str += `/>`;
         }
-        if (contextLine[0].type == 'UML_STATE') {
-            str += `<h3 style="margin-bottom: 0; margin-top: 5px">Label</h3>`;
-            str += `<input id="lineLabel" maxlength="50" type="text" placeholder="Label..."`;
-            if(contextLine[0].label && contextLine[0].label != "") str += `value="${contextLine[0].label}"`;
-            str += `/>`;
-        }
         if (contextLine[0].type == 'UML' || contextLine[0].type == 'IE' ) {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7884,16 +7884,16 @@ function drawLine(line, targetGhost = false)
                 break;
             case UMLSTATELineIcons.ARROW:
                 if (line.ctype == 'TB') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 5 * zoomfact} ${fy - 20 * zoomfact},${fx - 5 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if(line.ctype == 'BT'){
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 5 * zoomfact} ${fy + 20 * zoomfact},${fx - 5 * zoomfact} ${fy + 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 20 * zoomfact},${fx - 10 * zoomfact} ${fy + 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if (line.ctype == 'LR') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 10 * zoomfact} ${fy + 10 * zoomfact},${fx - 10 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 20 * zoomfact} ${fy + 10 * zoomfact},${fx - 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if (line.ctype == 'RL') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 10 * zoomfact},${fx + 10 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 20 * zoomfact} ${fy + 10 * zoomfact},${fx + 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 var iconSizeStart=40;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8103,20 +8103,20 @@ function drawLine(line, targetGhost = false)
                 var iconSizeEnd=40;
                 break;
             case UMLSTATELineIcons.ARROW:
-                if (line.ctype == 'TB') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                if (line.ctype == 'BT') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${tx - 10 * zoomfact} ${ty - 20 * zoomfact},${tx} ${ty},${tx + 10 * zoomfact} ${ty - 20 * zoomfact},${tx - 10 * zoomfact} ${ty - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
-                else if(line.ctype == 'BT'){
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 20 * zoomfact},${fx - 10 * zoomfact} ${fy + 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                }
-                else if (line.ctype == 'LR') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 20 * zoomfact} ${fy + 10 * zoomfact},${fx - 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                else if(line.ctype == 'TB'){
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${tx - 10 * zoomfact} ${ty + 20 * zoomfact},${tx} ${ty},${tx + 10 * zoomfact} ${ty + 20 * zoomfact},${tx - 10 * zoomfact} ${ty + 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
                 else if (line.ctype == 'RL') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 20 * zoomfact} ${fy + 10 * zoomfact},${fx + 20 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${tx - 20 * zoomfact} ${ty - 10 * zoomfact},${tx} ${ty},${tx - 20 * zoomfact} ${ty + 10 * zoomfact},${tx - 20 * zoomfact} ${ty - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
-                var iconSizeStart=40;
-                break;    
+                else if (line.ctype == 'LR') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${tx + 20 * zoomfact} ${ty - 10 * zoomfact},${tx} ${ty},${tx + 20 * zoomfact} ${ty + 10 * zoomfact},${tx + 20 * zoomfact} ${ty - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                var iconSizeEnd=20;
+                break;
             default:
                 var iconSizeEnd=0;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -926,6 +926,12 @@ const lineCardinalitys = {
     MANY: "M",
     WEAK: "Weak"
 };
+/**
+ * @description Available options of icons to display at the end of lines connecting two UML_STATE elements.
+ */
+ const UMLSTATELineIcons = {//TODO: Replace with actual icons for the dropdown
+    ARROW: "ARROW"
+};
 //#endregion ===================================================================================
 //#region ================================ GLOBAL VARIABLES     ================================
 // Data and html building variables
@@ -6683,6 +6689,41 @@ function generateContextProperties()
                     str += `<option value='${IELineIcons[icon]}'>${IELineIcons[icon]}</option>`;
                 }
             });
+            str += `</select>`;
+        }
+        if (contextLine[0].type == 'UML_STATE') {
+            str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
+            str  += `<option value=''>None</option>`;
+            //iterate through all the icons assicoated with UML, like Arrow or Black Diamond and add them to the drop down as options
+            Object.keys(UMLSTATELineIcons).forEach(icon => {
+                /* if (contextLine[0].startIcon != undefined) {
+                    //this covers Triangle and Arrow.
+                    //If the lines in context happen to be matching something in the drop down, it is set as selected.
+                    if (contextLine[0].startIcon.toUpperCase() == icon){
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                        console.log("icon is " + icon);
+                        console.log("startIcon is " + contextLine[0].startIcon.toUpperCase());
+                    }
+                    //white and diamond needs their own if statement since contextLine[0].startIcon can be White_Diamond,
+                    //while icon is WHITEDIAMOND. So I decided the most suitable way is to manually check it.
+                    else if ((contextLine[0].startIcon == "White_Diamond") && (icon == "WHITEDIAMOND")) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    else if ((contextLine[0].startIcon == "Black_Diamond") && (icon == "BLACKDIAMOND")) {
+                        str += `<option value='${UMLLineIcons[icon]}' selected>${UMLLineIcons[icon]}</option>`;
+                    }
+                    //else, its not matching and the option is just added to the dropdown normally.
+                    else {
+                        str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                    }
+                }
+                else {
+                    str += `<option value='${UMLLineIcons[icon]}'>${UMLLineIcons[icon]}</option>`;
+                } */
+                str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
+            });
+            str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
+            str  += `<option value=''>None</option>`;
             str += `</select>`;
         }
         str+=`<br><br><input type="submit" class='saveButton' value="Save" onclick="changeLineProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -929,7 +929,7 @@ const lineCardinalitys = {
 /**
  * @description Available options of icons to display at the end of lines connecting two UML_STATE elements.
  */
- const UMLSTATELineIcons = {//TODO: Replace with actual icons for the dropdown
+ const SDSTATELineIcons = {//TODO: Replace with actual icons for the dropdown
     ARROW: "ARROW"
 };
 //#endregion ===================================================================================
@@ -6696,36 +6696,36 @@ function generateContextProperties()
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
             //iterate through all the icons assicoated with UML_STATE, and add them to the drop down as options
-            Object.keys(UMLSTATELineIcons).forEach(icon => {
+            Object.keys(SDSTATELineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
                     if (contextLine[0].startIcon == icon){
-                        str += `<option value='${UMLSTATELineIcons[icon]}' selected>${UMLSTATELineIcons[icon]}</option>`;
+                        str += `<option value='${SDSTATELineIcons[icon]}' selected>${SDSTATELineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
                     else {
-                        str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
+                        str += `<option value='${SDSTATELineIcons[icon]}'>${SDSTATELineIcons[icon]}</option>`;
                     }
                 }
                 else {
-                    str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
+                    str += `<option value='${SDSTATELineIcons[icon]}'>${SDSTATELineIcons[icon]}</option>`;
                 }
             });
             str += `</select><select id='lineEndIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
-            Object.keys(UMLSTATELineIcons).forEach(icon => {
+            Object.keys(SDSTATELineIcons).forEach(icon => {
                 if (contextLine[0].endIcon != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
                     if (contextLine[0].endIcon == icon){
-                        str += `<option value='${UMLSTATELineIcons[icon]}' selected>${UMLSTATELineIcons[icon]}</option>`;
+                        str += `<option value='${SDSTATELineIcons[icon]}' selected>${SDSTATELineIcons[icon]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
                     else {
-                        str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
+                        str += `<option value='${SDSTATELineIcons[icon]}'>${SDSTATELineIcons[icon]}</option>`;
                     }
                 }
                 else {
-                    str += `<option value='${UMLSTATELineIcons[icon]}'>${UMLSTATELineIcons[icon]}</option>`;
+                    str += `<option value='${SDSTATELineIcons[icon]}'>${SDSTATELineIcons[icon]}</option>`;
                 }
             });
             str += `</select>`;
@@ -7882,7 +7882,7 @@ function drawLine(line, targetGhost = false)
                 }
                 var iconSizeStart=40;
                 break;
-            case UMLSTATELineIcons.ARROW:
+            case SDSTATELineIcons.ARROW:
                 if (line.ctype == 'TB') {
                     str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
@@ -8102,7 +8102,7 @@ function drawLine(line, targetGhost = false)
                 }
                 var iconSizeEnd=40;
                 break;
-            case UMLSTATELineIcons.ARROW:
+            case SDSTATELineIcons.ARROW:
                 if (line.ctype == 'BT') {
                     str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${tx - 10 * zoomfact} ${ty - 20 * zoomfact},${tx} ${ty},${tx + 10 * zoomfact} ${ty - 20 * zoomfact},${tx - 10 * zoomfact} ${ty - 20 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6540,7 +6540,7 @@ function generateContextProperties()
                 }
             }
         }
-        if ((contextLine[0].type == 'UML') || (contextLine[0].type == 'UML_STATE')) {
+        if (contextLine[0].type == 'UML') {
             str += `<h3 style="margin-bottom: 0; margin-top: 5px">Label</h3>`;
             str += `<input id="lineLabel" maxlength="50" type="text" placeholder="Label..."`;
             if(contextLine[0].label && contextLine[0].label != "") str += `value="${contextLine[0].label}"`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7882,21 +7882,6 @@ function drawLine(line, targetGhost = false)
                 }
                 var iconSizeStart=40;
                 break;
-            case UMLSTATELineIcons.ARROW:
-                if (line.ctype == 'TB') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy - 40 * zoomfact},${fx - 10 * zoomfact} ${fy - 20 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                }
-                else if(line.ctype == 'BT'){
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 20 * zoomfact},${fx} ${fy + 40 * zoomfact},${fx - 10 * zoomfact} ${fy + 20 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                }
-                else if (line.ctype == 'LR') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx - 20 * zoomfact} ${fy + 10 * zoomfact},${fx - 40 * zoomfact} ${fy},${fx - 20 * zoomfact} ${fy - 10 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                }
-                else if (line.ctype == 'RL') {
-                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode' points='${fx + 20 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy},${fx + 20 * zoomfact} ${fy + 10 * zoomfact},${fx + 40 * zoomfact} ${fy},${fx + 20 * zoomfact} ${fy - 10 * zoomfact}' fill='#000000' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                }
-                var iconSizeStart=40;
-                break;
             default:
                 var iconSizeStart=0;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -852,7 +852,7 @@ const entityType = {
 
     SD: "SD",
 
-    UML_STATE: "UML_STATE"
+    //UML_STATE: "UML_STATE"
 
 };
 /**
@@ -927,7 +927,7 @@ const lineCardinalitys = {
     WEAK: "Weak"
 };
 /**
- * @description Available options of icons to display at the end of lines connecting two UML_STATE elements.
+ * @description Available options of icons to display at the end of lines connecting two SD elements.
  */
  const SDLineIcons = {//TODO: Replace with actual icons for the dropdown
     ARROW: "ARROW"
@@ -3178,7 +3178,7 @@ function changeLineProperties()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { label: label.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     }
     // UML line
-    if ((line.type == 'UML') || (line.type == 'UML_STATE')) {
+    if ((line.type == 'UML') || (line.type == 'SD')) {
         // Start label, near side
         if(line.startLabel != startLabel.value){
             startLabel.value = startLabel.value.trim();
@@ -6540,7 +6540,7 @@ function generateContextProperties()
                 }
             }
         }
-        if ((contextLine[0].type == 'UML') || (contextLine[0].type == 'UML_STATE')) {
+        if ((contextLine[0].type == 'UML') || (contextLine[0].type == 'SD')) {
             str += `<h3 style="margin-bottom: 0; margin-top: 5px">Label</h3>`;
             str += `<input id="lineLabel" maxlength="50" type="text" placeholder="Label..."`;
             if(contextLine[0].label && contextLine[0].label != "") str += `value="${contextLine[0].label}"`;
@@ -6691,11 +6691,11 @@ function generateContextProperties()
             });
             str += `</select>`;
         }
-        //generate the dropdown for UML_STATE line icons.
-        if (contextLine[0].type == 'UML_STATE') {
+        //generate the dropdown for SD line icons.
+        if (contextLine[0].type == 'SD') {
             str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
             str  += `<option value=''>None</option>`;
-            //iterate through all the icons assicoated with UML_STATE, and add them to the drop down as options
+            //iterate through all the icons assicoated with SD, and add them to the drop down as options
             Object.keys(SDLineIcons).forEach(icon => {
                 if (contextLine[0].startIcon != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
@@ -7662,7 +7662,7 @@ function drawLine(line, targetGhost = false)
     } */
     //gives the lines the correct type based on the from and to element.
     if ((felem.type == 'UML_STATE') || (telem.type == 'UML_STATE')) {
-        line.type = 'UML_STATE';
+        line.type = 'SD';
     }
     else if ((felem.type == 'ER') || (telem.type == 'ER')) {
         line.type = 'ER';


### PR DESCRIPTION
created a new line type: UML_STATE and gave it its own set of icons, called SDLineIcons. This set of icons contains one icon called ARROW which uses the SVG from UML black triangle. Then I implemented this new line type and made it so that any line between two UML_STATES gets this type. I also modified the options panel for state lines to account for the new line type and its icons, so that the drop down for icon selection is correct.