### PR TITLE
G1 2023 v5 #13722

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3294,7 +3294,7 @@ function clearContextLine()
  * @param {Number} mouseY Pixel position in the y-axis.
  * @returns {Point} Point containing the calculated coordinates.
  * @see diagramToScreenPosition() For converting the other way.
- *//** 
+ */
 function screenToDiagramCoordinates(mouseX,mouseY)
 {
     // I guess this should be something that could be calculated with an expression but after 2 days we still cannot figure it out.
@@ -3318,7 +3318,7 @@ function screenToDiagramCoordinates(mouseX,mouseY)
     return new Point(Math.round( ((mouseX - 0) / zoomfact - scrollx) + zoomX * scrollx + 2 + zoomOrigo.x), // the 2 makes mouse hover over container
                     Math.round(((mouseY - 0) / zoomfact - scrolly) + zoomX * scrolly + zoomOrigo.y)
     );
-}* /
+}
 
 /**
  * @description Converts a coordinate on the canvas into a pixel position on the screen.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3293,7 +3293,6 @@ function clearContextLine()
  * @param {Number} mouseX Pixel position in the x-axis.
  * @param {Number} mouseY Pixel position in the y-axis.
  * @returns {Point} Point containing the calculated coordinates.
- * @see diagramToScreenPosition() For converting the other way.
  */
 function screenToDiagramCoordinates(mouseX,mouseY)
 {
@@ -3319,24 +3318,6 @@ function screenToDiagramCoordinates(mouseX,mouseY)
                     Math.round(((mouseY - 0) / zoomfact - scrolly) + zoomX * scrolly + zoomOrigo.y)
     );
 }
-
-/**
- * @description Converts a coordinate on the canvas into a pixel position on the screen.
- * @param {Number} coordX Coordinate position in the x-axis.
- * @param {Number} coordY Coordinate position in the y-axis.
- * @returns {Point} Point containing the calculated screen position.
- * @depricated TODO : Needs to be updated
- * @see screenToDiagramCoordinates() For converting the other way.
- */
-/** 
-function diagramToScreenPosition(coordX, coordY)
-{
-    console.warn("diagramToScreenPosition() is depricated. It should be updated to use new screenToDiagramCoordinates() algorithm reversed.");
-    return new Point(
-        Math.round((coordX + scrollx) / zoomfact + 0),
-        Math.round((coordY + scrolly) / zoomfact + 0)
-    );
-}*/
 
 /**
  * @description Test weither an enum object contains a certain property value.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3294,7 +3294,7 @@ function clearContextLine()
  * @param {Number} mouseY Pixel position in the y-axis.
  * @returns {Point} Point containing the calculated coordinates.
  * @see diagramToScreenPosition() For converting the other way.
- */
+ *//** 
 function screenToDiagramCoordinates(mouseX,mouseY)
 {
     // I guess this should be something that could be calculated with an expression but after 2 days we still cannot figure it out.
@@ -3318,7 +3318,7 @@ function screenToDiagramCoordinates(mouseX,mouseY)
     return new Point(Math.round( ((mouseX - 0) / zoomfact - scrollx) + zoomX * scrollx + 2 + zoomOrigo.x), // the 2 makes mouse hover over container
                     Math.round(((mouseY - 0) / zoomfact - scrolly) + zoomX * scrolly + zoomOrigo.y)
     );
-}
+}* /
 
 /**
  * @description Converts a coordinate on the canvas into a pixel position on the screen.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3328,6 +3328,7 @@ function screenToDiagramCoordinates(mouseX,mouseY)
  * @depricated TODO : Needs to be updated
  * @see screenToDiagramCoordinates() For converting the other way.
  */
+/** 
 function diagramToScreenPosition(coordX, coordY)
 {
     console.warn("diagramToScreenPosition() is depricated. It should be updated to use new screenToDiagramCoordinates() algorithm reversed.");
@@ -3335,7 +3336,7 @@ function diagramToScreenPosition(coordX, coordY)
         Math.round((coordX + scrollx) / zoomfact + 0),
         Math.round((coordY + scrolly) / zoomfact + 0)
     );
-}
+}*/
 
 /**
  * @description Test weither an enum object contains a certain property value.


### PR DESCRIPTION
Removed the diagramToScreenPosition function in diagram.js due to not being used, but keept screenToDiagramCoordinates due to it being used a bit in digram.js.