### PR TITLE
Remove consolelog #13657

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2478,7 +2478,7 @@ function mmoving(event)
 
         case pointerStates.CLICKED_ELEMENT:
             if(mouseMode != mouseModes.EDGE_CREATION){
-                console.log("Moving object")
+
                 var prevTargetPos = {
                     x: data[findIndex(data, targetElement.id)].x,
                     y: data[findIndex(data, targetElement.id)].y


### PR DESCRIPTION
removed the console log("Moving Obejct") when there is no display that show that you are moving an object