### PR TITLE
Function isClose() misfunctions #13833

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7658,11 +7658,8 @@ function isClose(fromX, toX, fromY, toY, zoom = 1) {
           deltaX = Math.abs(toX - fromX),
           deltaY = Math.abs(toY - fromY);
 
-    if (deltaX < concideredNearValue && deltaY < concideredNearValue) {
-        return true;
-    } else {
-        return false;
-    }
+    // Returns true if deltaX and deltaY is within considered near value, otherwise false
+    return deltaX < concideredNearValue && deltaY < concideredNearValue
 }
 
 /**


### PR DESCRIPTION
Solved an issue where isClose function would return false if both x and y was negative, causing the program to misbehave. Solves issue #13833.