### PR TITLE
 UML Super State darkmode issue #13905 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4308,8 +4308,6 @@ function toggleDarkmode()
         stylesheet.href = "../Shared/css/blackTheme.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
     }
-    
-    //toggleStrokeColorAllOfElements();
     showdata();
 }
 
@@ -12249,7 +12247,6 @@ function toggleStrokeColorAllOfElements() {
                     strokeColor = '#ffffff';
                     data[i].stroke[0] = strokeColor;
                 }
-                
             }
         }
         //else, if the theme isnt darkmode and the fill isn't gray, make the stroke gray.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,7 +12243,7 @@ function toggleStrokeColorAllOfElements() {
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == "#383737" && ((fillColor !=  "#ffffff") || (fillColor !=  "#FFFFFF"))) {
+                if (strokeColor == "#383737" && fillColor !=  "#ffffff") {
                     strokeColor = "#ffffff";
                     data[i].stroke[0] = strokeColor;
                 }
@@ -12254,7 +12254,7 @@ function toggleStrokeColorAllOfElements() {
             for (let i = 0; i < data.length; i++) {
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
-                if (((strokeColor ==  "#ffffff") || (strokeColor ==  "#FFFFFF")) && fillColor != "#383737") {
+                if (strokeColor == "#ffffff" && fillColor != "#383737") {
                     strokeColor = "#383737";
                     data[i].stroke[0] = strokeColor;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12237,7 +12237,21 @@ function toggleStrokeColorAllOfElements() {
       let cssUrl = localStorage.getItem('diagramTheme');
         //this turns, for example, '.../Shared/css/style.css' into just 'style.css'
         cssUrl = cssUrl.split("/").pop();
+    
         if(cssUrl == 'blackTheme.css'){
+            //iterate through all the elements that have the class 'text'.
+            /* for (let i = 0; i < allTexts.length; i++) {
+                let text = allTexts[i];
+                //assign their current stroke color to a variable.
+              let strokeColor = text.getAttribute('stroke');
+                let fillColor = text.getAttribute('fill');
+                //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
+                //this is because we dont want to affect the strokes that are null or other colors and have a contrasting border.
+                if (strokeColor == '#383737' && fillColor != '#ffffff') {
+                    strokeColor = '#ffffff';
+                    text.setAttribute('stroke', strokeColor);
+                }
+            } */
             //iterate through data
             for (let i = 0; i < data.length; i++) {
                 //assign their current stroke and fill color to variables.
@@ -12263,6 +12277,18 @@ function toggleStrokeColorAllOfElements() {
                 }
             }
         }
+        /* else{
+            for (let i = 0; i < allTexts.length; i++) {
+                let text = allTexts[i];
+                let strokeColor = text.getAttribute('stroke');
+                let fillColor = text.getAttribute('fill');
+                if (strokeColor == '#ffffff' && fillColor != '#383737') {
+                    strokeColor = '#383737';
+                    text.setAttribute('stroke', strokeColor);
+                }
+            }
+        } */
+        //showdata();
     }
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,7 +12243,7 @@ function toggleStrokeColorAllOfElements() {
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == "#383737" && fillColor !=  "#ffffff") {
+                if (strokeColor == "#383737" && ((fillColor !=  "#ffffff") || (fillColor !=  "#FFFFFF"))) {
                     strokeColor = "#ffffff";
                     data[i].stroke[0] = strokeColor;
                 }
@@ -12254,7 +12254,7 @@ function toggleStrokeColorAllOfElements() {
             for (let i = 0; i < data.length; i++) {
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
-                if (strokeColor == "#ffffff" && fillColor != "#383737") {
+                if (((strokeColor ==  "#ffffff") || (strokeColor ==  "#FFFFFF")) && fillColor != "#383737") {
                     strokeColor = "#383737";
                     data[i].stroke[0] = strokeColor;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12227,12 +12227,9 @@ function updateCSSForAllElements()
  * @description toggles the stroke color of all elements to white or gray; depending on current theme and fill.
  */
 function toggleStrokeColorAllOfElements() {
-    //get all elements with the class text. This inludes the text in the elements but also the non text svg that surrounds the text and just has a stroke.
-    //For the future, these svg elements should probably be given a class of their own and then this function should be updated.
-   let allTexts = document.getElementsByClassName('text');
     if (localStorage.getItem('diagramTheme') != null) {
         //in localStorage, diagramTheme holds a URL to the CSS file currently used. Like, style.css or blackTheme.css
-      let cssUrl = localStorage.getItem('diagramTheme');
+        let cssUrl = localStorage.getItem('diagramTheme');
         //this turns, for example, '.../Shared/css/style.css' into just 'style.css'
         cssUrl = cssUrl.split("/").pop();
         if(cssUrl == 'blackTheme.css'){
@@ -12244,7 +12241,7 @@ function toggleStrokeColorAllOfElements() {
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
                 if (strokeColor == "#383737") {
-                    if (fillColor ==  "#ffffff" || fillColor ==  "#FFFFFF") {
+                    if (fillColor !=  "#ffffff" || fillColor !=  "#FFFFFF") {
                         strokeColor = "#ffffff";
                         data[i].stroke[0] = strokeColor;
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12238,11 +12238,14 @@ function toggleStrokeColorAllOfElements() {
             //iterate through data
             for (let i = 0; i < data.length; i++) {
                 //assign their current stroke and fill color to variables.
+                let strokeColor = data[i].stroke[0];
+                let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 or black and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (data[i].stroke[0] == "#383737") {
-                    if (data[i].fill !=  "#ffffff" && data[i].fill !=  "#FFFFFF") {
-                        data[i].stroke[0] = "#ffffff";
+                if (strokeColor == "#383737") {
+                    if (fillColor !=  "#ffffff" && fillColor !=  "#FFFFFF") {
+                        strokeColor = "#ffffff";
+                        data[i].stroke[0] = strokeColor;
                     }
                 }
             }
@@ -12250,8 +12253,10 @@ function toggleStrokeColorAllOfElements() {
         //else, if the theme isnt darkmode and the stroke is white, make the stroke gray.
         else{
             for (let i = 0; i < data.length; i++) {
-                if (data[i].stroke[0] ==  "#ffffff" || data[i].stroke[0] ==  "#FFFFFF") {
-                    data[i].stroke[0] = "#383737";
+                let strokeColor = data[i].stroke[0];
+                if (strokeColor ==  "#ffffff" || strokeColor ==  "#FFFFFF") {
+                    strokeColor = "#383737";
+                    data[i].stroke[0] = strokeColor;
                 }
             }
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4308,12 +4308,9 @@ function toggleDarkmode()
         stylesheet.href = "../Shared/css/blackTheme.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
     }
-
-    showdata();
-
-    //toggleBorderOfElements();
+    
     toggleStrokeColorAllOfElements();
-
+    showdata();
 }
 
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,8 +12243,8 @@ function toggleStrokeColorAllOfElements() {
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == '#383737' && fillColor != '#ffffff') {
-                    strokeColor = '#ffffff';
+                if (strokeColor == "#383737" && fillColor !=  "#ffffff") {
+                    strokeColor = "#ffffff";
                     data[i].stroke[0] = strokeColor;
                 }
             }
@@ -12254,8 +12254,8 @@ function toggleStrokeColorAllOfElements() {
             for (let i = 0; i < data.length; i++) {
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
-                if (strokeColor == '#ffffff' && fillColor != '#383737') {
-                    strokeColor = '#383737';
+                if (strokeColor == "#ffffff" && fillColor != "#383737") {
+                    strokeColor = "#383737";
                     data[i].stroke[0] = strokeColor;
                 }
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4312,7 +4312,6 @@ function toggleDarkmode()
     showdata();
 
     //toggleBorderOfElements();
-    toggleStrokeColorAllOfElements();
 
 }
 
@@ -12291,7 +12290,6 @@ function toggleStrokeColorAllOfElements() {
                 }
             }
         } */
-        showdata();
     }
 }
 /**
@@ -12351,6 +12349,8 @@ function showdata()
     }
     container.innerHTML = str;
     updatepos(null, null);
+
+    toggleStrokeColorAllOfElements();
 }
 
 //#region ================================ Camera Functions     ================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,7 +12243,7 @@ function toggleBorderOfElements() {
     
         if(cssUrl == 'blackTheme.css'){
             //iterate through all the elements that have the class 'text'.
-            /* for (let i = 0; i < allTexts.length; i++) {
+            for (let i = 0; i < allTexts.length; i++) {
                 let text = allTexts[i];
                 //assign their current stroke color to a variable.
               let strokeColor = text.getAttribute('stroke');
@@ -12254,31 +12254,10 @@ function toggleBorderOfElements() {
                     strokeColor = '#ffffff';
                     text.setAttribute('stroke', strokeColor);
                 }
-            } */
-            //iterate through data
-            for (let i = 0; i < data.length; i++) {
-                //assign their current stroke and fill color to a variable.
-                let strokeColor = data[i].stroke[0];
-                let fillColor = data[i].fill;
-                if (strokeColor == '#383737' && fillColor != '#ffffff') {
-                    strokeColor = '#ffffff';
-                    data[i].stroke[0] = strokeColor;
-                }
-                
             }
         }
         //if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
         else{
-            for (let i = 0; i < data.length; i++) {
-                let strokeColor = data[i].stroke[0];
-                let fillColor = data[i].fill;
-                if (strokeColor == '#ffffff' && fillColor != '#383737') {
-                    strokeColor = '#383737';
-                    data[i].stroke[0] = strokeColor;
-                }
-            }
-        }
-        /* else{
             for (let i = 0; i < allTexts.length; i++) {
                 let text = allTexts[i];
                 let strokeColor = text.getAttribute('stroke');
@@ -12288,7 +12267,7 @@ function toggleBorderOfElements() {
                     text.setAttribute('stroke', strokeColor);
                 }
             }
-        } */
+        }
     }
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12226,6 +12226,7 @@ function updateCSSForAllElements()
         //If more than one element is marked.
         return inContext && context.length > 1 || inContext && context.length > 0 && contextLine.length > 0;
     }
+    toggleBorderOfElements();
 }
 /**
  * @description toggles the border of all elements to white or gray; depending on current theme and fill.
@@ -12256,11 +12257,9 @@ function toggleBorderOfElements() {
             } */
             //iterate through data
             for (let i = 0; i < data.length; i++) {
-                //assign their current stroke and fill color to variables.
+                //assign their current stroke and fill color to a variable.
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
-                //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
-                //this is because we dont want to affect the strokes that are null or other colors and have a contrasting border.
                 if (strokeColor == '#383737' && fillColor != '#ffffff') {
                     strokeColor = '#ffffff';
                     data[i].stroke[0] = strokeColor;
@@ -12268,7 +12267,7 @@ function toggleBorderOfElements() {
                 
             }
         }
-        //else, if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
+        //if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
         else{
             for (let i = 0; i < data.length; i++) {
                 let strokeColor = data[i].stroke[0];
@@ -12350,7 +12349,6 @@ function showdata()
     container.innerHTML = str;
     updatepos(null, null);
 
-    toggleBorderOfElements();
 }
 
 //#region ================================ Camera Functions     ================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4309,7 +4309,7 @@ function toggleDarkmode()
         localStorage.setItem('diagramTheme',stylesheet.href)
     }
     
-    toggleStrokeColorAllOfElements();
+    //toggleStrokeColorAllOfElements();
     showdata();
 }
 
@@ -12288,7 +12288,7 @@ function toggleStrokeColorAllOfElements() {
                 }
             }
         } */
-        showdata();
+        //showdata();
     }
 }
 /**
@@ -12330,6 +12330,7 @@ function isDarkTheme(){
  */
 function showdata()
 {
+    toggleStrokeColorAllOfElements();
     updateContainerBounds();
 
     var str = "";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12258,7 +12258,7 @@ function toggleStrokeColorAllOfElements() {
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
-                //this is because we dont want to affect the strokes that are null or other colors and have a contrasting border.
+                //this is because we dont want the border to be white on a white element, this would be hard to see.
                 if (strokeColor == '#383737' && fillColor != '#ffffff') {
                     strokeColor = '#ffffff';
                     data[i].stroke[0] = strokeColor;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9056,6 +9056,12 @@ function drawElement(element, ghosted = false)
     canvas.height = window.innerHeight;
     canvasContext = canvas.getContext('2d');
     
+    //since toggleStrokeColorAllOfElements checks the fill color to make sure we dont end up with white stroke on white fill, which is bad for IE and UML etc,
+    //we have to have another variable for those strokes that are irrlevant of the elements fill, like sequence actor or state superstate.
+    var nonFilledElementStrokeColor;
+    if (isDarkTheme()) nonFilledElementStrokeColor = '#FFFFFF';
+    else nonFilledElementStrokeColor = '#383737';
+
     // Caclulate font width using some canvas magic
     var font = canvasContext.font;
     font = `${texth}px ${font.split('px')[1]}`;
@@ -9256,7 +9262,7 @@ function drawElement(element, ghosted = false)
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>
                     <svg width="100%" height="100%">
-                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${element.stroke}' stroke-width='${linew}' rx="20"/>
+                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${nonFilledElementStrokeColor}' stroke-width='${linew}' rx="20"/>
                     <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill='${element.fill}' fill-opacity="1" stroke='${element.stroke}' stroke-width='${linew}' />
                         <text x='${80 * zoomfact}px' y='${40 * zoomfact}px' dominant-baseline='middle' text-anchor='${vAlignment}' font-size="${20 * zoomfact}px">${element.name}</text>
                     </svg>
@@ -9581,11 +9587,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            //this is a silly way of changing the color for the text for actor, I couldnt think of a better one though.
-            var actorFontColor;
-            if (isDarkTheme()) actorFontColor = '#FFFFFF';
-            else actorFontColor = '#383737';
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementStrokeColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12290,7 +12290,6 @@ function toggleStrokeColorAllOfElements() {
                 }
             }
         } */
-        showdata();
     }
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12258,7 +12258,7 @@ function toggleStrokeColorAllOfElements() {
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
-                //this is because we dont want the border to be white on a white element, this would be hard to see.
+                //this is because we dont want to affect the strokes that are null or other colors and have a contrasting border.
                 if (strokeColor == '#383737' && fillColor != '#ffffff') {
                     strokeColor = '#ffffff';
                     data[i].stroke[0] = strokeColor;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9051,6 +9051,12 @@ function drawElement(element, ghosted = false)
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
     canvasContext = canvas.getContext('2d');
+
+    //since toggleStrokeColorAllOfElements checks the fill color to make sure we dont end up with white stroke on white fill, which is bad for IE and UML etc,
+    //we have to have another variable for those strokes that are irrlevant of the elements fill, like sequence actor or state superstate.
+    var nonFilledElementStrokeColor;
+            if (isDarkTheme()) nonFilledElementStrokeColor = '#FFFFFF';
+            else nonFilledElementStrokeColor = '#383737';
     
     // Caclulate font width using some canvas magic
     var font = canvasContext.font;
@@ -9252,7 +9258,7 @@ function drawElement(element, ghosted = false)
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>
                     <svg width="100%" height="100%">
-                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${element.stroke}' stroke-width='${linew}' rx="20"/>
+                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${nonFilledElementStrokeColor}' stroke-width='${linew}' rx="20"/>
                     <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill='${element.fill}' fill-opacity="1" stroke='${element.stroke}' stroke-width='${linew}' />
                         <text x='${80 * zoomfact}px' y='${40 * zoomfact}px' dominant-baseline='middle' text-anchor='${vAlignment}' font-size="${20 * zoomfact}px">${element.name}</text>
                     </svg>
@@ -9577,11 +9583,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            //this is a silly way of changing the color for the text for actor, I couldnt think of a better one though.
-            var actorFontColor;
-            if (isDarkTheme()) actorFontColor = '#FFFFFF';
-            else actorFontColor = '#383737';
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementStrokeColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12238,14 +12238,11 @@ function toggleStrokeColorAllOfElements() {
             //iterate through data
             for (let i = 0; i < data.length; i++) {
                 //assign their current stroke and fill color to variables.
-                let strokeColor = data[i].stroke[0];
-                let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 or black and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == "#383737") {
-                    if (fillColor !=  "#ffffff" && fillColor !=  "#FFFFFF") {
-                        strokeColor = "#ffffff";
-                        data[i].stroke[0] = strokeColor;
+                if (data[i].stroke[0] == "#383737") {
+                    if (data[i].fill !=  "#ffffff" && data[i].fill !=  "#FFFFFF") {
+                        data[i].stroke[0] = "#ffffff";
                     }
                 }
             }
@@ -12253,10 +12250,8 @@ function toggleStrokeColorAllOfElements() {
         //else, if the theme isnt darkmode and the stroke is white, make the stroke gray.
         else{
             for (let i = 0; i < data.length; i++) {
-                let strokeColor = data[i].stroke[0];
-                if (strokeColor ==  "#ffffff" || strokeColor ==  "#FFFFFF") {
-                    strokeColor = "#383737";
-                    data[i].stroke[0] = strokeColor;
+                if (data[i].stroke[0] ==  "#ffffff" || data[i].stroke[0] ==  "#FFFFFF") {
+                    data[i].stroke[0] = "#383737";
                 }
             }
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1135,7 +1135,7 @@ var defaults = {
 
     UMLEntity: {name: "Class", kind: "UMLEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "UML", attributes: ['-Attribute'], functions: ['+Function'] },     //<-- UML functionality
     UMLRelation: {name: "Inheritance", kind: "UMLRelation", fill: "#ffffff", stroke: "#000000", width: 60, height: 60, type: "UML" }, //<-- UML functionality
-    IEEntity: {name: "IEEntity", kind: "IEEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "IE", attributes: ['-Attribute'], functions: ['+function'] },     //<-- IE functionality
+    IEEntity: {name: "IEEntity", kind: "IEEntity", fill: "#ffffff", width: 200, height: 50, type: "IE", attributes: ['-Attribute'], functions: ['+function'] },     //<-- IE functionality
     IERelation: {name: "Inheritance", kind: "IERelation", fill: "#ffffff", stroke: "#000000", width: 50, height: 50, type: "IE" }, //<-- IE inheritence functionality
     SDEntity: { name: "State", kind: "SDEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "SD", attributes: ['do: func'], functions: ['+function'] }, //<-- SD functionality
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,17 +12243,18 @@ function toggleStrokeColorAllOfElements() {
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == "#383737" && (fillColor !=  "#ffffff" || fillColor !=  "#FFFFFF")) {
+                if (strokeColor == "#383737" && ((fillColor !=  "#ffffff") || (fillColor !=  "#FFFFFF"))) {
                     strokeColor = "#ffffff";
                     data[i].stroke[0] = strokeColor;
                 }
             }
         }
-        //else, if the theme isnt darkmode and the stroke is white, make the stroke gray.
+        //else, if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
         else{
             for (let i = 0; i < data.length; i++) {
                 let strokeColor = data[i].stroke[0];
-                if (strokeColor ==  "#ffffff" || strokeColor ==  "#FFFFFF") {
+                let fillColor = data[i].fill;
+                if (((strokeColor ==  "#ffffff") || (strokeColor ==  "#FFFFFF")) && fillColor != "#383737") {
                     strokeColor = "#383737";
                     data[i].stroke[0] = strokeColor;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,8 +12243,8 @@ function toggleStrokeColorAllOfElements() {
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == "#383737" && fillColor !=  "#ffffff") {
-                    strokeColor = "#ffffff";
+                if (strokeColor == '#383737' && fillColor != '#ffffff') {
+                    strokeColor = '#ffffff';
                     data[i].stroke[0] = strokeColor;
                 }
             }
@@ -12254,8 +12254,8 @@ function toggleStrokeColorAllOfElements() {
             for (let i = 0; i < data.length; i++) {
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
-                if (strokeColor == "#ffffff" && fillColor != "#383737") {
-                    strokeColor = "#383737";
+                if (strokeColor == '#ffffff' && fillColor != '#383737') {
+                    strokeColor = '#383737';
                     data[i].stroke[0] = strokeColor;
                 }
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12238,10 +12238,10 @@ function toggleStrokeColorAllOfElements() {
                 //assign their current stroke and fill color to variables.
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
-                //if the element has a stroke which has the color #383737 or black and its fill isn't white: set it to white.
+                //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
                 if (strokeColor == "#383737") {
-                    if (fillColor !=  "#ffffff" && fillColor !=  "#FFFFFF") {
+                    if (fillColor !=  "#ffffff" || fillColor !=  "#FFFFFF") {
                         strokeColor = "#ffffff";
                         data[i].stroke[0] = strokeColor;
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4308,6 +4308,8 @@ function toggleDarkmode()
         stylesheet.href = "../Shared/css/blackTheme.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
     }
+    
+    //toggleStrokeColorAllOfElements();
     showdata();
 }
 
@@ -12247,6 +12249,7 @@ function toggleStrokeColorAllOfElements() {
                     strokeColor = '#ffffff';
                     data[i].stroke[0] = strokeColor;
                 }
+                
             }
         }
         //else, if the theme isnt darkmode and the fill isn't gray, make the stroke gray.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12237,21 +12237,7 @@ function toggleStrokeColorAllOfElements() {
       let cssUrl = localStorage.getItem('diagramTheme');
         //this turns, for example, '.../Shared/css/style.css' into just 'style.css'
         cssUrl = cssUrl.split("/").pop();
-    
         if(cssUrl == 'blackTheme.css'){
-            //iterate through all the elements that have the class 'text'.
-            /* for (let i = 0; i < allTexts.length; i++) {
-                let text = allTexts[i];
-                //assign their current stroke color to a variable.
-              let strokeColor = text.getAttribute('stroke');
-                let fillColor = text.getAttribute('fill');
-                //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
-                //this is because we dont want to affect the strokes that are null or other colors and have a contrasting border.
-                if (strokeColor == '#383737' && fillColor != '#ffffff') {
-                    strokeColor = '#ffffff';
-                    text.setAttribute('stroke', strokeColor);
-                }
-            } */
             //iterate through data
             for (let i = 0; i < data.length; i++) {
                 //assign their current stroke and fill color to variables.
@@ -12277,18 +12263,6 @@ function toggleStrokeColorAllOfElements() {
                 }
             }
         }
-        /* else{
-            for (let i = 0; i < allTexts.length; i++) {
-                let text = allTexts[i];
-                let strokeColor = text.getAttribute('stroke');
-                let fillColor = text.getAttribute('fill');
-                if (strokeColor == '#ffffff' && fillColor != '#383737') {
-                    strokeColor = '#383737';
-                    text.setAttribute('stroke', strokeColor);
-                }
-            }
-        } */
-        //showdata();
     }
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9257,7 +9257,7 @@ function drawElement(element, ghosted = false)
                      onmouseleave='mouseLeave();'>
                     <svg width="100%" height="100%">
                     <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${element.stroke}' stroke-width='${linew}' rx="20"/>
-                    <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill="#FFF" fill-opacity="1" stroke='${element.stroke}' stroke-width='${linew}' />
+                    <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill='${element.fill}' fill-opacity="1" stroke='${element.stroke}' stroke-width='${linew}' />
                         <text x='${80 * zoomfact}px' y='${40 * zoomfact}px' dominant-baseline='middle' text-anchor='${vAlignment}' font-size="${20 * zoomfact}px">${element.name}</text>
                     </svg>
                 </div>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,7 +12243,7 @@ function toggleBorderOfElements() {
     
         if(cssUrl == 'blackTheme.css'){
             //iterate through all the elements that have the class 'text'.
-            for (let i = 0; i < allTexts.length; i++) {
+            /* for (let i = 0; i < allTexts.length; i++) {
                 let text = allTexts[i];
                 //assign their current stroke color to a variable.
               let strokeColor = text.getAttribute('stroke');
@@ -12254,10 +12254,31 @@ function toggleBorderOfElements() {
                     strokeColor = '#ffffff';
                     text.setAttribute('stroke', strokeColor);
                 }
+            } */
+            //iterate through data
+            for (let i = 0; i < data.length; i++) {
+                //assign their current stroke and fill color to a variable.
+                let strokeColor = data[i].stroke[0];
+                let fillColor = data[i].fill;
+                if (strokeColor == '#383737' && fillColor != '#ffffff') {
+                    strokeColor = '#ffffff';
+                    data[i].stroke[0] = strokeColor;
+                }
+                
             }
         }
         //if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
         else{
+            for (let i = 0; i < data.length; i++) {
+                let strokeColor = data[i].stroke[0];
+                let fillColor = data[i].fill;
+                if (strokeColor == '#ffffff' && fillColor != '#383737') {
+                    strokeColor = '#383737';
+                    data[i].stroke[0] = strokeColor;
+                }
+            }
+        }
+        /* else{
             for (let i = 0; i < allTexts.length; i++) {
                 let text = allTexts[i];
                 let strokeColor = text.getAttribute('stroke');
@@ -12267,7 +12288,7 @@ function toggleBorderOfElements() {
                     text.setAttribute('stroke', strokeColor);
                 }
             }
-        }
+        } */
     }
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4311,7 +4311,7 @@ function toggleDarkmode()
 
     showdata();
 
-    //toggleBorderOfElements();
+    toggleBorderOfElements();
 
 }
 
@@ -12228,9 +12228,9 @@ function updateCSSForAllElements()
     }
 }
 /**
- * @description toggles the stroke color of all elements to white or gray; depending on current theme and fill.
+ * @description toggles the border of all elements to white or gray; depending on current theme and fill.
  */
-function toggleStrokeColorAllOfElements() {
+function toggleBorderOfElements() {
     //get all elements with the class text. This inludes the text in the elements but also the non text svg that surrounds the text and just has a stroke.
     //For the future, these svg elements should probably be given a class of their own and then this function should be updated.
    let allTexts = document.getElementsByClassName('text');
@@ -12350,7 +12350,7 @@ function showdata()
     container.innerHTML = str;
     updatepos(null, null);
 
-    toggleStrokeColorAllOfElements();
+    toggleBorderOfElements();
 }
 
 //#region ================================ Camera Functions     ================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,11 +12243,9 @@ function toggleStrokeColorAllOfElements() {
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == "#383737") {
-                    if (fillColor ==  "#ffffff" || fillColor ==  "#FFFFFF") {
-                        strokeColor = "#ffffff";
-                        data[i].stroke[0] = strokeColor;
-                    }
+                if (strokeColor == "#383737" && (fillColor !=  "#ffffff" || fillColor !=  "#FFFFFF")) {
+                    strokeColor = "#ffffff";
+                    data[i].stroke[0] = strokeColor;
                 }
             }
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9051,12 +9051,6 @@ function drawElement(element, ghosted = false)
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
     canvasContext = canvas.getContext('2d');
-
-    //since toggleStrokeColorAllOfElements checks the fill color to make sure we dont end up with white stroke on white fill, which is bad for IE and UML etc,
-    //we have to have another variable for those strokes that are irrlevant of the elements fill, like sequence actor or state superstate.
-    var nonFilledElementStrokeColor;
-            if (isDarkTheme()) nonFilledElementStrokeColor = '#FFFFFF';
-            else nonFilledElementStrokeColor = '#383737';
     
     // Caclulate font width using some canvas magic
     var font = canvasContext.font;
@@ -9258,7 +9252,7 @@ function drawElement(element, ghosted = false)
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>
                     <svg width="100%" height="100%">
-                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${nonFilledElementStrokeColor}' stroke-width='${linew}' rx="20"/>
+                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${element.stroke}' stroke-width='${linew}' rx="20"/>
                     <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill='${element.fill}' fill-opacity="1" stroke='${element.stroke}' stroke-width='${linew}' />
                         <text x='${80 * zoomfact}px' y='${40 * zoomfact}px' dominant-baseline='middle' text-anchor='${vAlignment}' font-size="${20 * zoomfact}px">${element.name}</text>
                     </svg>
@@ -9583,7 +9577,11 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementStrokeColor}'>${element.name}</text>`;
+            //this is a silly way of changing the color for the text for actor, I couldnt think of a better one though.
+            var actorFontColor;
+            if (isDarkTheme()) actorFontColor = '#FFFFFF';
+            else actorFontColor = '#383737';
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12238,10 +12238,10 @@ function toggleStrokeColorAllOfElements() {
                 //assign their current stroke and fill color to variables.
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
-                //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
+                //if the element has a stroke which has the color #383737 or black and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
                 if (strokeColor == "#383737") {
-                    if (fillColor !=  "#ffffff" || fillColor !=  "#FFFFFF") {
+                    if (fillColor !=  "#ffffff" && fillColor !=  "#FFFFFF") {
                         strokeColor = "#ffffff";
                         data[i].stroke[0] = strokeColor;
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4311,7 +4311,7 @@ function toggleDarkmode()
 
     showdata();
 
-    toggleBorderOfElements();
+    //toggleBorderOfElements();
 
 }
 
@@ -12228,9 +12228,9 @@ function updateCSSForAllElements()
     }
 }
 /**
- * @description toggles the border of all elements to white or gray; depending on current theme and fill.
+ * @description toggles the stroke color of all elements to white or gray; depending on current theme and fill.
  */
-function toggleBorderOfElements() {
+function toggleStrokeColorAllOfElements() {
     //get all elements with the class text. This inludes the text in the elements but also the non text svg that surrounds the text and just has a stroke.
     //For the future, these svg elements should probably be given a class of their own and then this function should be updated.
    let allTexts = document.getElementsByClassName('text');
@@ -12350,7 +12350,7 @@ function showdata()
     container.innerHTML = str;
     updatepos(null, null);
 
-    toggleBorderOfElements();
+    toggleStrokeColorAllOfElements();
 }
 
 //#region ================================ Camera Functions     ================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9621,7 +9621,7 @@ function drawElement(element, ghosted = false)
         str += `'>`;
         str += `<svg width='${boxw}' height='${boxh}'>`;
         //svg for the activation rect
-        str += `<rect rx='${sequenceCornerRadius}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}'" />`;
+        str += `<rect rx="12" style="height: 100%; width: 100%; fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)" />`;
         str += `</svg>`;  
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,18 +12243,17 @@ function toggleStrokeColorAllOfElements() {
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == "#383737" && ((fillColor !=  "#ffffff") || (fillColor !=  "#FFFFFF"))) {
+                if (strokeColor == "#383737" && (fillColor !=  "#ffffff" || fillColor !=  "#FFFFFF")) {
                     strokeColor = "#ffffff";
                     data[i].stroke[0] = strokeColor;
                 }
             }
         }
-        //else, if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
+        //else, if the theme isnt darkmode and the stroke is white, make the stroke gray.
         else{
             for (let i = 0; i < data.length; i++) {
                 let strokeColor = data[i].stroke[0];
-                let fillColor = data[i].fill;
-                if (((strokeColor ==  "#ffffff") || (strokeColor ==  "#FFFFFF")) && fillColor != "#383737") {
+                if (strokeColor ==  "#ffffff" || strokeColor ==  "#FFFFFF") {
                     strokeColor = "#383737";
                     data[i].stroke[0] = strokeColor;
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12227,9 +12227,12 @@ function updateCSSForAllElements()
  * @description toggles the stroke color of all elements to white or gray; depending on current theme and fill.
  */
 function toggleStrokeColorAllOfElements() {
+    //get all elements with the class text. This inludes the text in the elements but also the non text svg that surrounds the text and just has a stroke.
+    //For the future, these svg elements should probably be given a class of their own and then this function should be updated.
+   let allTexts = document.getElementsByClassName('text');
     if (localStorage.getItem('diagramTheme') != null) {
         //in localStorage, diagramTheme holds a URL to the CSS file currently used. Like, style.css or blackTheme.css
-        let cssUrl = localStorage.getItem('diagramTheme');
+      let cssUrl = localStorage.getItem('diagramTheme');
         //this turns, for example, '.../Shared/css/style.css' into just 'style.css'
         cssUrl = cssUrl.split("/").pop();
         if(cssUrl == 'blackTheme.css'){
@@ -12241,7 +12244,7 @@ function toggleStrokeColorAllOfElements() {
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
                 if (strokeColor == "#383737") {
-                    if (fillColor !=  "#ffffff" || fillColor !=  "#FFFFFF") {
+                    if (fillColor ==  "#ffffff" || fillColor ==  "#FFFFFF") {
                         strokeColor = "#ffffff";
                         data[i].stroke[0] = strokeColor;
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9256,8 +9256,8 @@ function drawElement(element, ghosted = false)
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>
                     <svg width="100%" height="100%">
-                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke="#000" stroke-width="2" rx="20"/>
-                    <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill="#FFF" fill-opacity="1" stroke="#000" stroke-width="2" />   
+                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${element.stroke}' stroke-width='${linew}' rx="20"/>
+                    <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill="#FFF" fill-opacity="1" stroke='${element.stroke}' stroke-width='${linew}' />
                         <text x='${80 * zoomfact}px' y='${40 * zoomfact}px' dominant-baseline='middle' text-anchor='${vAlignment}' font-size="${20 * zoomfact}px">${element.name}</text>
                     </svg>
                 </div>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9621,7 +9621,7 @@ function drawElement(element, ghosted = false)
         str += `'>`;
         str += `<svg width='${boxw}' height='${boxh}'>`;
         //svg for the activation rect
-        str += `<rect rx="12" style="height: 100%; width: 100%; fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)" />`;
+        str += `<rect rx='${sequenceCornerRadius}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}'" />`;
         str += `</svg>`;  
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12290,6 +12290,7 @@ function toggleStrokeColorAllOfElements() {
                 }
             }
         } */
+        showdata();
     }
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12226,7 +12226,6 @@ function updateCSSForAllElements()
         //If more than one element is marked.
         return inContext && context.length > 1 || inContext && context.length > 0 && contextLine.length > 0;
     }
-    toggleBorderOfElements();
 }
 /**
  * @description toggles the border of all elements to white or gray; depending on current theme and fill.
@@ -12257,9 +12256,11 @@ function toggleBorderOfElements() {
             } */
             //iterate through data
             for (let i = 0; i < data.length; i++) {
-                //assign their current stroke and fill color to a variable.
+                //assign their current stroke and fill color to variables.
                 let strokeColor = data[i].stroke[0];
                 let fillColor = data[i].fill;
+                //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
+                //this is because we dont want to affect the strokes that are null or other colors and have a contrasting border.
                 if (strokeColor == '#383737' && fillColor != '#ffffff') {
                     strokeColor = '#ffffff';
                     data[i].stroke[0] = strokeColor;
@@ -12267,7 +12268,7 @@ function toggleBorderOfElements() {
                 
             }
         }
-        //if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
+        //else, if the theme isnt darkmode and the fill isn't gray, make the stroke gray.
         else{
             for (let i = 0; i < data.length; i++) {
                 let strokeColor = data[i].stroke[0];
@@ -12349,6 +12350,7 @@ function showdata()
     container.innerHTML = str;
     updatepos(null, null);
 
+    toggleBorderOfElements();
 }
 
 //#region ================================ Camera Functions     ================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1135,7 +1135,7 @@ var defaults = {
 
     UMLEntity: {name: "Class", kind: "UMLEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "UML", attributes: ['-Attribute'], functions: ['+Function'] },     //<-- UML functionality
     UMLRelation: {name: "Inheritance", kind: "UMLRelation", fill: "#ffffff", stroke: "#000000", width: 60, height: 60, type: "UML" }, //<-- UML functionality
-    IEEntity: {name: "IEEntity", kind: "IEEntity", fill: "#ffffff", width: 200, height: 50, type: "IE", attributes: ['-Attribute'], functions: ['+function'] },     //<-- IE functionality
+    IEEntity: {name: "IEEntity", kind: "IEEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "IE", attributes: ['-Attribute'], functions: ['+function'] },     //<-- IE functionality
     IERelation: {name: "Inheritance", kind: "IERelation", fill: "#ffffff", stroke: "#000000", width: 50, height: 50, type: "IE" }, //<-- IE inheritence functionality
     SDEntity: { name: "State", kind: "SDEntity", fill: "#ffffff", stroke: "#000000", width: 200, height: 50, type: "SD", attributes: ['do: func'], functions: ['+function'] }, //<-- SD functionality
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4308,9 +4308,12 @@ function toggleDarkmode()
         stylesheet.href = "../Shared/css/blackTheme.css";
         localStorage.setItem('diagramTheme',stylesheet.href)
     }
-    
-    toggleStrokeColorAllOfElements();
+
     showdata();
+
+    //toggleBorderOfElements();
+    toggleStrokeColorAllOfElements();
+
 }
 
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4309,7 +4309,7 @@ function toggleDarkmode()
         localStorage.setItem('diagramTheme',stylesheet.href)
     }
     
-    //toggleStrokeColorAllOfElements();
+    toggleStrokeColorAllOfElements();
     showdata();
 }
 
@@ -12288,7 +12288,7 @@ function toggleStrokeColorAllOfElements() {
                 }
             }
         } */
-        //showdata();
+        showdata();
     }
 }
 /**
@@ -12330,7 +12330,6 @@ function isDarkTheme(){
  */
 function showdata()
 {
-    toggleStrokeColorAllOfElements();
     updateContainerBounds();
 
     var str = "";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9058,9 +9058,9 @@ function drawElement(element, ghosted = false)
     
     //since toggleBorderOfElements checks the fill color to make sure we dont end up with white stroke on white fill, which is bad for IE and UML etc,
     //we have to have another variable for those strokes that are irrlevant of the elements fill, like sequence actor or state superstate.
-    var nonFilledElementStrokeColor;
-    if (isDarkTheme()) nonFilledElementStrokeColor = '#FFFFFF';
-    else nonFilledElementStrokeColor = '#383737';
+    var nonFilledElementPartStrokeColor;
+    if (isDarkTheme()) nonFilledElementPartStrokeColor = '#FFFFFF';
+    else nonFilledElementPartStrokeColor = '#383737';
 
     // Caclulate font width using some canvas magic
     var font = canvasContext.font;
@@ -9262,7 +9262,7 @@ function drawElement(element, ghosted = false)
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>
                     <svg width="100%" height="100%">
-                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${nonFilledElementStrokeColor}' stroke-width='${linew}' rx="20"/>
+                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${nonFilledElementPartStrokeColor}' stroke-width='${linew}' rx="20"/>
                     <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill='${element.fill}' fill-opacity="1" stroke='${element.stroke}' stroke-width='${linew}' />
                         <text x='${80 * zoomfact}px' y='${40 * zoomfact}px' dominant-baseline='middle' text-anchor='${vAlignment}' font-size="${20 * zoomfact}px">${element.name}</text>
                     </svg>
@@ -9587,7 +9587,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementStrokeColor}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4312,6 +4312,7 @@ function toggleDarkmode()
     showdata();
 
     //toggleBorderOfElements();
+    toggleStrokeColorAllOfElements();
 
 }
 
@@ -12290,6 +12291,7 @@ function toggleStrokeColorAllOfElements() {
                 }
             }
         } */
+        showdata();
     }
 }
 /**
@@ -12349,8 +12351,6 @@ function showdata()
     }
     container.innerHTML = str;
     updatepos(null, null);
-
-    toggleStrokeColorAllOfElements();
 }
 
 //#region ================================ Camera Functions     ================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9056,7 +9056,7 @@ function drawElement(element, ghosted = false)
     canvas.height = window.innerHeight;
     canvasContext = canvas.getContext('2d');
     
-    //since toggleStrokeColorAllOfElements checks the fill color to make sure we dont end up with white stroke on white fill, which is bad for IE and UML etc,
+    //since toggleBorderOfElements checks the fill color to make sure we dont end up with white stroke on white fill, which is bad for IE and UML etc,
     //we have to have another variable for those strokes that are irrlevant of the elements fill, like sequence actor or state superstate.
     var nonFilledElementStrokeColor;
     if (isDarkTheme()) nonFilledElementStrokeColor = '#FFFFFF';

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12243,9 +12243,11 @@ function toggleStrokeColorAllOfElements() {
                 let fillColor = data[i].fill;
                 //if the element has a stroke which has the color #383737 and its fill isn't white: set it to white.
                 //this is because we dont want the border to be white on a white element, this would be hard to see.
-                if (strokeColor == "#383737" && (fillColor !=  "#ffffff" || fillColor !=  "#FFFFFF")) {
-                    strokeColor = "#ffffff";
-                    data[i].stroke[0] = strokeColor;
+                if (strokeColor == "#383737") {
+                    if (fillColor ==  "#ffffff" || fillColor ==  "#FFFFFF") {
+                        strokeColor = "#ffffff";
+                        data[i].stroke[0] = strokeColor;
+                    }
                 }
             }
         }


### PR DESCRIPTION
created a variable for holding the stroke color for special cases like super state outer border and sequence actor body called nonFilledElementPartStrokeColor. Then implemented that into actor and super state as the stroke color for the parts that do not have a fill. and the actor text.