### PR TITLE
G1 2023 v3 #13518 darkmode black entity

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8856,7 +8856,7 @@ function drawElement(element, ghosted = false)
             fill='${element.fill}'
         />
         
-        <text style='fill: ${element.stroke};' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`; //style shouldn't be needed, the div randomly gets fill: rgb(0, 0, 0), no clue why'
+        <text x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`; //style shouldn't be needed, the div randomly gets fill: rgb(0, 0, 0), no clue why'
         //end of svg for SD header
         str += `</svg>`;
         //end of div for SD header

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8841,7 +8841,7 @@ function drawElement(element, ghosted = false)
         str += `<div style='width: ${boxw}; height: ${boxh};'>`;
         //svg for SD header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
-        str += `<path 
+        str += `<path class="text" 
             d="M${linew+cornerRadius},${(linew)}
                 h${(boxw - (linew * 2))-(cornerRadius*2)}
                 a${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}
@@ -8868,7 +8868,7 @@ function drawElement(element, ghosted = false)
         if (elemAttri != 0) {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}'>`;
-            str += `<path 
+            str += `<path class="text"
                 d="M${linew},${(linew)}
                     h${(boxw - (linew * 2))}
                     v${(boxh / 2 + (boxh * elemAttri / 2) - (linew * 2))-cornerRadius}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8856,7 +8856,7 @@ function drawElement(element, ghosted = false)
             fill='${element.fill}'
         />
         
-        <text x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`; //style shouldn't be needed, the div randomly gets fill: rgb(0, 0, 0), no clue why'
+        <text x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
         //end of svg for SD header
         str += `</svg>`;
         //end of div for SD header

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8891,7 +8891,7 @@ function drawElement(element, ghosted = false)
         } else {
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh / 2)}'>`;
-            str += `<path 
+            str += `<path class="text"
                 d="M${linew},${(linew)}
                     h${(boxw - (linew * 2))}
                     v${(boxh / 2 + (boxh / 2) - (linew * 2))-cornerRadius}


### PR DESCRIPTION
There was a style-tag and a few missing classes that prevented the automated systems from kicking in when the color of an entity was set to black. That has now been fixed