### PR TITLE
G3 2023 v5 issue#13668

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -49,6 +49,7 @@ function updateCourse()
 			localStorage.setItem('courseid', courseid);
 			localStorage.setItem('updateCourseName', true);
 			alert("Course " + coursename + " updated with new GitHub-link!"); 
+			fetchLatestCommit(courseGitURL);
 		}
 		//Else: get error message from the fetchGitHubRepo function.
 

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -105,6 +105,7 @@ function createNewCourse()
 			localStorage.setItem('lastCC', true);
 			AJAXService("NEW", { coursename : coursename, coursecode : coursecode, courseGitURL : courseGitURL }, "COURSE");
 			alert("New course, " + coursename + " added with GitHub-link!");
+			fetchLatestCommit(courseGitURL);
 		}
 		//Else: get error message from the fetchGitHubRepo function.
 
@@ -128,6 +129,38 @@ function fetchGitHubRepo(gitHubURL)
 		url: "../recursivetesting/FetchGithubRepo.php",
 		type: "POST",
 		data: {'githubURL':regexURL, 'action':'getNewCourseGitHub'},
+		success: function() { 
+			//Returns true if the data and JSON is correct
+			dataCheck = true;
+		},
+		error: function(data){
+			//Check FetchGithubRepo for the meaning of the error code.
+			switch(data.status){
+				case 422:
+					alert(data.responseJSON.message + "\nDid not create/update course");
+					break;
+				case 503:
+					alert(data.responseJSON.message + "\nDid not create/update course");
+					break;
+				default:
+					alert("Something went wrong...");
+			}
+		 	dataCheck = false;
+		}
+	});
+	return dataCheck;
+}
+
+//Send valid GitHub-URL to PHP-script which gets and saves the latest commit in the sqllite db
+function fetchLatestCommit(gitHubURL) 
+{
+	//Used to return success(true) or error(false) to the calling function
+	var dataCheck;
+	$.ajax({
+		async: false,
+		url: "../recursivetesting/getLatestCommit.php",
+		type: "POST",
+		data: {'githubURL':gitHubURL, 'action':'getCourseID'},
 		success: function() { 
 			//Returns true if the data and JSON is correct
 			dataCheck = true;

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -473,14 +473,6 @@ function refreshGithubRepo(courseid)
 	return dataCheck;
 }
 
-// function courseUpdateAlerts(hasUpdated) {
-//   if(hasUpdated) {
-//     alert("The course has been updated!");
-//   } else {
-//     alert("The course is already up to date!");
-//   }
-// }
-
 //----------------------------------------------------------------------------------
 // showEditVersion: Displays Edit Version Dialog
 //----------------------------------------------------------------------------------

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -472,6 +472,14 @@ function refreshGithubRepo(courseid)
 	return dataCheck;
 }
 
+function courseUpdateAlerts(hasUpdated) {
+  if(hasUpdated) {
+    alert("The course has been updated!");
+  } else {
+    alert("The course is already up to date!");
+  }
+}
+
 //----------------------------------------------------------------------------------
 // showEditVersion: Displays Edit Version Dialog
 //----------------------------------------------------------------------------------

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -449,8 +449,9 @@ function refreshGithubRepo(courseid)
 		url: "../recursivetesting/getLatestCommit.php",
 		type: "POST",
 		data: {'cid':courseid, 'action':'refreshGithubRepo'},
-		success: function() { 
+		success: function(data) { 
 			//Returns true if the data and JSON is correct
+      alert(data);
 			dataCheck = true;
 		},
 		error: function(data){
@@ -472,13 +473,13 @@ function refreshGithubRepo(courseid)
 	return dataCheck;
 }
 
-function courseUpdateAlerts(hasUpdated) {
-  if(hasUpdated) {
-    alert("The course has been updated!");
-  } else {
-    alert("The course is already up to date!");
-  }
-}
+// function courseUpdateAlerts(hasUpdated) {
+//   if(hasUpdated) {
+//     alert("The course has been updated!");
+//   } else {
+//     alert("The course is already up to date!");
+//   }
+// }
 
 //----------------------------------------------------------------------------------
 // showEditVersion: Displays Edit Version Dialog

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -437,6 +437,42 @@ function changedType(kind) {
 }
 
 //----------------------------------------------------------------------------------
+// refreshGithubRepo: ....
+//----------------------------------------------------------------------------------
+
+function refreshGithubRepo(courseid) 
+{
+	//Used to return success(true) or error(false) to the calling function
+	var dataCheck;
+	$.ajax({
+		async: false,
+		url: "../recursivetesting/getLatestCommit.php",
+		type: "POST",
+		data: {'cid':courseid, 'action':'refreshGithubRepo'},
+		success: function() { 
+			//Returns true if the data and JSON is correct
+			dataCheck = true;
+		},
+		error: function(data){
+			//Check FetchGithubRepo for the meaning of the error code.
+			switch(data.status){
+				case 422:
+					alert(data.responseJSON.message + "\nDid not update course");
+					break;
+				case 503:
+					alert(data.responseJSON.message + "\nDid not update course");
+					break;
+				default:
+					alert("Something went wrong...");
+			}
+		 	dataCheck = false;
+		}
+	});
+  console.log("ajax done" + courseid);
+	return dataCheck;
+}
+
+//----------------------------------------------------------------------------------
 // showEditVersion: Displays Edit Version Dialog
 //----------------------------------------------------------------------------------
 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -249,7 +249,7 @@
             	echo "<a id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
 							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' src='../Shared/icons/refresh.svg'>";
 							echo "</a";
-							echo "<a class='burgerButtText' href='#' >Refresh github repo</a></div>";
+							echo "<span class='burgerButtText' href='#' >Refresh github repo</span></div>";
 					
 							//Adding home button to the teacher burger menu
 							echo "<div id='homeBurgerTeacher'>";

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -245,10 +245,10 @@
 							echo "<a class='burgerButtText' href='accessed.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers']."' >Change student access</a></div>";
 
 							// Refresh button for Github repo in hamburger menu
-							echo "<div id='refreshBurger'>";
-            	echo "<span id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
-							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' onclick='refreshGithubRepo(".$_SESSION['courseid'].");' src='../Shared/icons/refresh.svg'>";
-							echo "</span";
+							echo "<div id='refreshBurger 'onclick='refreshGithubRepo(".$_SESSION['courseid'].");'>";
+            	echo "<a id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
+							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' src='../Shared/icons/refresh.svg'>";
+							echo "</a";
 							echo "<a class='burgerButtText' href='#' >Refresh github repo</a></div>";
 					
 							//Adding home button to the teacher burger menu

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -246,9 +246,9 @@
 
 							// Refresh button for Github repo in hamburger menu
 							echo "<div id='refreshBurger 'onclick='refreshGithubRepo(".$_SESSION['courseid'].");'>";
-            	echo "<a id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
+            	echo "<span id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
 							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' src='../Shared/icons/refresh.svg'>";
-							echo "</a";
+							echo "</span";
 							echo "<span class='burgerButtText' href='#' >Refresh github repo</span></div>";
 					
 							//Adding home button to the teacher burger menu

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -249,7 +249,7 @@
             	echo "<span id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
 							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' src='../Shared/icons/refresh.svg'>";
 							echo "</span";
-							echo "<span class='burgerButtText' href='#' >Refresh github repo</span></div>";
+							echo "<a class='burgerButtText' href='#' >Refresh github repo</a></div>";
 					
 							//Adding home button to the teacher burger menu
 							echo "<div id='homeBurgerTeacher'>";

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -245,7 +245,7 @@
 							echo "<a class='burgerButtText' href='accessed.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers']."' >Change student access</a></div>";
 
 							// Refresh button for Github repo in hamburger menu
-							echo "<div id='refreshBurger 'onclick='refreshGithubRepo(".$_SESSION['courseid'].");'>";
+							echo "<div id='refreshBurger 'onclick='refreshGithubRepo(".$_SESSION['courseid'].");' style ='cursor:pointer;'>";
             	echo "<span id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
 							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' src='../Shared/icons/refresh.svg'>";
 							echo "</span";

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -200,9 +200,9 @@
 							// Refresh button for Github repo in nav
 							echo "<td class='refresh' style='display: inline-block;'>";
 							echo "<div class='refresh menuButton'>";
-            	echo "<a id='refreshBTN' title='Refresh Github repo' value='Refresh' href='#'>";
-             	echo "<img alt='refresh icon' id='refreshIMG' class='navButt whiteIcon' src='../Shared/icons/refresh.svg'>";
-							echo "</a>";
+            	echo "<span id='refreshBTN' title='Refresh Github repo' value='Refresh' href='#'>";
+             	echo "<img alt='refresh icon' id='refreshIMG' class='navButt whiteIcon' onclick='refreshGithubRepo(".$_SESSION['courseid'].");' src='../Shared/icons/refresh.svg'>";
+							echo "</span>";
 							echo "</div>";
 							echo "</td>";
 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -246,9 +246,9 @@
 
 							// Refresh button for Github repo in hamburger menu
 							echo "<div id='refreshBurger'>";
-            	echo "<a id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
-							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' src='../Shared/icons/refresh.svg'>";
-							echo "</a>";
+            	echo "<span id='refreshBTN' title='Refresh Github Repo' value='Refresh' href='#'>";
+							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' onclick='refreshGithubRepo(".$_SESSION['courseid'].");' src='../Shared/icons/refresh.svg'>";
+							echo "</span";
 							echo "<a class='burgerButtText' href='#' >Refresh github repo</a></div>";
 					
 							//Adding home button to the teacher burger menu

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -5,13 +5,13 @@ session_start();
 pdoConnect(); // Connect to database and start session
 
 //Get data from AJAX call in courseed.js and then runs the function getNewCourseGithub link
-if(isset($_POST['action'])) 
+/* if(isset($_POST['action'])) 
 {
     if($_POST['action'] == 'getNewCourseGitHub') 
     {
        getGitHubURL($_POST['githubURL']);
     }
-};
+}; */
 
 function getGitHubURL($url)
 {
@@ -92,10 +92,6 @@ function bfs($url, $cid, $opt)
     array_push($fifoQueue, $url);
     global $pdoLite;
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-
-    // TODO link the course with cid, should not be hardcoded 
-    // $cid = 1; // 1 för webbprogramering 
-    
     while (!empty($fifoQueue)) {
         $currentUrl = array_shift($fifoQueue);
         // Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -85,6 +85,8 @@ function downloadToWebServer($cid, $item)
     
 function bfs($url, $opt) 
 {
+    $cid = getOPG('courseid');
+    echo "<script>console.log('.$cid.');</script>";
     $visited = array();
     $fifoQueue = array();
     array_push($fifoQueue, $url);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -22,7 +22,7 @@ function getGitHubURL($url)
     $repository = $urlParts[4];
     // Translates the parts broken out of $url into the correct URL syntax for an API-URL 
     $translatedURL = 'https://api.github.com/repos/'.$username.'/'.$repository.'/contents/';
-    bfs($translatedURL);
+    bfs($translatedURL, "REFRESH");
 }
 
 function insertToFileLink($cid, $item) 

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -23,6 +23,7 @@ function getGitHubURL($url)
     // Translates the parts broken out of $url into the correct URL syntax for an API-URL 
     $translatedURL = 'https://api.github.com/repos/'.$username.'/'.$repository.'/contents/';
     // bfs($translatedURL, "REFRESH");
+    return $translatedURL;
 }
 
 function insertToFileLink($cid, $item) 

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -85,6 +85,7 @@ function downloadToWebServer($cid, $item)
     
 function bfs($url, $cid, $opt) 
 {
+    $url = getGitHubURL($url);
     $visited = array();
     $fifoQueue = array();
     array_push($fifoQueue, $url);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -94,7 +94,7 @@ function bfs($url, $opt)
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 
     // TODO link the course with cid, should not be hardcoded 
-    $cid = 1; // 1 för webbprogramering 
+    // $cid = 1; // 1 för webbprogramering 
     
     while (!empty($fifoQueue)) {
         $currentUrl = array_shift($fifoQueue);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -83,7 +83,7 @@ function downloadToWebServer($cid, $item)
     file_put_contents($path, $fileContents);    
 }
     
-function bfs($url) 
+function bfs($url, $opt) 
 {
     $visited = array();
     $fifoQueue = array();
@@ -122,9 +122,14 @@ function bfs($url)
                 foreach ($json as $item) {
                     // Checks if the fetched item is of type 'file'
                     if ($item['type'] == 'file') {
-                        insertToFileLink($cid, $item);
-                        insertToMetaData($cid, $item);
-                        downloadToWebserver($cid, $item);                   
+                        if($opt == "REFRESH") {
+                            insertToMetaData($cid, $item);
+                        }
+                        else if($opt == "DOWNLOAD") {
+                            insertToFileLink($cid, $item);
+                            insertToMetaData($cid, $item);
+                            downloadToWebserver($cid, $item);  
+                        }                 
                         // Checks if the fetched item is of type 'dir'
                     } else if ($item['type'] == 'dir') {
                         if (!in_array($item['url'], $visited)) {

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -22,7 +22,7 @@ function getGitHubURL($url)
     $repository = $urlParts[4];
     // Translates the parts broken out of $url into the correct URL syntax for an API-URL 
     $translatedURL = 'https://api.github.com/repos/'.$username.'/'.$repository.'/contents/';
-    bfs($translatedURL, "REFRESH");
+    // bfs($translatedURL, "REFRESH");
 }
 
 function insertToFileLink($cid, $item) 

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -83,10 +83,8 @@ function downloadToWebServer($cid, $item)
     file_put_contents($path, $fileContents);    
 }
     
-function bfs($url, $opt) 
+function bfs($url, $cid, $opt) 
 {
-    $cid = getOPG('courseid');
-    echo "<script>console.log('.$cid.');</script>";
     $visited = array();
     $fifoQueue = array();
     array_push($fifoQueue, $url);

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -16,7 +16,7 @@
 
 	global $pdo;
 
-	getCourseID("https://github.com/c21sebar/test"); // Dummy Code to see if everything works
+	//getCourseID("https://github.com/c21sebar/test"); // Dummy Code to see if everything works
 
 	// --------------------- Fetch CID from MySQL with Github URL and fetch latest commit ----------------------------------------------
 	// --------------------- This only happens when creating a new course --------------------------------------------------------------

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -25,6 +25,10 @@
 		{
 			getCourseID($_POST['githubURL']);
 		}
+		else if($_POST['action'] == 'refreshGithubRepo') 
+		{
+			refreshGithubRepo($_POST['cid']);
+		}
 	};
 
 	// --------------------- Fetch CID from MySQL with Github URL and fetch latest commit ----------------------------------------------

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -91,7 +91,6 @@
 		} else {
 			bfs($url, $cid, "REFRESH");
 		}
-		//refreshGithubRepo($cid); //testing !!!!!!! don't forget to remove!
 	}
 
 	// --------------------- Update git repo in course ---------------------------------------------------------------------------------

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -88,7 +88,9 @@
 			$errorvar = $error[2];
 			print_r($error);
 			echo $errorvar;
-		} 
+		} else {
+			bfs($url, $cid, "DOWNLOAD");
+		}
 		//refreshGithubRepo($cid); //testing !!!!!!! don't forget to remove!
 	}
 
@@ -128,7 +130,7 @@
 				
 				//print_r("The course should be updated!");
 				echo '<script>console.log("The course should be updated!"); </script>';
-				bfs($url, $cid, "DOWNLOAD");
+				bfs($url, $cid, "REFRESH");
 				echo '<script>console.log(' .$url. '); </script>';
 			} else {
 				//print_r("The course is already up to date!");

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -18,6 +18,15 @@
 
 	//getCourseID("https://github.com/c21sebar/test"); // Dummy Code to see if everything works
 
+	//Get data from AJAX call in courseed.js and then runs the function getNewCourseGithub link
+	if(isset($_POST['action'])) 
+	{
+		if($_POST['action'] == 'getCourseID') 
+		{
+			getCourseID($_POST['githubURL']);
+		}
+	};
+
 	// --------------------- Fetch CID from MySQL with Github URL and fetch latest commit ----------------------------------------------
 	// --------------------- This only happens when creating a new course --------------------------------------------------------------
 

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -131,10 +131,10 @@
 				echo '<script>console.log("The course should be updated!"); </script>';
 				bfs($url, $cid, "REFRESH");
 				echo '<script>console.log(' .$url. '); </script>';
-				echo '<script src="../DuggaSYS/Sectioned.js">courseUpdateAlerts(true);</script>';
+				echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(true);</script>';
 			} else {
 				echo '<script>console.log("The course is already up to date!"); </script>';
-				echo '<script src="../DuggaSYS/Sectioned.js">courseUpdateAlerts(false);</script>';
+				echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(false);</script>';
 			}
 		}
 	}

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -128,7 +128,7 @@
 				
 				//print_r("The course should be updated!");
 				echo '<script>console.log("The course should be updated!"); </script>';
