### PR TITLE
Changed resetDiagram() to load in empty diagram

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12222,12 +12222,12 @@ function exportWithoutHistory()
  * @param path the path to the JSON file on the server that you want to load from, for example, JSON/IEDiagramMockup.json
  */
 function loadMockupDiagram(path){
-    
-    // If the value for the dropdown is not set we may assume that the
-    // reset button was pressed
-    if (!document.getElementById("diagramTypeDropdown").value){
-        path = "JSON/EMPTYDiagramMockup.json";
-    } else{
+
+    // "resetDiagram()" calls this method with "EMPTYDiagram" as parameter
+
+    // The path is not set yet if we do it from the dropdown as the function
+    // is called without a parameter.
+    if(!path){
         let fileType = document.getElementById("diagramTypeDropdown").value;
         path = fileType;
     }
@@ -12456,7 +12456,7 @@ function resetDiagram(){
     //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
     //fetchDiagramFileContentOnLoad();
     */
-    loadMockupDiagram();
+    loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
 /**
  *

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -751,7 +751,7 @@
                     <select id="diagramTypeDropdown" onchange="checkDropdownOption()">
                         <option value="JSON/EMPTYDiagramMockup.json">Empty board</option>
                         <option value="JSON/IEDiagramMockup.json">IE diagrams</option>
-                        <option  value="JSON/UMLDiagramMockup.json">UML diagrams</option>
+                        <option value="JSON/UMLDiagramMockup.json">UML diagrams</option>
                         <option value="JSON/ERDiagramMockup.json">ER diagrams </option>
                     </select>
                     <button class="saveButton" id="diagramLoad" onclick="loadMockupDiagram();">Load</button>


### PR DESCRIPTION
It is now possible to reset the diagram from the reset-button aswell as the "Empty board"-option in the dropdown. There is a lot of outcommented code in resetDiagram() and arguably it serves no purpose anymore as it just calls another function.

The state machine value outputs correctly in both cases after a reset.
![e73900f284e6acffde9bab27249bd3ce](https://user-images.githubusercontent.com/102578165/236198958-bcf38bdc-d666-4433-b6f7-8dedcafa98a2.png)


