### PR TITLE
 Correct line type for state #13406 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7728,7 +7728,7 @@ function drawLine(line, targetGhost = false)
         line.type = 'ER';
     } */
     //gives the lines the correct type based on the from and to element.
-    if ((felem.type == 'UML_STATE') || (telem.type == 'UML_STATE')) {
+    if ((felem.type == 'SD') || (telem.type == 'SD')) {
         line.type = 'SD';
     }
     else if ((felem.type == 'ER') || (telem.type == 'ER')) {


### PR DESCRIPTION
Changed the if statement checking from and to elem that then assigns the correct type to no longer check UML_STATE but instead check SD.