### PR TITLE
Tooltip partially hidden #13641

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -630,5 +630,4 @@
 
 .diagramZoomIcons:hover .zoomToolTipText {
     visibility: visible;
-    z-index: 100;
 }

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -625,7 +625,7 @@
     padding: 5px 0;
     pointer-events: none;
     position: absolute;
-    z-index: 10;
+    z-index: 20;
 }
 
 .diagramZoomIcons:hover .zoomToolTipText {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -625,8 +625,10 @@
     padding: 5px 0;
     pointer-events: none;
     position: absolute;
-    z-index: 2;
+    z-index: 10;
 }
+
 .diagramZoomIcons:hover .zoomToolTipText {
     visibility: visible;
+    z-index: 100;
 }


### PR DESCRIPTION
Tooltips for zoom are no longer partially hidden underneath the ruler. Solves #13641 