### PR TITLE
G3 2023 v5 issue#13821

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -363,11 +363,11 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             console.log(obj.filePath);
-            if(obj.filePath == null) {
+            if(obj.filePath.includes("Github")) {
+                str = "<span class='iconBox'><img alt='octo-pus icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab'> 🐙 </span>";
+            } else {
                 str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
                 str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
-            } else {
-                str = "<span class='iconBox'><img alt='octo-pus icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab'> 🐙 </span>";
             }
         }
     } else if (col == "filename") {

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -345,10 +345,12 @@ function renderCell(col, celldata, cellid) {
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
+        console.log(obj);
     }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            console.log(obj.fileid);
+            let correctid = str.fileid;
+            console.log(correctid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -349,7 +349,7 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             if(obj.filePath.includes("Github")) {
-                str = "<span class='iconBox'><img alt='github icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab' src='../Shared/icons/githubLink-icon.svg' ";
+                str = "<span class='iconBox'><img alt='github icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab' src='../Shared/icons/githubLink-icon.png' ";
             } else {
                 str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
                 str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -348,7 +348,7 @@ function renderCell(col, celldata, cellid) {
     }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            console.log(fileid);
+            console.log(obj.fileid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -338,20 +338,6 @@ function validateForm() {
 }
 
 //----------------------------------------------------------------------------
-// fetchFilePath <- Function to check if specific object has filePath
-//----------------------------------------------------------------------------
-function checkFilePath(fileid, data) {
-    for (let i = 0; i < data.length; i++) {
-        let obj = JSON.parse(data[i]);
-        if(obj.fileid === fileid && obj.filePath !== null) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-}
-
-//----------------------------------------------------------------------------
 // renderCell <- Callback function that renders a specific cell in the table
 //----------------------------------------------------------------------------
 function renderCell(col, celldata, cellid) {

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -348,7 +348,7 @@ function renderCell(col, celldata, cellid) {
     }
 
     if (col == "trashcan") {
-        if (obj.showtrashcan && celldata.type === null) {
+        if (obj.showtrashcan && celldata.type == null) {
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -349,6 +349,7 @@ function renderCell(col, celldata, cellid) {
     console.log(obj);
     if (col == "trashcan") {
         if (obj.showtrashcan) {
+            console.log(obj.showtrashcan.fileid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -348,7 +348,7 @@ function renderCell(col, celldata, cellid) {
     }
 
     if (col == "trashcan") {
-        if (obj.showtrashcan) {
+        if (obj.showtrashcan && obj.type !== null) {
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -348,7 +348,7 @@ function renderCell(col, celldata, cellid) {
     }
 
     if (col == "trashcan") {
-        if (obj.showtrashcan && obj.type !== null) {
+        if (obj.showtrashcan && celldata.type === null) {
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -359,21 +359,10 @@ function renderCell(col, celldata, cellid) {
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
-        console.log(obj);
     }
-            if(checkFilePath(obj.fileid, obj)) {
-                console.log("test1 true"); 
-            } else {
-                console.log("test1 false");
-            }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            if(checkFilePath(obj.fileid, obj)) {
-                console.log("test2 true"); 
-            } else {
-                console.log("test2 false");
-            }
-            //console.log(correctid);
+            console.log(obj.filePath);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -346,6 +346,7 @@ function renderCell(col, celldata, cellid) {
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
+        console.log(obj.filePath);
         if(obj.filePath == null) {
             isGithub = false;
         } else {
@@ -355,9 +356,9 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             if(isGithub == true) {
-                console.log(obj.fileName + " is a github file");
+                console.log(obj.filename + " is a github file");
             } else if (isGithub == false) {
-                console.log(obj.fileName + " is not a github file");
+                console.log(obj.filename + " is not a github file");
             }
             //console.log(correctid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -349,7 +349,7 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             if(obj.filePath.includes("Github")) {
-                str = "<span class='iconBox'> 🐙 </span>";
+                str = "<span class='iconBox'><img alt='github icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab' src='../Shared/icons/githubLink-icon.svg' ";
             } else {
                 str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
                 str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -349,7 +349,7 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             if(obj.filePath.includes("Github")) {
-                str = "<span class='iconBox'><img alt='github icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab' style='width:16px' src='../Shared/icons/githubLink-icon.png' ";
+                str = "<span class='iconBox'><img alt='github icon' tabindex='0' title='Github file' style='width:16px' src='../Shared/icons/githubLink-icon.png' ";
             } else {
                 str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
                 str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -345,7 +345,7 @@ function renderCell(col, celldata, cellid) {
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
-        if(obj.filePath === null) {
+        if(obj.filePath == null) {
             console.log("hej");
         } else {
             console.log("nej");

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -351,6 +351,7 @@ function renderCell(col, celldata, cellid) {
         if (obj.showtrashcan) {
             console.log(celldata);
             console.log(obj.filePath);
+            console.log(obj);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -345,12 +345,16 @@ function renderCell(col, celldata, cellid) {
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
-        console.log(obj);
+        if(obj.filePath === null) {
+            console.log("hej");
+        } else {
+            console.log("nej");
+        }
     }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             let correctid = str.fileid;
-            console.log(correctid);
+            //console.log(correctid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -364,7 +364,7 @@ function renderCell(col, celldata, cellid) {
         if (obj.showtrashcan) {
             console.log(obj.filePath);
             if(obj.filePath.includes("Github")) {
-                str = "<span class='iconBox'><img alt='octo-pus icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab'> 🐙 </span>";
+                str = "<span class='iconBox'> 🐙 </span>";
             } else {
                 str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
                 str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -349,7 +349,7 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             if(obj.filePath.includes("Github")) {
-                str = "<span class='iconBox'><img alt='github icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab' src='../Shared/icons/githubLink-icon.png' ";
+                str = "<span class='iconBox'><img alt='github icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab' style='width:16px' src='../Shared/icons/githubLink-icon.png' ";
             } else {
                 str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
                 str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -338,6 +338,20 @@ function validateForm() {
 }
 
 //----------------------------------------------------------------------------
+// fetchFilePath <- Function to check if specific object has filePath
+//----------------------------------------------------------------------------
+function checkFilePath(fileid, data) {
+    for (let i = 0; i < data.length; i++) {
+        let obj = JSON.parse(data[i]);
+        if(obj.fileid === fileid && obj.filePath !== null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+
+//----------------------------------------------------------------------------
 // renderCell <- Callback function that renders a specific cell in the table
 //----------------------------------------------------------------------------
 function renderCell(col, celldata, cellid) {
@@ -345,20 +359,14 @@ function renderCell(col, celldata, cellid) {
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
-        console.log(obj.filePath);
-        console.log(obj);
-        if(obj.filePath == null) {
-            isGithub = false;
-        } else {
-            isGithub = true;
-        }
+
     }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            if(isGithub == true) {
-                console.log(obj.filename + " is a github file");
-            } else if (isGithub == false) {
-                console.log(obj.filename + " is not a github file");
+            if(checkFilePath(obj.fileid, obj)) {
+                console.log("true"); 
+            } else {
+                console.log("false");
             }
             //console.log(correctid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -384,21 +384,17 @@ function renderCell(col, celldata, cellid) {
     } else if (col == "extension" || col == "uploaddate") {
         str += "<span>" + celldata + "</span>";
     } else if (col == "editor") {
-        if(obj.showeditor){
-            if(obj.filePath.includes("Github")) {
-                str = "";
-            } else {
-                str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
-                str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
+        if (obj.showeditor) {
+            if (!obj.filePath.includes("Github")) {
+                if (obj.extension == "md" || obj.extension == "txt" || obj.extension == "html") {
+                    str = "<span class='iconBox' ><img alt='edit file icon' tabindex='0' id='dorf'  title='Edit file' class='markdownIcon markdownIconeditFile' src='../Shared/icons/markdownPen.svg' ";
+                    str += "onclick='loadPreview(\"" + obj.filePath + "\", \"" + obj.filename + "\", " + obj.kind + ")'></span>";
+                } else if (obj.extension == "js" || obj.extension == "css" || obj.extension == "php") {
+                    str = "<span class='iconBox'><img alt='edit file icon' id='dorf'  title='Edit file'  class='markdownIcon' src='../Shared/icons/markdownPen.svg' ";
+                    str += "onclick='loadFile(\"" + obj.filePath + "\", \"" + obj.filename + "\", " + obj.kind + ")'></span>";
+                }
             }
-        if (obj.extension == "md" || obj.extension == "txt" || obj.extension == "html") {
-            str = "<span class='iconBox' ><img alt='edit file icon' tabindex='0' id='dorf'  title='Edit file' class='markdownIcon markdownIconeditFile' src='../Shared/icons/markdownPen.svg' ";
-            str += "onclick='loadPreview(\"" + obj.filePath + "\", \"" + obj.filename + "\", " + obj.kind + ")'></span>";
-        } else if (obj.extension == "js"  || obj.extension == "css" || obj.extension == "php") {
-            str = "<span class='iconBox'><img alt='edit file icon' id='dorf'  title='Edit file'  class='markdownIcon' src='../Shared/icons/markdownPen.svg' ";
-            str += "onclick='loadFile(\"" + obj.filePath + "\", \"" + obj.filename + "\", " + obj.kind + ")'></span>";
         }
-    }
     } else if (col == "kind") {
         str += "<span>" + convertFileKind(celldata) + "</span>";
     } else if (col == "type") {

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -346,6 +346,7 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
         console.log(obj.filePath);
+        console.log(obj);
         if(obj.filePath == null) {
             isGithub = false;
         } else {

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -346,12 +346,11 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
     }
-
+    console.log(celldata);
+    console.log(obj.filePath);
+    console.log(obj);
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            console.log(celldata);
-            console.log(obj.filePath);
-            console.log(obj);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -348,7 +348,9 @@ function renderCell(col, celldata, cellid) {
     }
 
     if (col == "trashcan") {
-        if (obj.showtrashcan && celldata.type == null) {
+        if (obj.showtrashcan) {
+            console.log(celldata);
+            console.log(obj.filePath);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -362,7 +362,6 @@ function renderCell(col, celldata, cellid) {
     }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            console.log(obj.filePath);
             if(obj.filePath.includes("Github")) {
                 str = "<span class='iconBox'> 🐙 </span>";
             } else {
@@ -386,6 +385,12 @@ function renderCell(col, celldata, cellid) {
         str += "<span>" + celldata + "</span>";
     } else if (col == "editor") {
         if(obj.showeditor){
+            if(obj.filePath.includes("Github")) {
+                str = "";
+            } else {
+                str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
+                str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
+            }
         if (obj.extension == "md" || obj.extension == "txt" || obj.extension == "html") {
             str = "<span class='iconBox' ><img alt='edit file icon' tabindex='0' id='dorf'  title='Edit file' class='markdownIcon markdownIconeditFile' src='../Shared/icons/markdownPen.svg' ";
             str += "onclick='loadPreview(\"" + obj.filePath + "\", \"" + obj.filename + "\", " + obj.kind + ")'></span>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -346,10 +346,9 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
     }
-    console.log(obj);
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            console.log(obj.showtrashcan.fileid);
+            console.log(fileid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -349,7 +349,7 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             if(obj.filePath.includes("Github")) {
-                str = "<span class='iconBox'><img alt='github icon' tabindex='0' title='Github file' style='width:16px' src='../Shared/icons/githubLink-icon.png' ";
+                str = "<span class='iconBox'><img alt='github icon' tabindex='0' id='dorf' title='Github file' style='width:16px' src='../Shared/icons/githubLink-icon.png' ";
             } else {
                 str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
                 str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -359,11 +359,11 @@ function renderCell(col, celldata, cellid) {
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
-
+        console.log(obj);
     }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            if(checkFilePath(obj.fileid, obj)) {
+            if(checkFilePath(obj.fileid, data)) {
                 console.log("true"); 
             } else {
                 console.log("false");

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -363,8 +363,12 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan") {
         if (obj.showtrashcan) {
             console.log(obj.filePath);
-            str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
-            str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
+            if(obj.filePath == null) {
+                str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
+                str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
+            } else {
+                str = "<span class='iconBox'><img alt='octo-pus icon' tabindex='0' id='dorf' title='Github file' class='trashcanIcon trashcanTab'> 🐙 </span>";
+            }
         }
     } else if (col == "filename") {
         if (obj.kind == "Link") {

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -346,8 +346,6 @@ function renderCell(col, celldata, cellid) {
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
     }
-    console.log(celldata);
-    console.log(obj.filePath);
     console.log(obj);
     if (col == "trashcan") {
         if (obj.showtrashcan) {

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -361,12 +361,17 @@ function renderCell(col, celldata, cellid) {
         obj = JSON.parse(celldata);
         console.log(obj);
     }
+            if(checkFilePath(obj.fileid, obj)) {
+                console.log("test1 true"); 
+            } else {
+                console.log("test1 false");
+            }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            if(checkFilePath(obj.fileid, data)) {
-                console.log("true"); 
+            if(checkFilePath(obj.fileid, obj)) {
+                console.log("test2 true"); 
             } else {
-                console.log("false");
+                console.log("test2 false");
             }
             //console.log(correctid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -342,7 +342,6 @@ function validateForm() {
 //----------------------------------------------------------------------------
 function renderCell(col, celldata, cellid) {
     var str = "";
-    let isGithub = false;
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -342,18 +342,23 @@ function validateForm() {
 //----------------------------------------------------------------------------
 function renderCell(col, celldata, cellid) {
     var str = "";
+    let isGithub = false;
 
     if (col == "trashcan" || col == "filename" || col == "filesize" || col == "editor") {
         obj = JSON.parse(celldata);
         if(obj.filePath == null) {
-            console.log("hej");
+            isGithub = false;
         } else {
-            console.log("nej");
+            isGithub = true;
         }
     }
     if (col == "trashcan") {
         if (obj.showtrashcan) {
-            let correctid = str.fileid;
+            if(isGithub == true) {
+                console.log(obj.fileName + " is a github file");
+            } else if (isGithub == false) {
+                console.log(obj.fileName + " is not a github file");
+            }
             //console.log(correctid);
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -348,7 +348,7 @@ function renderCell(col, celldata, cellid) {
     }
 
     if (col == "trashcan") {
-        if (obj.showtrashcan && obj.type !== null) {
+        if (obj.showtrashcan) {
             str = "<span class='iconBox'><img alt='delete file icon' tabindex='0' id='dorf' title='Delete file' class='trashcanIcon trashcanTab' src='../Shared/icons/Trashcan.svg' ";
             str += " onclick='deleteFile(\"" + obj.fileid + "\",\"" + obj.filename + "\",\"" + obj.filekind + "\");' ></span>";
         }

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -288,7 +288,7 @@ if (checklogin() && $hasAccess) {
             'filesize' => json_encode(['size' => $row['filesize'], 'kind' => $filekindname]),
             'type' => $path,
             'uploaddate' => $row['uploaddate'],
-            'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor]),
+            'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor, 'filePath' => $filePath]),
             'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan, 'filePath' => $filePath]),
         );
 

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -289,7 +289,7 @@ if (checklogin() && $hasAccess) {
             'type' => $path,
             'uploaddate' => $row['uploaddate'],
             'editor' => json_encode(['filePath' => $filePath, 'kind' => $filekind, 'filename' => $filename, 'extension' => $extension, 'showeditor' => $showEditor]),
-            'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan])
+            'trashcan' => json_encode(['fileid' => $row['fileid'], 'filename' => $row['filename'], 'filekind' => $filekind, 'showtrashcan' => $showTrashcan, 'filePath' => $filePath]),
         );
 
         


### PR DESCRIPTION
Fixed the previous issue that @a21hugni couldn't solve, what i did was essentially feed the filePath into the json object for both "trashcan" and "editor" objects as well and used the filePath to determine if the path correctly contained the word "Github", hence marking it as a file originating from Github. If it is a github file i simply emptied the column containing the pen to edit and replaced the trashcan with an octopus-emoji as requested. 

Edit: Changed octopus-emoji to github-icon, as i found it's already saved on the webserver. Was unsure about the rights regarding the icon, but if it's already in use i assume somebody smarter and wiser than me made the decision that it's okay.

![Screenshot 2023-05-09 180429](https://github.com/HGustavs/LenaSYS/assets/102578849/0445b647-5073-429f-8bf5-25f7a6c8a9d4)

Relevant files: DuggaSys/fileed.js & DuggaSys/fileedservice.php