### PR TITLE
G3 2023 v4 issue#13633 setting the course id cid after the course

### DIFF
--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -4,8 +4,6 @@ include_once "../Shared/basic.php";
 session_start();
 pdoConnect(); // Connect to database and start session
 
-echo $courseId=getOP('courseid');
-
 //Get data from AJAX call in courseed.js and then runs the function getNewCourseGithub link
 if(isset($_POST['action'])) 
 {
@@ -109,7 +107,8 @@ function bfs($url, $originalURL)
     global $pdoLite;
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 
-    $cid = getCid($originalURL); // Get the cid based on the giturl from the input
+    //$cid = getCid($originalURL); // Get the cid based on the giturl from the input
+    $cid=getOPG('courseid');
 
     while (!empty($fifoQueue)) {
         $currentUrl = array_shift($fifoQueue);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -4,6 +4,8 @@ include_once "../Shared/basic.php";
 session_start();
 pdoConnect(); // Connect to database and start session
 
+echo $courseId=getOP('courseid');
+
 //Get data from AJAX call in courseed.js and then runs the function getNewCourseGithub link
 if(isset($_POST['action'])) 
 {

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -107,8 +107,7 @@ function bfs($url, $originalURL)
     global $pdoLite;
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 
-    //$cid = getCid($originalURL); // Get the cid based on the giturl from the input
-    $cid=getOPG('courseid');
+    $cid = getCid($originalURL); // Get the cid based on the giturl from the input
 
     while (!empty($fifoQueue)) {
         $currentUrl = array_shift($fifoQueue);


### PR DESCRIPTION
When creating a new course, the files for that course are saved in a folder in courses. The name of the folder should be the ID of the course (courses/"course id"/Github/"files").

For example:
![image](https://user-images.githubusercontent.com/102578746/235657236-55ffd179-e1c3-4ec4-a274-d8fb0a335058.png)

Test this by creating a new course and checking whether the correct files have appeared in the correct folder. To double check, you can test to see if the folder name matches the course id in the MySQL database.


co-author @g21emmka 