### PR TITLE
G3 2023 v6 issue#13890

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -49,7 +49,7 @@ function updateCourse()
 			localStorage.setItem('courseid', courseid);
 			localStorage.setItem('updateCourseName', true);
 			alert("Course " + coursename + " updated with new GitHub-link!"); 
-			fetchLatestCommit(courseGitURL);
+			updateGithubRepo(courseGitURL, cid);
 		}
 		//Else: get error message from the fetchGitHubRepo function.
 
@@ -162,6 +162,37 @@ function fetchLatestCommit(gitHubURL)
 		url: "../DuggaSys/gitcommitService.php",
 		type: "POST",
 		data: {'githubURL':gitHubURL, 'action':'getCourseID'},
+		success: function() { 
+			//Returns true if the data and JSON is correct
+			dataCheck = true;
+		},
+		error: function(data){
+			//Check FetchGithubRepo for the meaning of the error code.
+			switch(data.status){
+				case 422:
+					alert(data.responseJSON.message + "\nDid not create/update course");
+					break;
+				case 503:
+					alert(data.responseJSON.message + "\nDid not create/update course");
+					break;
+				default:
+					alert("Something went wrong...");
+			}
+		 	dataCheck = false;
+		}
+	});
+	return dataCheck;
+}
+
+//Send new Github URL and course id to PHP-script which gets and saves the latest commit in the sqllite db
+function updateGithubRepo(githubURL, cid) {
+	//Used to return success(true) or error(false) to the calling function
+	var dataCheck;
+	$.ajax({
+		async: false,
+		url: "../DuggaSys/gitcommitService.php",
+		type: "POST",
+		data: {'githubURL':githubURL, 'cid':cid, 'action':'updateGithubRepo'},
 		success: function() { 
 			//Returns true if the data and JSON is correct
 			dataCheck = true;

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -145,7 +145,7 @@
 	function updateGithubRepo($repoURL, $cid) {
 		clearGitFiles($cid); // Clear the files before changing git repo
 		
-		$lastCommit = getCommit($url); // Get the latest commit from the new URL
+		$lastCommit = getCommit($repoURL); // Get the latest commit from the new URL
 	
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 		$query = $pdolite->prepare("UPDATE gitRepos SET repoURL = :repoURL, lastCommit = :lastCommit WHERE cid = :cid"); 
@@ -160,7 +160,7 @@
 			print_r($error);
 			echo $errorvar;
 		} else {
-			bfs($url, $cid, "REFRESH");
+			bfs($repoURL, $cid, "REFRESH");
 		}
 	}
 


### PR DESCRIPTION
We have added functionality so that the SQLite database updates when the github repo URL is changed for a course (cogwheel on course page). This includes deleting all of the files connected to a course in the gitFiles table, then updating the course row with the new URL and commit. 

![image](https://github.com/HGustavs/LenaSYS/assets/102578746/67828264-a4ca-4f76-bbf3-3bdadc71693d)

To test this, create a course with a url. 
Open the sqlite database and look at both the gitRepos and gitFiles tables. 
Go to the course page and change the link to a new one. 
Go back to the SQLite db; now both gitRepos (URL and commit) and gitFiles (all new files) should have changed. 

co-author @g21emmka 