### PR TITLE
Add functionality for sequence loop or alternative #13914 #13949 part 2

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,7 @@ var defaults = {
 
     sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" }, // Sequence Activation.
-    sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
+    sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], numberOfDashedLines: 3, altOrLoop: "Alt"} // Sequence Loop or Alternative.
 
 }
 var defaultLine = { kind: "Normal" };
@@ -6693,7 +6693,9 @@ function generateContextProperties()
                             str += `<div>Each line is an alternative. Just one is a loop.`
                             //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`
                             //str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
-                            str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
+                            //str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
+                            //TODO in the future, this can be implemented as part of saveProperties and combine attribute and func and alternatives cases.
+                            str += `<textarea id='inputAlternatives' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
                             str += `</div>`
                             break;
                         default:
@@ -9073,7 +9075,7 @@ function drawElement(element, ghosted = false)
     canvas.height = window.innerHeight;
     canvasContext = canvas.getContext('2d');
 
-    //this is a silly way of changing the color for the text for actor, I couldnt think of a better one though. Currently it is also used for sequenceAltOrLoop
+    //this is a silly way of changing the color for the text for actor, I couldnt think of a better one though. Currently it is also used for sequenceLoopOrAlt
     //replace this with nonFilledElementPartStroke when it gets merged.
     var actorFontColor;
     if (isDarkTheme()) actorFontColor = '#FFFFFF';
@@ -12394,20 +12396,34 @@ function toggleActorOrbject(type){
     showdata();
 }
 /**
- * @description sets the attribute numberOfDashedLines in sequenceLoopOrAlt to the input box numberOfDashedLines's value.
+ * @description sets the attribute numberOfDashedLines in sequenceLoopOrAlt to the amount of lines in the input textarea called inputAlternatives.
  */
+//TODO This should be implemeted into saveProperties but as of this moment I could not becuase of a bug that was outside the scope of my issue.
 function setSequenceDashedLines(){
     //for each element in context, check if it has the property hasDashedLine and then change it to suit the checkbox.
-    /* for (let i = 0; i < context.length; i++) {
+    for (let i = 0; i < context.length; i++) {
         if (context[i].numberOfDashedLines != null) {
-            context[i].numberOfDashedLines =  Number(document.getElementById("inputNumberOfDashedLines").value);
+            /* let numberOfAttribute = document.getElementById("inputAlternatives");
+            //context[i].numberOfDashedLines =  Number(document.getElementById("inputNumberOfDashedLines").value);
             if (context[i].numberOfDashedLines == 0) {
                 context[i].altOrLoop = "Loop";
             } else {
                 context[i].altOrLoop = "Alt";
+            } */
+            //Create an array from string where newline seperates elements
+            let numberOfAttribute = document.getElementById("inputAlternatives").value.split('\n');
+            let formatArr = [];
+            for (var i = 0; i < numberOfAttribute.length; i++) {
+                if (!(numberOfAttribute[i] == '\n' || numberOfAttribute[i] == '' || numberOfAttribute[i] == ' ')) {
+                    formatArr.push(numberOfAttribute[i]);
+                } 
             }
+            //Update the attribute array
+            numberOfAttribute = formatArr;
+            console.log(numberOfAttribute);
+            console.log(numberOfAttribute.length);
         }
-    } */
+    }
     //elementProperty_numberOfDashedLines
     showdata();
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12407,6 +12407,12 @@ function setSequenceAlternatives(){
             } else {
                 context[i].altOrLoop = "Alt";
             }
+
+            stateMachine.save(
+                StateChangeFactory.ElementAttributesChanged(context[0].id, { 'alternatives': alternatives }),
+                StateChangeFactory.ElementAttributesChanged(context[0].id, { 'altOrLoop': context[i].altOrLoop }),
+                StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED
+            );
         }
     }
     showdata();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12411,17 +12411,18 @@ function setSequenceDashedLines(){
                 context[i].altOrLoop = "Alt";
             } */
             //Create an array from string where newline seperates elements
-            let numberOfAttribute = document.getElementById("inputAlternatives").value.split('\n');
+            let alternatives = document.getElementById("inputAlternatives").value.split('\n');
             let formatArr = [];
-            for (let i = 0; i < numberOfAttribute.length; i++) {
-                if (!(numberOfAttribute[i] == '\n' || numberOfAttribute[i] == '' || numberOfAttribute[i] == ' ')) {
-                    formatArr.push(numberOfAttribute[i]);
+            for (let i = 0; i < alternatives.length; i++) {
+                if (!(numberOfAttribute[i] == '\n' || alternatives[i] == '' || alternatives[i] == ' ')) {
+                    formatArr.push(alternatives[i]);
                 } 
             }
             //Update the attribute array
-            numberOfAttribute = formatArr;
-            console.log(numberOfAttribute);
-            console.log(numberOfAttribute.length);
+            alternatives = formatArr;
+            console.log(alternatives);
+            console.log(alternatives.length);
+            context[0].alternatives = alternatives;
         }
     }
     //elementProperty_numberOfDashedLines

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,7 @@ var defaults = {
 
     sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" }, // Sequence Activation.
-    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 200, type: "sequence", numberOfDashedLines: 1, altOrLoop: "Alt"} // Sequence Loop or Alternative.
+    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 200, type: "sequence", alternatives: ["alternative1","alternative2"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
 
 }
 var defaultLine = { kind: "Normal" };
@@ -6696,7 +6696,8 @@ function generateContextProperties()
                         case 'numberofdashedlines':
                             str += `<div>Amount of Dashed lines, 0 for loop.`
                             //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`
-                            str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
+                            //str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
+                            str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
                             str += `</div>`
                             break;
                         default:
@@ -9693,11 +9694,11 @@ function drawElement(element, ghosted = false)
             />`;
         } */
         //if the user chose to have alternative lines, iterate and draw them out one by one, evenly spaced out.
-        if ((element.numberOfDashedLines != null) && (element.numberOfDashedLines > 0)) {
-            let numberOfAlternatives = element.numberOfDashedLines + 1;
-            for (let i = 1; i < numberOfAlternatives; i++) {
+        if ((element.alternatives != null) && (element.alternatives.length > 0)) {
+            let numberOfAlternativeSpaces = element.alternatives.length + 1;
+            for (let i = 1; i < numberOfAlternativeSpaces; i++) {
                 str += `<path class="text"
-                d="M${boxw-linew},${(boxh/numberOfAlternatives)*i}
+                d="M${boxw-linew},${(boxh/numberOfAlternativeSpaces)*i}
                     H${linew}
                 "
                 stroke-width='${linew}'
@@ -9705,7 +9706,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${50*zoomfact+linew}' y='${((boxh/numberOfAlternatives)*i)+(texth/2)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
+                str += `<text x='${50*zoomfact+linew}' y='${((boxh/numberOfAlternativeSpaces)*i)+(texth/2)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
         }
         //svg for the small label in top left corner
@@ -9727,7 +9728,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
+        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality
@@ -12401,7 +12402,7 @@ function toggleActorOrbject(type){
  */
 function setSequenceDashedLines(){
     //for each element in context, check if it has the property hasDashedLine and then change it to suit the checkbox.
-    for (let i = 0; i < context.length; i++) {
+    /* for (let i = 0; i < context.length; i++) {
         if (context[i].numberOfDashedLines != null) {
             context[i].numberOfDashedLines =  Number(document.getElementById("inputNumberOfDashedLines").value);
             if (context[i].numberOfDashedLines == 0) {
@@ -12410,7 +12411,8 @@ function setSequenceDashedLines(){
                 context[i].altOrLoop = "Alt";
             }
         }
-    }
+    } */
+    //elementProperty_numberOfDashedLines
     showdata();
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9680,7 +9680,7 @@ function drawElement(element, ghosted = false)
         if ((element.alternatives != null) && (element.alternatives.length > 0)) {
             for (let i = 1; i < element.alternatives.length; i++) {
                 str += `<path class="text"
-                d="M${boxw-linew},${(boxh/element.alternatives.length)*i}
+                d="M${boxw-linew},${((boxh/element.alternatives.length)*i)*zoomfact}
                     H${linew}
                 "
                 stroke-width='${linew}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1018,12 +1018,12 @@ const elementheight = 50;
 const textheight = 18;
 const strokewidth = 2.0;
 const baseline = 10;
+const avgcharwidth = 6; // <-- This variable is never used anywhere in this file. 
 const colors = ["#ffffff", "#c4e4fc", "#ffd4d4", "#fff4c2", "#c4f8bd", "#648fff", "#DC267F", "#FFB000", "#FE6100", "#000000", "#0000ff"];
 const strokeColors = ["#383737"];
 const selectedColor = "#A000DC";
 const multioffs = 3;
 // Zoom values for offsetting the mouse cursor positioning
-
 const zoom1_25 = 0.36;
 const zoom1_5 = 0.555;
 const zoom2 = 0.75;
@@ -1416,7 +1416,6 @@ function getData()
     togglePlacementType(0,0)
     togglePlacementType(1,1)
     togglePlacementType(9,9)
-    togglePlacementType(12,12)
 }
 //<-- UML functionality start
 /**
@@ -1501,23 +1500,6 @@ function showDiagramTypes(){
     }
     else {
         Array.from(document.getElementsByClassName("SDButton")).forEach(button => {
-            button.classList.add("hiddenPlacementType");
-        });
-    }
-
-    // SE buttons
-    if (diagramType.UML) {
-        document.getElementById("elementPlacement12").onmousedown = function () {
-            holdPlacementButtonDown(0);
-        };
-
-        if (firstShown) {
-            document.getElementById("elementPlacement12").classList.add("hiddenPlacementType");
-        }
-        firstShown = true;
-    }
-    else {
-        Array.from(document.getElementsByClassName("SEButton")).forEach(button => {
             button.classList.add("hiddenPlacementType");
         });
     }
@@ -2871,9 +2853,8 @@ function changeState()
 {
     const element =  context[0],
           oldType = element.type,
-          newType = document.getElementById("typeSelect")?.value || undefined;
-          var oldRelation = element.state;
-          var newRelation = document.getElementById("propertySelect")?.value || undefined
+          newType = document.getElementById("typeSelect")?.value || document.getElementById("propertySelect")?.value || undefined;
+
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
         displayMessage("error", `
@@ -2882,7 +2863,7 @@ function changeState()
         )
         return;
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
-    } else if (oldType == newType && oldRelation == newRelation){
+    } else if (oldType == newType){
         return;
     }
 
@@ -6051,7 +6032,7 @@ function togglePlacementTypeBox(num){
 /**
  * @description toggles which entity placement type is selected for the different types of diagrams.
  * @param {Number} num the number connected to the element selected.
- * @param {Number} type the type of element selected. (which pop-out we are referring to)
+ * @param {Number} type the type of element selected.
  */
 function togglePlacementType(num,type){
     if(type==0){
@@ -6109,33 +6090,6 @@ function togglePlacementType(num,type){
         document.getElementById("elementPlacement11").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton11").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox11").classList.remove("activeTogglePlacementTypeBox"); // IE inheritance end
-    }
-
-    else if (type == 12) {
-        // Sequence lifetime
-        document.getElementById("elementPlacement12").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement12").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement12").children.item(1).classList.remove("hiddenToolTiptext");
-        document.getElementById("togglePlacementTypeButton12").classList.remove("activeTogglePlacementTypeButton");
-        document.getElementById("togglePlacementTypeBox12").classList.remove("activeTogglePlacementTypeBox"); 
-        // Sequence activation
-        document.getElementById("elementPlacement13").classList.add("hiddenPlacementType"); 
-        document.getElementById("elementPlacement13").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement13").children.item(1).classList.remove("hiddenToolTiptext");
-        document.getElementById("togglePlacementTypeButton13").classList.remove("activeTogglePlacementTypeButton");
-        document.getElementById("togglePlacementTypeBox13").classList.remove("activeTogglePlacementTypeBox");
-        // Sequence object
-        document.getElementById("elementPlacement14").classList.add("hiddenPlacementType"); 
-        document.getElementById("elementPlacement14").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement14").children.item(1).classList.remove("hiddenToolTiptext");
-        document.getElementById("togglePlacementTypeButton14").classList.remove("activeTogglePlacementTypeButton");
-        document.getElementById("togglePlacementTypeBox14").classList.remove("activeTogglePlacementTypeBox"); 
-        // Sequence condition/loop object
-        document.getElementById("elementPlacement15").classList.add("hiddenPlacementType"); 
-        document.getElementById("elementPlacement15").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement15").children.item(1).classList.remove("hiddenToolTiptext");
-        document.getElementById("togglePlacementTypeButton15").classList.remove("activeTogglePlacementTypeButton");
-        document.getElementById("togglePlacementTypeBox15").classList.remove("activeTogglePlacementTypeBox");
     }
     
     // Unhide the currently selected placement type