-				bfs($url, "REFRESH");
+				bfs($url, $cid, "REFRESH");
 				echo '<script>console.log(' .$url. '); </script>';
 			} else {
 				//print_r("The course is already up to date!");

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -128,7 +128,7 @@
 				
 				//print_r("The course should be updated!");
 				echo '<script>console.log("The course should be updated!"); </script>';
-				bfs($url, $cid, "REFRESH");
+				bfs($url, $cid, "DOWNLOAD");
 				echo '<script>console.log(' .$url. '); </script>';
 			} else {
 				//print_r("The course is already up to date!");

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -131,10 +131,12 @@
 				echo '<script>console.log("The course should be updated!"); </script>';
 				bfs($url, $cid, "REFRESH");
 				echo '<script>console.log(' .$url. '); </script>';
-				echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(true);</script>';
+				//echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(true);</script>';
+				courseUpdateAlerts(true);
 			} else {
 				echo '<script>console.log("The course is already up to date!"); </script>';
-				echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(false);</script>';
+				//echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(false);</script>';
+				courseUpdateAlerts(false);
 			}
 		}
 	}

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -89,7 +89,7 @@
 			print_r($error);
 			echo $errorvar;
 		} else {
-			bfs($url, $cid, "DOWNLOAD");
+			bfs($url, $cid, "REFRESH");
 		}
 		//refreshGithubRepo($cid); //testing !!!!!!! don't forget to remove!
 	}

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -132,11 +132,11 @@
 				bfs($url, $cid, "REFRESH");
 				echo '<script>console.log(' .$url. '); </script>';
 				//echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(true);</script>';
