### PR TITLE
G3 2023 v4 issue#13419 get previous commit from sqllite

### DIFF
--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -16,7 +16,7 @@
 	global $pdo;
 	$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 
-	getCourseID("https://github.com/HGustavs/Webbprogrammering-Examples"); // Dummy Code to see if everything works
+	getCourseID("https://github.com/HGustavs/saraTest"); // Dummy Code to see if everything works
 
 	// --------------------- Fetch CID from MySQL with Github URL and fetch latest commit -------------------------------
 	// --------------------- This only happens when creating a new course -----------------------------------------------
@@ -62,7 +62,7 @@
 
 	// Create a new row if it doesn't exist
 	function insertIntoSQLite($url, $cid, $commit) {
-		$query = $pdolite->prepare("INSERT INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits"); 
+		$query = $pdolite->prepare("INSERT INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits);"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoURL', $repoURL);
 		$query->bindParam(':commits', $commit);

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -70,7 +70,7 @@
 	function insertIntoSQLite($url, $cid, $commit) {
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 		// Remove "or replace" later when everything works like it should
-		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits)"); 
+		$query = $pdolite->prepare("INSERT INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits)"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoURL', $url);
 		$query->bindParam(':commits', $commit);

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -15,7 +15,7 @@
 
 	global $pdo;
 
-	getCourseID("https://github.com/HGustavs/saraTest"); // Dummy Code to see if everything works
+	getCourseID("https://github.com/g21emmka/test-for-se-project"); // Dummy Code to see if everything works
 
 	// --------------------- Fetch CID from MySQL with Github URL and fetch latest commit -------------------------------
 	// --------------------- This only happens when creating a new course -----------------------------------------------

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -86,6 +86,7 @@
 		$testquery->execute();
 		$norows = $testquery->fetchColumn();
 
+		print_r("It did it??");
 		print_r($norows);
 	}
 

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -84,10 +84,16 @@
 		} 
 		$testquery = $pdolite->prepare('SELECT * FROM gitRepos');
 		$testquery->execute();
-		$norows = $testquery->fetchRow();
+		//$norows = $testquery->fetchColumn();
 
 		print_r("It did it??");
-		print_r($norows);
+		foreach($testquery->fetchAll(PDO::FETCH_ASSOC) as $row){
+			echo "<p>Course ID: ".$row['cid']."</p>";
+			echo "<p>URL: ".$row['repoURL']."</p>";
+			echo "<p>Commit: ".$row['lastCommit']."</p>";
+		
+			// TODO: Limit this to only one result
+		}
 	}
 
 	// --------------------- Get Latest Commit Function -----------------------------------------

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -82,11 +82,13 @@
 			print_r($error);
 			echo $errorvar;
 		} 
-		$testquery = $pdolite->prepare('SELECT * FROM gitRepos');
+
+		// This is just for printing and should be removed later
+		$testquery = $pdolite->prepare('SELECT * FROM gitRepos WHERE cid = :cid');
+		$testquery->bindParam(':cid', $cid);
 		$testquery->execute();
 		//$norows = $testquery->fetchColumn();
 
-		print_r("It did it??");
 		foreach($testquery->fetchAll(PDO::FETCH_ASSOC) as $row){
 			echo "<p>Course ID: ".$row['cid']."</p>";
 			echo "<p>URL: ".$row['repoURL']."</p>";

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -15,7 +15,7 @@
 
 	global $pdo;
 
-	getCourseID("https://github.com/HGustavs/saraTest"); // Dummy Code to see if everything works
+	getCourseID("https://github.com/c21sebar/test"); // Dummy Code to see if everything works
 
 	// --------------------- Fetch CID from MySQL with Github URL and fetch latest commit -------------------------------
 	// --------------------- This only happens when creating a new course -----------------------------------------------

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -64,7 +64,7 @@
 		
 	}
 
-	// --------------------- Insert into SQL Lite db when new course is created -------------------------------
+	// --------------------- Insert into Sqlite db when new course is created -------------------------------
 
 	// Create a new row if it doesn't exist
 	function insertIntoSQLite($url, $cid, $commit) {
@@ -83,6 +83,8 @@
 			echo $errorvar;
 		} 
 
