### PR TITLE
Add functionality for all entities to elementHasLines #13865

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -7613,17 +7613,17 @@ function determineLine(line, targetGhost = false)
 
     // Add accordingly to association end
     if (line.ctype == "LR"){
-        if (felem.kind == "EREntity") felem.left.push(line.id);
-        if (telem.kind == "EREntity") telem.right.push(line.id);
+        felem.left.push(line.id);
+        telem.right.push(line.id);
     }else if (line.ctype == "RL"){
-        if (felem.kind == "EREntity") felem.right.push(line.id);
-        if (telem.kind == "EREntity") telem.left.push(line.id);
+        felem.right.push(line.id);
+        telem.left.push(line.id);
     }else if (line.ctype == "TB"){
-        if (felem.kind == "EREntity") felem.top.push(line.id);
-        if (telem.kind == "EREntity") telem.bottom.push(line.id);
+        felem.top.push(line.id);
+        telem.bottom.push(line.id);
     }else if (line.ctype == "BT"){
-        if (felem.kind == "EREntity") felem.bottom.push(line.id);
-        if (telem.kind == "EREntity") telem.top.push(line.id);
+        felem.bottom.push(line.id);
+        telem.top.push(line.id);
     }
 
     if (felem.neighbours[telem.id] == undefined) {


### PR DESCRIPTION
### What is changed:

Removed condition that made it so that only ER-elements count their lines and add them to their respective array.

### For tester:

Control this by writing `getElementLines(context[0])` after selecting an element *OR* try switching between types while lines are connected.

