### PR TITLE
G1 2023 v5 #13810

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7941,7 +7941,15 @@ function drawLine(line, targetGhost = false)
         var dy = ((fy + y1Offset)-(ty + y2Offset))/2;
 
         if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT)) {
-            str += `<line id='${line.id}' class='lineColor' x1='${fx + x1Offset}' y1='${fy + y1Offset}' x2='${tx + x2Offset}' y2='${ty + y2Offset}' fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'/>`;
+            if ((fy > ty) && (line.ctype == "TB")) {
+                y1Offset = 1;
+                y2Offset = -5 + 1 / zoomfact;
+            }
+            else if ((fy < ty) && (line.ctype == "BT")) {
+                y1Offset = -5 + 1 / zoomfact;
+                y2Offset = 1;
+            }
+            str += `<line id='${line.id}' class='lineColor' x1='${fx + x1Offset * zoomfact}' y1='${fy + y1Offset * zoomfact}' x2='${tx + x2Offset * zoomfact}' y2='${ty + y2Offset * zoomfact}' fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'/>`;
         }
         else if (line.ctype == 'TB' || line.ctype == 'BT') {
             str += `<polyline id='${line.id}' class='lineColor' points='${fx + x1Offset},${fy + y1Offset} ${fx + x1Offset},${fy + y1Offset - dy} ${tx + x2Offset},${ty + y2Offset + dy} ${tx + x2Offset},${ty + y2Offset}' `;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7943,10 +7943,10 @@ function drawLine(line, targetGhost = false)
         if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT)) {
             if ((fy > ty) && (line.ctype == "TB")) {
                 y1Offset = 1;
-                y2Offset = -5 + 1 / zoomfact;
+                y2Offset = -7 + 3 / zoomfact;
             }
             else if ((fy < ty) && (line.ctype == "BT")) {
-                y1Offset = -5 + 1 / zoomfact;
+                y1Offset = -7 + 3 / zoomfact;
                 y2Offset = 1;
             }
             str += `<line id='${line.id}' class='lineColor' x1='${fx + x1Offset * zoomfact}' y1='${fy + y1Offset * zoomfact}' x2='${tx + x2Offset * zoomfact}' y2='${ty + y2Offset * zoomfact}' fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'/>`;


### PR DESCRIPTION
Fixed issue with  y-offset that is currently blocking the implementation of issue #13689

The lines now ends closer to the edge of the elements when the line type is straight

![image](https://github.com/HGustavs/LenaSYS/assets/102599161/be10a696-b23c-4097-bad4-4ea2f756a0dd)
