### PR TITLE
G3 2023 v3 fix queries for new db

### DIFF
--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -258,7 +258,7 @@ $metadata_db->exec($sql2);
 
 $sql3 = '
 	CREATE TABLE IF NOT EXISTS gitFiles ( 
-		cid INTEGER PRIMARY KEY,
+		cid INTEGER,
 		fileName VARCHAR(50), 
     fileType VARCHAR(50),
 		fileURL VARCHAR(255),

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -258,14 +258,13 @@ $metadata_db->exec($sql2);
 
 $sql3 = '
 	CREATE TABLE IF NOT EXISTS gitFiles ( 
-		cid INTEGER,
+		cid INTEGER PRIMARY KEY,
 		fileName VARCHAR(50), 
     fileType VARCHAR(50),
 		fileURL VARCHAR(255),
     downloadURL VARCHAR(255), 
     fileSHA VARCHAR(255), 
-    filePath VARCHAR(255),
-	  PRIMARY KEY (cid, fileName)
+    filePath VARCHAR(255)
 	);
 '; 
 $metadata_db->exec($sql3);

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -258,8 +258,8 @@ $metadata_db->exec($sql2);
 
 $sql3 = '
 	CREATE TABLE IF NOT EXISTS gitFiles ( 
-		cid INTEGER,
-		fileName VARCHAR(50), 
+		cid INTEGER PRIMARY KEY,
+		fileName VARCHAR(50) PRIMARY KEY, 
     fileType VARCHAR(50),
 		fileURL VARCHAR(255),
     downloadURL VARCHAR(255), 

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -260,7 +260,8 @@ $sql3 = '
 	CREATE TABLE IF NOT EXISTS gitFiles ( 
 		cid INTEGER,
 		fileName VARCHAR(50), 
-    fileType VARCHAR(50), 
+    fileType VARCHAR(50),
+		fileURL VARCHAR(255),
     downloadURL VARCHAR(255), 
     fileSHA VARCHAR(255), 
     filePath VARCHAR(255),

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -258,13 +258,14 @@ $metadata_db->exec($sql2);
 
 $sql3 = '
 	CREATE TABLE IF NOT EXISTS gitFiles ( 
-		cid INTEGER PRIMARY KEY,
-		fileName VARCHAR(50) PRIMARY KEY, 
+		cid INTEGER,
+		fileName VARCHAR(50), 
     fileType VARCHAR(50),
 		fileURL VARCHAR(255),
     downloadURL VARCHAR(255), 
     fileSHA VARCHAR(255), 
-    filePath VARCHAR(255)
+    filePath VARCHAR(255),
+		PRIMARY KEY (cid, fileName)
 	);
 '; 
 $metadata_db->exec($sql3);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -157,9 +157,10 @@ function bfs($url, $repository)
                             array_push($fifoQueue, $item['url']);
                         }
                     }
-                    $query = $pdoLite->prepare('INSERT INTO gitFiles (fileName, fileType, downloadURL, fileSHA, filePath) VALUES (:fileName, :fileType, :downloadURL, :fileSHA, :filePath)');
+                    $query = $pdoLite->prepare('INSERT INTO gitFiles (fileName, fileType, fileURL, downloadURL, fileSHA, filePath) VALUES (:fileName, :fileType, , :fileURL, :downloadURL, :fileSHA, :filePath)');
                     $query->bindParam(':fileName', $item['name']);
                     $query->bindParam(':fileType', $item['type']);
+                    $query->bindParam(':fileURL', $item['url']);
                     $query->bindParam(':downloadURL', $item['download_url']);
                     $query->bindParam(':fileSHA', $item['sha']);
                     $query->bindParam(':filePath', $item['path']);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -157,7 +157,8 @@ function bfs($url, $repository)
                             array_push($fifoQueue, $item['url']);
                         }
                     }
-                    $query = $pdoLite->prepare('INSERT INTO gitFiles (fileName, fileType, fileURL, downloadURL, fileSHA, filePath) VALUES (:fileName, :fileType, , :fileURL, :downloadURL, :fileSHA, :filePath)');
+                    $query = $pdoLite->prepare('INSERT INTO gitFiles (cid, fileName, fileType, fileURL, downloadURL, fileSHA, filePath) VALUES (:cid, :fileName, :fileType, , :fileURL, :downloadURL, :fileSHA, :filePath)');
+                    $query->bindParam(':cid', 1);
                     $query->bindParam(':fileName', $item['name']);
                     $query->bindParam(':fileType', $item['type']);
                     $query->bindParam(':fileURL', $item['url']);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -157,7 +157,7 @@ function bfs($url, $repository)
                             array_push($fifoQueue, $item['url']);
                         }
                     }