@@ -6658,7 +6612,7 @@ function generateContextProperties()
                     selected = "disjoint"
                 }
 
-                if(element.kind =="IERelation") {
+                if(element.kind=="IERelation") {
                     value = Object.values(inheritanceStateIE);
                 }
                 str += '<select id="propertySelect">';
@@ -8311,33 +8265,19 @@ function drawLine(line, targetGhost = false)
                 var iconSizeStart=40;
                 break;
             case SDLineIcons.ARROW:
-                var iconSizeStart = 20;
-
-                // If the line is straight calculate the points required to draw the arrow at an angle.
-                if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT)) {
-                    let to = new Point(tx + x2Offset * zoomfact, ty + y2Offset * zoomfact);
-                    let from = new Point(fx + x1Offset * zoomfact, fy + y1Offset * zoomfact);  
-
-                    let base = calculateArrowBase(to, from, iconSizeStart / 2 * zoomfact);
-                    let right = rotateArrowPoint(base, from, true);
-                    let left = rotateArrowPoint(base, from, false);
-
-                    str += `<polygon id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode-sd' points='${right.x} ${right.y},${from.x} ${from.y},${left.x} ${left.y}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                if (line.ctype == 'TB') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${fx - 5 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy + zoomfact},${fx + 5 * zoomfact} ${fy - 10 * zoomfact},${fx - 5 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
-                else {
-                    if (line.ctype == 'TB') {
-                        str += `<polyline id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode-sd' points='${fx - 5 * zoomfact} ${fy - 10 * zoomfact},${fx} ${fy + zoomfact},${fx + 5 * zoomfact} ${fy - 10 * zoomfact},${fx - 5 * zoomfact} ${fy - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                    }
-                    else if (line.ctype == 'BT') {
-                        str += `<polyline id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode-sd' points='${fx - 5 * zoomfact} ${fy + 10 * zoomfact},${fx} ${fy - 5 * zoomfact},${fx + 5 * zoomfact} ${fy + 10 * zoomfact},${fx - 5 * zoomfact} ${fy + 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                    }
-                    else if (line.ctype == 'LR') {
-                        str += `<polyline id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode-sd' points='${fx - 10 * zoomfact} ${fy - 5 * zoomfact},${fx} ${fy},${fx - 10 * zoomfact} ${fy + 5 * zoomfact},${fx - 10 * zoomfact} ${fy - 5 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                    }
-                    else if (line.ctype == 'RL') {
-                        str += `<polyline id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode-sd' points='${fx + 10 * zoomfact} ${fy - 5 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 5 * zoomfact},${fx + 10 * zoomfact} ${fy - 5 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                    }
+                else if(line.ctype == 'BT'){
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${fx - 5 * zoomfact} ${fy + 10 * zoomfact},${fx} ${fy - 5 * zoomfact},${fx + 5 * zoomfact} ${fy + 10 * zoomfact},${fx - 5 * zoomfact} ${fy + 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
+                else if (line.ctype == 'LR') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${fx - 10 * zoomfact} ${fy - 5 * zoomfact},${fx} ${fy},${fx - 10 * zoomfact} ${fy + 5 * zoomfact},${fx - 10 * zoomfact} ${fy - 5 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                else if (line.ctype == 'RL') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${fx + 10 * zoomfact} ${fy - 5 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy + 5 * zoomfact},${fx + 10 * zoomfact} ${fy - 5 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                var iconSizeStart=40;
                 break;
             default:
                 var iconSizeStart=0;
@@ -8545,34 +8485,19 @@ function drawLine(line, targetGhost = false)
                 var iconSizeEnd=40;
                 break;
             case SDLineIcons.ARROW:
-                var iconSizeEnd = 20;
-
-                // If the line is straight calculate the points required to draw the arrow at an angle.
-                if ((felem.type == 'SD' && elemsAreClose && line.innerType == null) || (felem.type == 'SD' && line.innerType === SDLineType.STRAIGHT)) {
-                    let to = new Point(tx + x2Offset * zoomfact, ty + y2Offset * zoomfact);
-                    let from = new Point(fx + x1Offset * zoomfact, fy + y1Offset * zoomfact);  
-
-                    let base = calculateArrowBase(from, to, iconSizeEnd / 2 * zoomfact);
-                    let right = rotateArrowPoint(base, to, true);
-                    let left = rotateArrowPoint(base, to, false);
-
-                    str += `<polygon id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode-sd' points='${right.x} ${right.y},${to.x} ${to.y},${left.x} ${left.y}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                if (line.ctype == 'BT') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${tx - 5 * zoomfact} ${ty - 10 * zoomfact},${tx} ${ty},${tx + 5 * zoomfact} ${ty - 10 * zoomfact},${tx - 5 * zoomfact} ${ty - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
-                // If the line is segmented draw the arrow on a 90 degree angle matching the line.
-                else {
-                    if (line.ctype == 'BT') {
-                        str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${tx - 5 * zoomfact} ${ty - 10 * zoomfact},${tx} ${ty},${tx + 5 * zoomfact} ${ty - 10 * zoomfact},${tx - 5 * zoomfact} ${ty - 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                    }
-                    else if(line.ctype == 'TB'){
-                        str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${tx - 5 * zoomfact} ${ty + 10 * zoomfact},${tx} ${ty - 5 * zoomfact},${tx + 5 * zoomfact} ${ty + 10 * zoomfact},${tx - 5 * zoomfact} ${ty + 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                    }
-                    else if (line.ctype == 'RL') {
-                        str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${tx - 10 * zoomfact} ${ty - 5 * zoomfact},${tx} ${ty},${tx - 10 * zoomfact} ${ty + 5 * zoomfact},${tx - 10 * zoomfact} ${ty - 5 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                    }
-                    else if (line.ctype == 'LR') {
-                        str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${tx + 10 * zoomfact} ${ty - 5 * zoomfact},${tx} ${ty},${tx + 10 * zoomfact} ${ty + 5 * zoomfact},${tx + 10 * zoomfact} ${ty - 5 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
-                    }
+                else if(line.ctype == 'TB'){
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${tx - 5 * zoomfact} ${ty + 10 * zoomfact},${tx} ${ty - 5 * zoomfact},${tx + 5 * zoomfact} ${ty + 10 * zoomfact},${tx - 5 * zoomfact} ${ty + 10 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 }
+                else if (line.ctype == 'RL') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${tx - 10 * zoomfact} ${ty - 5 * zoomfact},${tx} ${ty},${tx - 10 * zoomfact} ${ty + 5 * zoomfact},${tx - 10 * zoomfact} ${ty - 5 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                else if (line.ctype == 'LR') {
+                    str += `<polyline id='${line.id+"IconOne"}' class='diagram-umlicon-darkmode-sd' points='${tx + 10 * zoomfact} ${ty - 5 * zoomfact},${tx} ${ty},${tx + 10 * zoomfact} ${ty + 5 * zoomfact},${tx + 10 * zoomfact} ${ty - 5 * zoomfact}' stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
+                }
+                var iconSizeEnd=20;
                 break;
             default:
                 var iconSizeEnd=0;
@@ -8851,57 +8776,6 @@ function drawLine(line, targetGhost = false)
     }
 
     return str;
-}
-/**
- * @description Calculates the coordinates of the point representing the base of the arrow, the point is @param size distance away and on the line between @param from and @param to .
- * @param {Point} from The coordinates/Point where the line between two elements start.
- * @param {Point} to The coordinates/Point where the line between two elements end.
- * @param {number} size The size(height) of the arrow that is to be drawn.
- * @returns The coordinates/Point where the arrow base is placed on the line.
- */
-function calculateArrowBase(from, to, size)
-{
-    /*
-        Since we know that the arrow is to be created on the line, we need a Point that is a set distance away from the element that is still on the line.
-        The set distance is the size, as it will be the height of the arrow.
-        Given two points we can find the distance of the line between them by calculating the hypotenuse.
-        Since we know the hypotenuse of the "small" triangle and all the lengths of the "large" triangle, we can calculate the cordinates of the "small" triangle since the triangles are "similar".
-        We start by calculating a ratio on the hypotenuse by taking the "small" hypotenuse divided by the "large" hypotenuse.
-        Then we apply this ratio on the other sides of the large triangle to get the distance in x and in y for the small triangle
-        Then we add these values to the end point to get the actual coordinates for the arrow base.
-    */
-
-    let ratio = size / Math.sqrt(Math.pow(from.x - to.x, 2) + Math.pow(from.y - to.y, 2));
-    let x = to.x + (from.x - to.x) * ratio;
-    let y = to.y + (from.y - to.y) * ratio;
-    return new Point(x, y);
-}
-/**
- * @description Calculates the coordiates of the point representing one of the arrows corners
- * @param {Point} base The coordinates/Point where the arrow base is placed on the line, this Point is the pivot that the corners are "rotated" around.
- * @param {Point} to The coordinates/Point where the line between @param base and the element end
- * @param {boolean} clockwise Should the rotation be clockwise (true) or counter-clockwise (false).
- */
-function rotateArrowPoint(base, to, clockwise)
-{
-    /*
-        To create the actual arrow we need the corners.
-        We need to rotate the point "to" around "base" by 90 or -90 degrees and divide the distance by 2 (as this decides how wide the triangle will be).
-        The rotation is done by applying the vector rotation math that states: 
-        Point(x,y) rotated 90 degrees clockwise = Point(y, -1 * x) or,
-        Point(x,y) rotated 90 degrees counter-clockwise = Point(-1 * y, x).
-        The "rotated" value can then be added to the base to get a corner.
-    */
-    if (clockwise) {
-        let point = new Point((to.y - base.y) / 2, -1 * (to.x - base.x) / 2);
-        point.add(base);
-        return point;
-    }
-    else {
-        let point = new Point(-1 * (to.y - base.y) / 2, (to.x - base.x) / 2);
-        point.add(base);
-        return point;
-    }
 }
 /**
  * @description Removes all existing lines and draw them again
@@ -9188,8 +9062,8 @@ function drawElement(element, ghosted = false)
 
     // Compute size variables
     var linew = Math.round(strokewidth * zoomfact);
-    var boxw = Math.round(element.width * zoomfact);
-    var boxh = Math.round(element.height * zoomfact);
+    var boxw  = Math.round(element.width * zoomfact);
+    var boxh  = Math.round(element.height * zoomfact);
     var texth = Math.round(zoomfact * textheight);
     var hboxw = Math.round(element.width * zoomfact * 0.5);
     var hboxh = Math.round(element.height * zoomfact * 0.5);
@@ -9209,12 +9083,6 @@ function drawElement(element, ghosted = false)
     if (isDarkTheme()) actorFontColor = '#FFFFFF';
     else actorFontColor = '#383737';
     
-    //since toggleBorderOfElements checks the fill color to make sure we dont end up with white stroke on white fill, which is bad for IE and UML etc,
-    //we have to have another variable for those strokes that are irrlevant of the elements fill, like sequence actor or state superstate.
-    var nonFilledElementPartStrokeColor;
-    if (isDarkTheme()) nonFilledElementPartStrokeColor = '#FFFFFF';
-    else nonFilledElementPartStrokeColor = '#383737';
-
     // Caclulate font width using some canvas magic
     var font = canvasContext.font;
     font = `${texth}px ${font.split('px')[1]}`;
@@ -9273,10 +9141,10 @@ function drawElement(element, ghosted = false)
             height : ((boxh + (boxh/2 + (boxh * elemAttri/2)) + (boxh/2 + (boxh * elemFunc/2))) / zoomfact)
         }
         UMLHeight.push(UMLEntityHeight);
-        
+
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.5))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -9358,7 +9226,7 @@ function drawElement(element, ghosted = false)
         const theme = document.getElementById("themeBlack");
         str += `<div id="${element.id}" 
                      class="element uml-state"
-                     style="margin-top:${((boxh / 2.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}" 
+                     style="width:${boxw}px;height:${boxh}px;${ghostAttr}" 
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>
@@ -9384,7 +9252,7 @@ function drawElement(element, ghosted = false)
         const theme = document.getElementById("themeBlack");
         str += `<div id="${element.id}" 
                      class="element uml-state"
-                     style="margin-top:${((boxh / 2.5))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                     style="width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>
@@ -9410,13 +9278,13 @@ function drawElement(element, ghosted = false)
         const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
         str += `<div id="${element.id}" 
                     class="element uml-Super"
-                    style="margin-top:${((boxh * 0.025))}px;width:${boxw}px;height:${boxh}px;${ghostAttr}"
+                    style="width:${boxw}px;height:${boxh}px;${ghostAttr}"
                      onmousedown='ddown(event);' 
                      onmouseenter='mouseEnter();' 
                      onmouseleave='mouseLeave();'>
                     <svg width="100%" height="100%">
-                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke='${nonFilledElementPartStrokeColor}' stroke-width='${linew}' rx="20"/>
-                    <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill='${element.fill}' fill-opacity="1" stroke='${element.stroke}' stroke-width='${linew}' />
+                    <rect width="${boxw}px" height="${boxh}px" fill="none" fill-opacity="0" stroke="#000" stroke-width="2" rx="20"/>
+                    <rect width="${boxw/2}px" height="${80 * zoomfact}px" fill="#FFF" fill-opacity="1" stroke="#000" stroke-width="2" />   
                         <text x='${80 * zoomfact}px' y='${40 * zoomfact}px' dominant-baseline='middle' text-anchor='${vAlignment}' font-size="${20 * zoomfact}px">${element.name}</text>
                     </svg>
                 </div>`;
@@ -9457,7 +9325,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.15))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9549,7 +9417,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxh /3))}px;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:5px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -9610,7 +9478,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.15))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;`;
 
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -9663,7 +9531,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'IERelation') {
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element ie-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; margin-top:${((boxh/1.5))}px; width:${boxw}px;height:${boxh/2}px;`;
+        style='left:0px; top:0px; margin-top:${((boxw/2))}px; width:${boxw}px;height:${boxh/2}px;`;
        
         if(context.includes(element)){
             str += `z-index: 1;`;
@@ -9678,7 +9546,6 @@ function drawElement(element, ghosted = false)
         str += `<svg width='${boxw}' height='${boxh/2}' style='transform:rotate(180deg);   stroke-width:${linew};'>`;
 
         // Overlapping IE-inheritance
-        
         if (element.state == 'overlapping') {
                 str+= `<circle cx="${(boxw/2)}" cy="0" r="${(boxw/2.08)}" fill="white"; stroke="black";'/> 
                 <line x1="0" y1="${boxw/50}" x2="${boxw}" y2="${boxw/50}" stroke="black"; />`
@@ -9741,7 +9608,7 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {
@@ -9772,7 +9639,7 @@ function drawElement(element, ghosted = false)
             str += `z-index: 1;`;
         }
         if (ghosted) {
-            str += `pointer-events: none; opacity: ${ghostPreview};`;
+            str += `pointer-events: none; opacity: ${ghostLine ? 0 : 0.0};`;
         }
         str += `'>`;
         str += `<svg width='${boxw}' height='${boxh}'>`;
@@ -9869,33 +9736,13 @@ function drawElement(element, ghosted = false)
     //ER element
     else {
         // Create div & svg element
-        if (element.kind == "EREntity") {
-            str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
+        str += `
+                    <div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxh / 2))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;
-        }
-        else if (element.kind == "ERAttr") {
-            str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
-                            left:0px;
-                            top:0px;
-                            margin-top:${((boxh / 2))}px;;
-                            width:${boxw}px;
-                            height:${boxh}px;
-                            font-size:${texth}px;`;
-        }
-        else if (element.kind == "ERRelation") {
-            str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
-                            left:0px;
-                            top:0px;
-                            margin-top:${((boxh / 2.75))}px;;
-                            width:${boxw}px;
-                            height:${boxh}px;
-                            font-size:${texth}px;`;
-        }
         if(context.includes(element)){
             str += `z-index: 1;`;
         }
@@ -9909,7 +9756,6 @@ function drawElement(element, ghosted = false)
         str += `<svg width='${boxw}' height='${boxh}' >`;
         // Create svg 
         if (element.kind == "EREntity") {
-
             var weak = "";
 
             if(element.state == "weak") {
@@ -9966,7 +9812,7 @@ function drawElement(element, ghosted = false)
             }
             
         }
-        else if (element.kind == "ERRelation") {         
+        else if (element.kind == "ERRelation") {
 
             var numOfLetters = element.name.length;
             if (tooBig) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9656,20 +9656,11 @@ function drawElement(element, ghosted = false)
         }
         str += `'>`;
         str += `<svg width='${boxw}' height='${boxh}'>`;
-        //svg for the loop/alt rectangle
-        str += `<rect class='text'
-            x='${linew}'
-            y='${linew}'
-            width='${boxw-(linew*2)}'
-            height='${boxh-(linew*2)}'
-            stroke-width='${linew}'
-            stroke='${element.stroke}'
-            fill='none'
-            rx='${7*zoomfact}'
-            fill-opacity="0"
-        />`;
+        //svg for the dashed lines for alternatives and their text 
         //if the user chose to have alternative lines, iterate and draw them out one by one, evenly spaced out.
         if ((element.alternatives != null) && (element.alternatives.length > 0)) {
+            //increase length of element to avoid squished alternatives
+            boxh += 250*element.alternatives.length;
             for (let i = 1; i < element.alternatives.length; i++) {
                 str += `<path class="text"
                 d="M${boxw-linew},${(boxh/element.alternatives.length)*i}
@@ -9682,10 +9673,20 @@ function drawElement(element, ghosted = false)
                 />`;
                 str += `<text x='${linew*2}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew*2}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
-            //increase length of element to avoid squished alternatives
-            boxh += 250*element.alternatives.length;
 
         }
+        //svg for the main loop/alt rectangle
+        str += `<rect class='text'
+            x='${linew}'
+            y='${linew}'
+            width='${boxw-(linew*2)}'
+            height='${boxh-(linew*2)}'
+            stroke-width='${linew}'
+            stroke='${element.stroke}'
+            fill='none'
+            rx='${7*zoomfact}'
+            fill-opacity="0"
+        />`;
         //svg for the small label in top left corner
         str += `<path 
             d="M${(7*zoomfact)+linew},${linew}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9680,7 +9680,7 @@ function drawElement(element, ghosted = false)
         if ((element.alternatives != null) && (element.alternatives.length > 0)) {
             for (let i = 1; i < element.alternatives.length; i++) {
                 str += `<path class="text"
-                d="M${boxw-linew},${((boxh/element.alternatives.length)*i)*zoomfact}
+                d="M${boxw-linew},${(boxh/element.alternatives.length)*i}
                     H${linew}
                 "
                 stroke-width='${linew}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9649,7 +9649,7 @@ function drawElement(element, ghosted = false)
             //increase length of element to avoid squished alternatives
             //boxh += 250*element.alternatives.length;
             for (let i = 0; i < element.alternatives.length; i++) {
-                boxh += 50*zoomfact;
+                boxh += 50;
             }
         }
         //div to encapsulate sequence loop 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12413,7 +12413,7 @@ function setSequenceDashedLines(){
             //Create an array from string where newline seperates elements
             let numberOfAttribute = document.getElementById("inputAlternatives").value.split('\n');
             let formatArr = [];
-            for (var i = 0; i < numberOfAttribute.length; i++) {
+            for (let i = 0; i < numberOfAttribute.length; i++) {
                 if (!(numberOfAttribute[i] == '\n' || numberOfAttribute[i] == '' || numberOfAttribute[i] == ' ')) {
                     formatArr.push(numberOfAttribute[i]);
                 } 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12409,6 +12409,7 @@ function setSequenceAlternatives(){
 
             stateMachine.save(
                 StateChangeFactory.ElementAttributesChanged(context[0].id, { 'alternatives': alternatives }),
+                StateChangeFactory.ElementAttributesChanged(context[0].id, { 'altOrLoop': context[0].altOrLoop }),
                 StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED
             );
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9656,7 +9656,6 @@ function drawElement(element, ghosted = false)
             //check if the length is less or equal to 1, if so its loop, else its alt.
             context[i].alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
             context[i].altOrLoop = newAltOrLoop;
-            setSequenceAlternatives();
         }
         
         //div to encapsulate sequence loop 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9727,7 +9727,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+linew+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
+        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,7 @@ var defaults = {
 
     sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" }, // Sequence Activation.
-    sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], numberOfDashedLines: 3, altOrLoop: "Alt"} // Sequence Loop or Alternative.
+    sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], numberOfAlternatives: 3, altOrLoop: "Alt"} // Sequence Loop or Alternative.
 
 }
 var defaultLine = { kind: "Normal" };
@@ -12396,7 +12396,7 @@ function toggleActorOrbject(type){
     showdata();
 }
 /**
- * @description sets the attribute numberOfDashedLines in sequenceLoopOrAlt to the amount of lines in the input textarea called inputAlternatives.
+ * @description sets the attribute numberOfAlternatives in sequenceLoopOrAlt to the amount of lines in the input textarea called inputAlternatives.
  */
 //TODO This should be implemeted into saveProperties but as of this moment I could not becuase of a bug that was outside the scope of my issue.
 function setSequenceDashedLines(){
@@ -12423,6 +12423,7 @@ function setSequenceDashedLines(){
             console.log(alternatives);
             console.log(alternatives.length);
             context[0].alternatives = alternatives;
+            context[0].numberOfAlternatives = alternatives.length;
         }
     }
     //elementProperty_numberOfDashedLines

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9706,7 +9706,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${50*zoomfact+linew}' y='${((boxh/element.alternatives.length)*i)+(texth/4)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
+                str += `<text x='${50*zoomfact+linew}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
         }
         //svg for the small label in top left corner
@@ -9728,7 +9728,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/4)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
+        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/1.5)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,7 @@ var defaults = {
 
     sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" }, // Sequence Activation.
-    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
+    sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
 
 }
 var defaultLine = { kind: "Normal" };
@@ -6689,10 +6689,6 @@ function generateContextProperties()
             else if(element.kind == 'sequenceLoopOrAlt'){
                 for (const property in element) {
                     switch (property.toLowerCase()) {
-                        case 'name':
-                            str += `<div style='color:white'>Name</div>`;
-                            str += `<input id='elementProperty_${property}' type='text' value='${element[property]}' onfocus='propFieldSelected(true)' onblur='propFieldSelected(false)'>`;
-                            break;
                         case 'alternatives':
                             str += `<div>Amount of Dashed lines, 0 for loop.`
                             //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6679,10 +6679,10 @@ function generateContextProperties()
                             break;
                         case 'actororobject':
                             //buttons for choosing object or actor via toggleActorOrbject
-                            str += `<div>`;
-                            str += `<button onclick='toggleActorOrbject("actor");'>Actor</button>`;
-                            str += `<button onclick='toggleActorOrbject("object");'>Object</button>`;
-                            str += `</div>`;
+                            str += `<div>`
+                            str += `<button onclick='toggleActorOrbject("actor");'>Actor</button>`
+                            str += `<button onclick='toggleActorOrbject("object");'>Object</button>`
+                            str += `</div>`
                             break;
                         default:
                             break;
@@ -6693,11 +6693,11 @@ function generateContextProperties()
                 for (const property in element) {
                     switch (property.toLowerCase()) {
                         case 'alternatives':
-                            str += `<div>Each line is an alternative. Just one is a loop.`;
+                            str += `<div>Each line is an alternative. Just one is a loop.`
                             //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`
                             //str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
                             str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
-                            str += `</div>`;
+                            str += `</div>`
                             break;
                         default:
                             break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6693,7 +6693,7 @@ function generateContextProperties()
                             str += `<div style='color:white'>Name</div>`;
                             str += `<input id='elementProperty_${property}' type='text' value='${element[property]}' onfocus='propFieldSelected(true)' onblur='propFieldSelected(false)'>`;
                             break;
-                        case 'numberofdashedlines':
+                        case 'alternatives':
                             str += `<div>Amount of Dashed lines, 0 for loop.`
                             //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`
                             //str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2993,7 +2993,7 @@ function saveProperties()
                 arrElementAttr = formatArr;
                 element[propName] = arrElementAttr;
                 propsChanged.attributes = arrElementAttr;
-                console.logpropsChanged.attributes);
+                console.log(propsChanged.attributes);
                 break;
         
             /* case 'functions':

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2977,7 +2977,6 @@ function saveProperties()
                 }
                 break;
             case 'attributes':
-            case 'functions':
                 //Get string from textarea
                 var elementAttr = child.value;
                 //Create an array from string where newline seperates elements
@@ -2994,7 +2993,7 @@ function saveProperties()
                 propsChanged.attributes = arrElementAttr;
                 break;
         
-            /* case 'functions':
+            case 'functions':
                 //Get string from textarea
                 var elementFunc = child.value;
                 //Create an array from string where newline seperates elements
@@ -3009,7 +3008,7 @@ function saveProperties()
                 arrElementFunc = formatArr;
                 element[propName] = arrElementFunc;
                 propsChanged.functions = arrElementFunc;
-                break; */
+                break;
 
             default:
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9704,7 +9704,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${linew}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
+                str += `<text x='${linew*2}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
         }
         //svg for the small label in top left corner
@@ -9726,7 +9726,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${linew}' y='${37.5*zoomfact+(linew*2)+(texth/1.5)}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
+        str += `<text x='${linew*2}' y='${37.5*zoomfact+(linew*2)+(texth/1.5)}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9705,7 +9705,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${50*zoomfact+linew}' y='${((boxh/numberOfAlternatives)*i)+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
+                str += `<text x='${50*zoomfact+linew}' y='${((boxh/numberOfAlternatives)*i)+(texth/2)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
             }
         }
         //svg for the small label in top left corner

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9656,11 +9656,20 @@ function drawElement(element, ghosted = false)
         }
         str += `'>`;
         str += `<svg width='${boxw}' height='${boxh}'>`;
-        //svg for the dashed lines for alternatives and their text 
+        //svg for the loop/alt rectangle
+        str += `<rect class='text'
+            x='${linew}'
+            y='${linew}'
+            width='${boxw-(linew*2)}'
+            height='${boxh-(linew*2)}'
+            stroke-width='${linew}'
+            stroke='${element.stroke}'
+            fill='none'
+            rx='${7*zoomfact}'
+            fill-opacity="0"
+        />`;
         //if the user chose to have alternative lines, iterate and draw them out one by one, evenly spaced out.
         if ((element.alternatives != null) && (element.alternatives.length > 0)) {
-            //increase length of element to avoid squished alternatives
-            boxh += 250*element.alternatives.length;
             for (let i = 1; i < element.alternatives.length; i++) {
                 str += `<path class="text"
                 d="M${boxw-linew},${(boxh/element.alternatives.length)*i}
@@ -9673,20 +9682,10 @@ function drawElement(element, ghosted = false)
                 />`;
                 str += `<text x='${linew*2}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew*2}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
+            //increase length of element to avoid squished alternatives
+            boxh += 250*element.alternatives.length;
 
         }
-        //svg for the main loop/alt rectangle
-        str += `<rect class='text'
-            x='${linew}'
-            y='${linew}'
-            width='${boxw-(linew*2)}'
-            height='${boxh-(linew*2)}'
-            stroke-width='${linew}'
-            stroke='${element.stroke}'
-            fill='none'
-            rx='${7*zoomfact}'
-            fill-opacity="0"
-        />`;
         //svg for the small label in top left corner
         str += `<path 
             d="M${(7*zoomfact)+linew},${linew}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12400,9 +12400,9 @@ function toggleActorOrbject(type){
  */
 //TODO This should be implemeted into saveProperties but as of this moment I could not becuase of a bug that was outside the scope of my issue.
 function setSequenceDashedLines(){
-    //for each element in context, check if it has the property hasDashedLine and then change it to suit the checkbox.
+    //for each element in context, check if it has the property alternatives
     for (let i = 0; i < context.length; i++) {
-        if (context[i].numberOfDashedLines != null) {
+        if (context[i].alternatives != null) {
             /* let numberOfAttribute = document.getElementById("inputAlternatives");
             //context[i].numberOfDashedLines =  Number(document.getElementById("inputNumberOfDashedLines").value);
             if (context[i].numberOfDashedLines == 0) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2977,8 +2977,6 @@ function saveProperties()
                 }
                 break;
             case 'attributes':
-            case 'functions':
-            case 'alternatives':
                 //Get string from textarea
                 var elementAttr = child.value;
                 //Create an array from string where newline seperates elements
@@ -2995,7 +2993,7 @@ function saveProperties()
                 propsChanged.attributes = arrElementAttr;
                 break;
         
-            /* case 'functions':
+            case 'functions':
                 //Get string from textarea
                 var elementFunc = child.value;
                 //Create an array from string where newline seperates elements
@@ -3010,7 +3008,7 @@ function saveProperties()
                 arrElementFunc = formatArr;
                 element[propName] = arrElementFunc;
                 propsChanged.functions = arrElementFunc;
-                break; */
+                break;
 
             default:
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9706,7 +9706,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${50*zoomfact+linew}' y='${((boxh/element.alternatives.length)*i)+(texth/2)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
+                str += `<text x='${50*zoomfact+linew}' y='${((boxh/element.alternatives.length)*i)+texth+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
         }
         //svg for the small label in top left corner
@@ -9728,7 +9728,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
+        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+texth}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12401,14 +12401,9 @@ function setSequenceAlternatives(){
             console.log(alternatives.length);
             context[0].alternatives = alternatives;
 
-            //set altOrLoop accordingly 
             let newAltOrLoop;
-            if (context[i].alternatives.length <= 1) {
-                newAltOrLoop = "Loop";
-                
-            } else {
-                newAltOrLoop = "Alt";
-            }
+            //check if the length is less or equal to 1, if so its loop, else its alt.
+            context[i].alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
             context[i].altOrLoop = newAltOrLoop;
             stateMachine.save(
                 StateChangeFactory.ElementAttributesChanged(context[0].id, { 'alternatives': alternatives }),

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6690,7 +6690,7 @@ function generateContextProperties()
                 for (const property in element) {
                     switch (property.toLowerCase()) {
                         case 'alternatives':
-                            str += `<div>Amount of Dashed lines, 0 for loop.`
+                            str += `<div>Each line is an alternative. Just one is a loop.`
                             //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`
                             //str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
                             str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9682,6 +9682,9 @@ function drawElement(element, ghosted = false)
                 />`;
                 str += `<text x='${linew*2}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew*2}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
+            //increase length of element to avoid squished alternatives
+            boxh += 250*element.alternatives.length;
+
         }
         //svg for the small label in top left corner
         str += `<path 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9656,6 +9656,7 @@ function drawElement(element, ghosted = false)
             //check if the length is less or equal to 1, if so its loop, else its alt.
             context[i].alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
             context[i].altOrLoop = newAltOrLoop;
+            setSequenceAlternatives();
         }
         
         //div to encapsulate sequence loop 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9656,7 +9656,6 @@ function drawElement(element, ghosted = false)
             //check if the length is less or equal to 1, if so its loop, else its alt.
             element.alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
             element.altOrLoop = newAltOrLoop;
-            console.log(newAltOrLoop);
         }
         
         //div to encapsulate sequence loop 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9645,13 +9645,19 @@ function drawElement(element, ghosted = false)
     // Sequence loop 
     else if (element.kind == 'sequenceLoopOrAlt') {
         //first, set a suggested height for the element based on the amount of alternatives
-        if ((element.alternatives != null) && (element.alternatives.length > 0)) {
+        if (element.alternatives != null) {
             //increase length of element to avoid squished alternatives
             //boxh += 250*element.alternatives.length;
             for (let i = 0; i < element.alternatives.length; i++) {
                 boxh += 50*zoomfact;
             }
+            //also set alt or loop to whatever is correct
+            let newAltOrLoop;
+            //check if the length is less or equal to 1, if so its loop, else its alt.
+            context[i].alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
+            context[i].altOrLoop = newAltOrLoop;
         }
+        
         //div to encapsulate sequence loop 
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
         style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;`;
@@ -12401,13 +12407,8 @@ function setSequenceAlternatives(){
             console.log(alternatives.length);
             context[0].alternatives = alternatives;
 
-            let newAltOrLoop;
-            //check if the length is less or equal to 1, if so its loop, else its alt.
-            context[i].alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
-            context[i].altOrLoop = newAltOrLoop;
             stateMachine.save(
                 StateChangeFactory.ElementAttributesChanged(context[0].id, { 'alternatives': alternatives }),
-                StateChangeFactory.ElementAttributesChanged(context[0].id, { 'altOrLoop': newAltOrLoop }),
                 StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED
             );
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9649,7 +9649,7 @@ function drawElement(element, ghosted = false)
             //increase length of element to avoid squished alternatives
             //boxh += 250*element.alternatives.length;
             for (let i = 0; i < element.alternatives.length; i++) {
-                boxh = 125*zoomfact;
+                boxh += 125*zoomfact;
             }
             //also set alt or loop to whatever is correct
             let newAltOrLoop;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2977,6 +2977,8 @@ function saveProperties()
                 }
                 break;
             case 'attributes':
+            case 'functions':
+            case 'alternatives':
                 //Get string from textarea
                 var elementAttr = child.value;
                 //Create an array from string where newline seperates elements
@@ -2993,7 +2995,7 @@ function saveProperties()
                 propsChanged.attributes = arrElementAttr;
                 break;
         
-            case 'functions':
+            /* case 'functions':
                 //Get string from textarea
                 var elementFunc = child.value;
                 //Create an array from string where newline seperates elements
@@ -3008,7 +3010,7 @@ function saveProperties()
                 arrElementFunc = formatArr;
                 element[propName] = arrElementFunc;
                 propsChanged.functions = arrElementFunc;
-                break;
+                break; */
 
             default:
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9644,6 +9644,11 @@ function drawElement(element, ghosted = false)
     }
     // Sequence loop 
     else if (element.kind == 'sequenceLoopOrAlt') {
+        //first, set a suggested height for the element based on the amount of alternatives
+        if ((element.alternatives != null) && (element.alternatives.length > 0)) {
+            //increase length of element to avoid squished alternatives
+            boxh += 250*element.alternatives.length;
+        }
         //div to encapsulate sequence loop 
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
         style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;`;
@@ -9682,9 +9687,6 @@ function drawElement(element, ghosted = false)
                 />`;
                 str += `<text x='${linew*2}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew*2}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
-            //increase length of element to avoid squished alternatives
-            boxh += 250*element.alternatives.length;
-
         }
         //svg for the small label in top left corner
         str += `<path 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2977,6 +2977,7 @@ function saveProperties()
                 }
                 break;
             case 'attributes':
+            case 'functions':
                 //Get string from textarea
                 var elementAttr = child.value;
                 //Create an array from string where newline seperates elements
@@ -2993,7 +2994,7 @@ function saveProperties()
                 propsChanged.attributes = arrElementAttr;
                 break;
         
-            case 'functions':
+            /* case 'functions':
                 //Get string from textarea
                 var elementFunc = child.value;
                 //Create an array from string where newline seperates elements
@@ -3008,7 +3009,7 @@ function saveProperties()
                 arrElementFunc = formatArr;
                 element[propName] = arrElementFunc;
                 propsChanged.functions = arrElementFunc;
-                break;
+                break; */
 
             default:
                 break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6679,10 +6679,10 @@ function generateContextProperties()
                             break;
                         case 'actororobject':
                             //buttons for choosing object or actor via toggleActorOrbject
-                            str += `<div>`
-                            str += `<button onclick='toggleActorOrbject("actor");'>Actor</button>`
-                            str += `<button onclick='toggleActorOrbject("object");'>Object</button>`
-                            str += `</div>`
+                            str += `<div>`;
+                            str += `<button onclick='toggleActorOrbject("actor");'>Actor</button>`;
+                            str += `<button onclick='toggleActorOrbject("object");'>Object</button>`;
+                            str += `</div>`;
                             break;
                         default:
                             break;
@@ -6693,11 +6693,11 @@ function generateContextProperties()
                 for (const property in element) {
                     switch (property.toLowerCase()) {
                         case 'alternatives':
-                            str += `<div>Each line is an alternative. Just one is a loop.`
+                            str += `<div>Each line is an alternative. Just one is a loop.`;
                             //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`
                             //str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
                             str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
-                            str += `</div>`
+                            str += `</div>`;
                             break;
                         default:
                             break;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2978,6 +2978,7 @@ function saveProperties()
                 break;
             case 'attributes':
             case 'functions':
+            case 'alternatives':
                 //Get string from textarea
                 var elementAttr = child.value;
                 //Create an array from string where newline seperates elements
@@ -6713,7 +6714,7 @@ function generateContextProperties()
             str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
                `<span id="BGColorMenu" class="colorMenu"></span></button>`;
         }
-        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="setSequenceDashedLines();changeState();saveProperties();generateContextProperties();">`;
+        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();generateContextProperties();">`;
       }
 
       // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.
@@ -12392,24 +12393,6 @@ function toggleActorOrbject(type){
             }
         }
     }
-    showdata();
-}
-/**
- * @description sets the attribute numberOfDashedLines in sequenceLoopOrAlt to the input box numberOfDashedLines's value.
- */
-function setSequenceDashedLines(){
-    //for each element in context, check if it has the property hasDashedLine and then change it to suit the checkbox.
-    /* for (let i = 0; i < context.length; i++) {
-        if (context[i].numberOfDashedLines != null) {
-            context[i].numberOfDashedLines =  Number(document.getElementById("inputNumberOfDashedLines").value);
-            if (context[i].numberOfDashedLines == 0) {
-                context[i].altOrLoop = "Loop";
-            } else {
-                context[i].altOrLoop = "Alt";
-            }
-        }
-    } */
-    //elementProperty_numberOfDashedLines
     showdata();
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9649,7 +9649,7 @@ function drawElement(element, ghosted = false)
             //increase length of element to avoid squished alternatives
             //boxh += 250*element.alternatives.length;
             for (let i = 0; i < element.alternatives.length; i++) {
-                boxh += 50;
+                boxh += 50*zoomfact;
             }
         }
         //div to encapsulate sequence loop 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9692,6 +9692,7 @@ function drawElement(element, ghosted = false)
             fill='transparent'
             />`;
         } */
+        //if the user chose to have alternative lines, iterate and draw them out one by one, evenly spaced out.
         if ((element.numberOfDashedLines != null) && (element.numberOfDashedLines > 0)) {
             let numberOfAlternatives = element.numberOfDashedLines + 1;
             for (let i = 1; i < numberOfAlternatives; i++) {
@@ -9704,7 +9705,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                
+                str += `<text x='${50*zoomfact+linew}' y='${((boxh/numberOfAlternatives)*i)+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
             }
         }
         //svg for the small label in top left corner

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,7 @@ var defaults = {
 
     sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" }, // Sequence Activation.
-    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 200, type: "sequence", alternatives: ["alternative1","alternative2"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
+    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 200, type: "sequence", numberOfDashedLines: 1, altOrLoop: "Alt"} // Sequence Loop or Alternative.
 
 }
 var defaultLine = { kind: "Normal" };
@@ -6696,8 +6696,7 @@ function generateContextProperties()
                         case 'numberofdashedlines':
                             str += `<div>Amount of Dashed lines, 0 for loop.`
                             //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`
-                            //str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
-                            str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
+                            str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
                             str += `</div>`
                             break;
                         default:
@@ -9694,11 +9693,11 @@ function drawElement(element, ghosted = false)
             />`;
         } */
         //if the user chose to have alternative lines, iterate and draw them out one by one, evenly spaced out.
-        if ((element.alternatives != null) && (element.alternatives.length > 0)) {
-            let numberOfAlternativeSpaces = element.alternatives.length + 1;
-            for (let i = 1; i < numberOfAlternativeSpaces; i++) {
+        if ((element.numberOfDashedLines != null) && (element.numberOfDashedLines > 0)) {
+            let numberOfAlternatives = element.numberOfDashedLines + 1;
+            for (let i = 1; i < numberOfAlternatives; i++) {
                 str += `<path class="text"
-                d="M${boxw-linew},${(boxh/numberOfAlternativeSpaces)*i}
+                d="M${boxw-linew},${(boxh/numberOfAlternatives)*i}
                     H${linew}
                 "
                 stroke-width='${linew}'
@@ -9706,7 +9705,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${50*zoomfact+linew}' y='${((boxh/numberOfAlternativeSpaces)*i)+(texth/2)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
+                str += `<text x='${50*zoomfact+linew}' y='${((boxh/numberOfAlternatives)*i)+(texth/2)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
             }
         }
         //svg for the small label in top left corner
@@ -9728,7 +9727,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
+        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.name}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality
@@ -12402,7 +12401,7 @@ function toggleActorOrbject(type){
  */
 function setSequenceDashedLines(){
     //for each element in context, check if it has the property hasDashedLine and then change it to suit the checkbox.
-    /* for (let i = 0; i < context.length; i++) {
+    for (let i = 0; i < context.length; i++) {
         if (context[i].numberOfDashedLines != null) {
             context[i].numberOfDashedLines =  Number(document.getElementById("inputNumberOfDashedLines").value);
             if (context[i].numberOfDashedLines == 0) {
@@ -12411,8 +12410,7 @@ function setSequenceDashedLines(){
                 context[i].altOrLoop = "Alt";
             }
         }
-    } */
-    //elementProperty_numberOfDashedLines
+    }
     showdata();
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2978,7 +2978,6 @@ function saveProperties()
                 break;
             case 'attributes':
             case 'functions':
-            case 'alternatives':
                 //Get string from textarea
                 var elementAttr = child.value;
                 //Create an array from string where newline seperates elements
@@ -6714,7 +6713,7 @@ function generateContextProperties()
             str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
                `<span id="BGColorMenu" class="colorMenu"></span></button>`;
         }
-        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="changeState();saveProperties();generateContextProperties();">`;
+        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="setSequenceDashedLines();changeState();saveProperties();generateContextProperties();">`;
       }
 
       // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.
@@ -12393,6 +12392,24 @@ function toggleActorOrbject(type){
             }
         }
     }
+    showdata();
+}
+/**
+ * @description sets the attribute numberOfDashedLines in sequenceLoopOrAlt to the input box numberOfDashedLines's value.
+ */
+function setSequenceDashedLines(){
+    //for each element in context, check if it has the property hasDashedLine and then change it to suit the checkbox.
+    /* for (let i = 0; i < context.length; i++) {
+        if (context[i].numberOfDashedLines != null) {
+            context[i].numberOfDashedLines =  Number(document.getElementById("inputNumberOfDashedLines").value);
+            if (context[i].numberOfDashedLines == 0) {
+                context[i].altOrLoop = "Loop";
+            } else {
+                context[i].altOrLoop = "Alt";
+            }
+        }
+    } */
+    //elementProperty_numberOfDashedLines
     showdata();
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9656,6 +9656,7 @@ function drawElement(element, ghosted = false)
             //check if the length is less or equal to 1, if so its loop, else its alt.
             context[i].alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
             context[i].altOrLoop = newAltOrLoop;
+            console.log(newAltOrLoop);
         }
         
         //div to encapsulate sequence loop 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9647,7 +9647,10 @@ function drawElement(element, ghosted = false)
         //first, set a suggested height for the element based on the amount of alternatives
         if ((element.alternatives != null) && (element.alternatives.length > 0)) {
             //increase length of element to avoid squished alternatives
-            boxh += 250*element.alternatives.length;
+            //boxh += 250*element.alternatives.length;
+            for (let i = 0; i < element.alternatives.length; i++) {
+                boxh += 250;
+            }
         }
         //div to encapsulate sequence loop 
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2993,7 +2993,6 @@ function saveProperties()
                 arrElementAttr = formatArr;
                 element[propName] = arrElementAttr;
                 propsChanged.attributes = arrElementAttr;
-                console.logpropsChanged.attributes);
                 break;
         
             /* case 'functions':

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12404,7 +12404,6 @@ function setSequenceDashedLines(){
             }
         }
     }
-    //elementProperty_numberOfDashedLines
     showdata();
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9704,7 +9704,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${50*zoomfact+linew}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
+                str += `<text x='${linew}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
         }
         //svg for the small label in top left corner
@@ -9726,7 +9726,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/1.5)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
+        str += `<text x='${linew}' y='${37.5*zoomfact+(linew*2)+(texth/1.5)}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,7 @@ var defaults = {
 
     sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" }, // Sequence Activation.
-    sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], numberOfAlternatives: 3, altOrLoop: "Alt"} // Sequence Loop or Alternative.
+    sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
 
 }
 var defaultLine = { kind: "Normal" };
@@ -9671,29 +9671,8 @@ function drawElement(element, ghosted = false)
             rx='${7*zoomfact}'
             fill-opacity="0"
         />`;
-        /* if ((element.numberOfDashedLines != null) && (element.numberOfDashedLines > 0)) {
-            //the first line is outside of the loop since it has a absolute M instead of a relative m.
-            str += `<path class="text" 
-                d="M${boxw-linew},${(boxh-(linew*2))/(element.numberOfDashedLines+1)}
-                H${linew}`
-            //loop through the rest of the dashed lines using the first one as reference for the relative m.
-            for (let i = 0; i < element.numberOfDashedLines-1; i++) {
-                str += `
-                m${boxw-linew},${(boxh-(linew*2))/(element.numberOfDashedLines+1)}
-                H${linew}`
-                console.log("text for each line");
-            }
-            //finally, close the path off with appropriate values.
-            str += `"
-            stroke-width='${linew}'
-            stroke='${element.stroke}'
-            stroke-dasharray='${linew*3},${linew*3}'
-            fill='transparent'
-            />`;
-        } */
         //if the user chose to have alternative lines, iterate and draw them out one by one, evenly spaced out.
         if ((element.alternatives != null) && (element.alternatives.length > 0)) {
-            //let numberOfAlternativeSpaces = element.alternatives.length;
             for (let i = 1; i < element.alternatives.length; i++) {
                 str += `<path class="text"
                 d="M${boxw-linew},${(boxh/element.alternatives.length)*i}
@@ -12396,20 +12375,13 @@ function toggleActorOrbject(type){
     showdata();
 }
 /**
- * @description sets the attribute numberOfAlternatives in sequenceLoopOrAlt to the amount of lines in the input textarea called inputAlternatives.
+ * @description sets the alternatives attribute for sequenceLoopOrAlt to whatever is in the input box inputAlternatives. one index in the array per line.
  */
 //TODO This should be implemeted into saveProperties but as of this moment I could not becuase of a bug that was outside the scope of my issue.
 function setSequenceDashedLines(){
     //for each element in context, check if it has the property alternatives
     for (let i = 0; i < context.length; i++) {
         if (context[i].alternatives != null) {
-            /* let numberOfAttribute = document.getElementById("inputAlternatives");
-            //context[i].numberOfDashedLines =  Number(document.getElementById("inputNumberOfDashedLines").value);
-            if (context[i].numberOfDashedLines == 0) {
-                context[i].altOrLoop = "Loop";
-            } else {
-                context[i].altOrLoop = "Alt";
-            } */
             //Create an array from string where newline seperates elements
             let alternatives = document.getElementById("inputAlternatives").value.split('\n');
             let formatArr = [];
@@ -12418,14 +12390,14 @@ function setSequenceDashedLines(){
                     formatArr.push(alternatives[i]);
                 } 
             }
-            //Update the attribute array
+            //Update the alternatives array
             alternatives = formatArr;
             console.log(alternatives);
             console.log(alternatives.length);
             context[0].alternatives = alternatives;
-            context[0].numberOfAlternatives = alternatives.length;
 
-            if (context[i].numberOfAlternatives <= 1) {
+            //set altOrLoop accordingly 
+            if (context[i].alternatives.length <= 1) {
                 context[i].altOrLoop = "Loop";
             } else {
                 context[i].altOrLoop = "Alt";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12402,15 +12402,17 @@ function setSequenceAlternatives(){
             context[0].alternatives = alternatives;
 
             //set altOrLoop accordingly 
+            let newAltOrLoop;
             if (context[i].alternatives.length <= 1) {
-                context[i].altOrLoop = "Loop";
+                newAltOrLoop = "Loop";
+                
             } else {
-                context[i].altOrLoop = "Alt";
+                newAltOrLoop = "Alt";
             }
-
+            context[i].altOrLoop = newAltOrLoop;
             stateMachine.save(
                 StateChangeFactory.ElementAttributesChanged(context[0].id, { 'alternatives': alternatives }),
-                StateChangeFactory.ElementAttributesChanged(context[0].id, { 'altOrLoop': context[i].altOrLoop }),
+                StateChangeFactory.ElementAttributesChanged(context[0].id, { 'altOrLoop': newAltOrLoop }),
                 StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED
             );
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9706,7 +9706,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${50*zoomfact+linew}' y='${((boxh/element.alternatives.length)*i)+texth+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
+                str += `<text x='${50*zoomfact+linew}' y='${((boxh/element.alternatives.length)*i)+(texth/4)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
         }
         //svg for the small label in top left corner
@@ -9728,7 +9728,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+texth}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
+        str += `<text x='${50*zoomfact+linew}' y='${37.5*zoomfact+(linew*2)+(texth/4)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9654,8 +9654,8 @@ function drawElement(element, ghosted = false)
             //also set alt or loop to whatever is correct
             let newAltOrLoop;
             //check if the length is less or equal to 1, if so its loop, else its alt.
-            context[i].alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
-            context[i].altOrLoop = newAltOrLoop;
+            element.alternatives.length <= 1 ? newAltOrLoop = "Loop" : newAltOrLoop = "Alt";
+            element.altOrLoop = newAltOrLoop;
             console.log(newAltOrLoop);
         }
         

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6690,13 +6690,10 @@ function generateContextProperties()
                 for (const property in element) {
                     switch (property.toLowerCase()) {
                         case 'alternatives':
-                            str += `<div>Each line is an alternative. Just one is a loop.`
-                            //str += `<input type="checkbox" id="dashedLineToggle" onclick="toggleDashedLine()" name="dashedLineToggle" checked><label for="dashedLineToggle">Toggle dashed line</label>`
-                            //str +=`<input id="inputNumberOfDashedLines" type="number" min="0" value='${element[property]}'/>`
-                            //str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
+                            str += `<div>Each line is an alternative. Just one is a loop.`;
                             //TODO in the future, this can be implemented as part of saveProperties and combine attribute and func and alternatives cases.
                             str += `<textarea id='inputAlternatives' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;
-                            str += `</div>`
+                            str += `</div>`;
                             break;
                         default:
                             break;
@@ -6714,7 +6711,7 @@ function generateContextProperties()
             str += `<button id="colorMenuButton1" class="colorMenuButton" onclick="toggleColorMenu('colorMenuButton1')" style="background-color: ${context[0].fill}">` +
                `<span id="BGColorMenu" class="colorMenu"></span></button>`;
         }
-        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="setSequenceDashedLines();changeState();saveProperties();generateContextProperties();">`;
+        str += `<br><br><input type="submit" value="Save" class='saveButton' onclick="setSequenceAlternatives();changeState();saveProperties();generateContextProperties();">`;
       }
 
       // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.
@@ -12378,7 +12375,7 @@ function toggleActorOrbject(type){
  * @description sets the alternatives attribute for sequenceLoopOrAlt to whatever is in the input box inputAlternatives. one index in the array per line.
  */
 //TODO This should be implemeted into saveProperties but as of this moment I could not becuase of a bug that was outside the scope of my issue.
-function setSequenceDashedLines(){
+function setSequenceAlternatives(){
     //for each element in context, check if it has the property alternatives
     for (let i = 0; i < context.length; i++) {
         if (context[i].alternatives != null) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9704,7 +9704,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${linew*2}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
+                str += `<text x='${linew*2}' y='${((boxh/element.alternatives.length)*i)+(texth/1.5)+linew*2}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
         }
         //svg for the small label in top left corner
@@ -9726,7 +9726,7 @@ function drawElement(element, ghosted = false)
         str += `<text x='${50*zoomfact+linew}' y='${18.75*zoomfact+linew}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.altOrLoop}</text>`;
         //text below the label
         //TODO when actorFontColor is replaced with nonFilledElementPartStroke, change this to that.
-        str += `<text x='${linew*2}' y='${37.5*zoomfact+(linew*2)+(texth/1.5)}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
+        str += `<text x='${linew*2}' y='${37.5*zoomfact+(linew*3)+(texth/1.5)}' fill='${actorFontColor}'>${element.alternatives[0]}</text>`;
         str += `</svg>`;
     }
     //=============================================== <-- End of Sequnece functionality

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12403,8 +12403,6 @@ function setSequenceAlternatives(){
             }
             //Update the alternatives array
             alternatives = formatArr;
-            console.log(alternatives);
-            console.log(alternatives.length);
             context[0].alternatives = alternatives;
 
             stateMachine.save(

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2993,6 +2993,7 @@ function saveProperties()
                 arrElementAttr = formatArr;
                 element[propName] = arrElementAttr;
                 propsChanged.attributes = arrElementAttr;
+                console.logpropsChanged.attributes);
                 break;
         
             /* case 'functions':

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,7 @@ var defaults = {
 
     sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" }, // Sequence Activation.
-    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 200, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
+    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
 
 }
 var defaultLine = { kind: "Normal" };

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9649,7 +9649,7 @@ function drawElement(element, ghosted = false)
             //increase length of element to avoid squished alternatives
             //boxh += 250*element.alternatives.length;
             for (let i = 0; i < element.alternatives.length; i++) {
-                boxh += 250;
+                boxh += 50;
             }
         }
         //div to encapsulate sequence loop 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2993,7 +2993,7 @@ function saveProperties()
                 arrElementAttr = formatArr;
                 element[propName] = arrElementAttr;
                 propsChanged.attributes = arrElementAttr;
-                console.log(propsChanged.attributes);
+                console.logpropsChanged.attributes);
                 break;
         
             /* case 'functions':

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12424,6 +12424,12 @@ function setSequenceDashedLines(){
             console.log(alternatives.length);
             context[0].alternatives = alternatives;
             context[0].numberOfAlternatives = alternatives.length;
+
+            if (context[i].numberOfAlternatives <= 1) {
+                context[i].altOrLoop = "Loop";
+            } else {
+                context[i].altOrLoop = "Alt";
+            }
         }
     }
     //elementProperty_numberOfDashedLines

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12414,7 +12414,7 @@ function setSequenceDashedLines(){
             let alternatives = document.getElementById("inputAlternatives").value.split('\n');
             let formatArr = [];
             for (let i = 0; i < alternatives.length; i++) {
-                if (!(numberOfAttribute[i] == '\n' || alternatives[i] == '' || alternatives[i] == ' ')) {
+                if (!(alternatives[i] == '\n' || alternatives[i] == '' || alternatives[i] == ' ')) {
                     formatArr.push(alternatives[i]);
                 } 
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9649,7 +9649,7 @@ function drawElement(element, ghosted = false)
             //increase length of element to avoid squished alternatives
             //boxh += 250*element.alternatives.length;
             for (let i = 0; i < element.alternatives.length; i++) {
-                boxh += 50*zoomfact;
+                boxh = 125*zoomfact;
             }
             //also set alt or loop to whatever is correct
             let newAltOrLoop;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1147,7 +1147,7 @@ var defaults = {
 
     sequenceActorAndObject: {name: "name", kind: "sequenceActorAndObject", fill: "#FFFFFF", stroke: "#000000", width: 100, height: 150, type: "sequence", actorOrObject: "actor" }, // sequence actor and object
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "sequence" }, // Sequence Activation.
-    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 200, type: "sequence", alternatives: ["alternative1","alternative2"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
+    sequenceLoopOrAlt: {name: "name", kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 200, type: "sequence", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt"} // Sequence Loop or Alternative.
 
 }
 var defaultLine = { kind: "Normal" };
@@ -9695,10 +9695,10 @@ function drawElement(element, ghosted = false)
         } */
         //if the user chose to have alternative lines, iterate and draw them out one by one, evenly spaced out.
         if ((element.alternatives != null) && (element.alternatives.length > 0)) {
-            let numberOfAlternativeSpaces = element.alternatives.length + 1;
-            for (let i = 1; i < numberOfAlternativeSpaces; i++) {
+            //let numberOfAlternativeSpaces = element.alternatives.length;
+            for (let i = 1; i < element.alternatives.length; i++) {
                 str += `<path class="text"
-                d="M${boxw-linew},${(boxh/numberOfAlternativeSpaces)*i}
+                d="M${boxw-linew},${(boxh/element.alternatives.length)*i}
                     H${linew}
                 "
                 stroke-width='${linew}'
@@ -9706,7 +9706,7 @@ function drawElement(element, ghosted = false)
                 stroke-dasharray='${linew*3},${linew*3}'
                 fill='transparent'
                 />`;
-                str += `<text x='${50*zoomfact+linew}' y='${((boxh/numberOfAlternativeSpaces)*i)+(texth/2)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
+                str += `<text x='${50*zoomfact+linew}' y='${((boxh/element.alternatives.length)*i)+(texth/2)+linew}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${actorFontColor}'>${element.alternatives[i]}</text>`;
             }
         }
         //svg for the small label in top left corner

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -440,6 +440,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>    
+                    
                     <div id="diagramPopOut"><!--Initial state -->
                         <div id="togglePlacementTypeBox9" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);'>
@@ -558,22 +559,26 @@
                         </div>
                     </div>
                 </div><!--<-- UML functionality end -->
-
-                <!-- SEQUENCE POP-OUT START-->
-
-                <div> <!-- SEQUENCE LIFELINE START -->
-                    <div id="elementPlacement12"
-                         class="SEButton diagramIcons toolbarMode"
-                         onclick='setElementPlacementType(12); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(12)">
-                         <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
-                        <span class="toolTipText"><b>Sequence lifeline</b><br>
-                            <p>Creates a lifeline for a sequnece diagram</p>
-                            <p>Represents the passage of time.</p>
-                            <p>Shows events that occur to an object during the process.</p>
-                            <br>
-                            <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                 <!--Sequence diagram lifeline | for now is bound to uml final state -->
+                <div id="elementPlacement12" class="diagramIcons toolbarMode" onclick='setElementPlacementType(12); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
+                    <span class="toolTipText"><b>Sequence lifeline</b><br>
+                        <p>Creates a lifeline for a sequnece diagram</p>
+                        <p>Represents the passage of time.</p>
+                        <p>Shows events that occur to an object during the process.</p>
+                        <br>
+                        <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                    </span>
+                </div>              
+                <!-- Sequence diagram object selection -->
+                <div id="elementPlacement14" class="diagramIcons toolbarMode" onclick='setElementPlacementType(2); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                    <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence Object"/>
+                    <span class="toolTipText"><b>Sequence Object</b><br>
+                        <p>Creates a sequence object.</p>
+                        <p>Represents a class or object.</p>
+                        <p>Used to show how an object will behave.</p>
+                        <br>
+                        <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
                         </span>
                 </div> 
                 <!-- Sequence activation selection -->
@@ -593,167 +598,7 @@
                         <p>Creates a option loop or alternative.</p><br>
                         <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
                         </span>
-                        <div id="togglePlacementTypeButton13" class="placementTypeIcon togglePlacementTypeButton">
-                            <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
-                        </div>
-                    </div>    
-                    <div id="diagramPopOut">
-                        <div id="togglePlacementTypeBox13" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> <!-- LIFETIME !-->
-                            <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
-                            <span class="toolTipText"><b>Sequence lifeline</b><br>
-                                <p>Creates a lifeline for a sequnece diagram</p>
-                                <p>Represents the passage of time.</p>
-                                <p>Shows events that occur to an object during the process.</p>
-                                <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
-                            <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
-                            <span class="toolTipText"><b>Sequence activation</b><br>
-                                <p>Creates an activation box.</p>
-                                <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
-                                <br>
-                                <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > <!-- OBJECT !-->
-                            <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence Object"/>
-                            <span class="toolTipText"><b>Sequence Object</b><br>
-                                <p>Creates a sequence object.</p>
-                                <p>Represents a class or object.</p>
-                                <p>Used to show how an object will behave.</p>
-                                <br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>        
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(15,12); setElementPlacementType(15); setMouseMode(2);' > <!-- LOOP !-->
-                            <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                            <span class="toolTipText"><b>Sequence Condition</b><br>
-                                <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>                         
-                        </div>
-                    </div>
-                </div> <!-- SEQUENCE ACTIVATION END -->
-                <div> <!-- SEQUENCE OBJECT START -->
-                    <div id="elementPlacement14"
-                         class="SEButton diagramIcons toolbarMode"
-                         onclick='setElementPlacementType(14); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(14)">
-                         <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence Object"/>
-                        <span class="toolTipText"><b>Sequence Object</b><br>
-                            <p>Creates a sequence object.</p>
-                            <p>Represents a class or object.</p>
-                            <p>Used to show how an object will behave.</p>
-                            <br>
-                            <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                        </span>
-                        <div id="togglePlacementTypeButton14" class="placementTypeIcon togglePlacementTypeButton">
-                            <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
-                        </div>
-                    </div>    
-                    <div id="diagramPopOut">
-                        <div id="togglePlacementTypeBox14" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> <!-- LIFETIME !-->
-                            <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
-                            <span class="toolTipText"><b>Sequence lifeline</b><br>
-                                <p>Creates a lifeline for a sequnece diagram</p>
-                                <p>Represents the passage of time.</p>
-                                <p>Shows events that occur to an object during the process.</p>
-                                <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
-                            <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
-                            <span class="toolTipText"><b>Sequence activation</b><br>
-                                <p>Creates an activation box.</p>
-                                <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
-                                <br>
-                                <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > <!-- OBJECT !-->
-                            <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence Object"/>
-                            <span class="toolTipText"><b>Sequence Object</b><br>
-                                <p>Creates a sequence object.</p>
-                                <p>Represents a class or object.</p>
-                                <p>Used to show how an object will behave.</p>
-                                <br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>        
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(15,12); setElementPlacementType(15); setMouseMode(2);' > <!-- LOOP !-->
-                            <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                            <span class="toolTipText"><b>Sequence Condition</b><br>
-                                <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>                         
-                        </div>
-                    </div>
-                </div> <!-- SEQUENCE OBJECT END -->
-                <div> <!-- SEQUENCE CONDITION/LOOP START -->
-                    <div id="elementPlacement15"
-                         class="SEButton diagramIcons toolbarMode"
-                         onclick='setElementPlacementType(15); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(15)">
-                         <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                            <span class="toolTipText"><b>Sequence Condition</b><br>
-                                <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                            </span>
-                        <div id="togglePlacementTypeButton15" class="placementTypeIcon togglePlacementTypeButton">
-                            <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
-                        </div>
-                    </div>    
-                    <div id="diagramPopOut">
-                        <div id="togglePlacementTypeBox15" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> <!-- LIFETIME !-->
-                            <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
-                            <span class="toolTipText"><b>Sequence lifeline</b><br>
-                                <p>Creates a lifeline for a sequnece diagram</p>
-                                <p>Represents the passage of time.</p>
-                                <p>Shows events that occur to an object during the process.</p>
-                                <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
-                            <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
-                            <span class="toolTipText"><b>Sequence activation</b><br>
-                                <p>Creates an activation box.</p>
-                                <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
-                                <br>
-                                <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > <!-- OBJECT !-->
-                            <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence Object"/>
-                            <span class="toolTipText"><b>Sequence Object</b><br>
-                                <p>Creates a sequence object.</p>
-                                <p>Represents a class or object.</p>
-                                <p>Used to show how an object will behave.</p>
-                                <br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>        
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(15,12); setElementPlacementType(15); setMouseMode(2);' > <!-- LOOP !-->
-                            <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                            <span class="toolTipText"><b>Sequence Condition</b><br>
-                                <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                            </span>
-                            </div>                         
-                        </div>
-                    </div>
-                </div> <!-- SEQUENCE CONDITION/LOOP END -->
-                <!-- SEQUENCE POP-OUT END -->
+                </div>
         </fieldset>
         <!-- <fieldset>
             <legend>Zoom</legend>


### PR DESCRIPTION
This is a continuation of #13949 since the issue leader accidentally merged that unfinished PR into v6.

Here's what both of these PRs is about though:

I created a new element type called sequenceLoopOrAlt and made the svg for this. I also added the functionality of adding/removing alternatives via a **textbox in the context panel**. These alternatives adjust themselves accordingly to fit and also the whole element changes size to fit them. I also made sure to call state machine so undo/redo should work, although if it doesnt I believe it is a new issue.