### PR TITLE
ER to UML, UML to ER options panel dropdown issue #12694

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2895,14 +2895,12 @@ function changeState()
     }
 
     else if(element.type=='SD') {
-        // State diagrams don't have properties, so this feels unneccessary (?)
-        /*
+
         if (element.kind != 'IEEntity') {
             var property = document.getElementById("propertySelect").value;
             element.state = property;
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
-        */
 
         //Check if type has been changed
         if (oldType != newType) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2832,7 +2832,7 @@ function changeState()
     }
 
     else if (element.type == 'ER') {
-
+        
         //If not attribute, also save the current type and check if kind also should be updated
         if (element.kind != 'ERAttr') {
 
@@ -2878,12 +2878,11 @@ function changeState()
     }
     else if(element.type=='IE') {
         //Save the current property if not an UML or IE entity since niether entities does have variants.
-        /*
         if (element.kind != 'IEEntity') {
             var property = document.getElementById("propertySelect").value;
             element.state = property;
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
-        }*/
+        }
 
         //Check if type has been changed
         if (oldType != newType) {
@@ -2901,12 +2900,6 @@ function changeState()
 
     else if(element.type=='SD') {
 
-        if (element.kind != 'SDEntity') {
-            var property = document.getElementById("propertySelect").value;
-            element.state = property;
-            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
-        }
-
         //Check if type has been changed
         if (oldType != newType) {
             var newKind = element.kind;
@@ -2920,7 +2913,7 @@ function changeState()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
-
+    generateContextProperties();
     displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
 
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2819,7 +2819,7 @@ function changeState()
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;
 
-    // TODO: elementHasLines() seems to not work for UML elements, this needs to be fixed/investigated!!
+    // TODO: elementHasLines() seems to not work for UML, SD elements, this needs to be fixed/investigated!!
     if ((newType !== undefined && oldType != newType && elementHasLines(element))){
         displayMessage("error", `
         Can't change type from \"${oldType}\" to \"${newType}\" as
@@ -2916,7 +2916,6 @@ function changeState()
 
     }
 
-    generateContextProperties();
     displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
 
 }
@@ -6618,7 +6617,7 @@ function generateContextProperties()
             str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
                `<span id="BGColorMenu" class="colorMenu"></span></button>`;
         }
-        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();">`;
+        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();generateContextProperties();saveProperties();">`;
       }
 
       // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2893,6 +2893,31 @@ function changeState()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
+
+    else if(element.type=='SD') {
+        // State diagrams don't have properties, so this feels unneccessary (?)
+        /*
+        if (element.kind != 'IEEntity') {
+            var property = document.getElementById("propertySelect").value;
+            element.state = property;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
+        */
+
+        //Check if type has been changed
+        if (oldType != newType) {
+            var newKind = element.kind;
+            newKind = newKind.replace(oldType, newType);
+            //Update element kind
+            element.kind = newKind;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
+        //Update element type
+        element.type = newType;
+        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+
+    }
+
     generateContextProperties();
     displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2809,7 +2809,7 @@ function getElementLines(element) {
 function elementHasLines(element) {
     return (getElementLines(element).length > 0);
 }
-/**
+/** TODO: elementHasLines() seems to not work for UML, SD elements, this needs to be fixed/investigated!!
  * @description Triggered on ENTER-key pressed when a property is being edited via the options panel. This will apply the new property onto the element selected in context.
  * @see context For currently selected element.
  */
@@ -2819,16 +2819,19 @@ function changeState()
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;
 
-    // TODO: elementHasLines() seems to not work for UML, SD elements, this needs to be fixed/investigated!!
+    // If we are changing types and the element has lines, we should not change
     if ((newType !== undefined && oldType != newType && elementHasLines(element))){
         displayMessage("error", `
         Can't change type from \"${oldType}\" to \"${newType}\" as
         different diagrams should not be able to connect to each other.`
         )
         return;
+    // If we are changing to the same type, (simply pressed save without changes), do nothing.
+    } else if (oldType == newType){
+        return;
     }
 
-    if (element.type == 'ER') {
+    else if (element.type == 'ER') {
 
         //If not attribute, also save the current type and check if kind also should be updated
         if (element.kind != 'ERAttr') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6620,7 +6620,7 @@ function generateContextProperties()
             str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
                `<span id="BGColorMenu" class="colorMenu"></span></button>`;
         }
-        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();generateContextProperties();saveProperties();">`;
+        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();generateContextProperties();">`;
       }
 
       // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1131,9 +1131,9 @@ var defaults = {
 
     UMLEntity: {name: "Class", kind: "UMLEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "UML", attributes: ['-Attribute'], functions: ['+Function'] },     //<-- UML functionality
     UMLRelation: {name: "Inheritance", kind: "UMLRelation", fill: "#ffffff", stroke: "#000000", width: 60, height: 60, type: "UML" }, //<-- UML functionality
-    IEEntity: {name: "IEEntity", kind: "IEEntity", fill: "#ffffff", width: 200, height: 50, type: "IE", attributes: ['-Attribute'] },     //<-- IE functionality
+    IEEntity: {name: "IEEntity", kind: "IEEntity", fill: "#ffffff", width: 200, height: 50, type: "IE", attributes: ['-Attribute'], functions: ['+function'] },     //<-- IE functionality
     IERelation: {name: "Inheritance", kind: "IERelation", fill: "#ffffff", stroke: "#000000", width: 50, height: 50, type: "IE" }, //<-- IE inheritence functionality
-    SDEntity: { name: "State", kind: "SDEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "SD", attributes: ['do: func'] }, //<-- SD functionality
+    SDEntity: { name: "State", kind: "SDEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "SD", attributes: ['do: func'], functions: ['+function'] }, //<-- SD functionality
 
     UMLInitialState: {name: "UML Initial State", kind: "UMLInitialState", fill: "#000000", stroke: "#000000", width: 60, height: 60, type: "SD" }, // UML Initial state.
     UMLFinalState: {name: "UML Final State", kind: "UMLFinalState", fill: "#000000", stroke: "#000000", width: 60, height: 60, type: "SD" }, // UML Final state.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -811,7 +811,7 @@ const elementTypesNames = {
     IEEntity: "IEEntity",
     IERelation: "IERelation",
 
-    SDState: "SDState",
+    SDState: "SDEntity",
 
     UMLInitialState: "UMLInitialState",
     UMLFinalState: "UMLFinalState",

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1133,7 +1133,7 @@ var defaults = {
     UMLRelation: {name: "Inheritance", kind: "UMLRelation", fill: "#ffffff", stroke: "#000000", width: 60, height: 60, type: "UML" }, //<-- UML functionality
     IEEntity: {name: "IEEntity", kind: "IEEntity", fill: "#ffffff", width: 200, height: 50, type: "IE", attributes: ['-Attribute'] },     //<-- IE functionality
     IERelation: {name: "Inheritance", kind: "IERelation", fill: "#ffffff", stroke: "#000000", width: 50, height: 50, type: "IE" }, //<-- IE inheritence functionality
-    SDState: { name: "State", kind: "SDState", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "SD", attributes: ['do: func'] }, //<-- SD functionality
+    SDState: { name: "State", kind: "SDEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "SD", attributes: ['do: func'] }, //<-- SD functionality
 
     UMLInitialState: {name: "UML Initial State", kind: "UMLInitialState", fill: "#000000", stroke: "#000000", width: 60, height: 60, type: "SD" }, // UML Initial state.
     UMLFinalState: {name: "UML Final State", kind: "UMLFinalState", fill: "#000000", stroke: "#000000", width: 60, height: 60, type: "SD" }, // UML Final state.
@@ -2896,7 +2896,7 @@ function changeState()
 
     else if(element.type=='SD') {
 
-        if (element.kind != 'SDState') {
+        if (element.kind != 'IEEntity') {
             var property = document.getElementById("propertySelect").value;
             element.state = property;
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
@@ -6573,7 +6573,7 @@ function generateContextProperties()
         //Selected SD type
         else if (element.type == 'SD') {
             //if SDState kind
-            if (element.kind == 'SDState') {
+            if (element.kind == 'SDEntity') {
                 for (const property in element) {
                     switch (property.toLowerCase()) {
                         case 'name':
@@ -7536,7 +7536,7 @@ function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, su
     }
 
     
-    if (fromElement.id === toElement.id && !(fromElement.kind === 'SDState' || toElement.kind === 'SDState')) {
+    if (fromElement.id === toElement.id && !(fromElement.kind === 'SDEntity' || toElement.kind === 'SDEntity')) {
         displayMessage(messageTypes.ERROR, `Not possible to draw a line between: ${fromElement.name} and ${toElement.name}, they are the same element`);
         return;
     }
@@ -9156,7 +9156,7 @@ function drawElement(element, ghosted = false)
     }
 
     // Check if element is SDState
-    else if (element.kind == "SDState") {
+    else if (element.kind == "SDEntity") {
 
         const maxCharactersPerLine = Math.floor(boxw / texth);
 
@@ -11914,7 +11914,7 @@ function updateCSSForAllElements()
                     }
                 }
                 // Update SDState
-                else if (element.kind == "SDState") {
+                else if (element.kind == "SDEntity") {
                     for (let index = 0; index < 2; index++) {
                         fillColor = elementDiv.children[index].children[0].children[0];
                         fontColor = elementDiv.children[index].children[0];
@@ -12010,7 +12010,7 @@ function updateCSSForAllElements()
                     }
                 }
                 // Update SDState
-                else if (element.kind == "SDState") {
+                else if (element.kind == "SDEntity") {
                     for (let index = 0; index < 2; index++) {
                         fillColor = elementDiv.children[index].children[0].children[0];
                         fontColor = elementDiv.children[index].children[0];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2809,7 +2809,7 @@ function getElementLines(element) {
 function elementHasLines(element) {
     return (getElementLines(element).length > 0);
 }
-/** TODO: elementHasLines() seems to not work for UML, SD elements, this needs to be fixed/investigated!!
+/** TODO: elementHasLines() seems to not work for UML, SD, IE elements, this needs to be fixed/investigated!!
  * @description Triggered on ENTER-key pressed when a property is being edited via the options panel. This will apply the new property onto the element selected in context.
  * @see context For currently selected element.
  */
@@ -2820,7 +2820,7 @@ function changeState()
           newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;
 
     // If we are changing types and the element has lines, we should not change
-    if ((newType !== undefined && oldType != newType && elementHasLines(element))){
+    if ((elementHasLines(element))){
         displayMessage("error", `
         Can't change type from \"${oldType}\" to \"${newType}\" as
         different diagrams should not be able to connect to each other.`

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2819,14 +2819,6 @@ function changeState()
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;
 
-    // OLD CODE
-
-    /*if ((newType !== undefined && oldType != newType && elementHasLines(element)) || 
-    (newType !== undefined &&  oldType == 'UML' && newType != 'UML'  && elementHasLines(element) == false) || 
-    (newType !== undefined &&  oldType == 'IE' && newType != 'IE'  && elementHasLines(element) == false)) {*/
-
-    // Should only change if not same type and no lines
-
     // TODO: elementHasLines() seems to not work for UML elements, this needs to be fixed/investigated!!
     if ((newType !== undefined && oldType != newType && elementHasLines(element))){
         displayMessage("error", `

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -789,7 +789,7 @@ const elementTypes = {
     IEEntity: 6,       //<-- IE functionality
     IERelation: 7, // IE inheritance functionality
 
-    SDState: 8,////SD(State diagram) functionality
+    SDEntity: 8,////SD(State diagram) functionality
     UMLInitialState: 9,
     UMLFinalState: 10,
     UMLSuperState:11,
@@ -811,7 +811,7 @@ const elementTypesNames = {
     IEEntity: "IEEntity",
     IERelation: "IERelation",
 
-    SDState: "SDEntity",
+    SDEntity: "SDEntity",
 
     UMLInitialState: "UMLInitialState",
     UMLFinalState: "UMLFinalState",
@@ -1133,7 +1133,7 @@ var defaults = {
     UMLRelation: {name: "Inheritance", kind: "UMLRelation", fill: "#ffffff", stroke: "#000000", width: 60, height: 60, type: "UML" }, //<-- UML functionality
     IEEntity: {name: "IEEntity", kind: "IEEntity", fill: "#ffffff", width: 200, height: 50, type: "IE", attributes: ['-Attribute'] },     //<-- IE functionality
     IERelation: {name: "Inheritance", kind: "IERelation", fill: "#ffffff", stroke: "#000000", width: 50, height: 50, type: "IE" }, //<-- IE inheritence functionality
-    SDState: { name: "State", kind: "SDEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "SD", attributes: ['do: func'] }, //<-- SD functionality
+    SDEntity: { name: "State", kind: "SDEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "SD", attributes: ['do: func'] }, //<-- SD functionality
 
     UMLInitialState: {name: "UML Initial State", kind: "UMLInitialState", fill: "#000000", stroke: "#000000", width: 60, height: 60, type: "SD" }, // UML Initial state.
     UMLFinalState: {name: "UML Final State", kind: "UMLFinalState", fill: "#000000", stroke: "#000000", width: 60, height: 60, type: "SD" }, // UML Final state.
@@ -1159,9 +1159,9 @@ var allAttrToEntityRelations = [];
 var attrViaAttrToEnt = [];
 var attrViaAttrCounter = 0;
 /* draws the State diagram on LOAD.
-function debugDrawSDState() {
+function debugDrawSDEntity() {
     const EMPLOYEE_ID = makeRandomID();
-    const demoState = { name: "STATE", x: 100, y: 200, width: 200, height: 50, kind: "SDState", fill: "#ffffff", stroke: "#000000", id: EMPLOYEE_ID, isLocked: false, state: "normal", type: "SD", attributes: ['do: func']};
+    const demoState = { name: "STATE", x: 100, y: 200, width: 200, height: 50, kind: "SDEntity", fill: "#ffffff", stroke: "#000000", id: EMPLOYEE_ID, isLocked: false, state: "normal", type: "SD", attributes: ['do: func']};
     addObjectToData(demoState, false);
     console.log(demoState.name);
 }
@@ -1389,7 +1389,7 @@ function getData()
     container = document.getElementById("container");
     DiagramResponse = fetchDiagram();
     // onSetup();
-    //debugDrawSDState(); // <-- debugfunc to show an sd entity
+    //debugDrawSDEntity(); // <-- debugfunc to show an sd entity
     generateToolTips();
     toggleGrid();
     updateGridPos();
@@ -2896,7 +2896,7 @@ function changeState()
 
     else if(element.type=='SD') {
 
-        if (element.kind != 'IEEntity') {
+        if (element.kind != 'SDEntity') {
             var property = document.getElementById("propertySelect").value;
             element.state = property;
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
@@ -4080,7 +4080,7 @@ const stateLinesLabels=[];
     // Picks out the entities related to State Diagrams and place them in their local arrays.
     for (let i=0; i<data.length; i++)
     {
-        if (data[i].kind == elementTypesNames.SDState) {
+        if (data[i].kind == elementTypesNames.SDEntity) {
             stateElements.push([data[i], false]);
         }
         else if (data[i].kind == elementTypesNames.UMLInitialState) {
@@ -6572,7 +6572,7 @@ function generateContextProperties()
         }
         //Selected SD type
         else if (element.type == 'SD') {
-            //if SDState kind
+            //if SDEntity kind
             if (element.kind == 'SDEntity') {
                 for (const property in element) {
                     switch (property.toLowerCase()) {
@@ -9155,7 +9155,7 @@ function drawElement(element, ghosted = false)
                 </div>`;
     }
 
-    // Check if element is SDState
+    // Check if element is SDEntity
     else if (element.kind == "SDEntity") {
 
         const maxCharactersPerLine = Math.floor(boxw / texth);
@@ -11913,7 +11913,7 @@ function updateCSSForAllElements()
                         }
                     }
                 }
-                // Update SDState
+                // Update SDEntity
                 else if (element.kind == "SDEntity") {
                     for (let index = 0; index < 2; index++) {
                         fillColor = elementDiv.children[index].children[0].children[0];
@@ -12009,7 +12009,7 @@ function updateCSSForAllElements()
                         fontContrast();
                     }
                 }
-                // Update SDState
+                // Update SDEntity
                 else if (element.kind == "SDEntity") {
                     for (let index = 0; index < 2; index++) {
                         fillColor = elementDiv.children[index].children[0].children[0];

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2896,7 +2896,7 @@ function changeState()
 
     else if(element.type=='SD') {
 
-        if (element.kind != 'IEEntity') {
+        if (element.kind != 'SDState') {
             var property = document.getElementById("propertySelect").value;
             element.state = property;
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2835,6 +2835,7 @@ function changeState()
 
         //If not attribute, also save the current type and check if kind also should be updated
         if (element.kind != 'ERAttr') {
+
             //Check if type has been changed
             if (oldType != newType) {
                 var newKind = element.kind;
@@ -2877,11 +2878,12 @@ function changeState()
     }
     else if(element.type=='IE') {
         //Save the current property if not an UML or IE entity since niether entities does have variants.
+        /*
         if (element.kind != 'IEEntity') {
             var property = document.getElementById("propertySelect").value;
             element.state = property;
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
-        }
+        }*/
 
         //Check if type has been changed
         if (oldType != newType) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2827,6 +2827,7 @@ function changeState()
 
     // Should only change if not same type and no lines
 
+    // TODO: elementHasLines() seems to not work for UML elements, this needs to be fixed/investigated!!
     if ((newType !== undefined && oldType != newType && elementHasLines(element))){
         displayMessage("error", `
         Can't change type from \"${oldType}\" to \"${newType}\" as

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2827,15 +2827,10 @@ function changeState()
 
     // Should only change if not same type and no lines
 
-    if ((newType == undefined || oldType == newType || elementHasLines(element))){
-        oldType == newType ? 
+    if ((newType == undefined && oldType != newType || elementHasLines(element))){
         displayMessage("error", `
-            Can't change to \"${oldType}\" as this type is already selected.`
-        )
-        :
-        displayMessage("error", `
-            Can't change type from \"${oldType}\" to \"${newType}\" as
-            different diagrams should not be able to connect to each other.`
+        Can't change type from \"${oldType}\" to \"${newType}\" as
+        different diagrams should not be able to connect to each other.`
         )
         return;
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2828,11 +2828,17 @@ function changeState()
 
     // Should only change if not same type and no lines
 
-    if ((newType == undefined || oldType == newType || elementHasLines(element))){
+    if ((newType == undefined || elementHasLines(element))){
+
+        oldType == newType ? 
+        displayMessage("error", `
+            Can't change to \"${oldType}\" as this type is already selected.`
+        )
+        :
         displayMessage("error", `
             Can't change type from \"${oldType}\" to \"${newType}\" as
             different diagrams should not be able to connect to each other.`
-        );
+        )
         return;
     }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2828,7 +2828,6 @@ function changeState()
     // Should only change if not same type and no lines
 
     if ((newType == undefined || oldType == newType || elementHasLines(element))){
-
         oldType == newType ? 
         displayMessage("error", `
             Can't change to \"${oldType}\" as this type is already selected.`
@@ -2838,14 +2837,6 @@ function changeState()
             Can't change type from \"${oldType}\" to \"${newType}\" as
             different diagrams should not be able to connect to each other.`
         )
-
-        if (elementHasLines(element)){
-            displayMessage("error", `
-            Can't change type from \"${oldType}\" to \"${newType}\" as
-            different diagrams should not be able to connect to each other.`
-        )
-        }
-
         return;
     }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2827,7 +2827,7 @@ function changeState()
 
     // Should only change if not same type and no lines
 
-    if ((newType == undefined && oldType != newType || elementHasLines(element))){
+    if ((newType == undefined && oldType != newType && elementHasLines(element))){
         displayMessage("error", `
         Can't change type from \"${oldType}\" to \"${newType}\" as
         different diagrams should not be able to connect to each other.`

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2819,13 +2819,19 @@ function changeState()
     const element =  context[0],
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;
-    /* If the element has a new type and got lines, then it can't change type. */
-    if ((newType !== undefined && oldType != newType && elementHasLines(element)) || 
+
+    // OLD CODE
+
+    /*if ((newType !== undefined && oldType != newType && elementHasLines(element)) || 
     (newType !== undefined &&  oldType == 'UML' && newType != 'UML'  && elementHasLines(element) == false) || 
-    (newType !== undefined &&  oldType == 'IE' && newType != 'IE'  && elementHasLines(element) == false)) {
+    (newType !== undefined &&  oldType == 'IE' && newType != 'IE'  && elementHasLines(element) == false)) {*/
+
+    // Should only change if not same type and no lines
+
+    if ((newType !== undefined && oldType != newType && elementHasLines(element) == false)){
         displayMessage("error", `
             Can't change type from \"${oldType}\" to \"${newType}\" as
-            these types should not be able to connect with each other.`
+            different diagrams should not be able to connect to each other.`
         );
         return;
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2828,7 +2828,7 @@ function changeState()
 
     // Should only change if not same type and no lines
 
-    if ((newType == undefined || elementHasLines(element))){
+    if ((newType == undefined || oldType == newType || elementHasLines(element))){
 
         oldType == newType ? 
         displayMessage("error", `

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2828,7 +2828,7 @@ function changeState()
 
     // Should only change if not same type and no lines
 
-    if ((newType !== undefined && oldType != newType && elementHasLines(element) == false)){
+    if ((newType == undefined || oldType == newType || elementHasLines(element))){
         displayMessage("error", `
             Can't change type from \"${oldType}\" to \"${newType}\" as
             different diagrams should not be able to connect to each other.`

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2838,6 +2838,14 @@ function changeState()
             Can't change type from \"${oldType}\" to \"${newType}\" as
             different diagrams should not be able to connect to each other.`
         )
+
+        if (elementHasLines(element)){
+            displayMessage("error", `
+            Can't change type from \"${oldType}\" to \"${newType}\" as
+            different diagrams should not be able to connect to each other.`
+        )
+        }
+
         return;
     }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2827,7 +2827,7 @@ function changeState()
 
     // Should only change if not same type and no lines
 
-    if ((newType == undefined && oldType != newType && elementHasLines(element))){
+    if ((newType !== undefined && oldType != newType && elementHasLines(element))){
         displayMessage("error", `
         Can't change type from \"${oldType}\" to \"${newType}\" as
         different diagrams should not be able to connect to each other.`

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1582,7 +1582,6 @@ document.addEventListener('keydown', function (e)
                     saveProperties(); 
                     propField.blur();
                 }
-                displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
             }
         }
     }
@@ -2907,6 +2906,8 @@ function changeState()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
+    generateContextProperties();
+    displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
 
 }
 
@@ -6607,7 +6608,7 @@ function generateContextProperties()
             str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
                `<span id="BGColorMenu" class="colorMenu"></span></button>`;
         }
-        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();generateContextProperties();displayMessage(messageTypes.SUCCESS, 'Successfully saved')">`;
+        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();">`;
       }
 
       // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.


### PR DESCRIPTION
It is now possible to switch types with enter and the save button with the options-pane acting accordning to the switch. 

An another note:
The type-changing is not 100% accurate and desirable yet (Because UML classes cant count lines for some reason). This makes it so that it is possible to change from UML - UML to UML - ER, between relations

Image below shows that the system seems to think there are 0 lines connected to the UML element:
![7d8560efd4160df8975b00990d27f54a](https://user-images.githubusercontent.com/102578165/236845471-aa814cef-4620-422d-a3c5-fb70dbd2be25.png)