-                    $query = $pdoLite->prepare('INSERT INTO gitFiles (cid, fileName, fileType, fileURL, downloadURL, fileSHA, filePath) VALUES (:cid, :fileName, :fileType, , :fileURL, :downloadURL, :fileSHA, :filePath)');
+                    $query = $pdoLite->prepare('INSERT INTO gitFiles (cid, fileName, fileType, fileURL, downloadURL, fileSHA, filePath) VALUES (:cid, :fileName, :fileType, :fileURL, :downloadURL, :fileSHA, :filePath)');
                     $query->bindParam(':cid', $cid);
                     $query->bindParam(':fileName', $item['name']);
                     $query->bindParam(':fileType', $item['type']);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -157,13 +157,12 @@ function bfs($url, $repository)
                             array_push($fifoQueue, $item['url']);
                         }
                     }
-                    $query = $pdoLite->prepare('INSERT INTO gitRepos (repoName, repoURL, repoFileType, repoDownloadURL, repoSHA, RepoPath) VALUES (:repoName, :repoURL, :repoFileType, :repoDownloadURL, :repoSHA, :repoPath)');
-                    $query->bindParam(':repoName', $item['name']);
-                    $query->bindParam(':repoURL', $item['repoURL']);
-                    $query->bindParam(':repoFileType', $item['type']);
-                    $query->bindParam(':repoDownloadURL', $item['download_url']);
-                    $query->bindParam(':repoSHA', $item['sha']);
-                    $query->bindParam(':repoPath', $item['path']);
+                    $query = $pdoLite->prepare('INSERT INTO gitFiles (fileName, fileType, downloadURL, fileSHA, filePath) VALUES (:fileName, :fileType, :downloadURL, :fileSHA, :filePath)');
+                    $query->bindParam(':fileName', $item['name']);
+                    $query->bindParam(':fileType', $item['type']);
+                    $query->bindParam(':downloadURL', $item['download_url']);
+                    $query->bindParam(':fileSHA', $item['sha']);
+                    $query->bindParam(':filePath', $item['path']);
                     $query->execute();
                     echo "</table>"; 
                 }

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -158,7 +158,7 @@ function bfs($url, $repository)
                         }
                     }
                     $query = $pdoLite->prepare('INSERT INTO gitFiles (cid, fileName, fileType, fileURL, downloadURL, fileSHA, filePath) VALUES (:cid, :fileName, :fileType, , :fileURL, :downloadURL, :fileSHA, :filePath)');
-                    $query->bindParam(':cid', 1);
+                    $query->bindParam(':cid', $cid);
                     $query->bindParam(':fileName', $item['name']);
                     $query->bindParam(':fileType', $item['type']);
                     $query->bindParam(':fileURL', $item['url']);

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -6,6 +6,13 @@
 
 	$url = "https://github.com/HGustavs/LenaSYS"; // TODO: This url should be the one you fetch from the database!
 
+  $urlParts = explode('/', $url);
+  // In normal GitHub Repo URL:s, the repo is the fourth object separated by a slash
+  $repository = $urlParts[4];
+
+	print_r($username);
+	print_r($repository);
+
 	$html = file_get_contents($url);
 	$dom = new DomDocument;
 	$dom->preserveWhiteSpace = FALSE;

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -8,7 +8,7 @@
 
   $urlParts = explode('/', $url);
   // In normal GitHub Repo URL:s, the repo is the fourth object separated by a slash
-  $repository = $urlParts[4];
+  $repository = $urlParts[4]; // Use the $repository variable to insert into "repoName"
 
 	print_r($username);
 	print_r($repository);


### PR DESCRIPTION
For issue https://github.com/HGustavs/LenaSYS/issues/13542
This will fix the issue with fetchGithubRepo.php to now be connected to the new SQLite db version and its new columns. 
The downloaded files will now be located under cid = 1 and under the folder Github. 

Since we now are running the fetch and download when creating a new course we are now hardcoding the courseid (cid) to be 1, but for testing purpose this is now ok. This will need to be changed when we dissconnect the fetch from the create new course button and connect it to the refreshbutton on the course page/moment on a course page we can then implement a solution to not hardcode cid to be 1 and instead used the correct cid for the course.  