### PR TITLE
Options-pane symbol incorrect when opened by double-click #13656

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1817,6 +1817,7 @@ function mdown(event)
     
                 if((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
                     wasDblClicked = true;
+                    document.getElementById('optmarker').innerHTML = "&#9650;Options";
                     document.getElementById("options-pane").className = "show-options-pane";
                 }
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1923,7 +1923,7 @@ function ddown(event)
                 input.focus();
                 input.setSelectionRange(0, input.value.length); // Select the whole text.
             }
-            document.getElementById('optmarker').innerHTML = "&#x203A;Options";
+            document.getElementById('optmarker').innerHTML = "&#9660;Options";
             document.getElementById("options-pane").className = "show-options-pane"; // Toggle optionspanel.
         }
     }   

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1923,7 +1923,7 @@ function ddown(event)
                 input.focus();
                 input.setSelectionRange(0, input.value.length); // Select the whole text.
             }
-            document.getElementById('optmarker').innerHTML = "&#9660;Options";
+            document.getElementById('optmarker').innerHTML = "&#9650;Options";
             document.getElementById("options-pane").className = "show-options-pane"; // Toggle optionspanel.
         }
     }   


### PR DESCRIPTION
Changed the unicode for ">Options" once an entity or line is double-clicked