-				courseUpdateAlerts(true);
+				print "funkar";
 			} else {
 				echo '<script>console.log("The course is already up to date!"); </script>';
 				//echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(false);</script>';
-				courseUpdateAlerts(false);
+				print "funkar2";
 			}
 		}
 	}

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -103,13 +103,9 @@
 		$query->bindParam(':cid', $cid);
 		$query->execute();
 
-		echo "<h2> Outputs for fetching data when updating a course </h2>";
-
 		$commmit = "";
 		$url = "";
 		foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-			echo "<p>Commit from select: ".$row['lastCommit']."</p>";
-			echo "<p>URL from select: ".$row['repoURL']."</p>";
 			$commit = $row['lastCommit'];
 			$url = $row['repoURL'];
 		}
@@ -128,15 +124,11 @@
 				$query->bindParam(':latestCommit', $latestCommit);
 				$query->execute();
 
-				echo '<script>console.log("The course should be updated!"); </script>';
 				bfs($url, $cid, "REFRESH");
-				echo '<script>console.log(' .$url. '); </script>';
-				//echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(true);</script>';
-				print "funkar";
+				//echo '<script>console.log(' .$url. '); </script>';
+				print "The course has been updated!";
 			} else {
-				echo '<script>console.log("The course is already up to date!"); </script>';
-				//echo '<script src="../DuggaSys/sectioned.js">courseUpdateAlerts(false);</script>';
-				print "funkar2";
+				print "The course is already up to date!";
 			}
 		}
 	}

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -8,6 +8,7 @@
 	// Include basic application services!
 	include_once "../Shared/basic.php";
 	include_once "../Shared/sessions.php";
