### PR TITLE
 State entity outline should be fixed for lightmode #13366 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8910,8 +8910,27 @@ function drawElement(element, ghosted = false)
         str += `<div style='width: ${boxw}; height: ${boxh};'>`;
         //svg for SD header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
-        str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh - (linew * 2)}'
-        stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />
+        //start slightly below at the top left corner, to account for the upcoming curvature
+        //then make a quadratic bezier curve to 5, -5 (relative to current position) via a control point stationed at 0, -5
+        //then make a horizontal line the length being the with of the svg element, minus the radius of the upcoming curve
+        //then make a quadratic bezier curve to 5, 5 (relative to current position) via a control point stationed at 5, 0
+        //then make a vertical line the height of the svg
+        //then make a horizontal line that is the negative width
+        //finally, close the path
+        str += `<path 
+            d="M'${linew}','${(linew)+5}'
+                q5,-5 0,-5
+                h'${(boxw - (linew * 2))-5}'
+                q5,5 5,0
+                v'${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
+                h'${(boxw - (linew * 2))*-1}'
+                z
+            "
+            stroke-width='${linew}'
+            stroke='${element.stroke}'
+            fill='${element.fill}'
+        />
+        
         <text style='fill: ${element.stroke};' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`; //style shouldn't be needed, the div randomly gets fill: rgb(0, 0, 0), no clue why'
         //end of svg for SD header
         str += `</svg>`;
@@ -8924,28 +8943,8 @@ function drawElement(element, ghosted = false)
         if (elemAttri != 0) {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}'>`;
-            /* str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
-            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`; */
-            //start slightly below at the top left corner, to account for the upcoming curvature
-            //then make a quadratic bezier curve to 5, -5 (relative to current position) via a control point stationed at 0, -5
-            //then make a horizontal line the length being the with of the svg element, minus the radius of the upcoming curve
-            //then make a quadratic bezier curve to 5, 5 (relative to current position) via a control point stationed at 5, 0
-            //then make a vertical line the height of the svg
-            //then make a horizontal line that is the negative width
-            //finally, close the path
-            str += `<path 
-                    d="M'${linew}','${(linew)+5}'
-                        q5,-5 0,-5
-                        h'${(boxw - (linew * 2))-5}'
-                        q5,5 5,0
-                        v'${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
-                        h'${(boxw - (linew * 2))*-1}'
-                        z
-                    "
-                    stroke-width='${linew}'
-                    stroke='${element.stroke}'
-                    fill='${element.fill}'
-                    />`
+            str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
+            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
             for (var i = 0; i < elemAttri; i++) {
                 str += `<text x='${xAnchor}' y='${hboxh + boxh * i / 2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.attributes[i]}</text>`;
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8918,12 +8918,12 @@ function drawElement(element, ghosted = false)
         //then make a horizontal line that is the negative width
         //finally, close the path
         str += `<path 
-            d="M'${linew}','${(linew)+5}'
+            d="M${linew},${(linew)+5}
                 q5,-5 0,-5
-                h'${(boxw - (linew * 2))-5}'
+                h${(boxw - (linew * 2))-5}
                 q5,5 5,0
-                v'${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
-                h'${(boxw - (linew * 2))*-1}'
+                v${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}
+                h${(boxw - (linew * 2))*-1}
                 z
             "
             stroke-width='${linew}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8919,7 +8919,7 @@ function drawElement(element, ghosted = false)
         //finally, close the path
         str += `<path 
             d="M${linew},${(linew)}
-                A 5 5 0 0 1
+                A 5 5 0 0 1 5,5
                 h${(boxw - (linew * 2))-5}
                 q5,5 5,0
                 v${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8912,7 +8912,7 @@ function drawElement(element, ghosted = false)
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<path 
             d="M${linew+cornerRadius},${(linew)}
-                h${(boxw - (linew * 2))-cornerRadius}
+                h${(boxw - (linew * 2))-(cornerRadius*2)}
                 a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}
                 v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-(cornerRadius)}
                 h${(boxw - (linew * 2))*-1}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8912,7 +8912,7 @@ function drawElement(element, ghosted = false)
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<path 
             d="M${linew+cornerRadius},${(linew)}
-                h${(boxw - (linew * 2))-30}
+                h${(boxw - (linew * 2))-cornerRadius}
                 a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}
                 v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-(cornerRadius)}
                 h${(boxw - (linew * 2))*-1}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8909,7 +8909,7 @@ function drawElement(element, ghosted = false)
         //div to encapuslate SD header
         str += `<div style='width: ${boxw}; height: ${boxh};'>`;
         //svg for SD header, background and text
