### PR TITLE
G1 2023 v5 #13736

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1381,7 +1381,6 @@ stateMachine = new StateMachine(data, lines);
  */
 function getData()
 { 
-    console.log(getVariantParam());
     container = document.getElementById("container");
     DiagramResponse = fetchDiagram();
     // onSetup();
@@ -7497,7 +7496,7 @@ function sortElementAssociations(element)
  */
 
 function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, successMessage = true, cardinal){
-
+    console.log(getVariantParam());
      // All lines should go from EREntity, instead of to, to simplify offset between multiple lines.
      if (toElement.kind == "EREntity"){
         var tempElement = toElement;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12355,7 +12355,7 @@ async function loadDiagram(file = null, shouldDisplayMessage = true)
         if (shouldDisplayMessage) displayMessage(messageTypes.ERROR, "Error, cant load the given file");
     }
 }
-
+//code has no functionallity execpt for when the hard coded diagram was used. looks like it reloaeded the diagram and got the file. Diagram in onSetup()
 /* function fetchDiagramFileContentOnLoad()
 {
     let temp = getVariantParam();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1381,6 +1381,7 @@ stateMachine = new StateMachine(data, lines);
  */
 function getData()
 { 
+    console.log(getVariantParam());
     container = document.getElementById("container");
     DiagramResponse = fetchDiagram();
     // onSetup();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7496,7 +7496,7 @@ function sortElementAssociations(element)
  */
 
 function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, successMessage = true, cardinal){
-    console.log(getVariantParam());
+    
      // All lines should go from EREntity, instead of to, to simplify offset between multiple lines.
      if (toElement.kind == "EREntity"){
         var tempElement = toElement;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12356,7 +12356,7 @@ async function loadDiagram(file = null, shouldDisplayMessage = true)
     }
 }
 
-function fetchDiagramFileContentOnLoad()
+/* function fetchDiagramFileContentOnLoad()
 {
     let temp = getVariantParam();
     var fullParam = temp[0];
@@ -12377,7 +12377,7 @@ function fetchDiagramFileContentOnLoad()
         // Failed to load content
         console.error("No content to load")
     }
-}
+} */
 
 // Save current diagram when user leaves the page
 function saveDiagramBeforeUnload() {
@@ -12461,7 +12461,7 @@ function resetDiagram(){
     stateMachine.lastFlag = {};
     stateMachine.removeFutureStates();
     localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
-    fetchDiagramFileContentOnLoad();
+    //fetchDiagramFileContentOnLoad();
 }
 /**
  *

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -92,10 +92,10 @@
             }			
         }
 
-        function getVariantParam()
+       /*  function getVariantParam()
         {
             return DiagramResponse.variant;
-        }
+        } */
 
 
     </script>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -91,7 +91,7 @@
                 }
             }			
         }
-
+        //does nothing, this code gets and old diagram that was used which is not in use anymore was used before for onSetup().
        /*  function getVariantParam()
         {
             return DiagramResponse.variant;


### PR DESCRIPTION
commented out function getVariantParam(); and another function that is connected to it, they are not in use anymore because they were used before when the diagram was hard coded. 