### PR TITLE
Ctrl+z when placing elements #13965

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -507,7 +507,9 @@ class StateMachine
             console.log(this.currentHistoryIndex);
         }
 
-        clearGhosts()
+        // Remove ghost only if stepBack while creating edge
+        if (mouseMode === mouseModes.EDGE_CREATION) clearGhosts()
+
         clearContext();
         clearContextLine();
         showdata();


### PR DESCRIPTION
Fixed an issue where ctrl+z when placing elements would cause the ghost to be removed, hence making it impossible to place another element without reselecting it in the toolbar. Solves issue #13965 