### PR TITLE
G3 2023 V3 13414 Create column/table in SQLLite for commit/link

### DIFF
--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -256,7 +256,7 @@ $sql2 = '
 		repoPath VARCHAR(255) 
 	);
 
-	CREATE TABLE latestCommit (
+	CREATE TABLE IF NOT EXISTS latestCommit (
 		githubURL VARCHAR(255) PRIMARY KEY,
 		commitID VARCHAR(50)
 	);

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -249,11 +249,16 @@ $sql2 = '
 	CREATE TABLE IF NOT EXISTS gitRepos ( 
 		repoID INTEGER PRIMARY KEY AUTOINCREMENT,
 		repoName VARCHAR(50), 
-    repoURL VARCHAR(255), 
-    repoFileType VARCHAR(50), 
-    repoDownloadURL VARCHAR(255), 
-    repoSHA VARCHAR(255) UNIQUE, 
-    repoPath VARCHAR(255) 
+		repoURL VARCHAR(255), 
+		repoFileType VARCHAR(50), 
+		repoDownloadURL VARCHAR(255), 
+		repoSHA VARCHAR(255) UNIQUE, 
+		repoPath VARCHAR(255) 
+	);
+
+	CREATE TABLE latestCommit (
+		githubURL VARCHAR(255) PRIMARY KEY,
+		commitID VARCHAR(50)
 	);
 '; 
 $metadata_db->exec($sql2);


### PR DESCRIPTION
Issue #13414 

Added another table in the SQL lite database, containing the columns githubURL and commitID.

![image](https://user-images.githubusercontent.com/102578746/233105761-581a1a45-7d8e-43e6-893d-0c054e50842e.png)

This can be seen in basic.php and in CMD:
- Enter students/"studentid"/githubMetadata
- Write sqlite3 metadata2.db
- Write .schema

The tables should show up.

(co-creator @g21emmka)