### PR TITLE
G3 2023 v4 issue#13621

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -651,6 +651,8 @@ function elementIsValid(element) {
 				console.log("debug2");
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
+				} else {
+					console.log("debug3");
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -652,7 +652,9 @@ function elementIsValid(element) {
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				} else {
-					messageElement.innerHTML = "";
+					if(messageElement.firstChild) {
+						messageElement.innerHTML = "";
+					}
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -652,7 +652,7 @@ function elementIsValid(element) {
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				} else {
-					console.log("debug3");
+					messageElement.innerHTML = ``;
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -652,7 +652,7 @@ function elementIsValid(element) {
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				} else {
-					messageElement.innerHTML = "";
+					messageElement.remove.firstChild;
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -649,8 +649,6 @@ function elementIsValid(element) {
 				if(activeCodes.includes(element.value)) {
 					messageElement.firstChild.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
-				} else {
-					$(messageElement.firstChild).fadeOut();
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -652,7 +652,7 @@ function elementIsValid(element) {
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				} else {
-					messageElement.innerHTML = ``;
+					messageElement.innerHTML = "";
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -653,7 +653,7 @@ function elementIsValid(element) {
 					return false;
 				} else {
 					if(messageElement.firstChild) {
-						messageElement.innerHTML = "";
+						messageElement.firstChild.innerHTML = "";
 					}
 				}
 			}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -647,14 +647,10 @@ function elementIsValid(element) {
 			//This prevents it from being impossible to save course code without changing it
 			if(element.value !== element.dataset.origincode) {
 				if(activeCodes.includes(element.value)) {
-					console.log(messageElement);
-					console.log(messageElement.firstChild);
 					messageElement.firstChild.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				} else {
-					console.log(messageElement);
-					console.log(messageElement.firstChild);
-					messageElement.firstChild.innerHTML = "";
+					$(messageElement.firstChild).fadeOut();
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -646,8 +646,9 @@ function elementIsValid(element) {
 			//Check for duplicate course codes only if value of input is not same as the course code that will be editied
 			//This prevents it from being impossible to save course code without changing it
 			if(element.value !== element.dataset.origincode) {
-				console.log("debug");
+				console.log("debug1");
 				if(activeCodes.includes(element.value)) {
+				console.log("debug2");
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -646,13 +646,13 @@ function elementIsValid(element) {
 			//Check for duplicate course codes only if value of input is not same as the course code that will be editied
 			//This prevents it from being impossible to save course code without changing it
 			if(element.value !== element.dataset.origincode) {
-				console.log("debug1");
 				if(activeCodes.includes(element.value)) {
-				console.log("debug2");
+					console.log(messageElement);
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				} else {
-					messageElement.remove.firstChild;
+					console.log(messageElement);
+					messageElement.innerHTML = "";
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -653,7 +653,6 @@ function elementIsValid(element) {
 					return false;
 				} else {
 					messageElement.innerHTML = "";
-					return true;
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -648,11 +648,13 @@ function elementIsValid(element) {
 			if(element.value !== element.dataset.origincode) {
 				if(activeCodes.includes(element.value)) {
 					console.log(messageElement);
-					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
+					console.log(messageElement.firstChild);
+					messageElement.firstChild.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				} else {
 					console.log(messageElement);
-					messageElement.innerHTML = "";
+					console.log(messageElement.firstChild);
+					messageElement.firstChild.innerHTML = "";
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -652,9 +652,8 @@ function elementIsValid(element) {
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;
 				} else {
-					if(messageElement.firstChild) {
-						messageElement.firstChild.innerHTML = "";
-					}
+					messageElement.innerHTML = "";
+					return true;
 				}
 			}
 		}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -646,6 +646,7 @@ function elementIsValid(element) {
 			//Check for duplicate course codes only if value of input is not same as the course code that will be editied
 			//This prevents it from being impossible to save course code without changing it
 			if(element.value !== element.dataset.origincode) {
+				console.log("debug");
 				if(activeCodes.includes(element.value)) {
 					messageElement.innerHTML = `${element.value} is already in use. Choose another.`;
 					return false;

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -88,7 +88,7 @@ if(isset($_SESSION['uid'])){
 					<span>Course code:</span>
 					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate' type='text' id='ncoursecode' name='coursecode' placeholder='Course Code' />
 				</div>
-				<div class="formDialog" style="display: block; left:50px; top:0px;"><span id="courseCodeError" style="display: none; left:0px;" class="formDialogText">2 Letters, 3 digits, 1 letter</span></div>
+				<div class="formDialog" style="display: block; left:50px; top:0px;"><span id="courseCodeError" style="display: none; left:0px; bottom:-5px;" class="formDialogText">2 Letters, 3 digits, 1 letter</span></div>
 				<p id="dialog3" class="validationDialog">2 Letters, 3 digits, 1 letter</p>
     		</div>
 				<!-- Input field to Github repository-->
@@ -97,7 +97,7 @@ if(isset($_SESSION['uid'])){
 						<span style="padding-right: 10px;">GitHub URL:</span>
 						<input oninput="quickValidateForm('newCourse','createCourse')" class="textinput validate" type="text" id="ncoursegit-url" name="courseGitURL" placeholder="https://github.com/..."/>
 					</div>
-					<div class="formDialog" style="display: block; left:50px; top:0px;"><span id="courseCodeError" style="display: none; left:0px;" class="formDialogText">Enter a valid github url</span></div>
+					<div class="formDialog" style="display: block; left:50px; top:0px;"><span id="courseCodeError" style="display: none; left:0px; bottom:0px;" class="formDialogText">Enter a valid github url</span></div>
 					<p id="dialog5" class="validationDialog">Enter a valid github url</p>
 				</div>
     		<div style='padding:5px;'>

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -82,13 +82,13 @@ if(isset($_SESSION['uid'])){
 					<span>Course Name:</span>
 					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate' type='text' id='ncoursename' name='coursename' placeholder='Course Name' />
 				</div>
-				<div class="formDialog" style="display: block;left:50px; top:-8px;"><span id="courseNameError" style="display: none; left:0px;" class="formDialogText">Only letters. Dash allowed in between words</span></div>
+				<div class="formDialog" style="display: block;left:50px; top:-8px;"><span id="courseNameError" style="display: none; left:0px; bottom:-10px;" class="formDialogText">Only letters. Dash allowed in between words</span></div>
 				<p id="dialog4" class="validationDialog">Only letters. Dash allowed in between words</p>
     			<div class='inputwrapper'>
 					<span>Course code:</span>
 					<input oninput="quickValidateForm('newCourse','createCourse')"  class='textinput validate' type='text' id='ncoursecode' name='coursecode' placeholder='Course Code' />
 				</div>
-				<div class="formDialog" style="display: block; left:50px; top:0px;"><span id="courseCodeError" style="display: none; left:0px; bottom:-5px;" class="formDialogText">2 Letters, 3 digits, 1 letter</span></div>
+				<div class="formDialog" style="display: block; left:50px; top:0px;"><span id="courseCodeError" style="display: none; left:0px; bottom:5px;" class="formDialogText">2 Letters, 3 digits, 1 letter</span></div>
 				<p id="dialog3" class="validationDialog">2 Letters, 3 digits, 1 letter</p>
     		</div>
 				<!-- Input field to Github repository-->


### PR DESCRIPTION
The actual error message that appears to the left of the input-field is the first child element of "messageElement", the previous developer of the error message for a course code already in use had implemented the error message as innerHTML of "messageElement", not of "messageElement.firstChild". This meant that the error message didn't disappear after the value of the input-field had been corrected and simply emptying the innerHTML would cause child nodes to be removed as well, wreaking havoc on the rest of the code. I have corrected this by applying the error message to "messageElement.firstChild". 
I have not been able to locate if this solution affects anything else after rigorous bug-testing. 

I also took the time to position the error message "more" in line with respective input-field after checking consistency of miss-alignment over a few different screens. But this will have to be done in a better fashion if it ever becomes an issue again. 

This is what it should look like now:
![bugfix](https://user-images.githubusercontent.com/102578849/234895879-6909a0d5-0cb6-4d72-98ef-8db59a0e9903.png)

And this is what it looked like before:
![imagebug](https://user-images.githubusercontent.com/102578849/234895924-2d4512dc-7aa8-446e-b4c2-4252d66dac73.png)

To test this, create a new course with a specific course-code, then attempt to create another one with the same course-code. The error message should appear in the same fashion as the others do, for example with wrong syntax. The error message should also disappear after correct course code has written into the input-field. 

Relevant file: courseed.php
