### PR TITLE
 Inconsistencies with selected lines highlight in both light and darkmode #13333 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7446,7 +7446,12 @@ function drawLine(line, targetGhost = false)
     else{
         var strokeDash="0";
     }
-    var lineColor = '#000000';
+    if (isDarkTheme) {
+        var lineColor = '#FFFFFF';
+    } else {
+        var lineColor = '#000000';
+    }
+    
 
     if(contextLine.includes(line)){
         lineColor = selectedColor;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -11104,7 +11104,7 @@ function drawSelectionBox(str)
         selectionBoxHighY = highY + 5;
 
         // Selection container of selected elements
-        str += `<rect width='${highX - lowX + 10}' height='${highY - lowY + 10}' x= '${lowX - 5}' y='${lowY - 5}'; style="fill:transparent; stroke-width:1.5; stroke:${selectedColor};" />`;
+        str += `<rect width='${highX - lowX + 10}' height='${highY - lowY + 10}' x= '${lowX - 5}' y='${lowY - 5}'; style="fill:transparent; stroke-width:1.5; stroke:white;" />`;
 
         //Determine size and position of delete button
         if (highX - lowX + 10 > highY - lowY + 10) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -11437,6 +11437,10 @@ function toggleBorderOfElements() {
         }
     }
 }
