### PR TITLE
G3 2023 v6 issue#13943

### DIFF
--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -144,8 +144,8 @@
 				$query->execute();
 
 				// Update metadata
-				bfs($url, $cid, "REFRESH");
-				print "The course has been updated!";
+				bfs($url, $cid, "DOWNLOAD");
+				print "The course has been updated, files have been downloaded!";
 			} else {
 				print "The course is already up to date!";
 			}

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -53,18 +53,10 @@
 			// TODO: Limit this to only one result
 		}
 
-		// Get the latest commit from the URL
-		// $latestCommit = getCommit($githubURL);
-
 		// Check if not null, else add it to Sqlite db
-		// && $latestCommit != ""
 		if($cid != null) {
 			insertIntoSQLite($githubURL, $cid);
-			//, $latestCommit
-		} //else if ($latestCommit == "") {
-			//print_r("Latest commit not valid");
-		//} 
-		else {
+		} else {
 			print_r("No matches in database!");
 		}
 	}
@@ -73,12 +65,11 @@
 	// insertIntoSQLite: Insert into Sqlite db when new course is created
 	//--------------------------------------------------------------------------------------------------
 
-	function insertIntoSQLite($url, $cid) { //, $commit
+	function insertIntoSQLite($url, $cid) { 
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid, repoURL) VALUES (:cid, :repoURL)"); // , lastCommit , :commits
+		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid, repoURL) VALUES (:cid, :repoURL)"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoURL', $url);
-		//$query->bindParam(':commits', $commit);
 		$query->execute();
 		if (!$query->execute()) {
 			$error = $query->errorInfo();
@@ -114,24 +105,7 @@
 		//If both values are valid
 		if($commit == "" && $url == "") {
 			print_r("Error! Couldn't get url and commit from SQLite db");
-		} 
-		// else if($url != "" && $commit == NULL) {
-		// 	// Get the latest commit from the URL
-		// 	$latestCommit = getCommit($url);
-
-		// 	// Compare old commit in db with the new one from the url
-		// 	if($latestCommit != $commit) {
-		// 		// Update the SQLite db with the new commit
-		// 		$query = $pdolite->prepare('UPDATE gitRepos SET lastCommit = :latestCommit WHERE cid = :cid');
-		// 		$query->bindParam(':cid', $cid);
-		// 		$query->bindParam(':latestCommit', $latestCommit);
-		// 		$query->execute();
-
-		// 		// Update metadata
-		// 		bfs($url, $cid, "REFRESH");
-		// 		print "The course has been updated!";
-		// 	}
-		else {
+		} else {
 			// Get the latest commit from the URL
 			$latestCommit = getCommit($url);
 
@@ -143,7 +117,7 @@
 				$query->bindParam(':latestCommit', $latestCommit);
 				$query->execute();
 
-				// Update metadata
+				// Download files and metadata
 				bfs($url, $cid, "DOWNLOAD");
 				print "The course has been updated, files have been downloaded!";
 			} else {

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -54,14 +54,17 @@
 		}
 
 		// Get the latest commit from the URL
-		$latestCommit = getCommit($githubURL);
+		// $latestCommit = getCommit($githubURL);
 
 		// Check if not null, else add it to Sqlite db
-		if($cid != null && $latestCommit != "") {
-			insertIntoSQLite($githubURL, $cid, $latestCommit);
-		} else if ($latestCommit == "") {
-			print_r("Latest commit not valid");
-		} else {
+		// && $latestCommit != ""
+		if($cid != null) {
+			insertIntoSQLite($githubURL, $cid);
+			//, $latestCommit
+		} //else if ($latestCommit == "") {
+			//print_r("Latest commit not valid");
+		//} 
+		else {
 			print_r("No matches in database!");
 		}
 	}
@@ -70,12 +73,12 @@
 	// insertIntoSQLite: Insert into Sqlite db when new course is created
 	//--------------------------------------------------------------------------------------------------
 
-	function insertIntoSQLite($url, $cid, $commit) {
+	function insertIntoSQLite($url, $cid) { //, $commit
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid, repoURL, lastCommit) VALUES (:cid, :repoURL, :commits)"); 
+		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid, repoURL) VALUES (:cid, :repoURL)"); // , lastCommit , :commits
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoURL', $url);
-		$query->bindParam(':commits', $commit);
+		//$query->bindParam(':commits', $commit);
 		$query->execute();
 		if (!$query->execute()) {
 			$error = $query->errorInfo();
@@ -109,9 +112,26 @@
 		}
 
 		//If both values are valid
-		if($commit == "" || $url == "") {
+		if($commit == "" && $url == "") {
 			print_r("Error! Couldn't get url and commit from SQLite db");
-		} else {
+		} 
+		// else if($url != "" && $commit == NULL) {
+		// 	// Get the latest commit from the URL
+		// 	$latestCommit = getCommit($url);
+
+		// 	// Compare old commit in db with the new one from the url
+		// 	if($latestCommit != $commit) {
+		// 		// Update the SQLite db with the new commit
+		// 		$query = $pdolite->prepare('UPDATE gitRepos SET lastCommit = :latestCommit WHERE cid = :cid');
+		// 		$query->bindParam(':cid', $cid);
+		// 		$query->bindParam(':latestCommit', $latestCommit);
+		// 		$query->execute();
+
+		// 		// Update metadata
+		// 		bfs($url, $cid, "REFRESH");
+		// 		print "The course has been updated!";
+		// 	}
+		else {
 			// Get the latest commit from the URL
 			$latestCommit = getCommit($url);
 


### PR DESCRIPTION
No longer saving the commit when creating a course. It now saves the commit when pressing the refresh button and instead of just refreshing the metadata it also downloads the files. 

Test this by creating a new course with a github url. 
Check the courses folder to see if you can find a folder with the course id. There should be nothing there.
Open the SQLite database and check the gitRepos table to see that no commit has been saved for the course.
Go into the course you've created and press the refresh button.
Go back into the courses folder. Now there should be a folder with the course id as name, containing the files from the repo you used.
Also check the SQLite database. It should have the latest commit saved for the course. 

co-author @c21rebja 