+	include_once "../recursivetesting/FetchGithubRepo.php";
 
 	// Connect to database and start session
 	pdoConnect();
@@ -114,6 +115,8 @@
 				
 				//print_r("The course should be updated!");
 				echo '<script>console.log("The course should be updated!"); </script>';
+				bfs($url, "REFRESH");
+				echo '<script>console.log(' .$url. '); </script>';
 			} else {
 				//print_r("The course is already up to date!");
 				echo '<script>console.log("The course is already up to date!"); </script>';

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -75,12 +75,12 @@
 			print_r($error);
 			echo $errorvar;
 		} 
-		getCommitSqlite($cid); //testing !!!!!!! don't forget to remove!
+		//refreshGithubRepo($cid); //testing !!!!!!! don't forget to remove!
 	}
 
 	// --------------------- Update git repo in course ---------------------------------------------------------------------------------
 
-	function getCommitSqlite($cid){
+	function refreshGithubRepo($cid){
 		// Get old commit from Sqlite 
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 		$query = $pdolite->prepare('SELECT lastCommit, repoURL FROM gitRepos WHERE cid = :cid');
@@ -106,9 +106,17 @@
 
 			// Compare old commit in db with the new one from the url
 			if($latestCommit != $commit) {
-				print_r("The course should be updated!");
+				// Update the SQLite DB with the new commit
+				$query = $pdolite->prepare('UPDATE gitRepos SET lastCommit = :latestCommit WHERE cid = :cid');
+				$query->bindParam(':cid', $cid);
+				$query->bindParam(':latestCommit', $latestCommit);
+				$query->execute();
+				
+				//print_r("The course should be updated!");
+				echo '<script>console.log("The course should be updated!"); </script>';
 			} else {
-				print_r("The course is already up to date!");
+				//print_r("The course is already up to date!");
+				echo '<script>console.log("The course is already up to date!"); </script>';
 			}
 		}
 	}

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -10,10 +10,6 @@
 	include_once "../Shared/sessions.php";
 	include_once "../recursivetesting/FetchGithubRepo.php";
 
