### PR TITLE
Border-radius is different on buttons for dark/light theme #13952

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -828,13 +828,6 @@ option:checked{
 }
 /* END */
 
-/* Style for "Input elements" */
-button{
-    background-color: var(--color-background-codeviewer-nav);
-    color: var(--color-text-light);
-    border-radius: 5px;
-}
-
 select{
     background-color: var(--color-background-light-surface);
     color: var(--color-text-list);


### PR DESCRIPTION
Removed it from blackTheme.css so it's the same as in style.css for light theme.