### PR TITLE
 ZOOM buttons borders are visible in both light and darkmode* #13643 

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -608,7 +608,6 @@
     height: 27px;
     width: 27px;
     float: left;
-    border: solid 1px rgba(0, 0, 0, 0.8);
 }
 .diagramZoomIcons:hover {
     border: solid 1px var(--color-primary-light);


### PR DESCRIPTION
After consulting with the group leader, as can be seen in #13643 , I removed the border.