### PR TITLE
G1 2023 v4 #13562 text-breaks in entites

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8776,7 +8776,7 @@ function drawElement(element, ghosted = false)
     //=============================================== <-- UML functionality
     //Check if the element is a UML entity
     if (element.kind == "UMLEntity") { 
-        const maxCharactersPerLine = Math.floor((boxw / texth)*1.5);
+        const maxCharactersPerLine = Math.floor((boxw / texth)*1.75);
 
         const splitLengthyLine = (str, max) => {
             if (str.length <= max) return str;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9138,7 +9138,7 @@ function drawElement(element, ghosted = false)
         str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh - (linew * 2)}'
         stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
         for (var i = 0; i < elemName; i++) {
-            str += `<text class='text' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}' > ${nameText[i]}</text >`;
+            str += `<text class='text' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${elemName[i]}</text>`;
          }
         //end of svg for IE header
         str += `</svg>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8776,7 +8776,7 @@ function drawElement(element, ghosted = false)
     //=============================================== <-- UML functionality
     //Check if the element is a UML entity
     if (element.kind == "UMLEntity") { 
-        const maxCharactersPerLine = Math.floor(boxw / texth);
+        const maxCharactersPerLine = Math.floor((boxw / texth)*1.5);
 
         const splitLengthyLine = (str, max) => {
             if (str.length <= max) return str;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9098,6 +9098,11 @@ function drawElement(element, ghosted = false)
             return splitLengthyLine(line, maxCharactersPerLine);
         }).flat();
 
+        const nameText = element.name.map(line => {
+            return splitLengthyLine(line, maxCharactersPerLine);
+        }).flat();
+
+        elemName = nameText.length;
         elemAttri = text.length;
 
         // Removes the previouse value in IEHeight for the element
@@ -9131,8 +9136,10 @@ function drawElement(element, ghosted = false)
         //svg for IE header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh - (linew * 2)}'
-        stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />
-        <text class='text' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+        stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
+        for (var i = 0; i < elemName; i++) {
+            str += `<text class='text' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}' > ${nameText[i]}</text >`;
+         }
         //end of svg for IE header
         str += `</svg>`;
         //end of div for IE header

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8776,8 +8776,25 @@ function drawElement(element, ghosted = false)
     //=============================================== <-- UML functionality
     //Check if the element is a UML entity
     if (element.kind == "UMLEntity") { 
-        elemAttri = element.attributes.length;
-        elemFunc = element.functions.length;
+        const maxCharactersPerLine = Math.floor(boxw / texth);
+
+        const splitLengthyLine = (str, max) => {
+            if (str.length <= max) return str;
+            else {
+                return [str.substring(0, max)].concat(splitLengthyLine(str.substring(max), max));
+            }
+        }
+
+        const text = element.attributes.map(line => {
+            return splitLengthyLine(line, maxCharactersPerLine);
+        }).flat();
+
+        const funcText = element.functions.map(line => {
+            return splitLengthyLine(line, maxCharactersPerLine);
+        }).flat();
+
+        elemAttri = text.length;
+        elemFunc = funcText.length;
 
         // Removes the previouse value in UMLHeight for the element
         for (var i = 0; i < UMLHeight.length; i++) {
@@ -8826,7 +8843,7 @@ function drawElement(element, ghosted = false)
             str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh/2 + (boxh * elemAttri/2) - (linew * 2)}'
             stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
             for (var i = 0; i < elemAttri; i++) {
-                str += `<text class='text' x='0.5em' y='${hboxh + boxh * i/2}' dominant-baseline='middle' text-anchor='right'>${element.attributes[i]}</text>`;
+                str += `<text class='text' x='0.5em' y='${hboxh + boxh * i/2}' dominant-baseline='middle' text-anchor='right'>${text[i]}</text>`;
             }
             //end of svg for background
             str += `</svg>`;
@@ -8852,7 +8869,7 @@ function drawElement(element, ghosted = false)
             str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh/2 + (boxh * elemFunc/2) - (linew * 2)}'
             stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
             for (var i = 0; i < elemFunc; i++) {
-                str += `<text class='text' x='0.5em' y='${hboxh + boxh * i/2}' dominant-baseline='middle' text-anchor='right'>${element.functions[i]}</text>`;
+                str += `<text class='text' x='0.5em' y='${hboxh + boxh * i/2}' dominant-baseline='middle' text-anchor='right'>${funcText[i]}</text>`;
             }
             //end of svg for background
             str += `</svg>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9094,11 +9094,13 @@ function drawElement(element, ghosted = false)
             }
         }
 
+        var nameArray = [element.name];
+
         const text = element.attributes.map(line => {
             return splitLengthyLine(line, maxCharactersPerLine);
         }).flat();
 
-        const nameText = element.name.map(line => {
+        const nameText = nameArray.map(line => {
             return splitLengthyLine(line, maxCharactersPerLine);
         }).flat();
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9094,7 +9094,7 @@ function drawElement(element, ghosted = false)
             }
         }
 
-        var nameArray = [element.name];
+        var nameArray = [element.name, ''];
 
         const text = element.attributes.map(line => {
             return splitLengthyLine(line, maxCharactersPerLine);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9094,17 +9094,10 @@ function drawElement(element, ghosted = false)
             }
         }
 
-        var nameArray = [element.name, ''];
-
         const text = element.attributes.map(line => {
             return splitLengthyLine(line, maxCharactersPerLine);
         }).flat();
 
-        const nameText = nameArray.map(line => {
-            return splitLengthyLine(line, maxCharactersPerLine);
-        }).flat();
-
-        elemName = nameText.length;
         elemAttri = text.length;
 
         // Removes the previouse value in IEHeight for the element
@@ -9138,10 +9131,8 @@ function drawElement(element, ghosted = false)
         //svg for IE header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh - (linew * 2)}'
-        stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
-        for (var i = 0; i < elemName; i++) {
-            str += `<text class='text' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${elemName[i]}</text>`;
-         }
+        stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />
+        <text class='text' x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
         //end of svg for IE header
         str += `</svg>`;
         //end of div for IE header

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9085,8 +9085,20 @@ function drawElement(element, ghosted = false)
     //=============================================== <-- IE functionality
     //Check if the element is a IE entity
     else if (element.kind == "IEEntity") { 
-        elemAttri = element.attributes.length;
-        //elemFunc = element.functions.length;
+        const maxCharactersPerLine = Math.floor((boxw / texth) * 1.75);
+
+        const splitLengthyLine = (str, max) => {
+            if (str.length <= max) return str;
+            else {
+                return [str.substring(0, max)].concat(splitLengthyLine(str.substring(max), max));
+            }
+        }
+
+        const text = element.attributes.map(line => {
+            return splitLengthyLine(line, maxCharactersPerLine);
+        }).flat();
+
+        elemAttri = text.length;
 
         // Removes the previouse value in IEHeight for the element
         for (var i = 0; i < IEHeight.length; i++) {
@@ -9135,7 +9147,7 @@ function drawElement(element, ghosted = false)
             str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh/2 + (boxh * elemAttri/2) - (linew * 2)}'
             stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
             for (var i = 0; i < elemAttri; i++) {
-                str += `<text class='text' x='5' y='${hboxh + boxh * i/2}' dominant-baseline='middle' text-anchor='right'>${element.attributes[i]}</text>`;
+                str += `<text class='text' x='5' y='${hboxh + boxh * i/2}' dominant-baseline='middle' text-anchor='right'>${text[i]}</text>`;
             }
             //end of svg for background
             str += `</svg>`;


### PR DESCRIPTION
I've copied Philip's function that he made in issue #13539 to UML and IE entities. Since these entities are left-aligned instead of centered I've given it some more room before folding because I thought it looked incorrect otherwise.