### PR TITLE
Centered the cursor for ghost elements

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw /2))}px;
+                            margin-top:${((boxw * -0.125))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9390,7 +9390,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /2.2))}px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /1.5))}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9251,7 +9251,7 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="margin-top:${((boxh * -1.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="margin-top:${((boxh * -0.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 5))}px;;
+                            margin-top:${((boxw / 6))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9251,7 +9251,7 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="margin-top:${((boxh * -0.125))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="margin-top:${((boxh * 0.125))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9251,7 +9251,7 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="margin-top:${((boxh / 2))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9251,7 +9251,7 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="margin-top:${((boxh / 2))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="margin-top:${((boxh / 1.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9651,7 +9651,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxh / 1.75))}px;;
+                            margin-top:${((boxh / 2.5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9140,7 +9140,7 @@ function drawElement(element, ghosted = false)
         str += `</div>`;
         
         //div to encapuslate UML content
-        //str += `<div class='uml-content' style='margin-top: -0.5em;'>`;
+        str += `<div class='uml-content' style='margin-top: -0.5em;'>`;
         //Draw UML-content if there exist at least one attribute
         if (elemAttri != 0) {
             //svg for background
@@ -9298,7 +9298,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxw * -0.025))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.25))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9298,7 +9298,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh /2))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh /4))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 3))}px;
+                            margin-top:${((boxw / 4))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9390,7 +9390,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /1.5))}px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /3))}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9504,7 +9504,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'IERelation') {
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element ie-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; margin-top:${((boxw/3))}px; width:${boxw}px;height:${boxh/2}px;`;
+        style='left:0px; top:0px; margin-top:${((boxw/1.5))}px; width:${boxw}px;height:${boxh/2}px;`;
        
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9390,7 +9390,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:5px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /2))}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw * -0.125))}px;
+                            margin-top:${((boxw / -0.125))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9251,7 +9251,7 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="margin-top:${((boxh / 1.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="margin-top:${((boxh * 1.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9651,7 +9651,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxh / 2))}px;;
+                            margin-top:${((boxh / 1.75))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 6))}px;;
+                            margin-top:${((boxw / 7))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,6 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
+                            margin-top:${((boxw * -2))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9117,7 +9117,7 @@ function drawElement(element, ghosted = false)
         
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.125))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxw * -0.125))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -9298,7 +9298,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.025))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxw * -0.025))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 7.5))}px;;
+                            margin-top:${((boxw / 7.2))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;
@@ -9642,7 +9642,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 2))}px;;
+                            margin-top:${((boxw / 1.25))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;
@@ -9651,7 +9651,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 2))}px;;
+                            margin-top:${((boxw / 1.75))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 1.5))}px;;
+                            margin-top:${((boxw / 5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,12 +9633,21 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw * 7.5))}px;;
+                            margin-top:${((boxw / 7.5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;
         }
-        else {
+        else if (element.kind == "ERAttr") {
+            str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
+                            left:0px;
+                            top:0px;
+                            margin-top:${((boxw / 2))}px;;
+                            width:${boxw}px;
+                            height:${boxh}px;
+                            font-size:${texth}px;`;
+        }
+        else if (element.kind == "ERRelation") {
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9117,7 +9117,7 @@ function drawElement(element, ghosted = false)
         
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -1.5))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.5))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9251,7 +9251,7 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="margin-top:${((boxh * 0.125))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="margin-top:${((boxh * 0.025))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 0.125))}px;
+                            margin-top:${((boxw / 1.125))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9451,7 +9451,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxw * -0.025))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.15))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9251,7 +9251,7 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="margin-top:${((boxh * 1.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="margin-top:${((boxh * -1.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9140,7 +9140,7 @@ function drawElement(element, ghosted = false)
         str += `</div>`;
         
         //div to encapuslate UML content
-        str += `<div class='uml-content' style='margin-top: -0.5em;'>`;
+        //str += `<div class='uml-content' style='margin-top: -0.5em;'>`;
         //Draw UML-content if there exist at least one attribute
         if (elemAttri != 0) {
             //svg for background

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9390,7 +9390,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /2))}px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /2.5))}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:5px;
+                            margin-top:${((boxw / 1.5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9117,7 +9117,7 @@ function drawElement(element, ghosted = false)
         
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh / 2))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -2))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9642,7 +9642,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 2.5))}px;;
+                            margin-top:${((boxh / 2))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9251,7 +9251,7 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="margin-top:${((boxh * -0.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="margin-top:${((boxh * -0.125))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 1.125))}px;
+                            margin-top:${((boxw * 1.125))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 4))}px;
+                            margin-top:-25px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9117,7 +9117,7 @@ function drawElement(element, ghosted = false)
         
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxw * -0.125))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh /2))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -9298,7 +9298,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxw * -0.025))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh /2))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9117,7 +9117,7 @@ function drawElement(element, ghosted = false)
         
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * 2))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh / 2))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw * -2))}px;
+                            margin-top:${((boxw /2))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9199,7 +9199,7 @@ function drawElement(element, ghosted = false)
         const theme = document.getElementById("themeBlack");
         str += `<div id="${element.id}" 
                      class="element uml-state"
-                     style="margin-top:${((boxh / 1.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}" 
+                     style="margin-top:${((boxh / 2))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}" 
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9390,7 +9390,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxh /2))}px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxh /3))}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9504,7 +9504,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'IERelation') {
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element ie-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; margin-top:${((boxw/2))}px; width:${boxw}px;height:${boxh/2}px;`;
+        style='left:0px; top:0px; margin-top:${((boxw/3))}px; width:${boxw}px;height:${boxh/2}px;`;
        
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9298,7 +9298,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.2))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.15))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9390,7 +9390,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /2.5))}px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /2.2))}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9225,7 +9225,7 @@ function drawElement(element, ghosted = false)
         const theme = document.getElementById("themeBlack");
         str += `<div id="${element.id}" 
                      class="element uml-state"
-                     style="width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                     style="margin-top:${((boxh / 2.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9199,7 +9199,7 @@ function drawElement(element, ghosted = false)
         const theme = document.getElementById("themeBlack");
         str += `<div id="${element.id}" 
                      class="element uml-state"
