### PR TITLE
Not possible to rename actors and objects #13958

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -860,7 +860,7 @@ const attrState = {
 };
 
 /**
- * @description Available types of entity, ie ER, IE, UML and SD(state diagram) This affect how the entity is drawn and which menu is displayed   //<-- UML functionality
+ * @description Available types of entity, ie ER, IE, UML, SD & SE This affect how the entity is drawn and which menu is displayed   //<-- UML functionality
  */
 const entityType = {
     UML: "UML",

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1143,8 +1143,8 @@ var defaults = {
     UMLFinalState: {name: "UML Final State", kind: "UMLFinalState", fill: "#000000", stroke: "#000000", width: 60, height: 60, type: "SD" }, // UML Final state.
     UMLSuperState: {name: "UML Super State", kind: "UMLSuperState", fill: "#FFFFFF", stroke: "#000000", width: 500, height: 500, type: "SD" },  // UML Super State.
 
-    sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
-    sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" } // Sequence Activation.
+    sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "SE", actorOrObject: "actor" }, // sequence actor and object
+    sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "SE" } // Sequence Activation.
 
 }
 var defaultLine = { kind: "Normal" };
@@ -2965,6 +2965,23 @@ function changeState()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
+    /*
+    else if(element.type=='SE') {
+
+        //Check if type has been changed
+        if (oldType != newType) {
+            var newKind = element.kind;
+            newKind = newKind.replace(oldType, newType);
+            //Update element kind
+            element.kind = newKind;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
+        //Update element type
+        element.type = newType;
+        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+
+    }
+    */
     generateContextProperties();
     displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
 
@@ -6708,7 +6725,7 @@ function generateContextProperties()
             }
         }
         //Selected sequence type
-        else if (element.type == 'sequence') {
+        else if (element.type == 'SE') {
             //if sequenceActorAndObject kind
             if (element.kind == 'sequenceActorAndObject') {
                 for (const property in element) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2965,7 +2965,7 @@ function changeState()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
-    /*
+    
     else if(element.type=='SE') {
 
         //Check if type has been changed
@@ -2981,7 +2981,7 @@ function changeState()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
-    */
+    
     generateContextProperties();
     displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -867,6 +867,7 @@ const entityType = {
     ER: "ER",
     IE: "IE",
     SD: "SD",
+    SE: "SE",
 };
 /**
  * @description Available types of the entity element. This will alter how the entity is drawn onto the screen.


### PR DESCRIPTION
### What's been done

Changed the default value `element.type` from "sequence" to "SE" for diagram.js and added the remaining implementation for SE in the option-pane