### PR TITLE
Fixed so that lines save properly

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7679,16 +7679,17 @@ function preProcessLine(line) {
         if (line.innerType === 'Segment') { 
             line.innerType = SDLineType.SEGMENT;
         }
-        else if (line.innerType === 'Straight') {
+        else (line.innerType === 'Straight') {
             line.innerType = SDLineType.STRAIGHT;
         }
+        /** 
         else if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {
             line.innerType = SDLineType.SEGMENT;
         }
-        
+        */
         
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6836,11 +6836,9 @@ function generateContextProperties()
             str += `<label style="display: block">Line Type:</label><select id='lineType' onchange='changeLineProperties()'>`;
             Object.keys(SDLineType).forEach(type => {
                 if (contextLine[0].innerType.localeCompare(type, undefined, { sensitivity: 'base' }) === 0) {
-                    console.log("base line");
                     str += `<option value='${SDLineType[type]}' selected>${SDLineType[type]}</option>`;
                 }
                 else {
-                    console.log("mod line");
                     str += `<option value='${SDLineType[type]}' >${SDLineType[type]}</option>`;
                 }
             });

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6831,7 +6831,7 @@ function generateContextProperties()
                     str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                 }
             });
-            str += `</select><select id='lineType' onchange="changeLineProperties()">`;
+            str += `<label style="display: block">Line Type:</label><select id='lineType' onchange='changeLineProperties()'>`;
             str += `<option value=''>None</option>`;
             Object.keys(SDLineIcons).forEach(icon => {
                 if (contextLine[0].endIcon != undefined) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6848,22 +6848,22 @@ function generateContextProperties()
                     str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
                 }
             });
-            str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
+            str += `<label style="display: block">Icons:</label> <select id='lineType' onchange="changeLineProperties()">`;
             str += `<option value=''>None</option>`;
             //iterate through all the icons assicoated with SD, and add them to the drop down as options