-        str += `<svg width='${boxw}' height='${boxh}' style='border-top-left-radius: ${boxh/2}px; border-top-right-radius: ${boxh/2}px;'>`; //This is a silly way to round corners, should be done in the rect but the merge is tomorrow
+        str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh - (linew * 2)}'
         stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />
         <text style='fill: ${element.stroke};' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`; //style shouldn't be needed, the div randomly gets fill: rgb(0, 0, 0), no clue why'
@@ -8923,7 +8923,7 @@ function drawElement(element, ghosted = false)
         //Draw SD-content if there exist at least one attribute
         if (elemAttri != 0) {
             //svg for background
-            str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}' style='border-bottom-left-radius: ${boxh / 2}px; border-bottom-right-radius: ${boxh / 2}px;'>`;
+            str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}'>`;
             str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
             stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
             for (var i = 0; i < elemAttri; i++) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8918,9 +8918,9 @@ function drawElement(element, ghosted = false)
         //then make a horizontal line that is the negative width
         //finally, close the path
         str += `<path 
-            d="M${linew},${(linew)}
-                h${(boxw - (linew * 2))-5}
-                A 5 5 0 0 1 5,5
+            d="M${(linew)},${(linew)}
+                h${(boxw - (linew * 2))-20}
+                a20,20 0 0 1 20,20
                 v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-5}
                 h${(boxw - (linew * 2))*-1}
                 z

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8914,7 +8914,7 @@ function drawElement(element, ghosted = false)
             d="M${linew+cornerRadius},${(linew)}
                 h${(boxw - (linew * 2))-(cornerRadius*2)}
                 a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}
-                v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-(cornerRadius)}
+                v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius)}
                 h${(boxw - (linew * 2))*-1}
                 v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-(cornerRadius))*-1}
                 a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${(cornerRadius)*-1}
@@ -8937,8 +8937,22 @@ function drawElement(element, ghosted = false)
         if (elemAttri != 0) {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}'>`;
-            str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
-            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
+            /* str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
+            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`; */
+            str += `<path 
+                d="M${linew},${(linew)}
+                    h${(boxw - (linew * 2))}
+                    v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius}
+                    a${cornerRadius},${cornerRadius} 0 0 1 ${(cornerRadius*-1)},${cornerRadius}
+                    h${(boxw - (linew * 2)-(cornerRadius*2))*-1}
+                    a${cornerRadius},${cornerRadius} 0 0 1 ${(cornerRadius)*-1},${(cornerRadius)*-1}
+                    v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius)*-1}
+                    z
+                "
+                stroke-width='${linew}'
+                stroke='${element.stroke}'
+                fill='${element.fill}'
+            />`;
             for (var i = 0; i < elemAttri; i++) {
                 str += `<text x='${xAnchor}' y='${hboxh + boxh * i / 2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.attributes[i]}</text>`;
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8910,18 +8910,11 @@ function drawElement(element, ghosted = false)
         str += `<div style='width: ${boxw}; height: ${boxh};'>`;
         //svg for SD header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
-        //start slightly below at the top left corner, to account for the upcoming curvature
-        //then make a quadratic bezier curve to 5, -5 (relative to current position) via a control point stationed at 0, -5
-        //then make a horizontal line the length being the with of the svg element, minus the radius of the upcoming curve
-        //then make a quadratic bezier curve to 5, 5 (relative to current position) via a control point stationed at 5, 0
-        //then make a vertical line the height of the svg
-        //then make a horizontal line that is the negative width
-        //finally, close the path
         str += `<path 
             d="M${(linew)},${(linew)}
                 h${(boxw - (linew * 2))-15}
                 a15,15 0 0 1 15,15
-                v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-5}
+                v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-15}
                 h${(boxw - (linew * 2))*-1}
                 z
             "

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8918,7 +8918,7 @@ function drawElement(element, ghosted = false)
         //then make a horizontal line that is the negative width
         //finally, close the path
         str += `<path 
-            d="M${linew},${(linew)-5}
+            d="M${linew},${(linew)}
                 A 5 5 0 0 1 5,5
                 h${(boxw - (linew * 2))-5}
                 q5,5 5,0

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8918,7 +8918,7 @@ function drawElement(element, ghosted = false)
         //then make a horizontal line that is the negative width
         //finally, close the path
         str += `<path 
-            d="M${linew},${(linew)+5}
+            d="M${linew},${(linew)+20}
                 q5,-5 0,-5
                 h${(boxw - (linew * 2))-5}
                 q5,5 5,0
@@ -8954,8 +8954,8 @@ function drawElement(element, ghosted = false)
         } else {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh / 2)}'>`;
-            /* str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh / 2) - (linew * 2)} rx='20'
-            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`; */
+            str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh / 2) - (linew * 2)} rx='20'
+            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
             //start path and define it as:
             //move to the x and y for the top left corner of this shape.
             //then crete a quadratic bezier curve to x5 y5, with -5.5 as a control point, relative to the current position of the path.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8914,9 +8914,9 @@ function drawElement(element, ghosted = false)
             d="M${linew+cornerRadius},${(linew)}
                 h${(boxw - (linew * 2))-(cornerRadius*2)}
                 a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}
