### PR TITLE
G1 2023 v3 #13423

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -581,3 +581,46 @@
 .SDState-rounded {
     border-radius: 12px;
 }
+#zoom-container {
+    visibility: visible;
+    position: absolute;
+    width: 90px;
+    height: 29px;
+    bottom: 4px;
+    left: -100px;
+    background: rgba(0, 0, 0, 0.8);
+    border-radius: 5px;
+    display: flex;
+    justify-content: space-around;
+    padding: 1px;
+}
+.diagramZoomIcons img {
+    height: 27px;
+    width: 27px;
+}
+.diagramZoomIcons {
+    height: 27px;
+    width: 27px;
+    float: left;
+    border: solid 1px rgba(0, 0, 0, 0.8);
+}
+.diagramZoomIcons:hover {
+    border: solid 1px var(--color-primary-light);
+}
+.zoomToolTipText {
+    bottom: 40px;
+    right: 0%;
+    visibility: hidden;
+    width: 250px;
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    text-align: center;
+    border-radius: 5px;
+    padding: 5px 0;
+    pointer-events: none;
+    position: absolute;
+    z-index: 2;
+}
+.diagramZoomIcons:hover .zoomToolTipText {
+    visibility: visible;
+}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1050,6 +1050,8 @@ var pointerState = pointerStates.DEFAULT;
 var movingObject = false;
 var movingContainer = false;
 
+var wasMovingObject = false;
+
 //setting the base values for the allowed diagramtypes
 var diagramType = {ER:false,UML:false,IE:false,SD:false};
 
@@ -2484,6 +2486,7 @@ function mmoving(event)
 
                 // Moving object
                 movingObject = true;
+                wasMovingObject = true;
                 // Moving object
                 deltaX = startX - event.clientX;
                 deltaY = startY - event.clientY;
@@ -3499,8 +3502,9 @@ function entityIsOverlapping(id, x, y)
         console.log(targetX, targetY)
 
         for(var i = 0; i < data.length; i++){
-            if(data[i].id === id) continue
-            
+            if (data[i].id === id) continue;
+            if (context.includes(data[i]) && wasMovingObject) continue;
+
             //COMPARED ELEMENT
             const compX2 = data[i].x + data[i].width;
             var compY2 = data[i].y + data[i].height;
@@ -3524,6 +3528,7 @@ function entityIsOverlapping(id, x, y)
                 break;
             }
         }
+        wasMovingObject = false;
         return isOverlapping;
     }
 }
@@ -4134,7 +4139,12 @@ function toggleReplay()
         zoomIndicator.style.bottom = "55px";
         zoomIndicator.style.left = "45px";
         zoomContainer.style.bottom = "54px";
-        zoomContainer.style.left = "-68px";
+        if (optionsPane.className == "show-options-pane") {
+            zoomContainer.style.left = "240px";
+        }
+        else {
+            zoomContainer.style.left = "-68px";
+        }
         replyMessage.style.visibility = "visible";
     }
     drawRulerBars(scrollx, scrolly);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1050,8 +1050,6 @@ var pointerState = pointerStates.DEFAULT;
 var movingObject = false;
 var movingContainer = false;
 
-var wasMovingObject = false;
-
 //setting the base values for the allowed diagramtypes
 var diagramType = {ER:false,UML:false,IE:false,SD:false};
 
@@ -2486,7 +2484,6 @@ function mmoving(event)
 
                 // Moving object
                 movingObject = true;
-                wasMovingObject = true;
                 // Moving object
                 deltaX = startX - event.clientX;
                 deltaY = startY - event.clientY;
@@ -3502,9 +3499,8 @@ function entityIsOverlapping(id, x, y)
         console.log(targetX, targetY)
 
         for(var i = 0; i < data.length; i++){
-            if (data[i].id === id) continue;
-            if (context.includes(data[i]) && wasMovingObject) continue;
-
+            if(data[i].id === id) continue
+            
             //COMPARED ELEMENT
             const compX2 = data[i].x + data[i].width;
             var compY2 = data[i].y + data[i].height;
@@ -3528,7 +3524,6 @@ function entityIsOverlapping(id, x, y)
                 break;
             }
         }
-        wasMovingObject = false;
         return isOverlapping;
     }
 }
@@ -4139,12 +4134,7 @@ function toggleReplay()
         zoomIndicator.style.bottom = "55px";
         zoomIndicator.style.left = "45px";
         zoomContainer.style.bottom = "54px";