-                     style="margin-top:${((boxh / 2))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}" 
+                     style="margin-top:${((boxh / 2.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}" 
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9504,7 +9504,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'IERelation') {
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element ie-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; margin-top:${((boxh/2))}px; width:${boxw}px;height:${boxh/2}px;`;
+        style='left:0px; top:0px; margin-top:${((boxh/3))}px; width:${boxw}px;height:${boxh/2}px;`;
        
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9199,7 +9199,7 @@ function drawElement(element, ghosted = false)
         const theme = document.getElementById("themeBlack");
         str += `<div id="${element.id}" 
                      class="element uml-state"
-                     style="width:${boxw}px;height:${boxh}px;${ghostAttr}" 
+                     style="margin-top:${((boxh / 1.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}" 
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:-25px;
+                            margin-top:5px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9504,7 +9504,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'IERelation') {
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element ie-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; margin-top:${((boxh/3))}px; width:${boxw}px;height:${boxh/2}px;`;
+        style='left:0px; top:0px; margin-top:${((boxh/1.5))}px; width:${boxw}px;height:${boxh/2}px;`;
        
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9390,7 +9390,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxw /3))}px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxh /2))}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9117,7 +9117,7 @@ function drawElement(element, ghosted = false)
         
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -2))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -1.5))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw * 1.125))}px;
+                            margin-top:${((boxw / 3))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9629,14 +9629,24 @@ function drawElement(element, ghosted = false)
     //ER element
     else {
         // Create div & svg element
-       /* str += `
-                    <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
+        if (element.kind == "EREntity") {
+            str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
                             margin-top:${((boxw / 7.5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
-                            font-size:${texth}px;`;*/
+                            font-size:${texth}px;`;
+        }
+        else {
+            str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
+                            left:0px;
+                            top:0px;
+                            margin-top:${((boxw / 2))}px;;
+                            width:${boxw}px;
+                            height:${boxh}px;
+                            font-size:${texth}px;`;
+        }
         if(context.includes(element)){
             str += `z-index: 1;`;
         }
@@ -9650,14 +9660,7 @@ function drawElement(element, ghosted = false)
         str += `<svg width='${boxw}' height='${boxh}' >`;
         // Create svg 
         if (element.kind == "EREntity") {
-            str += `
-                    <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
-                            left:0px;
-                            top:0px;
-                            margin-top:${((boxw / 7.5))}px;;
-                            width:${boxw}px;
-                            height:${boxh}px;
-                            font-size:${texth}px;`;
+
             var weak = "";
 
             if(element.state == "weak") {
@@ -9714,15 +9717,7 @@ function drawElement(element, ghosted = false)
             }
             
         }
-        else if (element.kind == "ERRelation") {
-            str += `
-                    <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
-                            left:0px;
-                            top:0px;
-                            margin-top:${((boxw / 2))}px;;
-                            width:${boxw}px;
-                            height:${boxh}px;
-                            font-size:${texth}px;`;
+        else if (element.kind == "ERRelation") {         
 
             var numOfLetters = element.name.length;
             if (tooBig) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9117,7 +9117,7 @@ function drawElement(element, ghosted = false)
         
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxw * -0.125))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * 2))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -9651,7 +9651,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxh / 2.5))}px;;
+                            margin-top:${((boxh / 2.75))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9298,7 +9298,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.25))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.2))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9629,14 +9629,14 @@ function drawElement(element, ghosted = false)
     //ER element
     else {
         // Create div & svg element
-        str += `
+       /* str += `
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
                             margin-top:${((boxw / 7.5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
-                            font-size:${texth}px;`;
+                            font-size:${texth}px;`;*/
         if(context.includes(element)){
             str += `z-index: 1;`;
         }
@@ -9650,6 +9650,14 @@ function drawElement(element, ghosted = false)
         str += `<svg width='${boxw}' height='${boxh}' >`;
         // Create svg 
         if (element.kind == "EREntity") {
+            str += `
+                    <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
+                            left:0px;
+                            top:0px;
+                            margin-top:${((boxw / 7.5))}px;;
+                            width:${boxw}px;
+                            height:${boxh}px;
+                            font-size:${texth}px;`;
             var weak = "";
 
             if(element.state == "weak") {
@@ -9707,6 +9715,14 @@ function drawElement(element, ghosted = false)
             
         }
         else if (element.kind == "ERRelation") {
+            str += `
+                    <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
+                            left:0px;
+                            top:0px;
+                            margin-top:${((boxw / 2))}px;;
+                            width:${boxw}px;
+                            height:${boxh}px;
+                            font-size:${texth}px;`;
 
             var numOfLetters = element.name.length;
             if (tooBig) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / -0.125))}px;
+                            margin-top:${((boxw / 0.125))}px;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9504,7 +9504,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'IERelation') {
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element ie-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; margin-top:${((boxw/1.5))}px; width:${boxw}px;height:${boxh/2}px;`;
+        style='left:0px; top:0px; margin-top:${((boxh/2))}px; width:${boxw}px;height:${boxh/2}px;`;
        
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9117,7 +9117,7 @@ function drawElement(element, ghosted = false)
         
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh /2))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.125))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -9298,7 +9298,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh /4))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.025))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9642,7 +9642,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 1.25))}px;;
+                            margin-top:${((boxw / 2.5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9451,7 +9451,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxw * -0.025))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
                     <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 7))}px;;
+                            margin-top:${((boxw / 7.5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 7.2))}px;;
+                            margin-top:${((boxh / 2))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;
@@ -9651,7 +9651,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 1.75))}px;;
+                            margin-top:${((boxh / 2))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9633,7 +9633,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxw / 7.5))}px;;
+                            margin-top:${((boxw * 7.5))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9298,7 +9298,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxw * -0.125))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxw * -0.025))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;


### PR DESCRIPTION
Centered the cursor close to the middle of each ghost element except the current sequance element. IE entity ghost appears doesnt have an utline while its a ghost and should be taken care of in another issue.

I also removed "avgcharwidth" which was a dead variable with no current use after getting permission.