### PR TITLE
Prevent label and cardinalities on IE lines #12860

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7900,6 +7900,9 @@ function drawLine(line, targetGhost = false)
             line.endIcon = "ARROW";
         }
     }
+    else if ((felem.type == "IE") || (telem.type == 'IE')) {
+        line.type = "IE"
+    }
     else if ((felem.type == 'ER') || (telem.type == 'ER')) {
         line.type = 'ER';
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8586,7 +8586,7 @@ function drawLine(line, targetGhost = false)
         str += `<rect x="${x-(2 * zoomfact)}" y="${y-(2 * zoomfact)}" width='${4 * zoomfact}' height='${4 * zoomfact}' style="fill:${lineColor}" stroke="${lineColor}" stroke-width="3"/>`;
     }
 
-    if (line.label && line.label != ""){
+    if (line.label && line.label != "" && line.type !== "IE"){
         //Get width of label's text through canvas 
         var height = Math.round(zoomfact * textheight);
         var canvas = document.getElementById('canvasOverlay');


### PR DESCRIPTION
It is no longer possible to add and render labels to IE lines as they will be ignored. Solves issue #12860 