### PR TITLE
G3 2023 v5 issue#13732

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -379,9 +379,9 @@ function renderCell(col, celldata, cellid) {
     } else if (col == "kind") {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
-        console.log(obj.path);
-        console.log(obj.filename);
-        console.log(celldata);
+        if(celldata !== null) {
+            console.log(celldata);
+        }
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -379,7 +379,8 @@ function renderCell(col, celldata, cellid) {
     } else if (col == "kind") {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
-        console.log(typeof obj.path);
+        console.log(obj.path);
+        console.log(obj.filename);
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -380,7 +380,7 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
         console.log("tja har har type");
-        if(obj.filePath.includes("GitHub")) {
+        if((obj.filePath).includes("GitHub")) {
             console.log("inte github");
         } else {
             console.log("är github");

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -84,10 +84,11 @@ function returnedFile(data) {
         extension: "Extension",
         kind: "Kind",
         filesize: "Size",
+        type: "Type",
         uploaddate: "Upload date",
         editor: ""
     }
-    var colOrderPre = ["filename", "extension", "kind", "filesize", "uploaddate", "editor"];
+    var colOrderPre = ["filename", "extension", "kind", "filesize", "type", "uploaddate", "editor"];
 
     if (data['studentteacher'] || data['supervisor']) {
         document.getElementById('fabButton').style.display = "none";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -380,7 +380,7 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
         console.log("tja har har type");
-        console.log((obj.filePath).toString());
+        console.log();
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -381,6 +381,7 @@ function renderCell(col, celldata, cellid) {
     } else if (col == "type") {
         console.log(obj.path);
         console.log(obj.filename);
+        console.log(celldata);
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -380,6 +380,7 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
         console.log("tja har har type");
+        console.log(obj.path);
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -380,7 +380,11 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
         console.log("tja har har type");
-        console.log();
+        if(obj.filePath !== null) {
+            console.log("inte null");
+        } else {
+            console.log("är null");
+        }
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -380,7 +380,7 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
         console.log("tja har har type");
-        console.log(obj.path);
+        console.log(obj.filePath);
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -380,7 +380,9 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
         if(celldata !== null) {
-            console.log(celldata);
+            str = "<span>" + "Github" + "</span>";
+        } else {
+            str += "<span>" + "Manual" + "</span>";
         }
     }
     return str;

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -379,7 +379,7 @@ function renderCell(col, celldata, cellid) {
     } else if (col == "kind") {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
-        console.log(typeof obj.filePath);
+        console.log(typeof obj.path);
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -380,10 +380,10 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
         console.log("tja har har type");
-        if(obj.filePath !== null) {
-            console.log("inte null");
+        if(obj.filePath.includes("GitHub")) {
+            console.log("inte github");
         } else {
-            console.log("är null");
+            console.log("är github");
         }
     }
     return str;

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -380,7 +380,7 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
         console.log("tja har har type");
-        console.log(obj.filePath);
+        console.log((obj.filePath).toString());
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -379,12 +379,7 @@ function renderCell(col, celldata, cellid) {
     } else if (col == "kind") {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {
-        console.log("tja har har type");
-        if((obj.filePath).includes("GitHub")) {
-            console.log("inte github");
-        } else {
-            console.log("är github");
-        }
+        console.log(typeof obj.filePath);
     }
     return str;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -378,6 +378,8 @@ function renderCell(col, celldata, cellid) {
     }
     } else if (col == "kind") {
         str += "<span>" + convertFileKind(celldata) + "</span>";
+    } else if (col == "type") {
+        console.log("tja har har type");
     }
     return str;
 }

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -204,6 +204,18 @@ $js = array(
                         <label for="dummyEmptyFile-sort" name="sortDummyFile" style='white-space:nowrap'>Dummy files</label>
                     </div>
                 </div>
+                 <div style='white-space:nowrap'>
+                    <div class="manualSortTab" tabIndex="0">
+                        <input type="radio" id="manual-sort" name="sortKind" value="Manual" onclick="filterFilesByKind('Manual');count=0;"/>
+                        <label for="manual-sort" name="sortManual" style='white-space:nowrap'>Manual</label>
+                    </div>
+                </div>
+                 <div style='white-space:nowrap'>
+                    <div class="githubSortTab" tabIndex="0">
+                        <input type="radio" id="github-sort" name="sortKind" value="Github" onclick="filterFilesByKind('Github');count=0;"/>
+                        <label for="github-sort" name="sortGithub" style='white-space:nowrap'>Github</label>
+                    </div>
+                </div>
             </div>
         </div>
 		<div id="fileLink" style='width:100%;margin-bottom: 30px;'></div>

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -213,7 +213,6 @@ $files = array();
 $lfiles = array();
 $gfiles = array();
 $access = False;
-$pathString = "Github";
 
 // Fetches information from the filelink table in the database, binds column result into vars and loops through each fetched result, building a new cell for each index.
 if (checklogin() && $hasAccess) {  
@@ -280,18 +279,12 @@ if (checklogin() && $hasAccess) {
             $showTrashcan = true;
         }
 
-        if($path == null){
-            $pathString = "Manual";
-        } else {
-            $pathString = "Github";
-        }
-
         $entry = array(
             'filename' => json_encode(['filename' => $row['filename'], 'shortfilename' => $shortfilename, "kind" => $filekindname, 'extension' => $extension, 'filePath' => $filePath]),
             'extension' => $extension,
             'kind' => "$filekind",
             'filesize' => json_encode(['size' => $row['filesize'], 'kind' => $filekindname]),
-            'type' => "$pathString",
+            'type' => $row['path'],
             'uploaddate' => $row['uploaddate'],
             'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor]),
             'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan])

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -35,7 +35,9 @@ $query->bindParam(':fid', $fid);
 $result = $query->execute();
 if($row = $query->fetch(PDO::FETCH_ASSOC)){
     $path = $row['path'];
-} 
+} else {
+    $path = "Lokal";
+}
 
 $debug = "NONE!";
 $studentTeacher = false;
@@ -284,7 +286,7 @@ if (checklogin() && $hasAccess) {
             'extension' => $extension,
             'kind' => "$filekind",
             'filesize' => json_encode(['size' => $row['filesize'], 'kind' => $filekindname]),
-            'type' => $row['path'],
+            'type' => $path,
             'uploaddate' => $row['uploaddate'],
             'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor]),
             'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan])

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -220,7 +220,6 @@ if (checklogin() && $hasAccess) {
     $query = $pdo->prepare("SELECT * FROM fileLink WHERE kind=2 OR (cid=:cid AND vers is null) OR (cid=:cid AND vers=:vers) ORDER BY kind,filename;");
     $query->bindParam(':cid', $cid);
     $query->bindParam(':vers', $coursevers);
-    echo "<script>console.log($filepath);</script>";
     
     if (!$query->execute()) {
         $error = $query->errorInfo();

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -220,6 +220,7 @@ if (checklogin() && $hasAccess) {
     $query = $pdo->prepare("SELECT * FROM fileLink WHERE kind=2 OR (cid=:cid AND vers is null) OR (cid=:cid AND vers=:vers) ORDER BY kind,filename;");
     $query->bindParam(':cid', $cid);
     $query->bindParam(':vers', $coursevers);
+    echo "<script>console.log($filepath);</script>";
     
     if (!$query->execute()) {
         $error = $query->errorInfo();

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -284,7 +284,7 @@ if (checklogin() && $hasAccess) {
             'extension' => $extension,
             'kind' => "$filekind",
             'filesize' => json_encode(['size' => $row['filesize'], 'kind' => $filekindname]),
-            'type' => $path,
+            'type' => $row['path'],
             'uploaddate' => $row['uploaddate'],
             'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor]),
             'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan])

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -284,6 +284,7 @@ if (checklogin() && $hasAccess) {
             'extension' => $extension,
             'kind' => "$filekind",
             'filesize' => json_encode(['size' => $row['filesize'], 'kind' => $filekindname]),
+            'type' => "$filepath",
             'uploaddate' => $row['uploaddate'],
             'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor]),
             'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan])

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -284,7 +284,7 @@ if (checklogin() && $hasAccess) {
             'extension' => $extension,
             'kind' => "$filekind",
             'filesize' => json_encode(['size' => $row['filesize'], 'kind' => $filekindname]),
-            'type' => "$filepath",
+            'type' => $path,
             'uploaddate' => $row['uploaddate'],
             'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor]),
             'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan])

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -213,6 +213,7 @@ $files = array();
 $lfiles = array();
 $gfiles = array();
 $access = False;
+$pathString = "Github";
 
 // Fetches information from the filelink table in the database, binds column result into vars and loops through each fetched result, building a new cell for each index.
 if (checklogin() && $hasAccess) {  
@@ -279,12 +280,18 @@ if (checklogin() && $hasAccess) {
             $showTrashcan = true;
         }
 
+        if($path == null){
+            $pathString = "Manual";
+        } else {
+            $pathString = "Github";
+        }
+
         $entry = array(
             'filename' => json_encode(['filename' => $row['filename'], 'shortfilename' => $shortfilename, "kind" => $filekindname, 'extension' => $extension, 'filePath' => $filePath]),
             'extension' => $extension,
             'kind' => "$filekind",
             'filesize' => json_encode(['size' => $row['filesize'], 'kind' => $filekindname]),
-            'type' => $row['path'],
+            'type' => "$pathString",
             'uploaddate' => $row['uploaddate'],
             'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor]),
             'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan])

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5188,7 +5188,8 @@ ul.hamburgerList button.menuButton {
 .fileLink-uploaddate,
 .fileLink-filesize,
 .fileLink-kind,
-.fileLink-extension {
+.fileLink-extension,
+.fileLink-type {
   text-align: center;
 }
 


### PR DESCRIPTION
Added a new column to the file editor. There should now be a column that is called "Type".  The data inside should be either "Manual" or "Github". This is decided by the method used when adding files. If you manually upload files the type is "Manual" and if you upload a course from github the files added should have the type "Github". We also added 2 radio buttons that will be used to filter files (they are not working currently, will fix the filtering in future issue).

Relevant files to test: fileed.php

Co-authored by @e21krida and @a21hugni 