### PR TITLE
 The buttons should react to user input and give feedback #13525 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4276,13 +4276,13 @@ function toggleErTable()
     else if (erTableToggle == true){
         erTableToggle = false;
     }
-    generateContextProperties();
     //if the options pane is hidden, show it.
     if (document.getElementById("options-pane").className == "hide-options-pane") {
         toggleOptionsPane();
         erTableToggle = true;
         testCaseToggle = false;
     }
+    generateContextProperties();
 }
 
 
@@ -4298,12 +4298,12 @@ function toggleTestCase()
     else if (testCaseToggle == true) {
         testCaseToggle = false;
     }
-    generateContextProperties();
     if (document.getElementById("options-pane").className == "hide-options-pane") {
         toggleOptionsPane();
         testCaseToggle = true;
         erTableToggle = false;
     }
+    generateContextProperties();
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5540,6 +5540,7 @@ function generateErTableString()
     for (var i = 0; i < stringList.length; i++) {
         stri += new String(stringList[i] + "\n\n");
     }
+    console.log(stri);
     return stri;
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5542,7 +5542,7 @@ function generateErTableString()
     }
     //if its empty, show a message instead.
     if (stri == "") {
-        stri = "The feature you are trying to use is linked to ER tables and it appears you do not have any ER elements placed."
+        stri = "The feature you are trying to use is linked to ER tables and it appears you do not have any ER elements placed. Please place an ER element and try again."
     }
     return stri;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4277,6 +4277,10 @@ function toggleErTable()
         erTableToggle = false;
     }
     generateContextProperties();
+    //if the options pane is hidden, show it.
+    if (document.getElementById("options-pane").className == "hide-options-pane") {
+        toggleOptionsPane();
+    }
 }
 
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3991,6 +3991,10 @@ if(data[i].kind==elementTypesNames.SDState)
 }
     }
     output+="line counter is "+lineCounter+" and state counter is "+elementCounter;
+    //if no state diagram exists, return a message to the user instead.
+    if ((lineCounter == 0) && (elementCounter == 0)) {
+        output = "The feature you are trying to use is linked to state diagrams and it appears you do not have any state elements placed. Please place a state element and try again."
+    }
     return output;
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -5540,7 +5540,10 @@ function generateErTableString()
     for (var i = 0; i < stringList.length; i++) {
         stri += new String(stringList[i] + "\n\n");
     }
-    console.log(stri);
+    //if its empty, show a message instead.
+    if (stri == "") {
+        stri = "The feature you are trying to use is linked to ER tables and it appears you do not have any ER elements placed."
+    }
     return stri;
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4280,6 +4280,7 @@ function toggleErTable()
     //if the options pane is hidden, show it.
     if (document.getElementById("options-pane").className == "hide-options-pane") {
         toggleOptionsPane();
+        erTableToggle = true;
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4281,6 +4281,7 @@ function toggleErTable()
     if (document.getElementById("options-pane").className == "hide-options-pane") {
         toggleOptionsPane();
         erTableToggle = true;
+        testCaseToggle = false;
     }
 }
 
@@ -4298,6 +4299,11 @@ function toggleTestCase()
         testCaseToggle = false;
     }
     generateContextProperties();
+    if (document.getElementById("options-pane").className == "hide-options-pane") {
+        toggleOptionsPane();
+        testCaseToggle = true;
+        erTableToggle = false;
+    }
 }
 
 /**


### PR DESCRIPTION
Made it so that the options pane opens automatically when any of these buttons is pressed, also made it so that if there isn't a ER diagram or, respectively, state diagram present at all: the buttons will show a message in their output box informing the user of this.