-        if (optionsPane.className == "show-options-pane") {
-            zoomContainer.style.left = "240px";
-        }
-        else {
-            zoomContainer.style.left = "-68px";
-        }
+        zoomContainer.style.left = "-68px";
         replyMessage.style.visibility = "visible";
     }
     drawRulerBars(scrollx, scrolly);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4086,6 +4086,7 @@ function toggleReplay()
     var ruler = document.getElementById("rulerOverlay");
     var zoomIndicator = document.getElementById("zoom-message-box");
     var replyMessage = document.getElementById("diagram-replay-message");
+    var zoomContainer = document.getElementById("zoom-container");
 
     if (settings.replay.active) {
         // Restore the diagram to state before replay-mode
@@ -4099,6 +4100,8 @@ function toggleReplay()
         ruler.style.left = "50px";
         zoomIndicator.style.bottom = "5px";
         zoomIndicator.style.left = "100px";
+        zoomContainer.style.bottom = "4px";
+        zoomContainer.style.left = "-100px";
         replyMessage.style.visibility = "hidden";
     } else {
         settings.replay.timestamps = { 0: 0 }; // Clear the array with all timestamp.
@@ -4130,6 +4133,8 @@ function toggleReplay()
         ruler.style.left = "0";
         zoomIndicator.style.bottom = "55px";
         zoomIndicator.style.left = "45px";
+        zoomContainer.style.bottom = "54px";
+        zoomContainer.style.left = "-68px";
         replyMessage.style.visibility = "visible";
     }
     drawRulerBars(scrollx, scrolly);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4134,7 +4134,12 @@ function toggleReplay()
         zoomIndicator.style.bottom = "55px";
         zoomIndicator.style.left = "45px";
         zoomContainer.style.bottom = "54px";
-        zoomContainer.style.left = "-68px";
+        if (optionsPane.className == "show-options-pane") {
+            zoomContainer.style.left = "240px";
+        }
+        else {
+            zoomContainer.style.left = "-68px";
+        }
         replyMessage.style.visibility = "visible";
     }
     drawRulerBars(scrollx, scrolly);

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -436,7 +436,7 @@
                     </span>
                 </div>
         </fieldset>
-        <fieldset>
+        <!-- <fieldset>
             <legend>Zoom</legend>
             <div class="diagramIcons" onclick='zoomin();'>
                 <img src="../Shared/icons/diagram_zoomin.svg"/>
@@ -459,7 +459,7 @@
                     <p id="tooltip-ZOOM_RESET" class="key_tooltip">Keybinding:</p>
                 </span>
             </div>
-        </fieldset>
+        </fieldset> -->
         <fieldset>
             <legend>Camera</legend>
             <div id="camtoOrigo" class="diagramIcons" onclick="centerCamera(); centerCamera();">
@@ -616,6 +616,29 @@
                 <input style="width: 100%" id="importDiagramFile" type="file"><br><br>
                 <button class="saveButton" onclick="loadDiagram();">Load</button>
             </fieldset>
+        </div>
+        <div id="zoom-container">
+            <div class="diagramZoomIcons" onclick='zoomin();'>
+                <img src="../Shared/icons/diagram_zoomin.svg"/>
+                <span class="zoomToolTipText"><b>Zoom IN</b><br>
+                    <p>Zoom in on viewed area</p><br>
+                    <p id="tooltip-ZOOM_IN" class="key_tooltip">Keybinding:</p>
+                </span>
+            </div>
+            <div class="diagramZoomIcons" onclick='zoomout();'>
+                <img src="../Shared/icons/diagram_zoomout.svg"/>
+                <span class="zoomToolTipText"><b>Zoom OUT</b><br>
+                    <p>Zoom out on viewed area</p><br>
+                    <p id="tooltip-ZOOM_OUT" class="key_tooltip">Keybinding:</p>
+                </span>
+            </div>
+            <div class="diagramZoomIcons" onclick="zoomreset()">
+                <img src="../Shared/icons/diagram_zoomratio1to1.svg"/>
+                <span class="zoomToolTipText"><b>Zoom RESET</b><br>
+                    <p>Reset the zoom to 1x</p><br>
+                    <p id="tooltip-ZOOM_RESET" class="key_tooltip">Keybinding:</p>
+                </span>
+            </div>
         </div>
     </div>
     </div>


### PR DESCRIPTION
Moved Zoom-buttons out of the toolbar to the canvas.

The buttons are now placed bottom right and moves with the options panel.
The placement is also updated when the user enters "Replay mode"