### PR TITLE
G1 2023 v3 #13446

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4231,6 +4231,7 @@ function toggleErTable()
 {
     if(erTableToggle == false){
         erTableToggle = true;
+        testCaseToggle = false;
     }
     else if (erTableToggle == true){
         erTableToggle = false;
@@ -4246,6 +4247,7 @@ function toggleTestCase()
 {
     if (testCaseToggle == false) {
         testCaseToggle = true;
+        erTableToggle = false;
     }
     else if (testCaseToggle == true) {
         testCaseToggle = false;
@@ -6148,7 +6150,7 @@ function generateContextProperties()
     }
     //If testCaseToggle is true, then display the current ER-table instead of anything else that would be visible in the "Properties" area.
     else if (testCaseToggle) {
-        str += '<div id="Testcase"';
+        str += '<div id="ERTable"'; //using same styling for now, maybe change later
         // Here is the place to add the contect of the generated text-cases
         str += '</div>';
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6127,7 +6127,7 @@ function generateContextProperties()
     } */
 
     //No element or line selected
-    if (context.length == 0 && contextLine.length == 0 && !erTableToggle) {
+    if (context.length == 0 && contextLine.length == 0 && !erTableToggle && !testCaseToggle) {
         //Hide properties and show the other options
         propSet.classList.add('options-fieldset-hidden');
         propSet.classList.remove('options-fieldset-show');
@@ -6146,7 +6146,12 @@ function generateContextProperties()
         str += ertable;
         str += `</div>`
     }
-    //erokimarker
+    //If testCaseToggle is true, then display the current ER-table instead of anything else that would be visible in the "Properties" area.
+    else if (testCaseToggle) {
+        str += '<div id="Testcase"';
+        // Here is the place to add the contect of the generated text-cases
+        str += '</div>';
+    }
     else {
       //One element selected, no lines
       if (context.length == 1 && contextLine.length == 0) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -962,6 +962,7 @@ var wasDblClicked = false;
 var targetDelta;
 var mousePressed;
 var erTableToggle = false; //Used only in toggleErTable() and generateContextProperties().
+var testCaseToggle = false;
 var selectionBoxLowX;
 var selectionBoxHighX;
 var selectionBoxLowY;
@@ -4237,6 +4238,21 @@ function toggleErTable()
     generateContextProperties();
 }
 
+
+/**
+ * @description Toggles the testcases for the diagram in the "Options side-bar" on/off.
+ */
+function toggleTestCase()
+{
+    if (testCaseToggle == false) {
+        testCaseToggle = true;
+    }
+    else if (testCaseToggle == true) {
+        testCaseToggle = false;
+    }
+    generateContextProperties();
+}
+
 /**
  * @description Generates the string which holds the ER table for the current ER-model/ER-diagram.
  * @returns Current ER table in the form of a string.
@@ -6130,6 +6146,7 @@ function generateContextProperties()
         str += ertable;
         str += `</div>`
     }
+    //erokimarker
     else {
       //One element selected, no lines
       if (context.length == 1 && contextLine.length == 0) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6150,8 +6150,8 @@ function generateContextProperties()
     }
     //If testCaseToggle is true, then display the current ER-table instead of anything else that would be visible in the "Properties" area.
     else if (testCaseToggle) {
-        str += '<div id="ERTable"'; //using same styling for now, maybe change later
-        // Here is the place to add the contect of the generated text-cases
+        str += '<div id="ERTable">'; //using same styling for now, maybe change later
+        str += 'Debug testcase'
         str += '</div>';
     }
     else {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -512,11 +512,11 @@
         </fieldset>
         <fieldset>
             <legend>Testcase</legend>
-            <div id="testCaseGeneration" class="diagramIcons" onclick=""> <!--add func here later-->
+            <div id="testCaseToggle" class="diagramIcons" onclick="toggleTestCase()"> <!--add func here later-->
                 <img src="../Shared/icons/diagram_ER_table_info.svg"/>
-                <span class="toolTipText"><b>Generate test-cases from state diagram</b><br>
-                    <p>Click to generate test-cases</p><br>
-                    <p id="tooltip-GEN_TEST_CASES" class="key_tooltip">Keybinding:</p>
+                <span class="toolTipText"><b>Toggle test-cases</b><br>
+                    <p>Click to toggle test-cases in options</p><br>
+                    <p id="tooltip-TOGGLE_TEST_CASE" class="key_tooltip">Keybinding:</p>
                 </span>
             </div>
         </fieldset> 


### PR DESCRIPTION
The button to toggle now behaves like the button for ER-tables. Clicking one also untoggles the other for simplicity of use. 

However this does mean that this implementation suffers from a bug present with the ER-table. If one of the two toggles are set before clicking an entity, no information will be shown in the options-tab and selecting an entity will not show anything except the standard buttons for import, export, etc.. To see any information such as the entities name and attributes both toggles must be off, at which point the standard options are displayed, before they can be toggled again to show either the ER-table or the testcases. This is probably due to some fault in the display-logic in the function "generateContextProperties" in diagram.js and should be an issue on it's own. However I deem it needed information since this may otherwise be flagged as a fault with this issue despite being unrelated.