-            Object.keys(SDLineIcons).forEach(icon => {
-                if (contextLine[0].startIcon != undefined) {
+            Object.keys(SDLineType).forEach(type => {
+                if (contextLine[0].innerType != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                    if (contextLine[0].startIcon == icon) {
-                        str += `<option value='${SDLineIcons[icon]}' selected>${SDLineIcons[icon]}</option>`;
+                    if (contextLine[0].innerType == Type) {
+                        str += `<option value='${SDLineType[type]}' selected>${SDLineType[type]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
                     else {
-                        str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
+                        str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
                     }
                 }
                 else {
-                    str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
+                    str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
                 }
             });
             /*

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7676,16 +7676,17 @@ function preProcessLine(line) {
         }
 
 
-        line.innerType = SDLineType.SEGMENT;
-
-        /** 
-        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+        
+        if (line.innerType = SDLineType.SEGMENT) {
+            line.innerType = SDLineType.SEGMENT;
+        }
+        else if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {
             line.innerType = SDLineType.SEGMENT;
         }
-        */
+        
         
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7904,7 +7904,7 @@ function drawLine(line, targetGhost = false)
         var dx = ((fx + x1Offset)-(tx + x2Offset))/2;
         var dy = ((fy + y1Offset)-(ty + y2Offset))/2;
 
-        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT)) {
+        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT) || (felem.type == 'SD' && line.innerType !== SDLineType.SEGMENT)) {
             str += `<line id='${line.id}' class='lineColor' x1='${fx + x1Offset}' y1='${fy + y1Offset}' x2='${tx + x2Offset}' y2='${ty + y2Offset}' fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'/>`;
         }
         else if (line.ctype == 'TB' || line.ctype == 'BT') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6831,7 +6831,7 @@ function generateContextProperties()
                     str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                 }
             });
-            str += `<label style="display: block">Line Type:</label><select id='lineType' onchange='changeLineProperties()'>`;
+            str += `</select><select id='lineType' onchange="changeLineProperties()">`;
             str += `<option value=''>None</option>`;
             Object.keys(SDLineIcons).forEach(icon => {
                 if (contextLine[0].endIcon != undefined) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6848,6 +6848,24 @@ function generateContextProperties()
                     str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
                 }
             });
+            str += `<label style="display: block">Icons:</label> <select id='lineStartIcon' onchange="changeLineProperties()">`;
+            str += `<option value=''>None</option>`;
+            //iterate through all the icons assicoated with SD, and add them to the drop down as options
+            Object.keys(SDLineIcons).forEach(icon => {
+                if (contextLine[0].startIcon != undefined) {
+                    //If the lines in context happen to be matching something in the drop down, it is set as selected.
+                    if (contextLine[0].startIcon == icon) {
+                        str += `<option value='${SDLineIcons[icon]}' selected>${SDLineIcons[icon]}</option>`;
+                    }
+                    //else, its not matching and the option is just added to the dropdown normally.
+                    else {
+                        str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
+                    }
+                }
+                else {
+                    str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
+                }
+            });
             /*
             str += `</select>`;
             str += `<label style="display: block">Line Type:</label><select id='lineType' onchange='changeLineProperties()'>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6835,9 +6835,11 @@ function generateContextProperties()
             str += `<label style="display: block">Line Type:</label><select id='lineType' onchange='changeLineProperties()'>`;
             Object.keys(SDLineType).forEach(type => {
                 if (contextLine[0].innerType.localeCompare(type, undefined, { sensitivity: 'base' }) === 0) {
+                    console.log("base line");
                     str += `<option value='${SDLineType[type]}' selected>${SDLineType[type]}</option>`;
                 }
                 else {
+                    console.log("mod line");
                     str += `<option value='${SDLineType[type]}' >${SDLineType[type]}</option>`;
                 }
             });

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7675,11 +7675,6 @@ function preProcessLine(line) {
             line.endIcon = 'ARROW';
         }
 
-        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
-            line.innerType = SDLineType.SEGMENT;
-        }
-        else {
-            line.innerType = SDLineType.STRAIGHT;
         /** 
         if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7906,7 +7906,7 @@ function drawLine(line, targetGhost = false)
         var dx = ((fx + x1Offset)-(tx + x2Offset))/2;
         var dy = ((fy + y1Offset)-(ty + y2Offset))/2;
 
-        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT)) {
+        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.SEGMENT)) {
             str += `<line id='${line.id}' class='lineColor' x1='${fx + x1Offset}' y1='${fy + y1Offset}' x2='${tx + x2Offset}' y2='${ty + y2Offset}' fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'/>`;
         }
         else if (line.ctype == 'TB' || line.ctype == 'BT') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3024,7 +3024,7 @@ function changeLineProperties()
     if (line.type == 'SD') {
         if (line.innerType != lineType.value) {
             line.innerType = lineType.value.trim();
-            stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { lineType: endIcon.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { lineType: lineType.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         // Start label, near side
         if (line.startLabel != startLabel.value) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7676,6 +7676,7 @@ function preProcessLine(line) {
         }
 
         if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+            console.log("test: line was reset due to being to close");
             line.innerType = SDLineType.STRAIGHT;
         }
         else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3023,7 +3023,8 @@ function changeLineProperties()
     // SD line
     if (line.type == 'SD') {
         if (line.innerType != lineType.value) {
-            line.innerType = lineType.value.trim();
+            lineType.value = lineType.value.trim();
+            line.innerType = lineType.value
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { lineType: lineType.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         // Start label, near side

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7904,7 +7904,7 @@ function drawLine(line, targetGhost = false)
         var dx = ((fx + x1Offset)-(tx + x2Offset))/2;
         var dy = ((fy + y1Offset)-(ty + y2Offset))/2;
 
-        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT) || (felem.type == 'SD' && line.innerType !== SDLineType.SEGMENT)) {
+        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT)) {
             str += `<line id='${line.id}' class='lineColor' x1='${fx + x1Offset}' y1='${fy + y1Offset}' x2='${tx + x2Offset}' y2='${ty + y2Offset}' fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'/>`;
         }
         else if (line.ctype == 'TB' || line.ctype == 'BT') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7677,10 +7677,8 @@ function preProcessLine(line) {
 
 
         
-        if (line.innerType = SDLineType.SEGMENT) {
-            line.innerType = SDLineType.SEGMENT;
-        }
-        else if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+        
+        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7674,12 +7674,20 @@ function preProcessLine(line) {
         } else {
             line.endIcon = 'ARROW';
         }
+
+        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+            line.innerType = SDLineType.SEGMENT;
+        }
+        else {
+            line.innerType = SDLineType.STRAIGHT;
+        /** 
         if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {
             line.innerType = SDLineType.SEGMENT;
         }
+        */
     }
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6854,7 +6854,7 @@ function generateContextProperties()
             Object.keys(SDLineType).forEach(type => {
                 if (contextLine[0].innerType != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                    if (contextLine[0].innerType == Type) {
+                    if (contextLine[0].innerType == type) {
                         str += `<option value='${SDLineType[type]}' selected>${SDLineType[type]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7676,20 +7676,14 @@ function preProcessLine(line) {
         }
 
 
-        if (line.innerType === 'Segment') { 
-            line.innerType = SDLineType.SEGMENT;
-        }
-        else (line.innerType === 'Straight') {
-            line.innerType = SDLineType.STRAIGHT;
-        }
-        /** 
-        else if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+       
+        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {
             line.innerType = SDLineType.SEGMENT;
         }
-        */
+        
         
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6831,6 +6831,7 @@ function generateContextProperties()
                     str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                 }
             });
+            /*
             str += `</select>`;
             str += `<label style="display: block">Line Type:</label><select id='lineType' onchange='changeLineProperties()'>`;
             Object.keys(SDLineType).forEach(type => {
@@ -6844,6 +6845,7 @@ function generateContextProperties()
                 }
             });
             str += `</select>`;
+            */
         }
         str+=`<br><br><input type="submit" class='saveButton' value="Save" onclick="changeLineProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
       }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7675,21 +7675,13 @@ function preProcessLine(line) {
             line.endIcon = 'ARROW';
         }
 
-
-        if (line.innerType === SDLineType.SEGMENT) {
-            line.innerType = SDLineType.SEGMENT;
-        }
-        if (line.innerType === SDLineType.STRAIGHT) {
-            line.innerType = SDLineType.STRAIGHT;
-        }
-        /* 
-        else if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {
             line.innerType = SDLineType.SEGMENT;
         }
-        */
+        
         
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7676,7 +7676,6 @@ function preProcessLine(line) {
         }
 
         if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
-            console.log("test: line was reset due to being to close");
             line.innerType = SDLineType.STRAIGHT;
         }
         else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3024,7 +3024,7 @@ function changeLineProperties()
     if (line.type == 'SD') {
         if (line.innerType != lineType.value) {
             lineType.value = lineType.value.trim();
-            line.lineType = lineType.value
+            line.innerType = lineType.value
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { lineType: lineType.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         // Start label, near side

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7675,14 +7675,14 @@ function preProcessLine(line) {
             line.endIcon = 'ARROW';
         }
 
-        /** 
+       
         if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {
             line.innerType = SDLineType.SEGMENT;
         }
-        */
+        
     }
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6831,7 +6831,7 @@ function generateContextProperties()
                     str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                 }
             });
-            str += `</select><select id='lineType' onchange="changeLineProperties()">`;
+            str += `<label style="display: block">Line Type:</label> <select id='lineType' onchange="changeLineProperties()">`;
             str += `<option value=''>None</option>`;
             Object.keys(SDLineIcons).forEach(icon => {
                 if (contextLine[0].endIcon != undefined) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7676,7 +7676,7 @@ function preProcessLine(line) {
         }
 
 
-       
+        line.innerType = SDLineType.SEGMENT;
 
         /** 
         if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6831,42 +6831,6 @@ function generateContextProperties()
                     str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                 }
             });
-            str += `<label style="display: block">Line Type:</label> <select id='lineType' onchange="changeLineProperties()">`;
-            str += `<option value=''>None</option>`;
-            Object.keys(SDLineType).forEach(type => {
-                if (contextLine[0].innerType != undefined) {
-                    //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                    if (contextLine[0].innerType == type) {
-                        str += `<option value='${SDLineType[type]}' selected>${SDLineType[type]}</option>`;
-                    }
-                    //else, its not matching and the option is just added to the dropdown normally.
-                    else {
-                        str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
-                    }
-                }
-                else {
-                    str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
-                }
-            });
-            str += `<label style="display: block">Icons:</label> <select id='lineType' onchange="changeLineProperties()">`;
-            str += `<option value=''>None</option>`;
-            //iterate through all the icons assicoated with SD, and add them to the drop down as options
-            Object.keys(SDLineType).forEach(type => {
-                if (contextLine[0].innerType != undefined) {
-                    //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                    if (contextLine[0].innerType == type) {
-                        str += `<option value='${SDLineType[type]}' selected>${SDLineType[type]}</option>`;
-                    }
-                    //else, its not matching and the option is just added to the dropdown normally.
-                    else {
-                        str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
-                    }
-                }
-                else {
-                    str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
-                }
-            });
-            /*
             str += `</select>`;
             str += `<label style="display: block">Line Type:</label><select id='lineType' onchange='changeLineProperties()'>`;
             Object.keys(SDLineType).forEach(type => {
@@ -6879,8 +6843,7 @@ function generateContextProperties()
                     str += `<option value='${SDLineType[type]}' >${SDLineType[type]}</option>`;
                 }
             });
-            str += `</select>`;
-            */
+            str += `</select>`; 
         }
         str+=`<br><br><input type="submit" class='saveButton' value="Save" onclick="changeLineProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
       }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6831,6 +6831,23 @@ function generateContextProperties()
                     str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
                 }
             });
+            str += `</select><select id='lineType' onchange="changeLineProperties()">`;
+            str += `<option value=''>None</option>`;
+            Object.keys(SDLineIcons).forEach(icon => {
+                if (contextLine[0].endIcon != undefined) {
+                    //If the lines in context happen to be matching something in the drop down, it is set as selected.
+                    if (contextLine[0].endIcon == icon) {
+                        str += `<option value='${SDLineIcons[icon]}' selected>${SDLineIcons[icon]}</option>`;
+                    }
+                    //else, its not matching and the option is just added to the dropdown normally.
+                    else {
+                        str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
+                    }
+                }
+                else {
+                    str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
+                }
+            });
             /*
             str += `</select>`;
             str += `<label style="display: block">Line Type:</label><select id='lineType' onchange='changeLineProperties()'>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7906,7 +7906,7 @@ function drawLine(line, targetGhost = false)
         var dx = ((fx + x1Offset)-(tx + x2Offset))/2;
         var dy = ((fy + y1Offset)-(ty + y2Offset))/2;
 
-        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.SEGMENT)) {
+        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType == SDLineType.STRAIGHT)) {
             str += `<line id='${line.id}' class='lineColor' x1='${fx + x1Offset}' y1='${fy + y1Offset}' x2='${tx + x2Offset}' y2='${ty + y2Offset}' fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'/>`;
         }
         else if (line.ctype == 'TB' || line.ctype == 'BT') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6833,19 +6833,19 @@ function generateContextProperties()
             });
             str += `<label style="display: block">Line Type:</label> <select id='lineType' onchange="changeLineProperties()">`;
             str += `<option value=''>None</option>`;