+	//---------------------------------------For testing only -------------------------------------------------------------
+
 		// This is just for printing and should be removed later
 		$testquery = $pdolite->prepare('SELECT * FROM gitRepos WHERE cid = :cid');
 		$testquery->bindParam(':cid', $cid);
@@ -90,15 +92,18 @@
 		//$norows = $testquery->fetchColumn();
 
 		foreach($testquery->fetchAll(PDO::FETCH_ASSOC) as $row){
-			echo "<p>Course ID: ".$row['cid']."</p>";
-			echo "<p>URL: ".$row['repoURL']."</p>";
-			echo "<p>Commit: ".$row['lastCommit']."</p>";
+			echo "<p>Course ID from insert: ".$row['cid']."</p>";
+			echo "<p>URL from insert: ".$row['repoURL']."</p>";
+			echo "<p>Commit from insert: ".$row['lastCommit']."</p>";
 		
 			// TODO: Limit this to only one result
 		}
+
+		getCommitSqlite($cid);
+	//----------------------------------------------------------------------------------------------------------------------
 	}
 
-	// --------------------- Get Latest Commit Function -----------------------------------------
+	// --------------------- Get Latest Commit Function from URL-----------------------------------------
 
 	function getCommit($url) {
 
@@ -134,4 +139,19 @@
 			//print_r("No matches in database!");
 		}
 	}
+
+		// --------------------- Get Latest Commit from Sqlite-----------------------------------------
+
+	function getCommitSqlite($cid){
+
+		$query = $pdolite->prepare('SELECT lastCommit FROM gitRepos WHERE cid = :cid');
+		$query->bindParam(':cid', $cid);
+		$query->execute();
+
+		foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
+			echo "<p>Commit from select: ".$row['lastCommit']."</p>";
+		}
+	}
+
+
 ?>

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -54,7 +54,13 @@
 				break;
 			}
 		}
-		insertIntoSQLite($githubURL, $cid, $latestCommit);
+
+		if($cid != null) {
+			insertIntoSQLite($githubURL, $cid, $latestCommit);
+		} else {
+			print_r("No matches in database!");
+		}
+		
 	}
 
 	// --------------------- Insert into SQL Lite db when new course is created -------------------------------

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -84,7 +84,7 @@
 		} 
 		$testquery = $pdolite->prepare('SELECT * FROM gitRepos');
 		$testquery->execute();
