### PR TITLE
G3 2023 v6 issue#13897

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -550,6 +550,28 @@ function sendValue(moment) {
   xhr.send("momentid=" + encodeURIComponent(value));
 }
 
+function sendValue(moment) 
+{
+  let lid = moment.getAttribute("value");
+	var dataCheck;
+	$.ajax({
+		async: false,
+		url: "../LenaSYS/sectioned.php",
+		type: "POST",
+		data: {'lid':lid},
+		success: function(data) { 
+      alert(data);
+			dataCheck = true;
+		},
+		error: function(data){
+      alert(data);
+		 	dataCheck = false;
+		}
+	});
+  console.log("ajax done" + lid);
+	return dataCheck;
+}
+
 
 // Displaying and hidding the dynamic comfirmbox for the section edit dialog
 function confirmBox(operation, item = null) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -553,8 +553,8 @@ function showSaveButton() {
 function sendValue(lid) {
   console.log(lid);
 	$.ajax({
-		url: "sectioned.php",
-		type: "POST",
+		url: "../DuggaSys/sectioned.php?lid=" +lid,
+		type: "GET",
 		data: {lid: lid},
 		success: function(data) {
       console.log(data);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -474,6 +474,27 @@ function refreshGithubRepo(courseid)
 }
 
 //----------------------------------------------------------------------------------
+// lidToSectioned: Sends the correct "lid" to sectioned.php
+//----------------------------------------------------------------------------------
+
+function sendToSectioned(moment) {
+  $.ajax({
+  async: false,
+  url: "sectioned.php",
+  type: "POST",
+  data: {
+    'cid': moment.getAttribute('value-data')
+  },
+  success: function(data) {
+    alert(data);
+  },
+  error: function(data) {
+    alert("Error:" + data);
+  }
+  })
+}
+
+//----------------------------------------------------------------------------------
 // showEditVersion: Displays Edit Version Dialog
 //----------------------------------------------------------------------------------
 
@@ -1696,7 +1717,7 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
-          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this)'>`;
+          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this), sendToSectioned(this)'>`;
           str += "</td>";
         }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -553,7 +553,7 @@ function showSaveButton() {
 function sendValue(lid) {
   console.log(lid);
 	$.ajax({
-		url: "sectioned.php",
+		url: "../DuggaSys/sectioned.php",
 		type: "POST",
 		data: {lid: lid},
 		success: function(data) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -552,6 +552,7 @@ function showSaveButton() {
 
 function sendValue(moment) {
   let lid = moment.getAttribute("data-value");
+  console.log(lid);
 	$.ajax({
 		url: "../DuggaSys/sectioned.php",
 		type: "POST",

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -547,7 +547,7 @@ function sendValue(moment) {
     }
   };
   console.log(value);
-  xhr.send(value);
+  xhr.send("momentid=" + encodeURIComponent(value));
 }
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -531,15 +531,14 @@ function showSaveButton() {
 }
 
 function sendValue(element) {
-  let dataValue = element.getAttribute('data-value');
-  fetch('sectioned.php?data_value=' + encodeURIComponent(dataValue))
-    .then(response => response.text())
-    .then(data => {
+  let value = $(element).attr('data-value');
+  console.log(value);
+  const data = {
+    data_value: value
+  };
+  $.post('sectioned.php', data, function(response) {
 
-    })
-    .catch(error => {
-
-    });
+  });
 }
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -553,8 +553,8 @@ function showSaveButton() {
 function sendValue(lid) {
   console.log(lid);
 	$.ajax({
-		url: "../DuggaSys/sectioned.php?lid=" + lid,
-		type: "GET",
+		url: "sectioned.php",
+		type: "POST",
 		data: {lid: lid},
 		success: function(data) {
       console.log(data);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -530,25 +530,6 @@ function showSaveButton() {
   $(".closeDugga").css("display", "block");
 }
 
-function sendValue(element) {
-  let value = $(element).attr('data-value');
-
-  var form = document.createElement('form');
-  form.type = 'hidden';
-  form.method = 'POST';
-  form.action = 'sectioned.php';
-
-  var input = document.createElement('input');
-  input.type = 'hidden'; 
-  input.name = 'data_value';
-  input.value = value;
-
-  form.appendChild(input);
-  document.body.appendChild(form);
-  form.submit();
-}
-
-
 // Displaying and hidding the dynamic comfirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
   if (operation == "openConfirmBox") {
@@ -1715,7 +1696,7 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
-          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this); sendValue(this)'>`;
+          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this)'>`;
           str += "</td>";
         }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -550,8 +550,7 @@ function showSaveButton() {
   xhr.send("momentid=" + encodeURIComponent(value));
 } */
 
-function sendValue(moment) {
-  let lid = moment.getAttribute("data-value");
+function sendValue(lid) {
   console.log(lid);
 	$.ajax({
 		url: "../DuggaSys/sectioned.php",
@@ -1732,7 +1731,7 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
-          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this); sendValue(this)'>`;
+          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this); sendValue(${item['lid']})'>`;
           str += "</td>";
         }
 
@@ -1742,7 +1741,7 @@ function returnedSection(data) {
 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github' class=''
-          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubTemplate\", this); sendValue(this)'>`;
+          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubTemplate\", this); sendValue(${item['lid']})'>`;
           str += "</td>"; 
        }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -551,7 +551,7 @@ function showSaveButton() {
 } */
 
 function sendValue(moment) {
-  let lid = moment.getAttribute("value");
+  let lid = moment.getAttribute("data-value");
 	$.ajax({
 		url: "../DuggaSys/sectioned.php",
 		type: "POST",
@@ -1730,7 +1730,7 @@ function returnedSection(data) {
         if (itemKind === 4 && data['writeaccess'] || data['studentteacher'])  {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<img style='max-width: 60%;' value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
+          str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
           src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this); sendValue(this)'>`;
           str += "</td>";
         }
@@ -1740,7 +1740,7 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<img style='max-width: 60%;' value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github' class=''
+          str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github' class=''
           src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubTemplate\", this); sendValue(this)'>`;
           str += "</td>"; 
        }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -554,7 +554,7 @@ function sendValue(lid) {
   console.log(lid);
 	$.ajax({
 		url: "../DuggaSys/sectioned.php?lid=" + lid,
-		type: "POST",
+		type: "GET",
 		data: {lid: lid},
 		success: function(data) {
       console.log(data);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -532,13 +532,20 @@ function showSaveButton() {
 
 function sendValue(element) {
   let value = $(element).attr('data-value');
-  console.log(value);
-  const data = {
-    data_value: value
-  };
-  $.post('sectioned.php', data, function(response) {
 
-  });
+  var form = document.createElement('form');
+  form.type = 'hidden';
+  form.method = 'POST';
+  form.action = 'sectioned.php';
+
+  var input = document.createElement('input');
+  input.type = 'hidden'; 
+  input.name = 'data_value';
+  input.value = value;
+
+  form.appendChild(input);
+  document.body.appendChild(form);
+  form.submit();
 }
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1709,7 +1709,7 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
-          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this); sendValue(${item['lid']})'>`;
+          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this); sendValue(this)'>`;
           str += "</td>";
         }
 
@@ -1718,7 +1718,7 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github' class=''
+          str += `<img style='max-width: 60%;' class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github' class=''
           src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubTemplate\", this)'>`;
           str += "</td>"; 
        }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -530,39 +530,16 @@ function showSaveButton() {
   $(".closeDugga").css("display", "block");
 }
 
-// Fetching the value from clicked button
-/* function sendValue(moment) {
-  var value = moment.getAttribute("value");
-  var xhr = new XMLHttpRequest();
-  xhr.open("POST", "sectioned.php");
-  xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded")
-  xhr.onreadystatechange = function() {
-    if(xhr.readyState == XMLHttpRequest.DONE) {
-      if(xhr.status === 200) {
-        console.log(value);
-        console.log("value was sent correctly");      
-      } else {
-        console.log("value was not sent correctly");
-      }
-    }
-  };
-  console.log(value);
-  xhr.send("momentid=" + encodeURIComponent(value));
-} */
+function sendValue(element) {
+  let dataValue = element.getAttribute('data-value');
+  fetch('sectioned.php?data_value=' + encodeURIComponent(dataValue))
+    .then(response => response.text())
+    .then(data => {
 
-function sendValue(lid) {
-  console.log(lid);
-	$.ajax({
-		url: "../DuggaSys/sectioned.php?lid=" +lid,
-		type: "GET",
-		data: {lid: lid},
-		success: function(data) {
-      console.log(data);
-		},
-		error: function(data){
-      console.log("Error:", data);
-		}
-	});
+    })
+    .catch(error => {
+
+    });
 }
 
 
@@ -1742,7 +1719,7 @@ function returnedSection(data) {
 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github' class=''
-          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubTemplate\", this); sendValue(${item['lid']})'>`;
+          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubTemplate\", this)'>`;
           str += "</td>"; 
        }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -553,7 +553,7 @@ function showSaveButton() {
 function sendValue(lid) {
   console.log(lid);
 	$.ajax({
-		url: "../DuggaSys/sectioned.php",
+		url: "../DuggaSys/sectioned.php?lid=" + lid,
 		type: "POST",
 		data: {lid: lid},
 		success: function(data) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -556,7 +556,7 @@ function sendValue(moment)
 	var dataCheck;
 	$.ajax({
 		async: false,
-		url: "../LenaSYS/sectioned.php",
+		url: "../DuggaSys/sectioned.php",
 		type: "POST",
 		data: {'lid':lid},
 		success: function(data) { 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -477,23 +477,22 @@ function refreshGithubRepo(courseid)
 // lidToSectioned: Sends the correct "lid" to sectioned.php
 //----------------------------------------------------------------------------------
 
-function sendToSectioned(moment) {
+function sendToSectioned(moment, callback) {
   $.ajax({
-  async: false,
-  url: "sectioned.php",
-  type: "POST",
-  data: {
-    'cid': moment.getAttribute('value-data')
-  },
-  success: function(data) {
-    alert(data);
-  },
-  error: function(data) {
-    alert("Error:" + data);
-  }
-  })
+    async: false,
+    url: "sectioned.php",
+    type: "POST",
+    data: {
+      'cid': moment.getAttribute('value-data')
+    },
+    success: function(data) {
+      callback(data); // Execute the callback function with the returned data
+    },
+    error: function(data) {
+      callback(null, "Error:" + data); // Execute the callback function with an error message
+    }
+  });
 }
-
 //----------------------------------------------------------------------------------
 // showEditVersion: Displays Edit Version Dialog
 //----------------------------------------------------------------------------------

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -474,26 +474,6 @@ function refreshGithubRepo(courseid)
 }
 
 //----------------------------------------------------------------------------------
-// lidToSectioned: Sends the correct "lid" to sectioned.php
-//----------------------------------------------------------------------------------
-
-function sendToSectioned(moment, callback) {
-  $.ajax({
-    async: false,
-    url: "sectioned.php",
-    type: "POST",
-    data: {
-      'cid': moment.getAttribute('value-data')
-    },
-    success: function(data) {
-      callback(data); // Execute the callback function with the returned data
-    },
-    error: function(data) {
-      callback(null, "Error:" + data); // Execute the callback function with an error message
-    }
-  });
-}
-//----------------------------------------------------------------------------------
 // showEditVersion: Displays Edit Version Dialog
 //----------------------------------------------------------------------------------
 
@@ -1716,7 +1696,7 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
-          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this), sendToSectioned(this)'>`;
+          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this), imageClick(this)'>`;
           str += "</td>";
         }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -553,15 +553,16 @@ function showSaveButton() {
 function sendValue(lid) {
   console.log(lid);
 	$.ajax({
-		url: "../DuggaSys/sectioned.php",
+		url: "sectioned.php",
 		type: "POST",
-		data: {'lid':lid},
-		success: function(data) { 
+		data: {lid: lid},
+		success: function(data) {
+      console.log(data);
 		},
 		error: function(data){
+      console.log("Error:", data);
 		}
 	});
-  console.log("ajax done" + lid);
 }
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1695,8 +1695,8 @@ function returnedSection(data) {
         if (itemKind === 4 && data['writeaccess'] || data['studentteacher'])  {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section", 
           "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<img style='max-width: 60%;' data-value="${item['lid']}" class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
-          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this), imageClick(this)'>`;
+          str += `<img style='max-width: 60%;' class="githubPointer" alt='gitgub icon' tabIndex="0" id='dorf' title='Github repo' class='' 
+          src='../Shared/icons/githubLink-icon.png' onclick='confirmBox(\"openGitHubBox\", this), getLidFromButton("${item['lid']}")'>`;
           str += "</td>";
         }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -531,7 +531,7 @@ function showSaveButton() {
 }
 
 // Fetching the value from clicked button
-function sendValue(moment) {
+/* function sendValue(moment) {
   var value = moment.getAttribute("value");
   var xhr = new XMLHttpRequest();
   xhr.open("POST", "sectioned.php");
@@ -548,28 +548,20 @@ function sendValue(moment) {
   };
   console.log(value);
   xhr.send("momentid=" + encodeURIComponent(value));
-}
+} */
 
-function sendValue(moment) 
-{
+function sendValue(moment) {
   let lid = moment.getAttribute("value");
-	var dataCheck;
 	$.ajax({
-		async: false,
 		url: "../DuggaSys/sectioned.php",
 		type: "POST",
 		data: {'lid':lid},
 		success: function(data) { 
-      alert(data);
-			dataCheck = true;
 		},
 		error: function(data){
-      alert(data);
-		 	dataCheck = false;
 		}
 	});
   console.log("ajax done" + lid);
-	return dataCheck;
 }
 
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -48,7 +48,7 @@
 </head>
 <script>
 	function imageClick(value) {
-		let lid = value.getAttribute(data-value);
+		let lid = value.getAttribute('data-value');
 		console.log('Clicked image: ', lid);
 	}
 </script>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -14,6 +14,7 @@
 	}else{
 		$userid="00";
 	}
+	$dataValue = $_GET['data_value'];
 ?>
 
 <!DOCTYPE html>
@@ -571,11 +572,7 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-			echo "<script>console.log('debug 1');</script>";
-			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_GET['lid'])) {
-				echo "<script>console.log('debug 2');</script>";
-				$lid = (int)$_GET['lid'];
-				echo $lid;
+			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
 				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 				$query->bindParam(':githubdir', $_POST['githubDir']);
 				$query->bindParam(':lid', $lid, PDO::PARAM_INT);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -14,12 +14,6 @@
 	}else{
 		$userid="00";
 	}
-
-	if(isset($_GET['lid'])) {
-		$lid = $_GET['lid'];
-	} else {
-		echo "error";
-	}
 ?>
 
 <!DOCTYPE html>
@@ -578,9 +572,9 @@
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			echo "<script>console.log('debug 1');</script>";
-			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_GET['lid'])) {
+			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['lid'])) {
 				echo "<script>console.log('debug 2');</script>";
-				$lid = (int)$_GET['lid'];
+				$lid = (int)$_POST['lid'];
 				echo $lid;
 				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 				$query->bindParam(':githubdir', $_POST['githubDir']);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -578,26 +578,28 @@
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		echo "debug 1";
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
-			echo "debug 2";
-			$lid = (int)$_POST['lid'];
-			echo $lid;
-			$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
-			$query->bindParam(':githubdir', $_POST['githubDir']);
-			$query->bindParam(':lid', $lid, PDO::PARAM_INT);
-			try {
-				if($query->execute()) {
-					echo "debug 3";
-					echo "<script>console.log('update successful!');</script>";		
-				} else {
-					echo "<script>console.log('update failed!');</script>";		
-				} 
-			} catch (PDOException $e) {
-				$errorMessage = $e->getMessage();
-				echo "<script>console.log('" . addslashes($errorMessage) . "');</script>";
+		if(isset($_POST['lid'])) {
+			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
+				echo "debug 2";
+				$lid = (int)$_POST['lid'];
+				echo $lid;
+				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
+				$query->bindParam(':githubdir', $_POST['githubDir']);
+				$query->bindParam(':lid', $lid, PDO::PARAM_INT);
+				try {
+					if($query->execute()) {
+						echo "debug 3";
+						echo "<script>console.log('update successful!');</script>";		
+					} else {
+						echo "<script>console.log('update failed!');</script>";		
+					} 
+				} catch (PDOException $e) {
+					$errorMessage = $e->getMessage();
+					echo "<script>console.log('" . addslashes($errorMessage) . "');</script>";
+				}
+			} else {
+				echo "<script>console.log('it did not run');</script>";		
 			}
-		} else {
-			echo "<script>console.log('it did not run');</script>";		
 		}
 	?>
 	<form action="" method="POST">

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -621,7 +621,7 @@
 				<script>
 					function imageClick(value) {
 						let lid = value.getAttribute('data-value');
-						document.getElementById('lidInpuit').value = lid;
+						document.getElementById('lidInput').value = lid;
 						document.getElementById('myForm').submit();
 					}
 				</script>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -576,9 +576,9 @@
 			$query->bindParam(':lid', $_POST['lid']);
 			try {
 				if($query->execute()) {
-					echo "<script>console.log('insert successful!');</script>";		
+					echo "<script>console.log('Update successful!');</script>";		
 				} else {
-					echo "<script>console.log('insert failed!');</script>";		
+					echo "<script>console.log('Update failed!');</script>";		
 				} 
 			} catch (PDOException $e) {
 				$errorMessage = $e->getMessage();
@@ -603,7 +603,6 @@
 									$dirname = basename($dir);
 									if(strstr($dirname, 'Examples')) {
 										echo "<option value='$dirname'>$dirname</option>";
-										echo "<script>console.log('$dirname');</script>";
 									}		
 								}			
 							?>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -571,15 +571,8 @@
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['githubForm']) && $_POST['githubForm'] === 'githubForm') {
-			$lid = $_POST['lid'];
-			echo "<script>console.log('.$lid.');</script>";
-			$cid = getOPG('courseid');
-			$feedbackenabled = 0;
-			$query = $pdo->prepare("INSERT INTO listentries (cid, githubDir, creator, feedbackenabled, pos) VALUES (:cid, :githubdir, :creator, :feedbackenabled, :lid)");
-			$query->bindParam(':cid', $cid);
+			$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubDir WHERE lid = :lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
-			$query->bindParam(':creator', $userid);
-			$query->bindParam(':feedbackenabled', $feedbackenabled);
 			$query->bindParam(':lid', $_POST['lid']);
 			try {
 				if($query->execute()) {

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -577,10 +577,10 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		echo "debug 1";
+				echo "<script>console.log('debug 1');</script>";
 		if(isset($_POST['lid'])) {
 			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
-				echo "debug 2";
+				echo "<script>console.log('debug 2');</script>";
 				$lid = (int)$_POST['lid'];
 				echo $lid;
 				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -1,6 +1,6 @@
 <?php
-	include "../Shared/basic.php";
-	include "../Shared/sessions.php";
+	include_once "../Shared/basic.php";
+	include_once "../Shared/sessions.php";
 	session_start();
 	//include_once "../../coursesyspw.php";
 	pdoConnect();

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -571,7 +571,7 @@
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['githubForm']) && $_POST['githubForm'] === 'githubForm') {
-			$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubDir WHERE lid = :lid");
+			$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubdir WHERE lid = :lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
 			$query->bindParam(':lid', $_POST['lid']);
 			try {

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -569,28 +569,29 @@
 	<!-- github moments box  -->
 	<?php
 		global $pdo;
-		updateGithubTable("pelle");
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['data_value'])) {
-				$dataValue = $_POST['data_value'];
-				echo "<script>console.log('. $dataValue .');</script>";		
-				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
-				$query->bindParam(':githubdir', $_POST['githubDir']);
-				$query->bindParam(':lid', $_POST['data_value']);
-				try {
-					if($query->execute()) {
-						echo $_POST['data_value'];
-						echo "<script>console.log('update successful!');</script>";		
-					} else {
-						echo "<script>console.log('update failed!');</script>";		
-					} 
-				} catch (PDOException $e) {
-					$errorMessage = $e->getMessage();
-					echo "<script>console.log('" . addslashes($errorMessage) . "');</script>";
-				}
-			} else {
-				echo "<script>console.log('it did not run');</script>";		
+		$lid = getOPG('lid');
+		$lid = getOP('lid');
+		echo "<script>console.log('$lid');</script>";
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['githubForm']) && $_POST['githubForm'] === 'githubForm') {
+			$cid = getOPG('courseid');
+			$feedbackenabled = 0;
+			$query = $pdo->prepare("INSERT INTO listentries (cid, githubDir, creator, feedbackenabled) VALUES (:cid, :githubdir, :creator, :feedbackenabled)");
+			$query->bindParam(':cid', $cid);
+			$query->bindParam(':githubdir', $_POST['githubDir']);
+			$query->bindParam(':creator', $userid);
+			$query->bindParam(':feedbackenabled', $feedbackenabled);
+			try {
+				if($query->execute()) {
+					echo "<script>console.log('insert successful!');</script>";		
+				} else {
+					echo "<script>console.log('insert failed!');</script>";		
+				} 
+			} catch (PDOException $e) {
+				$errorMessage = $e->getMessage();
+				echo "<script>console.log('" . addslashes($errorMessage) . "');</script>";
 			}
+		}
 	?>
 	<form action="" method="POST">
 		<div id='gitHubBox' class='loginBoxContainer' style='display:none;'>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -571,11 +571,10 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['lid'])) {
-			echo "<script>console.log('it ran');</script>";		
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['lid'])) {	
 			$query = $pdo->prepare("UPDATE listentries set githubDir=:githubdir WHERE lid=:lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
-			$query->bindParam(':lid', $_POST['momentid']);
+			$query->bindParam(':lid', $_POST['lid']);
 			try {
 				if($query->execute()) {
 					echo "<script>console.log('update successful!');</script>";		

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -572,6 +572,7 @@
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['momentid'])) {
+			echo "<script>console.log('it ran');</script>";		
 			$query = $pdo->prepare("UPDATE listentries set githubDir=:githubdir WHERE lid=:lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
 			$query->bindParam(':lid', $_POST['momentid']);
@@ -585,6 +586,8 @@
 				$errorMessage = $e->getMessage();
 				echo "<script>console.log('" . addslashes($errorMessage) . "');</script>";
 			}
+		} else {
+			echo "<script>console.log('it did not run');</script>";		
 		}
 	?>
 	<form action="" method="POST">

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -580,7 +580,7 @@
 			echo "<script>console.log('debug 1');</script>";
 			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_GET['lid'])) {
 				echo "<script>console.log('debug 2');</script>";
-				$lid = (int)$_POST['lid'];
+				$lid = (int)$_GET['lid'];
 				echo $lid;
 				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 				$query->bindParam(':githubdir', $_POST['githubDir']);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -575,7 +575,7 @@
 			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
 				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 				$query->bindParam(':githubdir', $_POST['githubDir']);
-				$query->bindParam(':lid', $lid, PDO::PARAM_INT);
+				$query->bindParam(':lid', $dataValue, PDO::PARAM_INT);
 				try {
 					if($query->execute()) {
 						echo "debug 3";

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -573,7 +573,7 @@
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {	
 			$lid = $_POST['lid'];
-			$query = $pdo->prepare("UPDATE listentries set githubDir=:githubdir WHERE lid=:lid");
+			$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
 			$query->bindParam(':lid', $lid);
 			try {

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -575,7 +575,7 @@
 			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
 				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 				$query->bindParam(':githubdir', $_POST['githubDir']);
-				$query->bindParam(':lid', $dataValue, PDO::PARAM_INT);
+				$query->bindParam(':lid', $_POST['data_value']);
 				try {
 					if($query->execute()) {
 						echo "debug 3";

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -13,8 +13,6 @@
 	}else{
 		$userid="00";
 	}
-	$lid = getOP('lid');
-	echo "'. $lid .'";
 ?>
 
 <!DOCTYPE html>
@@ -571,6 +569,7 @@
 	<!-- github moments box  -->
 	<?php
 		global $pdo;
+		updateGithubTable("pelle");
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['data_value'])) {
 				$dataValue = $_POST['data_value'];

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -18,10 +18,10 @@
 		global $pdo;
 		$githubDir = $_POST['githubDir'];
 		$lid = $_POST['lid'];
-		updateGithubDirectory($pdo, $githubDir, $lid);
+		updateGithubDir($pdo, $githubDir, $lid);
 	}
 
-	function updateGithubDirectory($pdo, $githubDir, $lid) {
+	function updateGithubDir($pdo, $githubDir, $lid) {
 		try {
 			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubdir WHERE lid = :lid");
@@ -600,12 +600,16 @@
 				</div>
 				<div class='inputwrapper'>
 					<span>Github Directory:</span>
-						<select name="githubDir" placeholder='Github Folder'> 
+						<select name="githubDir" placeholder='Github Folder'>
+							<!-- Below inputs are made that are fed into the "if-statement" in the top of the code, just before "updateGithubDir" -->
 							<?php
+								// Gets "cid" via getOPG.
 								$cid = getOPG('courseid');
+								// Traverses the github map for the respective course, only fetches directories. 
 								$dirs = glob("../courses/$cid/Github/*", GLOB_ONLYDIR);
 								foreach ($dirs as $dir) {
 									$dirname = basename($dir);
+									// Creates an option for each directory containing the string "Examples". 
 									if(strstr($dirname, 'Examples')) {
 										echo "<option value='$dirname'>$dirname</option>";
 									}		
@@ -614,8 +618,10 @@
 						</select>
 					</div>
 				<input type="hidden" name="lid" id="lidInput">
+				<!-- Hidden input using the "lid" from "getLidFromButton" -->
 				<input type="submit" name="githubInsert" value="Submit!">
 				<script>
+					// In sectioned.js, each <img>-tag with a Github icon has an onClick, this "getLidFromButton" is an onClick function to send the "lid" into this document for use in hidden input.
 					function getLidFromButton(lid) {
 						document.getElementById('lidInput').value = lid;
 					}

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -46,6 +46,9 @@
 	<script src="backToTop.js"></script>
 	
 </head>
+<script>
+	console.log("test");
+</script>
 <body onload="setup();">
 
 	<?php

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -13,6 +13,11 @@
 	}else{
 		$userid="00";
 	}
+	if(isset($_POST['cid'])) {
+		echo "<script>console.log('cid found');</script>";
+	} else {
+		echo "<script>console.log('cid not found');</script>";
+	}
 ?>
 
 <!DOCTYPE html>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -598,7 +598,7 @@
 						<select name="githubDir" placeholder='Github Folder'> 
 							<option value="">Choose a directory</option>
 							<?php
-								$cid = getOP('courseid');
+								$cid = getOPG('courseid');
 								$dirs = glob('../courses/${cid}/Github/*', GLOB_ONLYDIR);
 								foreach ($dirs as $dir) {
 									$dirname = basename($dir);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -622,7 +622,6 @@
 					function imageClick(value) {
 						let lid = value.getAttribute('data-value');
 						document.getElementById('lidInput').value = lid;
-						document.getElementById('form').submit();
 					}
 				</script>
 			</div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -588,9 +588,9 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		$lid = $_POST['lid'];
-		echo "<script>console.log('.$lid.');</script>";
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['githubForm']) && $_POST['githubForm'] === 'githubForm') {
+			$lid = $_POST['lid'];
+			echo "<script>console.log('.$lid.');</script>";
 			$cid = getOPG('courseid');
 			$feedbackenabled = 0;
 			$query = $pdo->prepare("INSERT INTO listentries (cid, githubDir, creator, feedbackenabled) VALUES (:cid, :githubdir, :creator, :feedbackenabled)");

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -593,7 +593,7 @@
 			}
 		}
 	?>
-	<form action="" method="POST">
+	<form action="" method="POST" id="form">
 		<div id='gitHubBox' class='loginBoxContainer' style='display:none;'>
 			<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
 				<div class='loginBoxheader'>
@@ -622,7 +622,7 @@
 					function imageClick(value) {
 						let lid = value.getAttribute('data-value');
 						document.getElementById('lidInput').value = lid;
-						document.getElementById('myForm').submit();
+						document.getElementById('form').submit();
 					}
 				</script>
 			</div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -1,7 +1,6 @@
 <?php
 	include "../Shared/basic.php";
 	include "../Shared/sessions.php";
-	include_once "sectionedservice.php";
 	session_start();
 	//include_once "../../coursesyspw.php";
 	pdoConnect();
@@ -14,7 +13,8 @@
 	}else{
 		$userid="00";
 	}
-	$dataValue = $_GET['data_value'];
+	$lid = getOP('lid');
+	echo "'. $lid .'";
 ?>
 
 <!DOCTYPE html>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -568,24 +568,32 @@
 
 	<!-- github moments box  -->
 	<?php
-		global $pdo;
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && isset($_POST['lid']) && !empty($_POST['githubDir'])) {
-			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-			$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubdir WHERE lid = :lid");
-			$query->bindParam(':githubdir', $_POST['githubDir']);
-			$query->bindParam(':lid', $_POST['lid']);
+			global $pdo;
+			$githubDir = $_POST['githubDir'];
+			$lid = $_POST['lid'];
+			updateGithubDirectory($pdo, $githubDir, $lid);
+		}
+
+		function updateGithubDirectory($pdo, $githubDir, $lid) {
 			try {
+				$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+				$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubdir WHERE lid = :lid");
+				$query->bindParam(':githubdir', $githubDir);
+				$query->bindParam(':lid',$lid);
 				if($query->execute()) {
 					$message = 'Update Successful!';
 				} else {
 					$message = 'Update failed.';
 				} 
-			} catch (PDOException $e) {
-				$message = 'Update failed: ' . $e->getMessage();
+				echo "<script>console.log('. $message .');</script>";
 			}
-			echo "<script>console.log('" . addslashes($message) . "');</script>";
+			catch(PDOException $exception) {
+				$message = 'Update failed: ' . $exception->getMessage();
+			}
 		}
 	?>
+
 	<form action="" method="POST" id="form">
 		<div id='gitHubBox' class='loginBoxContainer' style='display:none;'>
 			<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:460px;'>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -1,7 +1,7 @@
 <?php
 	include "../Shared/basic.php";
 	include "../Shared/sessions.php";
-	include_once "sectioned.js";
+	//include_once "sectioned.js";
 	session_start();
 	//include_once "../../coursesyspw.php";
 	pdoConnect();

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -49,7 +49,14 @@
 <script>
 	function imageClick(value) {
 		let lid = value.getAttribute('data-value');
-		console.log('Clicked image: ', lid);
+		$.ajax({
+		url: window.location.href,
+		method: 'POST',
+		data: { lid: lid },
+		success: function(response) {
+			console.log('PHP script response:', response);
+			}
+		});
 	}
 </script>
 <body onload="setup();">
@@ -581,9 +588,8 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		$lid = getOPG('lid');
-		$lid = getOP('lid');
-		echo "<script>console.log('$lid');</script>";
+		$lid = $_POST['lid'];
+		echo "<script>console.log('.$lid.');</script>";
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['githubForm']) && $_POST['githubForm'] === 'githubForm') {
 			$cid = getOPG('courseid');
 			$feedbackenabled = 0;

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -569,21 +569,21 @@
 	<!-- github moments box  -->
 	<?php
 		global $pdo;
-		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && isset($_POST['lid']) && !empty($_POST['githubDir'])) {
+			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubdir WHERE lid = :lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
 			$query->bindParam(':lid', $_POST['lid']);
 			try {
 				if($query->execute()) {
-					echo "<script>console.log('Update successful!');</script>";		
+					$message = 'Update Successful!';
 				} else {
-					echo "<script>console.log('Update failed!');</script>";		
+					$message = 'Update failed.';
 				} 
 			} catch (PDOException $e) {
-				$errorMessage = $e->getMessage();
-				echo "<script>console.log('" . addslashes($errorMessage) . "');</script>";
+				$message = 'Update failed: ' . $e->getMessage();
 			}
+			echo "<script>console.log('" . addslashes($message) . "');</script>";
 		}
 	?>
 	<form action="" method="POST" id="form">
@@ -598,7 +598,8 @@
 						<select name="githubDir" placeholder='Github Folder'> 
 							<option value="">Choose a directory</option>
 							<?php
-								$dirs = glob('../courses/1/Github/*', GLOB_ONLYDIR);
+								$cid = getOP('courseid');
+								$dirs = glob('../courses/${cid}/Github/*', GLOB_ONLYDIR);
 								foreach ($dirs as $dir) {
 									$dirname = basename($dir);
 									if(strstr($dirname, 'Examples')) {

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -15,8 +15,8 @@
 		$userid="00";
 	}
 
-	if(isset($_POST['lid'])) {
-		$lid = $_POST['lid'];
+	if(isset($_GET['lid'])) {
+		$lid = $_GET['lid'];
 	} else {
 		echo "error";
 	}
@@ -578,7 +578,7 @@
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			echo "<script>console.log('debug 1');</script>";
-			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['lid'])) {
+			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_GET['lid'])) {
 				echo "<script>console.log('debug 2');</script>";
 				$lid = (int)$_POST['lid'];
 				echo $lid;

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -571,13 +571,17 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {	
+		echo "debug 1";
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
+			echo "debug 2";
 			$lid = (int)$_POST['lid'];
+			echo $lid;
 			$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
 			$query->bindParam(':lid', $lid, PDO::PARAM_INT);
 			try {
 				if($query->execute()) {
+					echo "debug 3";
 					echo "<script>console.log('update successful!');</script>";		
 				} else {
 					echo "<script>console.log('update failed!');</script>";		

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -572,10 +572,10 @@
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {	
-			$lid = $_POST['lid'];
+			$lid = (int)$_POST['lid'];
 			$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
-			$query->bindParam(':lid', $lid);
+			$query->bindParam(':lid', $lid, PDO::PARAM_INT);
 			try {
 				if($query->execute()) {
 					echo "<script>console.log('update successful!');</script>";		

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -571,10 +571,11 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['lid'])) {	
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {	
+			$lid = $_POST['lid'];
 			$query = $pdo->prepare("UPDATE listentries set githubDir=:githubdir WHERE lid=:lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
-			$query->bindParam(':lid', $_POST['lid']);
+			$query->bindParam(':lid', $lid);
 			try {
 				if($query->execute()) {
 					echo "<script>console.log('update successful!');</script>";		

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -599,7 +599,7 @@
 							<option value="">Choose a directory</option>
 							<?php
 								$cid = getOPG('courseid');
-								$dirs = glob('../courses/${cid}/Github/*', GLOB_ONLYDIR);
+								$dirs = glob("../courses/$cid/Github/*", GLOB_ONLYDIR);
 								foreach ($dirs as $dir) {
 									$dirname = basename($dir);
 									if(strstr($dirname, 'Examples')) {

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -48,7 +48,8 @@
 </head>
 <script>
 	function imageClick(value) {
-		console.log('Clicked image: ', value);
+		let lid = value.getAttribute(data-value);
+		console.log('Clicked image: ', lid);
 	}
 </script>
 <body onload="setup();">

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -1,6 +1,7 @@
 <?php
 	include "../Shared/basic.php";
 	include "../Shared/sessions.php";
+	include "sectionedservice.php";
 	//include_once "sectioned.js";
 	session_start();
 	//include_once "../../coursesyspw.php";

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -570,7 +570,7 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['githubForm']) && $_POST['githubForm'] === 'githubForm') {
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && isset($_POST['lid']) && !empty($_POST['githubDir'])) {
 			$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubdir WHERE lid = :lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);
 			$query->bindParam(':lid', $_POST['lid']);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -596,7 +596,6 @@
 				<div class='inputwrapper'>
 					<span>Github Directory:</span>
 						<select name="githubDir" placeholder='Github Folder'> 
-							<option value="">Choose a directory</option>
 							<?php
 								$cid = getOPG('courseid');
 								$dirs = glob("../courses/$cid/Github/*", GLOB_ONLYDIR);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -572,7 +572,9 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
+			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['data_value'])) {
+				$dataValue = $_POST['data_value'];
+				echo "<script>console.log('. $dataValue .');</script>";		
 				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 				$query->bindParam(':githubdir', $_POST['githubDir']);
 				$query->bindParam(':lid', $_POST['data_value']);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -47,13 +47,9 @@
 	
 </head>
 <script>
-function handleAjaxResponse(data, error) {
-  if (data) {
-    console.log('cid found');
-  } else {
-    console.log('cid not found');
-  }
-}
+	function imageClick(value) {
+		console.log('Clicked image: ', value);
+	}
 </script>
 <body onload="setup();">
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -593,11 +593,12 @@
 			echo "<script>console.log('.$lid.');</script>";
 			$cid = getOPG('courseid');
 			$feedbackenabled = 0;
-			$query = $pdo->prepare("INSERT INTO listentries (cid, githubDir, creator, feedbackenabled) VALUES (:cid, :githubdir, :creator, :feedbackenabled)");
+			$query = $pdo->prepare("INSERT INTO listentries (cid, githubDir, creator, feedbackenabled, pos) VALUES (:cid, :githubdir, :creator, :feedbackenabled, :lid)");
 			$query->bindParam(':cid', $cid);
 			$query->bindParam(':githubdir', $_POST['githubDir']);
 			$query->bindParam(':creator', $userid);
 			$query->bindParam(':feedbackenabled', $feedbackenabled);
+			$query->bindParam(':lid', $_POST['lid']);
 			try {
 				if($query->execute()) {
 					echo "<script>console.log('insert successful!');</script>";		

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -13,11 +13,6 @@
 	}else{
 		$userid="00";
 	}
-	if(isset($_POST['cid'])) {
-		echo "<script>console.log('cid found');</script>";
-	} else {
-		echo "<script>console.log('cid not found');</script>";
-	}
 ?>
 
 <!DOCTYPE html>
@@ -46,19 +41,6 @@
 	<script src="backToTop.js"></script>
 	
 </head>
-<script>
-	function imageClick(value) {
-		let lid = value.getAttribute('data-value');
-		$.ajax({
-		url: window.location.href,
-		method: 'POST',
-		data: { lid: lid },
-		success: function(response) {
-			console.log('PHP script response:', response);
-			}
-		});
-	}
-</script>
 <body onload="setup();">
 
 	<?php
@@ -634,7 +616,15 @@
 							?>
 						</select>
 					</div>
+				<input type="hidden" name="lid" id="lidInput">
 				<input type="submit" name="githubInsert" value="Submit!">
+				<script>
+					function imageClick(value) {
+						let lid = value.getAttribute('data-value');
+						document.getElementById('lidInpuit').value = lid;
+						document.getElementById('myForm').submit();
+					}
+				</script>
 			</div>
 		</div>
 	</form>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -612,8 +612,7 @@
 				<input type="hidden" name="lid" id="lidInput">
 				<input type="submit" name="githubInsert" value="Submit!">
 				<script>
-					function imageClick(value) {
-						let lid = value.getAttribute('data-value');
+					function getLidFromButton(lid) {
 						document.getElementById('lidInput').value = lid;
 					}
 				</script>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -599,7 +599,6 @@
 			} else {
 				echo "<script>console.log('it did not run');</script>";		
 			}
-		}
 	?>
 	<form action="" method="POST">
 		<div id='gitHubBox' class='loginBoxContainer' style='display:none;'>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -14,6 +14,12 @@
 	}else{
 		$userid="00";
 	}
+
+	if(isset($_POST['lid'])) {
+		$lid = $_POST['lid'];
+	} else {
+		echo "error";
+	}
 ?>
 
 <!DOCTYPE html>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -577,9 +577,8 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-				echo "<script>console.log('debug 1');</script>";
-		if(isset($_POST['lid'])) {
-			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir'])) {
+			echo "<script>console.log('debug 1');</script>";
+			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['lid'])) {
 				echo "<script>console.log('debug 2');</script>";
 				$lid = (int)$_POST['lid'];
 				echo $lid;

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -13,6 +13,30 @@
 	}else{
 		$userid="00";
 	}
+
+	if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && isset($_POST['lid']) && !empty($_POST['githubDir'])) {
+		global $pdo;
+		$githubDir = $_POST['githubDir'];
+		$lid = $_POST['lid'];
+		updateGithubDirectory($pdo, $githubDir, $lid);
+	}
+
+	function updateGithubDirectory($pdo, $githubDir, $lid) {
+		try {
+			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+			$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubdir WHERE lid = :lid");
+			$query->bindParam(':githubdir', $githubDir);
+			$query->bindParam(':lid',$lid);
+			if($query->execute()) {
+				echo "<script>console.log('Update Successful!');</script>";
+			} else {
+				echo "<script>console.log('Update Failed.');</script>";
+			} 
+		}
+		catch(PDOException $exception) {
+			echo "<script>console.log('Update Failed: " . addslashes($exception->getMessage()) . "');</script>";
+		}
+	}
 ?>
 
 <!DOCTYPE html>
@@ -567,33 +591,6 @@
 
 
 	<!-- github moments box  -->
-	<?php
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && isset($_POST['lid']) && !empty($_POST['githubDir'])) {
-			global $pdo;
-			$githubDir = $_POST['githubDir'];
-			$lid = $_POST['lid'];
-			updateGithubDirectory($pdo, $githubDir, $lid);
-		}
-
-		function updateGithubDirectory($pdo, $githubDir, $lid) {
-			try {
-				$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-				$query = $pdo->prepare("UPDATE listentries SET githubDir = :githubdir WHERE lid = :lid");
-				$query->bindParam(':githubdir', $githubDir);
-				$query->bindParam(':lid',$lid);
-				if($query->execute()) {
-					$message = 'Update Successful!';
-				} else {
-					$message = 'Update failed.';
-				} 
-				echo "<script>console.log('. $message .');</script>";
-			}
-			catch(PDOException $exception) {
-				$message = 'Update failed: ' . $exception->getMessage();
-			}
-		}
-	?>
-
 	<form action="" method="POST" id="form">
 		<div id='gitHubBox' class='loginBoxContainer' style='display:none;'>
 			<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:460px;'>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -571,7 +571,7 @@
 	<?php
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['momentid'])) {
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['lid'])) {
 			echo "<script>console.log('it ran');</script>";		
 			$query = $pdo->prepare("UPDATE listentries set githubDir=:githubdir WHERE lid=:lid");
 			$query->bindParam(':githubdir', $_POST['githubDir']);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -578,7 +578,7 @@
 				$query->bindParam(':lid', $_POST['data_value']);
 				try {
 					if($query->execute()) {
-						echo "debug 3";
+						echo $_POST['data_value'];
 						echo "<script>console.log('update successful!');</script>";		
 					} else {
 						echo "<script>console.log('update failed!');</script>";		

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -572,9 +572,9 @@
 		global $pdo;
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			echo "<script>console.log('debug 1');</script>";
-			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_POST['lid'])) {
+			if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['githubInsert']) && !empty($_POST['githubDir']) && isset($_GET['lid'])) {
 				echo "<script>console.log('debug 2');</script>";
-				$lid = (int)$_POST['lid'];
+				$lid = (int)$_GET['lid'];
 				echo $lid;
 				$query = $pdo->prepare("UPDATE listentries SET githubDir=:githubdir WHERE lid=:lid");
 				$query->bindParam(':githubdir', $_POST['githubDir']);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -47,7 +47,13 @@
 	
 </head>
 <script>
-	console.log("test");
+function handleAjaxResponse(data, error) {
+  if (data) {
+    console.log('cid found');
+  } else {
+    console.log('cid not found');
+  }
+}
 </script>
 <body onload="setup();">
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -1,8 +1,7 @@
 <?php
 	include "../Shared/basic.php";
 	include "../Shared/sessions.php";
-	include "sectionedservice.php";
-	//include_once "sectioned.js";
+	include_once "sectionedservice.php";
 	session_start();
 	//include_once "../../coursesyspw.php";
 	pdoConnect();

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -1050,13 +1050,6 @@ if($gradesys=="UNK") $gradesys=0;
 				}
 			}
 
-		function updateGithubTable($dir) {
-			global $pdo;
-			$query = $pdo->prepare("UPDATE listentries SET githubDir = $dir WHERE lid = :lid");
-			$sectid = $sectid=getOP('lid');
-			$query->bindParam(':lid', $sectid);
-			$query->execute();
-		}
 
 		echo json_encode($array);
 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -1050,7 +1050,6 @@ if($gradesys=="UNK") $gradesys=0;
 				}
 			}
 
-
 		echo json_encode($array);
 
 		logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "sectionedservice.php",$userid,$info);

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -1050,6 +1050,14 @@ if($gradesys=="UNK") $gradesys=0;
 				}
 			}
 
+		function updateGithubTable($dir) {
+			global $pdo;
+			$query = $pdo->prepare("UPDATE listentries SET githubDir = $dir WHERE lid = :lid");
+			$sectid = $sectid=getOP('lid');
+			$query->bindParam(':lid', $sectid);
+			$query->execute();
+		}
+
 		echo json_encode($array);
 
 		logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "sectionedservice.php",$userid,$info);


### PR DESCRIPTION
What we've done is created a dropdown menu within the github buttons for each moment in sectioned.php
![image](https://github.com/HGustavs/LenaSYS/assets/102578849/1fdcea7c-df5c-4877-86bb-3febc6292d22)
![image](https://github.com/HGustavs/LenaSYS/assets/102578849/a71cac63-6604-44af-aa8f-145ef4115404)
With this dropdown menu, you can traverse the webserver repostitory for all directories under the courses/{course id}/Github path containing the string "Examples" (This is done as the filtering for downloading files to webserver is not complete yet as far as i'm aware). When you choose one of them, this is supposed to call the automatic creation of course content via issue #13549, but this might not be testable for now. 

This also updates the database table "listentries" with a newly added column "githubDir" with the chosen directory. It will look something like this.

![image](https://github.com/HGustavs/LenaSYS/assets/102578849/38fdbd88-11cc-4a98-99e1-d4a44bc81ccb)

To test this, open a sample course with folders within the courses/{course id}/Github folder that match the syntax of containing the string "Examples", these should then come up within the dropdown-menu. Choose one, then check that the "listentries" table has an entry with the correct course id and a value matching the chosen directory within the "githubDir" column. 

A working example exists on my branch, under the "Webbprogrammering" course. There you can see the syntax checked for right now, if you fail to create the environment to test this, simply remove the filtering done on line 613-615 here:

`if(strstr($dirname, 'Examples')) {
	echo "<option value='$dirname'>$dirname</option>";
}		`

And simply keep the line "echo `"<option value='$dirname'>$dirname</option>";"`

Relevant files: sectioned.php 