-                v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius)}
+                v${((boxh / 2 + (boxh / 2) - (linew * 2))-cornerRadius)}
                 h${(boxw - (linew * 2))*-1}
-                v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-(cornerRadius))*-1}
+                v${((boxh / 2 + (boxh / 2) - (linew * 2))-(cornerRadius))*-1}
                 a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${(cornerRadius)*-1}
                 z
             "

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8916,6 +8916,8 @@ function drawElement(element, ghosted = false)
                 a15,15 0 0 1 15,15
                 v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-15}
                 h${(boxw - (linew * 2))*-1}
+                v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-15)*-1}
+                a15,15 0 0 1 15,-15
                 z
             "
             stroke-width='${linew}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8918,11 +8918,10 @@ function drawElement(element, ghosted = false)
         //then make a horizontal line that is the negative width
         //finally, close the path
         str += `<path 
-            d="M${linew},${(linew)+5}
-                A 5 5 0 0 1 5,5
+            d="M${linew},${(linew)}
                 h${(boxw - (linew * 2))-5}
-                q5,5 5,0
-                v${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}
+                A 5 5 0 0 1 5,5
+                v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-5}
                 h${(boxw - (linew * 2))*-1}
                 z
             "

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8724,7 +8724,7 @@ function drawElement(element, ghosted = false)
     var elemAttri = 3;//element.attributes.length;          //<-- UML functionality This is hardcoded will be calcualted in issue regarding options panel
                                 //This value represents the amount of attributes, hopefully this will be calculated through
                                 //an array in the UML document that contains the element's attributes.
-    var cornerRadius = Math.round((element.height/10) * zoomfact); //used for rounding the corners for SD states
+    var cornerRadius = Math.round((element.height/8) * zoomfact); //determines the corner radius for the SD states.
     canvas = document.getElementById('canvasOverlay');
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8724,7 +8724,7 @@ function drawElement(element, ghosted = false)
     var elemAttri = 3;//element.attributes.length;          //<-- UML functionality This is hardcoded will be calcualted in issue regarding options panel
                                 //This value represents the amount of attributes, hopefully this will be calculated through
                                 //an array in the UML document that contains the element's attributes.
-    
+    var cornerRadius = Math.round((element.height/10) * zoomfact); //used for rounding the corners for SD states
     canvas = document.getElementById('canvasOverlay');
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
@@ -8911,13 +8911,13 @@ function drawElement(element, ghosted = false)
         //svg for SD header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<path 
-            d="M${(linew)+15},${(linew)}
+            d="M${(linew)+(cornerRadius)},${(linew)}
                 h${(boxw - (linew * 2))-30}
-                a15,15 0 0 1 15,15
-                v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-15}
+                a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}
+                v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-(cornerRadius)}
                 h${(boxw - (linew * 2))*-1}
-                v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-15)*-1}
-                a15,15 0 0 1 15,-15
+                v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-(cornerRadius))*-1}
+                a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${(cornerRadius)*-1}
                 z
             "
             stroke-width='${linew}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8963,11 +8963,11 @@ function drawElement(element, ghosted = false)
             str += `<path 
                 d="M${linew},${(linew)}
                     h${(boxw - (linew * 2))}
-                    v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius}
+                    v${(boxh / 2 + (boxh / 2) - (linew * 2))-cornerRadius}
                     a${cornerRadius},${cornerRadius} 0 0 1 ${(cornerRadius*-1)},${cornerRadius}
                     h${(boxw - (linew * 2)-(cornerRadius*2))*-1}
                     a${cornerRadius},${cornerRadius} 0 0 1 ${(cornerRadius)*-1},${(cornerRadius)*-1}
