### PR TITLE
G1 2023 v6 #13991

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4125,7 +4125,6 @@ function generateStateDiagramInfo()
     const queue = [];
     let output = "";
     let re = new RegExp("\\[.+\\]");
-const stateLinesLabels=[];
     // Picks out the lines of type "State Diagram" and place it in its local array.
     for (let i=0; i<lines.length; i++)
     {
@@ -4164,7 +4163,6 @@ const stateLinesLabels=[];
         // Finds all entities connected to the current "head" and adds line labels to a list.
         for (let i = 0; i < stateLines.length; i++) {
             if (stateLines[i].fromID == head[ENTITY].id) {
-                stateLinesLabels.push(stateLines[i].label);
                 for (let j = 0; j < stateElements.length; j++) {
                     if (stateLines[i].toID == stateElements[j][ENTITY].id) {
                         stateElements[j][LABEL] = stateLines[i].label;
@@ -4204,14 +4202,6 @@ const stateLinesLabels=[];
     }
 
     // Adds additional information in the view.
-    output+=`<p>Line labels:</p>`;
-    for(var i=0; i<stateLinesLabels.length; i++)
-    {
-        if(stateLinesLabels[i]==undefined)
-        output+=`<p>Unlabeled</p>`;
-        else
-        output+=`<p>${stateLinesLabels[i]}</p>`;
-    }
     output += `<p>Initial States: ${stateInitial.length}</p>`;
     output += `<p>Final States: ${stateFinal.length}</p>`;
     output += `<p>Super States: ${stateSuper.length}</p>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4124,6 +4124,7 @@ function generateStateDiagramInfo()
     const stateLines = [];
     const queue = [];
     let output = "";
+    let re = new RegExp("\\[.+\\]");
 const stateLinesLabels=[];
     // Picks out the lines of type "State Diagram" and place it in its local array.
     for (let i=0; i<lines.length; i++)
@@ -4187,6 +4188,9 @@ const stateLinesLabels=[];
         for (let i = 0; i < connections.length; i++) {
             if (connections[i][2] == undefined) {
                 output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}"</p>`;
+            }
+            else if (re.test(connections[i][2])) {
+                output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with guard "${connections[i][2]}"</p>`;
             }
             else {
                 output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with lable "${connections[i][2]}"</p>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4166,11 +4166,13 @@ const stateLinesLabels=[];
                 stateLinesLabels.push(stateLines[i].label);
                 for (let j = 0; j < stateElements.length; j++) {
                     if (stateLines[i].toID == stateElements[j][ENTITY].id) {
+                        stateElements[j][2] = stateLines[i].label;
                         connections.push(stateElements[j]);
                     }
                 }
                 for (let j = 0; j < stateFinal.length; j++) {
                     if (stateLines[i].toID == stateFinal[j][ENTITY].id) {
+                        stateFinal[j][2] = stateLines[i].label;
                         connections.push(stateFinal[j]);
                     }
                 }
@@ -4181,10 +4183,14 @@ const stateLinesLabels=[];
                 }
             }
         }
-
         // Add any connected entity to the output string, and if it has not been "seen" it is added to the queue.
         for (let i = 0; i < connections.length; i++) {
-        output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" </p>`;
+            if (connections[i][2] == undefined) {
+                output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}"</p>`;
+            }
+            else {
+                output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with lable "${connections[i][2]}"</p>`;
+            }
             if (connections[i][SEEN] === false) {
                 connections[i][SEEN] = true;
                 queue.push(connections[i]);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4179,6 +4179,7 @@ const stateLinesLabels=[];
                 }
                 for (let j = 0; j < stateSuper.length; j++) {
                     if (stateLines[i].toID == stateSuper[j][ENTITY].id) {
+                        stateSuper[j][LABEL] = stateLines[i].label;
                         connections.push(stateSuper[j]);
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4116,7 +4116,7 @@ function boxSelect_Draw(str)
  */
 function generateStateDiagramInfo()
 {
-    const ENTITY = 0, SEEN = 1;
+    const ENTITY = 0, SEEN = 1, LABEL = 2;
     const stateInitial = [];
     const stateFinal = [];
     const stateSuper = [];
@@ -4167,13 +4167,13 @@ const stateLinesLabels=[];
                 stateLinesLabels.push(stateLines[i].label);
                 for (let j = 0; j < stateElements.length; j++) {
                     if (stateLines[i].toID == stateElements[j][ENTITY].id) {
-                        stateElements[j][2] = stateLines[i].label;
+                        stateElements[j][LABEL] = stateLines[i].label;
                         connections.push(stateElements[j]);
                     }
                 }
                 for (let j = 0; j < stateFinal.length; j++) {
                     if (stateLines[i].toID == stateFinal[j][ENTITY].id) {
-                        stateFinal[j][2] = stateLines[i].label;
+                        stateFinal[j][LABEL] = stateLines[i].label;
                         connections.push(stateFinal[j]);
                     }
                 }
@@ -4186,14 +4186,14 @@ const stateLinesLabels=[];
         }
         // Add any connected entity to the output string, and if it has not been "seen" it is added to the queue.
         for (let i = 0; i < connections.length; i++) {
-            if (connections[i][2] == undefined) {
+            if (connections[i][LABEL] == undefined) {
                 output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}"</p>`;
             }
-            else if (re.test(connections[i][2])) {
-                output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with guard "${connections[i][2]}"</p>`;
+            else if (re.test(connections[i][LABEL])) {
+                output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with guard "${connections[i][LABEL]}"</p>`;
             }
             else {
-                output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with lable "${connections[i][2]}"</p>`;
+                output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with lable "${connections[i][LABEL]}"</p>`;
             }
             if (connections[i][SEEN] === false) {
                 connections[i][SEEN] = true;


### PR DESCRIPTION
If a transition has a label it will now show up like the following:
> "A" goes to "B" with lable "Test"

and if the label has square brackets like `[Test]` it will show up as the following:
> "B" goes to "C" with guard "[Test]"
