### PR TITLE
g1-2023-v2-#13357 Add SD to togglePlacementType()

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5951,6 +5951,11 @@ function togglePlacementType(num,type){
         document.getElementById("elementPlacement6").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton6").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox6").classList.remove("activeTogglePlacementTypeBox");// IE entity end
+        document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD state start
+        document.getElementById("elementPlacement8").children.item(1).classList.add("toolTipText");
+        document.getElementById("elementPlacement8").children.item(1).classList.remove("hiddenToolTiptext");
+        document.getElementById("togglePlacementTypeButton8").classList.remove("activeTogglePlacementTypeButton");
+        document.getElementById("togglePlacementTypeBox8").classList.remove("activeTogglePlacementTypeBox");// SD state end
     }
     else if(type==1){
         document.getElementById("elementPlacement1").classList.add("hiddenPlacementType");// ER relation start


### PR DESCRIPTION
Before this issue clicking the button for placing SD states would break the system, after this issue the system will not break in this case, however it still breaks if you attempt to place an SD state. Meaning you can select said button and then select another without it breaking as long as you do not click in the diagram area