### PR TITLE
 Initial and final states break the system #13387 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8913,6 +8913,7 @@ function drawElement(element, ghosted = false)
 
     // Check if element is SDState
     else if (element.kind == "SDState") {
+        elemAttri = element.attributes.length;
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
         style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;`;
@@ -8939,9 +8940,8 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD content
         str += `<div style='margin-top: ${-8 * zoomfact}px;'>`;
-        //Draw SD-content if any attributes exists
-        if ((element.attributes != null) && (element.attributes != 0)) {
-            elemAttri = element.attributes.length;
+        //Draw SD-content if there exist at least one attribute
+        if (elemAttri != 0) {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}' style='border-bottom-left-radius: ${boxh / 2}px; border-bottom-right-radius: ${boxh / 2}px;'>`;
             str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -810,8 +810,8 @@ const elementTypesNames = {
 
     SDState: "SDState",
 
-    UMLInitialState: "UMLInitialState",
-    UMLFinalState: "UMLFinalState"
+    UMLInitialState: "UMLInitialState", //TODO these seem unused, remove?
+    UMLFinalState: "UMLFinalState" //TODO these seem unused, remove?
 
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7748,7 +7748,7 @@ function drawLine(line, targetGhost = false)
         line.type = 'ER';
     } */
     //gives the lines the correct type based on the from and to element.
-    if ((felem.type == 'SD') || (telem.type == 'SD')) {
+    if ((felem.type == 'UML_STATE') || (telem.type == 'UML_STATE')) {
         line.type = 'SD';
     }
     else if ((felem.type == 'ER') || (telem.type == 'ER')) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -810,8 +810,8 @@ const elementTypesNames = {
 
     SDState: "SDState",
 
-    UMLInitialState: "UMLInitialState", //TODO these seem unused, remove?
-    UMLFinalState: "UMLFinalState" //TODO these seem unused, remove?
+    UMLInitialState: "UMLInitialState",
+    UMLFinalState: "UMLFinalState"
 
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7728,7 +7728,7 @@ function drawLine(line, targetGhost = false)
         line.type = 'ER';
     } */
     //gives the lines the correct type based on the from and to element.
-    if ((felem.type == 'UML_STATE') || (telem.type == 'UML_STATE')) {
+    if ((felem.type == 'SD') || (telem.type == 'SD')) {
         line.type = 'SD';
     }
     else if ((felem.type == 'ER') || (telem.type == 'ER')) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8893,7 +8893,6 @@ function drawElement(element, ghosted = false)
 
     // Check if element is SDState
     else if (element.kind == "SDState") {
-        elemAttri = element.attributes.length;
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
         style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;`;
@@ -8920,8 +8919,9 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD content
         str += `<div style='margin-top: ${-8 * zoomfact}px;'>`;
-        //Draw SD-content if there exist at least one attribute
-        if (elemAttri != 0) {
+        //Draw SD-content if any attributes exists
+        if ((element.attributes != null) && (element.attributes != 0)) {
+            elemAttri = element.attributes.length;
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}' style='border-bottom-left-radius: ${boxh / 2}px; border-bottom-right-radius: ${boxh / 2}px;'>`;
             str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6519,7 +6519,7 @@ function generateContextProperties()
                 str += '</select>'; 
             }
         }
-                else if (element.kind ='SDState'){
+                /* else if (element.kind ='SDState'){
                     
                 for (const property in element) {
                     switch (property.toLowerCase()) {
@@ -6536,6 +6536,26 @@ function generateContextProperties()
                     }
                 }
             
+        } */
+        //Selected SD type
+        else if (element.type == 'SD') {
+            //if SDState kind
+            if (element.kind == 'SDState') {
+                for (const property in element) {
+                    switch (property.toLowerCase()) {
+                        case 'name':
+                            str += `<div style='color:white'>Name</div>`;
+                            str += `<input id='elementProperty_${property}' type='text' value='${element[property]}' onfocus='propFieldSelected(true)' onblur='propFieldSelected(false)'>`;
+                            break;
+                        case 'attributes':
+                            str += `<div style='color:white'>Attributes</div>`;
+                            str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
         }
     
 


### PR DESCRIPTION
While trying to fix this issue, which I thought had something to do with generateContextProperties, I tried going through the code in generateContextProperties and I couldn't read it properly, it was had such horrible indentation that it was next to impossible to know which bracket belonged to which block. After consulting with the issue leader I got permission to rewrite the part pertaining to SDState; I made it more correct indentation-wise and also added a check for if the element is of the type SD before it checks any "kind". This was done more so for ease of expansion, so more kinds can be added more easily, but somehow this fixed the issue entirely. I am not sure why, but my best guess is that the horrible indentation made a bracket not be included or perhaps the whole block was included in the block above it (IE) which then lead to the element that was having its context generated got its kind overwritten from, for example, UMLInitialState to SDState.