-	// Connect to database and start session
-	pdoConnect();
-	session_start();
-
 	global $pdo;
 
 	//getCourseID("https://github.com/c21sebar/test"); // Dummy Code to see if everything works
@@ -35,6 +31,10 @@
 	// --------------------- This only happens when creating a new course --------------------------------------------------------------
 
 	function getCourseID($githubURL) {
+		// Connect to database and start session
+		pdoConnect();
+		session_start();
+
 
 		echo "<h2> Outputs for creating a new course </h2>";
 		echo "<p>Original URL: ".$githubURL."</p>";

--- a/recursivetesting/getLatestCommit.php
+++ b/recursivetesting/getLatestCommit.php
@@ -127,14 +127,14 @@
 				$query->bindParam(':cid', $cid);
 				$query->bindParam(':latestCommit', $latestCommit);
 				$query->execute();
-				
-				//print_r("The course should be updated!");
+
 				echo '<script>console.log("The course should be updated!"); </script>';
 				bfs($url, $cid, "REFRESH");
 				echo '<script>console.log(' .$url. '); </script>';
+				echo '<script src="../DuggaSYS/Sectioned.js">courseUpdateAlerts(true);</script>';
 			} else {
-				//print_r("The course is already up to date!");
 				echo '<script>console.log("The course is already up to date!"); </script>';
+				echo '<script src="../DuggaSYS/Sectioned.js">courseUpdateAlerts(false);</script>';
 			}
 		}
 	}


### PR DESCRIPTION
issue #13668 

"The bfs and fetchgithubrepo.php functions has been redesigned and the functions has been implemented under the refresh button on the navigation meny at the top.

The bfs function now look at an option parameter to be able to download and insert to sqlite or just insert to sqlite. We also changed so that when creating a new course all the files from the repo are not created on the webserver, the metadata from the files are added to the sqlite db. We tested that the files can be created with the DOWNLOAD parameter and it works.

The refresh button in the navbar is set to the REFRESH parameter to fetch the metadata from the githubrepo only if there has been a new commit to the repo."

To test this, create a course with a github repo you can edit (preferrably your own). After creating a new course, go to the course page and press the refresh button in the top navbar. It should say the course is up to date. Then open the sqlite database in CMD and "select * from gitRepos;" This will show you the latest commit for that repo.  Now go to the repo you have on your github and make some changes (so that the commit nr will change), then press the refresh button again. This time it should say the course has been updated. Then check the sqlite database again to see if the commit number for the specific course has changed.

co-author @g21emmka 