+/**
+ * @description checks the current CSS file the item diagramTheme currently holds in localStorage to determine if the current theme is darkmode or not.
+ * @return a boolean value depending on if it is darktheme or not.
+ */
 function isDarkTheme(){
     if (localStorage.getItem('diagramTheme') != null) {
         //in localStorage, themeBlack holds a URL to the CSS file currently used. Like, style.css or blackTheme.css

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -11433,9 +11433,9 @@ function toggleBorderOfElements() {
     }
 }
 function isDarkTheme(){
-    if (localStorage.getItem('themeBlack') != null) {
+    if (localStorage.getItem('diagramTheme') != null) {
         //in localStorage, themeBlack holds a URL to the CSS file currently used. Like, style.css or blackTheme.css
-	    let cssUrl = localStorage.getItem('themeBlack');
+	    let cssUrl = localStorage.getItem('diagramTheme');
         //this turns, for example, '.../Shared/css/style.css' into just 'style.css'
         cssUrl = cssUrl.split("/").pop();
         if(cssUrl == 'blackTheme.css'){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -992,7 +992,6 @@ const avgcharwidth = 6; // <-- This variable is never used anywhere in this file
 const colors = ["#ffffff", "#c4e4fc", "#ffd4d4", "#fff4c2", "#c4f8bd", "#648fff", "#DC267F", "#FFB000", "#FE6100", "#000000"];
 const strokeColors = ["#383737"];
 const selectedColor = "#A000DC";
-const lineColor = "#000000";
 const multioffs = 3;
 // Zoom values for offsetting the mouse cursor positioning
 const zoom1_25 = 0.36;
@@ -7449,7 +7448,7 @@ function drawLine(line, targetGhost = false)
     else{
         var strokeDash="0";
     }
-    //var lineColor = '#000000';
+    var lineColor = '#000000';
 
     if(contextLine.includes(line)){
         lineColor = selectedColor;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -992,6 +992,7 @@ const avgcharwidth = 6; // <-- This variable is never used anywhere in this file
 const colors = ["#ffffff", "#c4e4fc", "#ffd4d4", "#fff4c2", "#c4f8bd", "#648fff", "#DC267F", "#FFB000", "#FE6100", "#000000"];
 const strokeColors = ["#383737"];
 const selectedColor = "#A000DC";
+const lineColor = "#000000";
 const multioffs = 3;
 // Zoom values for offsetting the mouse cursor positioning
 const zoom1_25 = 0.36;
@@ -7448,7 +7449,7 @@ function drawLine(line, targetGhost = false)
     else{
         var strokeDash="0";
     }
-    var lineColor = '#000000';
+    //var lineColor = '#000000';
 
     if(contextLine.includes(line)){
         lineColor = selectedColor;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4198,10 +4198,12 @@ function toggleDarkmode()
         // if it's dark -> go light
         stylesheet.href = "../Shared/css/style.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
+        lineColor = "#000000";
     } else if(stylesheet.href.includes('style')) {
         // if it's light -> go dark
         stylesheet.href = "../Shared/css/blackTheme.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
+        lineColor = "#FFFFFF";
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -991,7 +991,7 @@ const baseline = 10;
 const avgcharwidth = 6; // <-- This variable is never used anywhere in this file. 
 const colors = ["#ffffff", "#c4e4fc", "#ffd4d4", "#fff4c2", "#c4f8bd", "#648fff", "#DC267F", "#FFB000", "#FE6100", "#000000"];
 const strokeColors = ["#383737"];
-const selectedColor = "#00FFFF";
+const selectedColor = "#A000DC";
 const multioffs = 3;
 // Zoom values for offsetting the mouse cursor positioning
 const zoom1_25 = 0.36;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4203,6 +4203,7 @@ function toggleDarkmode()
         stylesheet.href = "../Shared/css/blackTheme.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
     }
+    showdata();
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4198,12 +4198,10 @@ function toggleDarkmode()
         // if it's dark -> go light
         stylesheet.href = "../Shared/css/style.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
-        lineColor = "#000000";
     } else if(stylesheet.href.includes('style')) {
         // if it's light -> go dark
         stylesheet.href = "../Shared/css/blackTheme.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
-        lineColor = "#FFFFFF";
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7446,7 +7446,7 @@ function drawLine(line, targetGhost = false)
     else{
         var strokeDash="0";
     }
-    if (isDarkTheme) {
+    if (isDarkTheme()) {
         var lineColor = '#FFFFFF';
     } else {
         var lineColor = '#000000';

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -991,7 +991,7 @@ const baseline = 10;
 const avgcharwidth = 6; // <-- This variable is never used anywhere in this file. 
 const colors = ["#ffffff", "#c4e4fc", "#ffd4d4", "#fff4c2", "#c4f8bd", "#648fff", "#DC267F", "#FFB000", "#FE6100", "#000000"];
 const strokeColors = ["#383737"];
-const selectedColor = "#A000DC";
+const selectedColor = "#00FFFF";
 const multioffs = 3;
 // Zoom values for offsetting the mouse cursor positioning
 const zoom1_25 = 0.36;
@@ -11104,7 +11104,7 @@ function drawSelectionBox(str)
         selectionBoxHighY = highY + 5;
 
         // Selection container of selected elements
-        str += `<rect width='${highX - lowX + 10}' height='${highY - lowY + 10}' x= '${lowX - 5}' y='${lowY - 5}'; style="fill:transparent; stroke-width:1.5; stroke:white;" />`;
+        str += `<rect width='${highX - lowX + 10}' height='${highY - lowY + 10}' x= '${lowX - 5}' y='${lowY - 5}'; style="fill:transparent; stroke-width:1.5; stroke:${selectedColor};" />`;
 
         //Determine size and position of delete button
         if (highX - lowX + 10 > highY - lowY + 10) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -11432,6 +11432,18 @@ function toggleBorderOfElements() {
         }
     }
 }
+function isDarkTheme(){
+    if (localStorage.getItem('themeBlack') != null) {
+        //in localStorage, themeBlack holds a URL to the CSS file currently used. Like, style.css or blackTheme.css
+	    let cssUrl = localStorage.getItem('themeBlack');
+        //this turns, for example, '.../Shared/css/style.css' into just 'style.css'
+        cssUrl = cssUrl.split("/").pop();
+        if(cssUrl == 'blackTheme.css'){
+            return true;
+        }
+        else return false;
+    }
+}
 /**
  * @description Redraw all elements and lines
  */

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -968,9 +968,9 @@ input{
     background: linear-gradient(90deg, rgba(18,18,18,1) 21%, rgba(67,42,90,1) 55%);
   
   }
-  .lineColor {
+  /* .lineColor {
     stroke: white;
-  }
+  } */
 
   /*/ END /*/
 

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -968,9 +968,9 @@ input{
     background: linear-gradient(90deg, rgba(18,18,18,1) 21%, rgba(67,42,90,1) 55%);
   
   }
-  /* .lineColor {
+  .lineColor {
     stroke: white;
-  } */
+  }
 
   /*/ END /*/
 


### PR DESCRIPTION
Removed the CSS code for setting the line color in darkmode. It overwrote the selection color. This fixes the issue but this made the lines black in darkmode though, so to fix that I: 

Added a function called isDarkTheme for returning true/false if the current theme is dark mode or not and then used this function for setting the current linecolor in DrawLine. Then called upon showdata() on the bottom of toggleDarkMode() which redraws everything and therefore makes the lines automatically the correct color when switching themes.