### PR TITLE
State without attributes displays incorrectly #13961

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9487,8 +9487,9 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}'
             />`;
-            
-            str += `<text x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${text[i]}</text>`;
+            for (var i = 0; i < elemAttri; i++) {
+                str += `<text x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${text[i]}</text>`;
+            }
             //end of svg for background
             str += `</svg>`;
             // Draw SD-content if there are no attributes.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3005,7 +3005,10 @@ function saveProperties()
                 }
                 //Update the attribute array
                 arrElementAttr = formatArr;
-                element[propName] = arrElementAttr;
+                if (element.kind == "SDEntity"){
+                    element[propName] = "do: " + arrElementAttr;
+                } else  element[propName] = arrElementAttr;
+
                 propsChanged.attributes = arrElementAttr;
                 break;
         

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9510,7 +9510,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}'
             />`;
-            str += `<text x='5' y='${hboxh + boxh / 2}' dominant-baseline='middle' text-anchor='right'>Do: </text>`;
+            str += `<text x='5' y='${hboxh + boxh / 2}' dominant-baseline='middle' text-anchor='right'></text>`;
             //end of svg for background
             str += `</svg>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9487,9 +9487,8 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}'
             />`;
-            for (var i = 0; i < elemAttri; i++) {
-                str += `<text x='${xAnchor}' y='${hboxh + boxh * i / 2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${text[i]}</text>`;
-            }
+            
+            str += `<text x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${text[i]}</text>`;
             //end of svg for background
             str += `</svg>`;
             // Draw SD-content if there are no attributes.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3005,10 +3005,7 @@ function saveProperties()
                 }
                 //Update the attribute array
                 arrElementAttr = formatArr;
-                if (element.kind == "SDEntity"){
-                    element[propName] = "do: " + arrElementAttr;
-                } else  element[propName] = arrElementAttr;
-
+                element[propName] = arrElementAttr;
                 propsChanged.attributes = arrElementAttr;
                 break;
         

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9488,7 +9488,7 @@ function drawElement(element, ghosted = false)
                 fill='${element.fill}'
             />`;
             for (var i = 0; i < elemAttri; i++) {
-                str += `<text x='${xAnchor}' y='${hboxh}' dominant-baseline='middle' text-anchor='${vAlignment}'>${text[i]}</text>`;
+                str += `<text x='${xAnchor}' y='${hboxh + boxh * i / 2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${text[i]}</text>`;
             }
             //end of svg for background
             str += `</svg>`;


### PR DESCRIPTION
### What's been done

Removed hardcoded "Do:" string which was appended to the empty textarea, this lead to it "creeping from below" as described in the issue