### PR TITLE
G3 2023 v6 issue#13904 Index file now filters code examples

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -125,11 +125,12 @@ function fetchGitHubRepo(gitHubURL)
 	regexURL = gitHubURL.replace(/.git$/, "");
 	//Used to return success(true) or error(false) to the calling function
 	var dataCheck;
+	//console.log("Inside fetchGithubRepo with Url: " + regexURL);
 	$.ajax({
 		async: false,
 		url: "../recursivetesting/FetchGithubRepo.php",
 		type: "POST",
-		data: {'githubURL':regexURL, 'action':'getNewCourseGitHub'},
+		data: {'url':regexURL, 'action':'getIndexFile'},
 		success: function() { 
 			//Returns true if the data and JSON is correct
 			dataCheck = true;

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -125,12 +125,11 @@ function fetchGitHubRepo(gitHubURL)
 	regexURL = gitHubURL.replace(/.git$/, "");
 	//Used to return success(true) or error(false) to the calling function
 	var dataCheck;
-	//console.log("Inside fetchGithubRepo with Url: " + regexURL);
 	$.ajax({
 		async: false,
 		url: "../recursivetesting/FetchGithubRepo.php",
 		type: "POST",
-		data: {'url':regexURL, 'action':'getIndexFile'},
+		data: {'githubURL':regexURL, 'action':'getNewCourseGitHub'},
 		success: function() { 
 			//Returns true if the data and JSON is correct
 			dataCheck = true;

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -86,7 +86,8 @@ function downloadToWebServer($cid, $item)
     
 //Retrieves the content of a repos index-file
 function getIndexFile($url) {
-	$url = $url . "/index.txt";
+	$indexFilePath = "/index.txt";
+	$url = $url . $indexFilePath;
   // Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
   $opts = [
     'http' => [
@@ -108,6 +109,7 @@ function getIndexFile($url) {
   if($data) {
     $json = json_decode($data, true);
     if($json) {
+			//Get content of JSON-object and split files to individual index of the array
       $array = file_get_contents($json['download_url']);
 	    return explode("\n", $array);
     }
@@ -150,10 +152,9 @@ function bfs($url, $cid, $opt)
             if ($json) {
                 foreach ($json as $item) {
 									if ($item['type'] == 'file') {
-										//if item is part of filestoDownload
+										//If file is part of filestoDownload (Index file)
 										if(in_array($item['name'], $filesToDownload)){
 											// Checks if the fetched item is of type 'file'
-											print($item['name'] . "\n");
 											if($opt == "REFRESH") {
 												insertToMetaData($cid, $item);
 											}

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -89,35 +89,35 @@ function getIndexFile($url) {
 	$indexFilePath = "/index.txt";
 	$url = $url . $indexFilePath;
 
-	$headers = get_headers($url);
-  if(substr($headers[0], 9, 3) == "200"){
-		// Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
-		$opts = [
-			'http' => [
-			'method' => 'GET',
-			'header' => [
-			'User-Agent: PHP',
-				// If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
-				// simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
-				// To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
-				// Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
-				//'Authorization: Bearer YOUR_GITHUB_API_KEY'
-				]
+	// Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
+	$opts = [
+		'http' => [
+		'method' => 'GET',
+		'header' => [
+		'User-Agent: PHP',
+			// If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
+			// simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
+			// To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
+			// Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
+			//'Authorization: Bearer YOUR_GITHUB_API_KEY'
 			]
-		];
-		// Starts a stream with the required headers
-		$context = stream_context_create($opts);
-		// Fetches the data with the stream included
-		$data = @file_get_contents($url, true, $context);
-		if($data) {
-			$json = json_decode($data, true);
-			if($json) {
-				//Get content of JSON-object and split files to individual index of the array
-				$array = file_get_contents($json['download_url']);
-				return explode("\n", $array);
-			}
+		]
+	];
+	// Starts a stream with the required headers
+	$context = stream_context_create($opts);
+	// Fetches the data with the stream included
+	
+	if($data = @file_get_contents($url, true, $context)) {
+		$json = json_decode($data, true);
+		if($json) {
+			//Get content of JSON-object and split files to individual index of the array
+			$array = file_get_contents($json['download_url']);
+			return explode("\n", $array);
 		}
-	}	
+	} else {
+		return false;
+	}
+	
 }
 
 function bfs($url, $cid, $opt) 

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -103,6 +103,7 @@ function getIndexFile($url) {
 			]
 		]
 	];
+
 	// Starts a stream with the required headers
 	$context = stream_context_create($opts);
 	// Fetches the data with the stream included
@@ -117,7 +118,6 @@ function getIndexFile($url) {
 	} else {
 		return false;
 	}
-	
 }
 
 function bfs($url, $cid, $opt) 
@@ -156,6 +156,7 @@ function bfs($url, $cid, $opt)
             if ($json) {
 							foreach ($json as $item) {
 								if ($item['type'] == 'file') {
+									//If an index file has been found, check against the content of the index file
 									if($filesToDownload){
 										//If file is part of filestoDownload (Index file)
 										if(in_array($item['name'], $filesToDownload)){
@@ -169,6 +170,7 @@ function bfs($url, $cid, $opt)
 												downloadToWebserver($cid, $item);  
 											}                 
 										}
+										//Otherwise, fetch and download all files
 									} else {
 											// Checks if the fetched item is of type 'file'
 											if($opt == "REFRESH") {

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -113,7 +113,7 @@ function getIndexFile($url) {
       $array = file_get_contents($json['download_url']);
 	    return explode("\n", $array);
     }
-  }
+  } 
 }
 
 function bfs($url, $cid, $opt) 
@@ -152,17 +152,29 @@ function bfs($url, $cid, $opt)
             if ($json) {
 							foreach ($json as $item) {
 								if ($item['type'] == 'file') {
-									//If file is part of filestoDownload (Index file)
-									if(in_array($item['name'], $filesToDownload)){
-										// Checks if the fetched item is of type 'file'
-										if($opt == "REFRESH") {
-											insertToMetaData($cid, $item);
+									if($filesToDownload){
+										//If file is part of filestoDownload (Index file)
+										if(in_array($item['name'], $filesToDownload)){
+											// Checks if the fetched item is of type 'file'
+											if($opt == "REFRESH") {
+												insertToMetaData($cid, $item);
+											}
+											else if($opt == "DOWNLOAD") {
+												insertToFileLink($cid, $item);
+												insertToMetaData($cid, $item);
+												downloadToWebserver($cid, $item);  
+											}                 
 										}
-										else if($opt == "DOWNLOAD") {
-											insertToFileLink($cid, $item);
-											insertToMetaData($cid, $item);
-											downloadToWebserver($cid, $item);  
-										}                 
+									} else {
+											// Checks if the fetched item is of type 'file'
+											if($opt == "REFRESH") {
+												insertToMetaData($cid, $item);
+											}
+											else if($opt == "DOWNLOAD") {
+												insertToFileLink($cid, $item);
+												insertToMetaData($cid, $item);
+												downloadToWebserver($cid, $item);  
+											}      
 									}
 									// Checks if the fetched item is of type 'dir'
 								} else if ($item['type'] == 'dir') {

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -150,28 +150,28 @@ function bfs($url, $cid, $opt)
             $json = json_decode($data, true);
             // Loops through each item fetched in the JSON data
             if ($json) {
-                foreach ($json as $item) {
-									if ($item['type'] == 'file') {
-										//If file is part of filestoDownload (Index file)
-										if(in_array($item['name'], $filesToDownload)){
-											// Checks if the fetched item is of type 'file'
-											if($opt == "REFRESH") {
-												insertToMetaData($cid, $item);
-											}
-											else if($opt == "DOWNLOAD") {
-												insertToFileLink($cid, $item);
-												insertToMetaData($cid, $item);
-												downloadToWebserver($cid, $item);  
-											}                 
+							foreach ($json as $item) {
+								if ($item['type'] == 'file') {
+									//If file is part of filestoDownload (Index file)
+									if(in_array($item['name'], $filesToDownload)){
+										// Checks if the fetched item is of type 'file'
+										if($opt == "REFRESH") {
+											insertToMetaData($cid, $item);
 										}
-										// Checks if the fetched item is of type 'dir'
-									} else if ($item['type'] == 'dir') {
-										if (!in_array($item['url'], $visited)) {
-											array_push($visited, $item['url']);
-											array_push($fifoQueue, $item['url']);
-										}
+										else if($opt == "DOWNLOAD") {
+											insertToFileLink($cid, $item);
+											insertToMetaData($cid, $item);
+											downloadToWebserver($cid, $item);  
+										}                 
 									}
-                }
+									// Checks if the fetched item is of type 'dir'
+								} else if ($item['type'] == 'dir') {
+									if (!in_array($item['url'], $visited)) {
+										array_push($visited, $item['url']);
+										array_push($fifoQueue, $item['url']);
+									}
+								}
+              }
             } else {
                 //422: Unprocessable entity
                 http_response_code(422);

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -103,7 +103,7 @@ function getIndexFile($url) {
   // Starts a stream with the required headers
   $context = stream_context_create($opts);
   // Fetches the data with the stream included
-  $data = @file_get_contents($indexFile, true, $context);
+  $data = @file_get_contents($url, true, $context);
   if($data) {
     $json = json_decode($data, true);
     if($json) {

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -84,6 +84,7 @@ function downloadToWebServer($cid, $item)
     file_put_contents($path, $fileContents);    
 }
     
+//Retrieves the content of a repos index-file
 function getIndexFile($url) {
 	$url = $url . "/index.txt";
   // Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
@@ -108,7 +109,7 @@ function getIndexFile($url) {
     $json = json_decode($data, true);
     if($json) {
       $array = file_get_contents($json['download_url']);
-			return explode("\n", $array);
+	    return explode("\n", $array);
     }
   }
 }
@@ -148,14 +149,11 @@ function bfs($url, $cid, $opt)
             // Loops through each item fetched in the JSON data
             if ($json) {
                 foreach ($json as $item) {
-									//if item is part of filestoDownload
-									print_r($filesToDownload);
-									if(in_array($item['name'], $filesToDownload)){
-										// Checks if the fetched item is of type 'file'
-										// print ($item['name']);
-										print("inside");
-
-										if ($item['type'] == 'file') {
+									if ($item['type'] == 'file') {
+										//if item is part of filestoDownload
+										if(in_array($item['name'], $filesToDownload)){
+											// Checks if the fetched item is of type 'file'
+											print($item['name'] . "\n");
 											if($opt == "REFRESH") {
 												insertToMetaData($cid, $item);
 											}
@@ -164,12 +162,12 @@ function bfs($url, $cid, $opt)
 												insertToMetaData($cid, $item);
 												downloadToWebserver($cid, $item);  
 											}                 
-											// Checks if the fetched item is of type 'dir'
-										} else if ($item['type'] == 'dir') {
-											if (!in_array($item['url'], $visited)) {
-												array_push($visited, $item['url']);
-												array_push($fifoQueue, $item['url']);
-											}
+										}
+										// Checks if the fetched item is of type 'dir'
+									} else if ($item['type'] == 'dir') {
+										if (!in_array($item['url'], $visited)) {
+											array_push($visited, $item['url']);
+											array_push($fifoQueue, $item['url']);
 										}
 									}
                 }

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -88,32 +88,36 @@ function downloadToWebServer($cid, $item)
 function getIndexFile($url) {
 	$indexFilePath = "/index.txt";
 	$url = $url . $indexFilePath;
-  // Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
-  $opts = [
-    'http' => [
-    'method' => 'GET',
-    'header' => [
-    'User-Agent: PHP',
-      // If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
-      // simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
-      // To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
-      // Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
-      //'Authorization: Bearer YOUR_GITHUB_API_KEY'
-      ]
-    ]
-  ];
-  // Starts a stream with the required headers
-  $context = stream_context_create($opts);
-  // Fetches the data with the stream included
-  $data = @file_get_contents($url, true, $context);
-  if($data) {
-    $json = json_decode($data, true);
-    if($json) {
-			//Get content of JSON-object and split files to individual index of the array
-      $array = file_get_contents($json['download_url']);
-	    return explode("\n", $array);
-    }
-  } 
+
+	$headers = get_headers($url);
+  if(substr($headers[0], 9, 3) == "200"){
+		// Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
+		$opts = [
+			'http' => [
+			'method' => 'GET',
+			'header' => [
+			'User-Agent: PHP',
+				// If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
+				// simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
+				// To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
+				// Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
+				//'Authorization: Bearer YOUR_GITHUB_API_KEY'
+				]
+			]
+		];
+		// Starts a stream with the required headers
+		$context = stream_context_create($opts);
+		// Fetches the data with the stream included
+		$data = @file_get_contents($url, true, $context);
+		if($data) {
+			$json = json_decode($data, true);
+			if($json) {
+				//Get content of JSON-object and split files to individual index of the array
+				$array = file_get_contents($json['download_url']);
+				return explode("\n", $array);
+			}
+		}
+	}	
 }
 
 function bfs($url, $cid, $opt) 

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -5,13 +5,13 @@ session_start();
 pdoConnect(); // Connect to database and start session
 
 //Get data from AJAX call in courseed.js and then runs the function getNewCourseGithub link
-/* if(isset($_POST['action'])) 
+ if(isset($_POST['action'])) 
 {
-    if($_POST['action'] == 'getNewCourseGitHub') 
+    if($_POST['action'] == 'getIndexFile') 
     {
-       getGitHubURL($_POST['githubURL']);
+      getIndexFile($_POST['url']);
     }
-}; */
+};
 
 function getGitHubURL($url)
 {
@@ -84,6 +84,45 @@ function downloadToWebServer($cid, $item)
     file_put_contents($path, $fileContents);    
 }
     
+function getIndexFile($url) {
+  $url = getGitHubURL($url);
+  // Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
+  $opts = [
+    'http' => [
+    'method' => 'GET',
+    'header' => [
+    'User-Agent: PHP',
+      // If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
+      // simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
+      // To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
+      // Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
+      //'Authorization: Bearer '
+      ]
+    ]
+  ];
+  // Starts a stream with the required headers
+  $context = stream_context_create($opts);
+  // Fetches the data with the stream included
+  $data = @file_get_contents($indexFile, true, $context);
+  if($data) {
+    $json = json_decode($data, true);
+    if($json) {
+      print_r($json);
+      foreach($json as $file) {
+        print_r($file);
+        if($file == 'index.txt') {
+          $indexFile = $file;
+          print_r($indexFile);
+        }
+      }
+    }
+  }
+}
+
+function openIndexFile($file) {
+
+}
+
 function bfs($url, $cid, $opt) 
 {
     $url = getGitHubURL($url);


### PR DESCRIPTION
When fetching a github-repo, we now search for an index file containing the names of what files to keep, located at the root of the repo with the name "index.txt". These names are to be separated with a new line, an example of this is listed below.

For Testing:
1. Fork a repo you want to download into LenaSys
2. Create an index file with the name 'index.txt' in root (/index.txt)
3. Add all the file names you want to add with file extension in the name and separate by a new line
4. Push it up to the repo
5. You should remove the previous metadata-db to start with a fresh one containing 0 gitFiles.
6. Create a course with the GitHub-URL
7. Check database if all the files you added in the index.txt are in the database (metadata-db) by entering the metadata-db from  your terminal and select * from gitFiles .
8. If they exist, try to add another file into the index.txt file or remove the index file completely
9. Push it to your repo.
10. Wait 3-5 minutes untill you refresh the course. (Github api is slow)
12. See if the files are there. 

As mentioned, github-api takes about 5 minutes to actually update which means that you will have to wait. A good way to see the changes and when they happen is by entering the link of your index-file into the browser. An example of that link is listed below, where you replace the user with your username and your reponame:

https://raw.githubusercontent.com/user/name of repo/master/index.txt

Once the update occurs in that link, then you can test on LenaSys to see the change.

When you finally remove the index-file from the repo, when you update the course the database should be filled with all of the files from the repo instead.

![image](https://github.com/HGustavs/LenaSYS/assets/102596053/bf3da3f7-0791-4645-9c66-6a6086895f07)

Co-authored by b21leowa