-                    v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius)*-1}
+                    v${((boxh / 2 + (boxh / 2) - (linew * 2))-cornerRadius)*-1}
                     z
                 "
                 stroke-width='${linew}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8911,7 +8911,7 @@ function drawElement(element, ghosted = false)
         //svg for SD header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<path 
-            d="M${(linew)+(cornerRadius)},${(linew)}
+            d="M${linew+cornerRadius},${(linew)}
                 h${(boxw - (linew * 2))-30}
                 a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}
                 v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-(cornerRadius)}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8721,10 +8721,10 @@ function drawElement(element, ghosted = false)
     var texth = Math.round(zoomfact * textheight);
     var hboxw = Math.round(element.width * zoomfact * 0.5);
     var hboxh = Math.round(element.height * zoomfact * 0.5);
+    var cornerRadius = Math.round((element.height/8) * zoomfact); //determines the corner radius for the SD states.
     var elemAttri = 3;//element.attributes.length;          //<-- UML functionality This is hardcoded will be calcualted in issue regarding options panel
                                 //This value represents the amount of attributes, hopefully this will be calculated through
                                 //an array in the UML document that contains the element's attributes.
-    var cornerRadius = Math.round((element.height/8) * zoomfact); //determines the corner radius for the SD states.
     canvas = document.getElementById('canvasOverlay');
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8920,7 +8920,7 @@ function drawElement(element, ghosted = false)
         str += `<path 
             d="M${linew},${(linew)}
                 A 5 5 0 0 1 5,5
-                h${(boxw - (linew * 2))-5}
+                h${(boxw - (linew * 2))+5}
                 q5,5 5,0
                 v${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}
                 h${(boxw - (linew * 2))*-1}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8918,7 +8918,7 @@ function drawElement(element, ghosted = false)
         //then make a horizontal line that is the negative width
         //finally, close the path
         str += `<path 
-            d="M${linew},${(linew)}
+            d="M${linew},${(linew)+5}
                 A 5 5 0 0 1 5,5
                 h${(boxw - (linew * 2))-5}
                 q5,5 5,0

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8920,7 +8920,7 @@ function drawElement(element, ghosted = false)
         str += `<path 
             d="M${linew},${(linew)}
                 A 5 5 0 0 1 5,5
-                h${(boxw - (linew * 2))+5}
+                h${(boxw - (linew * 2))-5}
                 q5,5 5,0
                 v${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}
                 h${(boxw - (linew * 2))*-1}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8918,8 +8918,8 @@ function drawElement(element, ghosted = false)
         //then make a horizontal line that is the negative width
         //finally, close the path
         str += `<path 
-            d="M${linew},${(linew)+20}
-                q5,-5 0,-5
+            d="M${linew},${(linew)}
+                A 5 5 0 0 1
                 h${(boxw - (linew * 2))-5}
                 q5,5 5,0
                 v${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8924,8 +8924,28 @@ function drawElement(element, ghosted = false)
         if (elemAttri != 0) {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}'>`;
-            str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
-            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
+            /* str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
+            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`; */
+            //start slightly below at the top left corner, to account for the upcoming curvature
+            //then make a quadratic bezier curve to 5, -5 (relative to current position) via a control point stationed at 0, -5
+            //then make a horizontal line the length being the with of the svg element, minus the radius of the upcoming curve
+            //then make a quadratic bezier curve to 5, 5 (relative to current position) via a control point stationed at 5, 0
+            //then make a vertical line the height of the svg
+            //then make a horizontal line that is the negative width
+            //finally, close the path
+            str += `<path 
+                    d="M'${linew}','${(linew)+5}'
+                        q5,-5 0,-5
+                        h'${(boxw - (linew * 2))-5}'
+                        q5,5 5,0
+                        v'${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
+                        h'${(boxw - (linew * 2))*-1}'
+                        z
+                    "
+                    stroke-width='${linew}'
+                    stroke='${element.stroke}'
+                    fill='${element.fill}'
+                    />`
             for (var i = 0; i < elemAttri; i++) {
                 str += `<text x='${xAnchor}' y='${hboxh + boxh * i / 2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.attributes[i]}</text>`;
             }
@@ -8935,8 +8955,23 @@ function drawElement(element, ghosted = false)
         } else {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh / 2)}'>`;
