### PR TITLE
 Investigate getlines ToDo comment in diagram.js #13497 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1699,7 +1699,7 @@ document.addEventListener('keyup', function (e)
             if (context.length !== 0){
                 
                 // Filter - keeps only the lines that are connectet to and from selected elements.
-                var contextConnectedLines = getLines().filter(line => {
+                var contextConnectedLines = lines.filter(line => {
                     return (context.filter(element => {
                         return line.toID == element.id || line.fromID == element.id
                     })).length > 1
@@ -2699,16 +2699,6 @@ function removeLines(linesArray, stateMachineShouldSave = true)
     showdata();
     redrawArrows();
 }
-
-/**
- * @description Will return all lines in the data array. This is mainly used for debugging purposes since we can log whenever the lines are read from.
- * @returns Returns all lines in the data array.
- */
-function getLines() // TODO : Replace all lines[i] with getLines()[i], or event introduce a new getLineAt(i)?
-{
-    return lines;
-}
-
 /**
  * @description Generatesa a new ghost element that is used for visual feedback to the end user when creating new elements and/or lines. Setting ghostElement to null will remove the ghost element.
  * @see ghostElement


### PR DESCRIPTION
removed get lines since its only purpose was returning a readily available, global, variable and it was only called once in the whole codebase. I changed the code where it was called to just use the global variable "lines" and then removed the, now unused, function.