-		$norows = $testquery->fetchColumn();
+		$norows = $testquery->fetchRow();
 
 		print_r("It did it??");
 		print_r($norows);

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -143,7 +143,7 @@
 		// --------------------- Get Latest Commit from Sqlite-----------------------------------------
 
 	function getCommitSqlite($cid){
-
+		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 		$query = $pdolite->prepare('SELECT lastCommit FROM gitRepos WHERE cid = :cid');
 		$query->bindParam(':cid', $cid);
 		$query->execute();

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -14,7 +14,7 @@
 	session_start();
 
 	global $pdo;
-	$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+	global $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 
 	getCourseID("https://github.com/HGustavs/saraTest"); // Dummy Code to see if everything works
 

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -14,7 +14,6 @@
 	session_start();
 
 	global $pdo;
-	$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 
 	getCourseID("https://github.com/HGustavs/saraTest"); // Dummy Code to see if everything works
 
@@ -62,6 +61,7 @@
 
 	// Create a new row if it doesn't exist
 	function insertIntoSQLite($url, $cid, $commit) {
+		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 		$query = $pdolite->prepare("INSERT INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits);"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoURL', $repoURL);

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -14,7 +14,7 @@
 	session_start();
 
 	global $pdo;
-	global $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+	$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 
 	getCourseID("https://github.com/HGustavs/saraTest"); // Dummy Code to see if everything works
 

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -15,7 +15,7 @@
 
 	global $pdo;
 
-	getCourseID("https://github.com/g21emmka/test-for-se-project"); // Dummy Code to see if everything works
+	getCourseID("https://github.com/HGustavs/saraTest"); // Dummy Code to see if everything works
 
 	// --------------------- Fetch CID from MySQL with Github URL and fetch latest commit -------------------------------
 	// --------------------- This only happens when creating a new course -----------------------------------------------

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -34,6 +34,7 @@
 		$query->execute();
 
 		// printing the result
+		$cid = "";
 		foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
 			echo "<p>Course ID: ".$row['cid']."</p>";
 			$cid = $row['cid'];

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -69,7 +69,8 @@
 	// Create a new row if it doesn't exist
 	function insertIntoSQLite($url, $cid, $commit) {
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-		$query = $pdolite->prepare("INSERT INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits)"); 
+		// Remove "or replace" later when everything works like it should
+		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits)"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoURL', $url);
 		$query->bindParam(':commits', $commit);

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -5,8 +5,6 @@
 	ini_set('display_startup_errors', 1);
 	error_reporting(E_ALL);
 
-	// --------------------- Fetch CID from MySQL with Github URL -------------------------------
-
 	// Include basic application services!
 	include_once "../Shared/basic.php";
 	include_once "../Shared/sessions.php";
@@ -15,7 +13,13 @@
 	pdoConnect();
 	session_start();
 
+	global $pdo;
+	$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+
 	getCourseID("https://github.com/HGustavs/Webbprogrammering-Examples"); // Dummy Code to see if everything works
+
+	// --------------------- Fetch CID from MySQL with Github URL and fetch latest commit -------------------------------
+	// --------------------- This only happens when creating a new course -----------------------------------------------
 
 	function getCourseID($githubURL) {
 
@@ -51,10 +55,33 @@
 				break;
 			}
 		}
+		insertIntoSQLite($githubURL, $cid, $latestCommit);
+	}
+
+	// --------------------- Insert into SQL Lite db when new course is created -------------------------------
+
+	// Create a new row if it doesn't exist
+	function insertIntoSQLite($url, $cid, $commit) {
+		$query = $pdolite->prepare("INSERT INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits"); 
+		$query->bindParam(':cid', $cid);
+		$query->bindParam(':repoURL', $repoURL);
+		$query->bindParam(':commits', $commit);
+		$query->execute();
+		if (!$query->execute()) {
+			$error = $query->errorInfo();
+			echo "Error updating file entries" . $error[2];
+			$errorvar = $error[2];
+			print_r($error);
+			echo $errorvar;
+		} 
+		$testquery = $pdolite->prepare('SELECT * FROM gitRepos');
+		$testquery->execute();
+		$norows = $testquery->fetchColumn();
+
+		print_r($norows);
 	}
 
 	// --------------------- Get Latest Commit Function -----------------------------------------
-
 
 	function getCommit($url) {
 

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -62,9 +62,9 @@
 	// Create a new row if it doesn't exist
 	function insertIntoSQLite($url, $cid, $commit) {
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-		$query = $pdolite->prepare("INSERT INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits);"); 
+		$query = $pdolite->prepare("INSERT INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits)"); 
 		$query->bindParam(':cid', $cid);
-		$query->bindParam(':repoURL', $repoURL);
+		$query->bindParam(':repoURL', $url);
 		$query->bindParam(':commits', $commit);
 		$query->execute();
 		if (!$query->execute()) {


### PR DESCRIPTION
issue #13419, issue #13420 is also resolved in this pull req.

Added sqlite connection to getLatestCommit. Saved the data (cid, url, latest commit nr) into sqlite db and then makes a select to bring the latest commit nr back. This is in preparation for a later issue. 

When testting you should see the following things: 
![image](https://user-images.githubusercontent.com/102578908/234613031-115de348-2c35-411b-9d11-e358930d7ce3.png)

Don't mind the error, it exists because the course already has a row in the database, so the course id isn't unique. This will not be an issue once the information in the database gets removed when a course is deleted.

Test this by going to getLatestCommit.php. For the code to work you need to have an entry in the MySQL database that matches the url "https://github.com/c21sebar/test" since it's hardcoded.

co-author @c21rebja 