-            str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh / 2) - (linew * 2)} rx='20'
-            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
+            /* str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh / 2) - (linew * 2)} rx='20'
+            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`; */
+            //start path and define it as:
+            //move to the x and y for the top left corner of this shape.
+            //then crete a quadratic bezier curve to x5 y5, with -5.5 as a control point, relative to the current position of the path.
+            //then draw a horizontal line that is the length of the width of the shape.
+            //then make another quadratic bezier curve
+            /* str += `<path 
+                        d="M'${linew}','${linew}'
+                        q5,5 -5,5
+                        h'${boxw - (linew * 2)}'
+                        q5,5 -5,5
+                        v'${boxh / 2 + (boxh / 2) - (linew * 2)}'
+                        h'${(boxw - (linew * 2))*-1}'
+                        z
+                        "
+                        />` */
             str += `<text x='5' y='${hboxh + boxh / 2}' dominant-baseline='middle' text-anchor='right'> </text>`;
             //end of svg for background
             str += `</svg>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8919,8 +8919,8 @@ function drawElement(element, ghosted = false)
         //finally, close the path
         str += `<path 
             d="M${(linew)},${(linew)}
-                h${(boxw - (linew * 2))-20}
-                a20,20 0 0 1 20,20
+                h${(boxw - (linew * 2))-15}
+                a15,15 0 0 1 15,15
                 v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-5}
                 h${(boxw - (linew * 2))*-1}
                 z

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8911,8 +8911,8 @@ function drawElement(element, ghosted = false)
         //svg for SD header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<path 
-            d="M${(linew)},${(linew)}
-                h${(boxw - (linew * 2))-15}
+            d="M${(linew)+15},${(linew)}
+                h${(boxw - (linew * 2))-30}
                 a15,15 0 0 1 15,15
                 v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-15}
                 h${(boxw - (linew * 2))*-1}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8918,7 +8918,7 @@ function drawElement(element, ghosted = false)
         //then make a horizontal line that is the negative width
         //finally, close the path
         str += `<path 
-            d="M${linew},${(linew)}
+            d="M${linew},${(linew)-5}
                 A 5 5 0 0 1 5,5
                 h${(boxw - (linew * 2))-5}
                 q5,5 5,0

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8937,8 +8937,6 @@ function drawElement(element, ghosted = false)
         if (elemAttri != 0) {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}'>`;
-            /* str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
-            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`; */
             str += `<path 
                 d="M${linew},${(linew)}
                     h${(boxw - (linew * 2))}
@@ -8962,23 +8960,20 @@ function drawElement(element, ghosted = false)
         } else {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh / 2)}'>`;
-            str += `<rect x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh / 2) - (linew * 2)} rx='20'
-            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
-            //start path and define it as:
-            //move to the x and y for the top left corner of this shape.
-            //then crete a quadratic bezier curve to x5 y5, with -5.5 as a control point, relative to the current position of the path.
-            //then draw a horizontal line that is the length of the width of the shape.
-            //then make another quadratic bezier curve
-            /* str += `<path 
-                        d="M'${linew}','${linew}'
-                        q5,5 -5,5
-                        h'${boxw - (linew * 2)}'
-                        q5,5 -5,5
-                        v'${boxh / 2 + (boxh / 2) - (linew * 2)}'
-                        h'${(boxw - (linew * 2))*-1}'
-                        z
-                        "
-                        />` */
+            str += `<path 
+                d="M${linew},${(linew)}
+                    h${(boxw - (linew * 2))}
+                    v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius}
+                    a${cornerRadius},${cornerRadius} 0 0 1 ${(cornerRadius*-1)},${cornerRadius}
+                    h${(boxw - (linew * 2)-(cornerRadius*2))*-1}
+                    a${cornerRadius},${cornerRadius} 0 0 1 ${(cornerRadius)*-1},${(cornerRadius)*-1}
+                    v${((boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius)*-1}
+                    z
+                "
+                stroke-width='${linew}'
+                stroke='${element.stroke}'
+                fill='${element.fill}'
+            />`;
             str += `<text x='5' y='${hboxh + boxh / 2}' dominant-baseline='middle' text-anchor='right'> </text>`;
             //end of svg for background
             str += `</svg>`;


### PR DESCRIPTION
It was not just lightmode, the corers were rounded in a way that cut off the borders no matter the theme. I fixed this by first removing the CSS border radius since that would never have worked and then i replaced the svg <rect> with a path that had arcs on the appropriate corners. I chose this over rx on the rects because these are two rects on top of eachother which would mean 8 corners are rounded when it really should only look like 4. I guess I could've used a clip for rx but path seems better and more proper.