### PR TITLE
G3 2023 v3 issue#13411

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -98,13 +98,11 @@ function fetchGitHubRepo(gitHubURL)
 			type: "POST",
 			data: {'githubURL':regexURL, 'action':'getNewCourseGitHub'},
 			success: function(response) { 
-				console.log(response)
+				console.log(response);
 			},
 			error: function(data){
-				console.log(data)
 				switch(data.status){
 					case 422:
-						console.log("hallå")
 						alert(data.responseJSON.message);
 						break;
 					case 503:

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -97,12 +97,22 @@ function fetchGitHubRepo(gitHubURL)
 			url: "../recursivetesting/FetchGithubRepo.php",
 			type: "POST",
 			data: {'githubURL':regexURL, 'action':'getNewCourseGitHub'},
-			dataType: "json",
 			success: function(response) { 
 				console.log(response)
 			},
-			error: function(response){
-				alert("The service is unavailable at the time")
+			error: function(data){
+				console.log(data)
+				switch(data.status){
+					case 422:
+						console.log("hallå")
+						alert(data.responseJSON.message);
+						break;
+					case 503:
+						alert(data.responseJSON.message);
+						break;
+					default:
+						alert("Something went wrong...");
+				}
 			}
 		});
 	} 

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -98,7 +98,12 @@ function fetchGitHubRepo(gitHubURL)
 			type: "POST",
 			data: {'githubURL':regexURL, 'action':'getNewCourseGitHub'},
 			dataType: "json",
-			success: function(response) { console.log(response) }
+			success: function(response) { 
+				console.log(response)
+			},
+			error: function(response){
+				alert("The service is unavailable at the time")
+			}
 		});
 	} 
 }

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -1,167 +1,143 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-</head>
-
-<style>
-    html {
-        font-family: "Lucida Console", "Monaco", monospace;
-    }
-
-    table {
-        margin: 0 auto;
-        border-collapse: collapse;
-        text-align: left;
-        border: 1px solid black;
-    }
-
-    th,
-    td,
-    tr {
-        width: 325px;
-        padding: 10px;
-        border: 1px solid black;
-        font-size: 14px;
-    }
-</style>
-
-<body>
-    <?php
-
-    //Get data from AJAX call in courseed.js and then runs the function getNewCourseGithub link
-    if(isset($_POST['action'])) 
+<?php
+//Get data from AJAX call in courseed.js and then runs the function getNewCourseGithub link
+if(isset($_POST['action'])) 
+{
+    if($_POST['action'] == 'getNewCourseGitHub') 
     {
-        if($_POST['action'] == 'getNewCourseGitHub') 
-        {
-            getNewCourseGitHub($_POST['githubURL']);
-        }
-    };
-
-    //Calls getGithubURL to get the correct URL for the API. Then calls the Breadth-first algorithm to get all files.
-    function getNewCourseGitHub($githubURL)
-    {
-        getGitHubURL($githubURL);
+        getNewCourseGitHub($_POST['githubURL']);
     }
+};
 
+//Calls getGithubURL to get the correct URL for the API. Then calls the Breadth-first algorithm to get all files.
+function getNewCourseGitHub($githubURL)
+{
+    getGitHubURL($githubURL);
+}
 
-    function getGitHubURL($url)
-    {
-        $urlParts = explode('/', $url);
-        // In normal GitHub Repo URL:s, the username is the third object separated by a slash
-        $username = $urlParts[3];
-        // In normal GitHub Repo URL:s, the repo is the fourth object separated by a slash
-        $repository = $urlParts[4];
-        // Translates the parts broken out of $url into the correct URL syntax for an API-URL 
-        $translatedURL = 'https://api.github.com/repos/'.$username.'/'.$repository.'/contents/';
-        bfs($translatedURL, $repository);
-    }
-
-    // ------ DUMMY DATA FOR TESTING------ 
-    // Here you paste the appropriate link for the given repo that you wish to inspect and traverse.
-    // $url = 'https://github.com/e21krida/Webbprogrammering-Examples';
-    // Dismantles the $url into an array of each component, separated by a slash
-    // $urlParts = explode('/', $url);
+function getGitHubURL($url)
+{
+    $urlParts = explode('/', $url);
     // In normal GitHub Repo URL:s, the username is the third object separated by a slash
-    // $username = $urlParts[3];
+    $username = $urlParts[3];
     // In normal GitHub Repo URL:s, the repo is the fourth object separated by a slash
-    // $repository = $urlParts[4];
+    $repository = $urlParts[4];
     // Translates the parts broken out of $url into the correct URL syntax for an API-URL 
-    // $translatedURL = 'https://api.github.com/repos/'.$username.'/'.$repository.'/contents/';
-    // bfs($translatedURL, $repository);
-    // ----------------------------------
+    $translatedURL = 'https://api.github.com/repos/'.$username.'/'.$repository.'/contents/';
+    bfs($translatedURL, $repository);
+}
 
