### PR TITLE
 Unable to place other elements within the superstate #13627 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3542,8 +3542,11 @@ function entityIsOverlapping(id, x, y)
                   compY2 = data[i].y + SDHeight[j].height;
                 }
               }
-
-              if ((targetX < compX2) && (targetX + element.width) > data[i].x &&
+              //if youre moving something ontop of a super state, just break.
+              if (data[i].kind == "UMLSuperState") {
+                break;
+              }
+              else if ((targetX < compX2) && (targetX + element.width) > data[i].x &&
                 (targetY < compY2) && (targetY + elementHeight) > data[i].y) {
                 isOverlapping = true;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3372,9 +3372,7 @@ function rectsIntersect (left, right)
      
      objects.forEach(obj => {
         if(entityIsOverlapping(obj.id, obj.x - deltaX / zoomfact, obj.y - deltaY / zoomfact)){
-            if (obj.kind != "UMLSuperState") {
-                overlapping = true;
-            } 
+            overlapping = true;
         }
      });
 
@@ -3545,7 +3543,11 @@ function entityIsOverlapping(id, x, y)
                 }
               }
 
-              if ((targetX < compX2) && (targetX + element.width) > data[i].x &&
+              if (data[i].kind == "UMLSuperState") {
+                break;
+              }
+
+              else if ((targetX < compX2) && (targetX + element.width) > data[i].x &&
                 (targetY < compY2) && (targetY + elementHeight) > data[i].y) {
                 isOverlapping = true;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3544,11 +3544,7 @@ function entityIsOverlapping(id, x, y)
                 }
               }
 
-              if (data[i].kind == "UMLSuperState") {
-                break;
-              }
-
-              else if ((targetX < compX2) && (targetX + element.width) > data[i].x &&
+              if ((targetX < compX2) && (targetX + element.width) > data[i].x &&
                 (targetY < compY2) && (targetY + elementHeight) > data[i].y) {
                 isOverlapping = true;
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1099,7 +1099,6 @@ var errorData = []; // List of all elements with an error in diagram
 var UMLHeight = []; // List with UML Entities' real height
 var IEHeight = []; // List with IE Entities' real height
 var SDHeight = []; // List with SD Entities' real height
-var SDSuperStateHeight = []; // List with state diagram super states' real height
 
 
 // Ghost element is used for placing new elements. DO NOT PLACE GHOST ELEMENTS IN DATA ARRAY UNTILL IT IS PRESSED!
@@ -8944,20 +8943,6 @@ function drawElement(element, ghosted = false)
                 </div>`;
     }
     else if (element.kind == 'UMLSuperState') {
-        // Removes the previouse value in SDSuperStateHeight for the element
-        for (var i = 0; i < SDSuperStateHeight.length; i++) {
-            if (element.id == SDSuperStateHeight[i].id) {
-                SDSuperStateHeight.splice(i, 1);
-            }
-        }
-
-        // Calculate and store the SDSuperStateHeight's real height
-        var SDSuperStateEntityHeight = {
-            id: element.id,
-            height: ((boxh + (boxh / 2 + (boxh * elemAttri / 2))) / zoomfact)
-        }
-        SDSuperStateHeight.push(SDSuperStateEntityHeight);
-
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostLine ? 0 : 0.0};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3372,7 +3372,9 @@ function rectsIntersect (left, right)
      
      objects.forEach(obj => {
         if(entityIsOverlapping(obj.id, obj.x - deltaX / zoomfact, obj.y - deltaY / zoomfact)){
-            overlapping = true;
+            if (obj.type != "UMLSuperState") {
+                overlapping = true;
+            } 
         }
      });
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3372,7 +3372,7 @@ function rectsIntersect (left, right)
      
      objects.forEach(obj => {
         if(entityIsOverlapping(obj.id, obj.x - deltaX / zoomfact, obj.y - deltaY / zoomfact)){
-            if (obj.type != "UMLSuperState") {
+            if (obj.kind != "UMLSuperState") {
                 overlapping = true;
             } 
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3542,7 +3542,7 @@ function entityIsOverlapping(id, x, y)
                   compY2 = data[i].y + SDHeight[j].height;
                 }
               }
-              //if youre moving something ontop of a super state, just break.
+              //if its overlapping with a super state, just break since that is allowed.
               if (data[i].kind == "UMLSuperState") {
                 break;
               }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1099,6 +1099,7 @@ var errorData = []; // List of all elements with an error in diagram
 var UMLHeight = []; // List with UML Entities' real height
 var IEHeight = []; // List with IE Entities' real height
 var SDHeight = []; // List with SD Entities' real height
+var SDSuperStateHeight = []; // List with state diagram super states' real height
 
 
 // Ghost element is used for placing new elements. DO NOT PLACE GHOST ELEMENTS IN DATA ARRAY UNTILL IT IS PRESSED!
@@ -8947,6 +8948,20 @@ function drawElement(element, ghosted = false)
                 </div>`;
     }
     else if (element.kind == 'UMLSuperState') {
+        // Removes the previouse value in SDSuperStateHeight for the element
+        for (var i = 0; i < SDSuperStateHeight.length; i++) {
+            if (element.id == SDSuperStateHeight[i].id) {
+                SDSuperStateHeight.splice(i, 1);
+            }
+        }
+
+        // Calculate and store the SDSuperStateHeight's real height
+        var SDSuperStateEntityHeight = {
+            id: element.id,
+            height: ((boxh + (boxh / 2 + (boxh * elemAttri / 2))) / zoomfact)
+        }
+        SDSuperStateHeight.push(SDSuperStateEntityHeight);
+
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostLine ? 0 : 0.0};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"


### PR DESCRIPTION
Made it so that you can overlap any element with a superstate, thereby making it so that you can place any element withing a super state. **Note** that I did not manage to implement so that states can be spawned inside the superstate directly since the selection box got in the way and I couldn't figure out a way around this, but I did make it so that you can spawn states elsewhere, normally, and then simply drag them into the superstate. 