-            Object.keys(SDLineIcons).forEach(icon => {
-                if (contextLine[0].endIcon != undefined) {
+            Object.keys(SDLineType).forEach(type => {
+                if (contextLine[0].innerType != undefined) {
                     //If the lines in context happen to be matching something in the drop down, it is set as selected.
-                    if (contextLine[0].endIcon == icon) {
-                        str += `<option value='${SDLineIcons[icon]}' selected>${SDLineIcons[icon]}</option>`;
+                    if (contextLine[0].innerType == type) {
+                        str += `<option value='${SDLineType[type]}' selected>${SDLineType[type]}</option>`;
                     }
                     //else, its not matching and the option is just added to the dropdown normally.
                     else {
-                        str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
+                        str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
                     }
                 }
                 else {
-                    str += `<option value='${SDLineIcons[icon]}'>${SDLineIcons[icon]}</option>`;
+                    str += `<option value='${SDLineType[type]}'>${SDLineType[type]}</option>`;
                 }
             });
             /*

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7674,7 +7674,7 @@ function preProcessLine(line) {
         } else {
             line.endIcon = 'ARROW';
         }
-        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact) && line.innerType != SDLineType.SEGMENT) {
+        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7676,10 +7676,10 @@ function preProcessLine(line) {
         }
 
 
-        if (line.innerType === 'Segment') {
+        if (line.innerType === SDLineType.SEGMENT) {
             line.innerType = SDLineType.SEGMENT;
         }
-        if (line.innerType === 'Straight') {
+        if (line.innerType === SDLineType.STRAIGHT) {
             line.innerType = SDLineType.STRAIGHT;
         }
         /* 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7676,12 +7676,14 @@ function preProcessLine(line) {
         }
 
 
-       
-        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+        if (line.innerType === 'Segment') {
             line.innerType = SDLineType.SEGMENT;
         }
-        else {
+        else if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
+        }
+        else {
+            line.innerType = SDLineType.SEGMENT;
         }
         
         

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3022,7 +3022,7 @@ function changeLineProperties()
     }
     // SD line
     if (line.type == 'SD') {
-        if (line.lineType != lineType.value) {
+        if (line.innerType != lineType.value) {
             lineType.value = lineType.value.trim();
             line.lineType = lineType.value
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { lineType: lineType.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7674,7 +7674,7 @@ function preProcessLine(line) {
         } else {
             line.endIcon = 'ARROW';
         }
-        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact) && line.innerType != SDLineType.SEGMENT) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3022,9 +3022,9 @@ function changeLineProperties()
     }
     // SD line
     if (line.type == 'SD') {
-        if (line.innerType != lineType.value) {
+        if (line.lineType != lineType.value) {
             lineType.value = lineType.value.trim();
-            line.innerType = lineType.value
+            line.lineType = lineType.value
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { lineType: lineType.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         // Start label, near side

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7678,10 +7678,10 @@ function preProcessLine(line) {
 
        
         if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
-            line.innerType = SDLineType.STRAIGHT;
+            line.innerType = SDLineType.SEGMENT;
         }
         else {
-            line.innerType = SDLineType.SEGMENT;
+            line.innerType = SDLineType.STRAIGHT;
         }
         
         
@@ -7906,7 +7906,7 @@ function drawLine(line, targetGhost = false)
         var dx = ((fx + x1Offset)-(tx + x2Offset))/2;
         var dy = ((fy + y1Offset)-(ty + y2Offset))/2;
 
-        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType == SDLineType.STRAIGHT)) {
+        if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT)) {
             str += `<line id='${line.id}' class='lineColor' x1='${fx + x1Offset}' y1='${fy + y1Offset}' x2='${tx + x2Offset}' y2='${ty + y2Offset}' fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'/>`;
         }
         else if (line.ctype == 'TB' || line.ctype == 'BT') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3025,7 +3025,7 @@ function changeLineProperties()
         if (line.innerType != lineType.value) {
             lineType.value = lineType.value.trim();
             line.innerType = lineType.value
-            stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { lineType: lineType.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, { innerType: lineType.value }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         // Start label, near side
         if (line.startLabel != startLabel.value) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7676,9 +7676,13 @@ function preProcessLine(line) {
         }
 
 
-        
-        
-        if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
+        if (line.innerType === 'Segment') { 
+            line.innerType = SDLineType.SEGMENT;
+        }
+        else if (line.innerType === 'Straight') {
+            line.innerType = SDLineType.STRAIGHT;
+        }
+        else if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7675,13 +7675,17 @@ function preProcessLine(line) {
             line.endIcon = 'ARROW';
         }
 
+
        
+
+        /** 
         if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {
             line.innerType = SDLineType.SEGMENT;
         }
+        */
         
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7679,13 +7679,17 @@ function preProcessLine(line) {
         if (line.innerType === 'Segment') {
             line.innerType = SDLineType.SEGMENT;
         }
+        if (line.innerType === 'Straight') {
+            line.innerType = SDLineType.STRAIGHT;
+        }
+        /* 
         else if (isClose(felem.cx, telem.cx, felem.cy, telem.cy, zoomfact)) {
             line.innerType = SDLineType.STRAIGHT;
         }
         else {
             line.innerType = SDLineType.SEGMENT;
         }
-        
+        */
         
     }
 }


### PR DESCRIPTION
The save function for sd lines was a copy of the endIcon save, but not all endIcon mentions were replaced with innerType or lineType. innerType and lineType was also a bit mixed upp.