### PR TITLE
 fixed the output of diagram.js for state line labels. 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4092,9 +4092,13 @@ const stateLinesLabels=[];
     }
 
     // Adds additional information in the view.
+    output+=`<p>Line labels:</p>`;
     for(var i=0; i<stateLinesLabels.length; i++)
     {
-    output+=`<p>${stateLinesLabels[i]}</p>`;
+        if(stateLinesLabels[i]==undefined)
+        output+=`<p>Unlabeled</p>`;
+        else
+        output+=`<p>${stateLinesLabels[i]}</p>`;
     }
     output += `<p>Initial States: ${stateInitial.length}</p>`;
     output += `<p>Final States: ${stateFinal.length}</p>`;


### PR DESCRIPTION
fixed so that the output now looks better and unlabled lines are printed as unlabeled. Also the strange changes that were there yesterday are no longer there.