### PR TITLE
 Text without whitebackground remains black in darkmode #13869 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            //str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight}' fill='${element.fill}' />`;
+            //this is a silly way of changing the color for the text for actor, I couldnt think of a better one though.
             var actorFontColor;
             if (isDarkTheme()) actorFontColor = '#FFFFFF';
             else actorFontColor = '#383737';

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' stroke='${element.stroke}' fill='${element.stroke}'>${element.name}</text>`;
+            str += `<text class='textNoBG' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {
@@ -9487,7 +9487,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}' 
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
+            str += `<text class='textNoBG' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${12*zoomfact}' fill='${element.fill}' />`;
+            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9491,7 +9491,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}' 
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${linew}' y='${boxw/4}' width='${boxw - (linew * 2)}' height='${(textheight)-(linew * 2)}' fill='${element.fill}' />`;
+            str += `<rect class='text' x='${linew}' y='${boxw}' width='${boxw - (linew * 2)}' height='${(textheight)-(linew * 2)}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12112,7 +12112,7 @@ function toggleBorderOfElements() {
     
         if(cssUrl == 'blackTheme.css'){
             //iterate through all the elements that have the class 'text'.
-            /* for (let i = 0; i < allTexts.length; i++) {
+            for (let i = 0; i < allTexts.length; i++) {
                 let text = allTexts[i];
                 //assign their current stroke color to a variable.
               let strokeColor = text.getAttribute('stroke');
@@ -12123,15 +12123,11 @@ function toggleBorderOfElements() {
                     strokeColor = '#ffffff';
                     text.setAttribute('stroke', strokeColor);
                 }
-            } */
-            for (let i = 0; i < data.length; i++) {
-                data[i].stroke[0] = '#ffffff';
-                
             }
         }
         //if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
         else{
-            /* for (let i = 0; i < allTexts.length; i++) {
+            for (let i = 0; i < allTexts.length; i++) {
                 let text = allTexts[i];
                 let strokeColor = text.getAttribute('stroke');
                 let fillColor = text.getAttribute('fill');
@@ -12139,10 +12135,6 @@ function toggleBorderOfElements() {
                     strokeColor = '#383737';
                     text.setAttribute('stroke', strokeColor);
                 }
-            } */
-            for (let i = 0; i < data.length; i++) {
-                data[i].stroke[0] = '#383737';
-                
             }
         }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${linew}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight*zoomfact}' fill='${element.fill}' />`;
+            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight*zoomfact}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' stroke='${element.stroke}' fill='transparent'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' stroke='${element.stroke}' fill='transparent'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' stroke='${element.stroke}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {
@@ -9487,7 +9487,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}' 
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9472,7 +9472,10 @@ function drawElement(element, ghosted = false)
                 fill='transparent'
             />`;
             //str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight}' fill='${element.fill}' />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
+            var actorFontColor;
+            if (isDarkTheme()) actorFontColor = '#FFFFFF';
+            else actorFontColor = '#383737';
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight}' fill='${element.fill}' />`;
+            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${(element.name).length()+"em"}' height='${textheight}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9451,7 +9451,7 @@ function drawElement(element, ghosted = false)
         stroke-dasharray='${linew*3},${linew*3}'
         fill='transparent'
         />`;
-        //actor or object is determined via the radio buttons in the context menu. the default is actor.
+        //actor or object is determined via the buttons in the context menu. the default is actor.
         if (element.actorOrObject == "actor") {
             //svg for actor.
             str += `<g>`
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+            str += `<rect class='text' x='${xAnchor}' y='${boxw}'><text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text></rect>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' stroke="white" fill="black" stroke-width="0.5">${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
+            str += `<text x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' stroke="white" fill="black" stroke-width="0.5">${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${xAnchor}' y='${boxw}'><text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text></rect>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,8 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${linew}' y='${boxw/4}' width='${boxw - (linew * 2)}' height='${(textheight)-(linew * 2)}'
-            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
+            str += `<rect class='text' x='${linew}' y='${boxw/4}' width='${boxw - (linew * 2)}' height='${(textheight)-(linew * 2)}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${linew}' y='${boxw/4}' width='${boxw - (linew * 2)}' height='${boxh/5-(linew * 2)}'
+            str += `<rect class='text' x='${linew}' y='${boxw/4}' width='${boxw - (linew * 2)}' height='${(textheight)-(linew * 2)}'
             stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${(element.name).length()+"em"}' height='${textheight}' fill='${element.fill}' />`;
+            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${linew}' y='${boxw}' width='${boxw - (linew * 2)}' height='${(textheight)-(linew * 2)}' fill='${element.fill}' />`;
+            str += `<rect class='text' x='${linew}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight*zoomfact}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,9 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='textNoBG' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
+            str += `<rect class='text' x='${linew}' y='${boxw/4}' width='${boxw - (linew * 2)}' height='${boxh/5-(linew * 2)}'
+            stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {
@@ -9487,7 +9489,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}' 
             />`;
-            str += `<text class='textNoBG' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight*zoomfact}' fill='${element.fill}' />`;
+            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${12*zoomfact}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9471,7 +9471,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight}' fill='${element.fill}' />`;
+            //str += `<rect class='text' x='${xAnchor-(textWidth/2)}' y='${boxw-(textheight/2)}' width='${textWidth}' height='${textheight}' fill='${element.fill}' />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${element.stroke}'>${element.name}</text>`;
             str += `</g>`;
         }
@@ -12112,7 +12112,7 @@ function toggleBorderOfElements() {
     
         if(cssUrl == 'blackTheme.css'){
             //iterate through all the elements that have the class 'text'.
-            for (let i = 0; i < allTexts.length; i++) {
+            /* for (let i = 0; i < allTexts.length; i++) {
                 let text = allTexts[i];
                 //assign their current stroke color to a variable.
               let strokeColor = text.getAttribute('stroke');
@@ -12123,11 +12123,15 @@ function toggleBorderOfElements() {
                     strokeColor = '#ffffff';
                     text.setAttribute('stroke', strokeColor);
                 }
+            } */
+            for (let i = 0; i < data.length; i++) {
+                data[i].stroke[0] = '#ffffff';
+                
             }
         }
         //if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
         else{
-            for (let i = 0; i < allTexts.length; i++) {
+            /* for (let i = 0; i < allTexts.length; i++) {
                 let text = allTexts[i];
                 let strokeColor = text.getAttribute('stroke');
                 let fillColor = text.getAttribute('fill');
@@ -12135,6 +12139,10 @@ function toggleBorderOfElements() {
                     strokeColor = '#383737';
                     text.setAttribute('stroke', strokeColor);
                 }
+            } */
+            for (let i = 0; i < data.length; i++) {
+                data[i].stroke[0] = '#383737';
+                
             }
         }
     }


### PR DESCRIPTION
Calling isDarkMode in drawElement and using that to change just the text for actor. This is not a perfect solution but it does solve this issue. 