-    function bfs($url, $repository)
-    {
-        $visited = array();
-        $fifoQueue = array();
-        // If the directory doesn't exist, make it
-        if(!file_exists('../../LenaSYS/courses/' . $repository . '')) {
-	        if(!mkdir('../../LenaSYS/courses/' . $repository . '')){
-		        echo "Error creating folder: $repository";
-		        die;
-	        }
-        }
-        array_push($fifoQueue, $url);
-        $pdo = new PDO('sqlite:../../githubMetadata/metadata2.db');
+// ------ DUMMY DATA FOR TESTING------ 
+// Here you paste the appropriate link for the given repo that you wish to inspect and traverse.
+// $url = 'https://github.com/e21krida/Webbprogrammering-Examples';
+// Dismantles the $url into an array of each component, separated by a slash
+// $urlParts = explode('/', $url);
+// In normal GitHub Repo URL:s, the username is the third object separated by a slash
+// $username = $urlParts[3];
+// In normal GitHub Repo URL:s, the repo is the fourth object separated by a slash
+// $repository = $urlParts[4];
+// Translates the parts broken out of $url into the correct URL syntax for an API-URL 
+// $translatedURL = 'https://api.github.com/repos/'.$username.'/'.$repository.'/contents/';
+// bfs($translatedURL, $repository);
+// ----------------------------------
 
-        while (!empty($fifoQueue)) {
-            // Randomizes colors for easier presentation
-            $R = rand(155, 255);
-            $G = rand(155, 255);
-            $B = rand(155, 255);
-            $currentUrl = array_shift($fifoQueue);
-            echo "<h3 style='display: flex; place-content: center;'>" . $currentUrl . "</h3>";
-            // Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
-            $opts = [
-                'http' => [
-                    'method' => 'GET',
-                    'header' => [
-                        'User-Agent: PHP',
-                        // If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
-                        // simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
-                        // To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
-                        // Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
-                        // 'Authorization: Bearer YOUR_GITHUB_API_KEY'
-                    ]
+function bfs($url, $repository)
+{
+    $visited = array();
+    $fifoQueue = array();
+    // If the directory doesn't exist, make it
+    if(!file_exists('../../LenaSYS/courses/' . $repository . '')) {
+      if(!mkdir('../../LenaSYS/courses/' . $repository . '')){
+        echo "Error creating folder: $repository";
+        die;
+      }
+    }
+    array_push($fifoQueue, $url);
+    $pdo = new PDO('sqlite:../../githubMetadata/metadata2.db');
+
+    while (!empty($fifoQueue)) {
+        // Randomizes colors for easier presentation
+        $R = rand(155, 255);
+        $G = rand(155, 255);
+        $B = rand(155, 255);
+        $currentUrl = array_shift($fifoQueue);
+        // Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
+        $opts = [
+            'http' => [
+                'method' => 'GET',
+                'header' => [
+                    'User-Agent: PHP',
+                    // If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
+                    // simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
+                    // To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
+                    // Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
+                    // 'Authorization: Bearer YOUR_GITHUB_API_KEY'
                 ]
-            ];
-            // Starts a stream with the required headers
-            $context = stream_context_create($opts);
-            // Fetches the data with the stream included
-            $data = @file_get_contents($currentUrl, true, $context);
-            $data = false;
-            if ($data) {
-                // Decodes the fetched data into JSON
-                $json = json_decode($data, true);
-                // Loops through each item fetched in the JSON data
+            ]
+        ];
+        // Starts a stream with the required headers
+        $context = stream_context_create($opts);
+        // Fetches the data with the stream included
+        $data = @file_get_contents($currentUrl, true, $context);
+        $data = false;
+        if ($data) {
+            // Decodes the fetched data into JSON
+            $json = json_decode($data, true);
+            // Loops through each item fetched in the JSON data
+            if ($json) {
                 foreach ($json as $item) {
-                    if ($json) {
-                        // Checks if the fetched item is of type 'file'
-                        if ($item['type'] == 'file') {
-                            // Retrieves the contents of each individual file based on the fetched "download_url"
-                            $fileContents = file_get_contents($item['download_url']);
-                            $path = '../../LenaSYS/courses/'.  $repository . '/' . $item['path'];
-                            echo "<script>console.log('Debug Objects: " . $path . "' );</script>";
-                            // Creates the directory for each individual file based on the fetched "path"
-                            if (!file_exists((dirname($path)))) {
-                                mkdir(dirname($path), 0777, true);
-                            } 
-                            // Writes the file to the respective folder. 
-                            file_put_contents($path, $fileContents);
-                            echo '<table style="background-color: rgb(' . $R . ',' . $G . ',' . $B . ')"><tr><th>Name</th><th>URL</th><th>Type</th><th>Size</th><th>Download URL</th><th>SHA</th><th>Path</th></tr>';
-                            echo '<tr><td>' . $item['name'] . '</td><td><a href="' . $item['html_url'] . '">HTML URL</a></td><td>' . $item['type'] . '</td><td>' . $item['size'] . '</td><td><a href="' . $item['download_url'] . '">Download URL</a></td><td>' . $item['sha'] . '</td><td>' . $item['path'] . '</td></tr>';
-                            // Checks if the fetched item is of type 'dir'
-                        } else if ($item['type'] == 'dir') {
-                            echo '<table style="background-color: rgb(' . $R . ',' . $G . ',' . $B . ')"><tr><th>Name</th><th>URL</th><th>Type</th><th>Size</th><th>Download URL</th><th>SHA</th><th>Path</th></tr>';
-                            echo '<tr><td>' . $item['name'] . '</td><td><a href="' . $item['html_url'] . '">HTML URL</a></td><td>' . $item['type'] . '</td><td>-</td><td>NULL</td><td>' . $item['sha'] . '</td><td>' . $item['path'] . '</td></tr>';
-                            if (!in_array($item['url'], $visited)) {
-                                array_push($visited, $item['url']);
-                                array_push($fifoQueue, $item['url']);
-                            }
+                    // Checks if the fetched item is of type 'file'
+                    if ($item['type'] == 'file') {
+                        // Retrieves the contents of each individual file based on the fetched "download_url"
+                        $fileContents = file_get_contents($item['download_url']);
+                        $path = '../../LenaSYS/courses/'.  $repository . '/' . $item['path'];
+                        echo "<script>console.log('Debug Objects: " . $path . "' );</script>";
+                        // Creates the directory for each individual file based on the fetched "path"
+                        if (!file_exists((dirname($path)))) {
+                            mkdir(dirname($path), 0777, true);
+                        } 
+                        // Writes the file to the respective folder. 
+                        file_put_contents($path, $fileContents);
+                        echo '<table style="background-color: rgb(' . $R . ',' . $G . ',' . $B . ')"><tr><th>Name</th><th>URL</th><th>Type</th><th>Size</th><th>Download URL</th><th>SHA</th><th>Path</th></tr>';
+                        echo '<tr><td>' . $item['name'] . '</td><td><a href="' . $item['html_url'] . '">HTML URL</a></td><td>' . $item['type'] . '</td><td>' . $item['size'] . '</td><td><a href="' . $item['download_url'] . '">Download URL</a></td><td>' . $item['sha'] . '</td><td>' . $item['path'] . '</td></tr>';
+                        // Checks if the fetched item is of type 'dir'
+                    } else if ($item['type'] == 'dir') {
+                        echo '<table style="background-color: rgb(' . $R . ',' . $G . ',' . $B . ')"><tr><th>Name</th><th>URL</th><th>Type</th><th>Size</th><th>Download URL</th><th>SHA</th><th>Path</th></tr>';
+                        echo '<tr><td>' . $item['name'] . '</td><td><a href="' . $item['html_url'] . '">HTML URL</a></td><td>' . $item['type'] . '</td><td>-</td><td>NULL</td><td>' . $item['sha'] . '</td><td>' . $item['path'] . '</td></tr>';
+                        if (!in_array($item['url'], $visited)) {
+                            array_push($visited, $item['url']);
+                            array_push($fifoQueue, $item['url']);
                         }
-                        $query = $pdo->prepare('INSERT INTO gitRepos (repoName, repoURL, repoFileType, repoDownloadURL, repoSHA, RepoPath) VALUES (:repoName, :repoURL, :repoFileType, :repoDownloadURL, :repoSHA, :repoPath)');
-                        $query->bindParam(':repoName', $item['name']);
-                        $query->bindParam(':repoURL', $item['repoURL']);
-                        $query->bindParam(':repoFileType', $item['type']);
-                        $query->bindParam(':repoDownloadURL', $item['download_url']);
-                        $query->bindParam(':repoSHA', $item['sha']);
-                        $query->bindParam(':repoPath', $item['path']);
-                        $query->execute();
-                        echo "</table>";
-                    } else {
-                        echo "<h2 style='display: flex; place-content: center;'>Invalid JSON</h2>";
                     }
+                    $query = $pdo->prepare('INSERT INTO gitRepos (repoName, repoURL, repoFileType, repoDownloadURL, repoSHA, RepoPath) VALUES (:repoName, :repoURL, :repoFileType, :repoDownloadURL, :repoSHA, :repoPath)');
+                    $query->bindParam(':repoName', $item['name']);
+                    $query->bindParam(':repoURL', $item['repoURL']);
+                    $query->bindParam(':repoFileType', $item['type']);
+                    $query->bindParam(':repoDownloadURL', $item['download_url']);
+                    $query->bindParam(':repoSHA', $item['sha']);
+                    $query->bindParam(':repoPath', $item['path']);
+                    $query->execute();
+                    echo "</table>";
                 }
             } else {
-                echo "<h2 style='display: flex; place-content: center;'>Invalid Link or API-Fetch limited</h2>";  
+                //422: Unprocessable entity
+                http_response_code(422);
+                header('Content-type: application/json');
+                $response = array(
+                    'message' => "The JSON-file is invalid"
+                );
+
+                echo json_encode($response);
             }
+        } else {
+            //503: Service is unavailable
+            http_response_code(503);
+            header('Content-type: application/json');
+            $response = array(
+                'message' => "Github services are unavailable at this time."
+            );
+
+            echo json_encode($response);
         }
     }
-    ?>
-</body>
-
-</html>
+}
+?>

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -78,11 +78,11 @@ function bfs($url, $repository)
         $context = stream_context_create($opts);
         // Fetches the data with the stream included
         $data = @file_get_contents($currentUrl, true, $context);
-        $data = false;
         if ($data) {
             // Decodes the fetched data into JSON
             $json = json_decode($data, true);
             // Loops through each item fetched in the JSON data
+            $json = false;
             if ($json) {
                 foreach ($json as $item) {
                     // Checks if the fetched item is of type 'file'

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -82,7 +82,6 @@ function bfs($url, $repository)
             // Decodes the fetched data into JSON
             $json = json_decode($data, true);
             // Loops through each item fetched in the JSON data
-            $json = false;
             if ($json) {
                 foreach ($json as $item) {
                     // Checks if the fetched item is of type 'file'

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -113,6 +113,7 @@
             $context = stream_context_create($opts);
             // Fetches the data with the stream included
             $data = @file_get_contents($currentUrl, true, $context);
+            $data = false;
             if ($data) {
                 // Decodes the fetched data into JSON
                 $json = json_decode($data, true);
@@ -156,7 +157,7 @@
                     }
                 }
             } else {
-                echo "<h2 style='display: flex; place-content: center;'>Invalid Link or API-Fetch limited</h2>";     
+                echo "<h2 style='display: flex; place-content: center;'>Invalid Link or API-Fetch limited</h2>";  
             }
         }
     }


### PR DESCRIPTION
The script fetchGitHubRepo.php now sends http-error codes and error messages that can be dealt and showcased by the frontend (which will be done in issue #13410 ). To test if this works, you need to intenionally break the code by setting the variable "$json" to false and test that error message, and then setting the variable "$data" to false and test that error message. These will be showcased in an alert when creating a course with a github-url or editing a course with a github-url. When no error occurs, the console.log in the "success"-part of the ajax-query in the file courseed.js should be fired and should put a response in the console.

Me and b21leowa have tested both these faults on the webserver since we need to push faulty code to the webserver in order to test and it seems to be working. You can also check that the returned object looks fine by clicking on the tab "Network -> fetchGithubRepo.php -> preview" in the developer tools. 

Note: even when the faults are generated, the user is still being prompted with the alert that the course has been updated : this will be dealt with in the above mentioned issue)

Co-authored by b21leowa