### PR TITLE
getElementLines now works for UML, ER, IE and SD

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2855,7 +2855,7 @@ function constructElementOfType(type)
  * @returns {array} result
  */
 function getElementLines(element) {
-    console.log("GotELementLines");
+    console.log(getElementLines(element));
     return element.top.concat(element.right, element.bottom, element.left);
 }
 
@@ -2865,7 +2865,7 @@ function getElementLines(element) {
  * @returns {boolean} result
  */
 function elementHasLines(element) {
-    console.log("HasLines");
+    console.log(elementHasLines(element));
     return (getElementLines(element).length > 0);
 }
 /** TODO: elementHasLines() seems to not work for UML, SD, IE elements, this needs to be fixed/investigated!!

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2856,7 +2856,7 @@ function constructElementOfType(type)
  */
 function getElementLines(element) {
     //console.log(getElementLines(element));
-    return element.left.concat(element.right, element.bottom, element.top);
+    return element.bottom.concat(element.right, element.top, element.left);
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2856,7 +2856,7 @@ function constructElementOfType(type)
  */
 function getElementLines(element) {
     //console.log(getElementLines(element));
-    return element.bottom.concat(element.right, element.top, element.left);
+    return element.right.concat(element.top, element.bottom, element.left);
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2917,21 +2917,22 @@ function changeState()
         //Save the current property if not an UML or IE entity since niether entities does have variants.
         if (element.kind != 'UMLEntity') {
 
-            //Check if type has been changed
-            if (oldType != newType) {
-                var newKind = element.kind;
-                newKind = newKind.replace(oldType, newType);
-                //Update element kind
-                element.kind = newKind;
-                stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
-            }
-            //Update element type
-            element.type = newType;
-            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+            var property = document.getElementById("propertySelect").value;
+            element.state = property;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
-        var property = document.getElementById("propertySelect").value;
-        element.state = property;
-        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+    //Check if type has been changed
+    if (oldType != newType) {
+        var newKind = element.kind;
+        newKind = newKind.replace(oldType, newType);
+        //Update element kind
+        element.kind = newKind;
+        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+    }
+    //Update element type
+    element.type = newType;
+    stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+    
 
     }
     else if(element.type=='IE') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2921,18 +2921,17 @@ function changeState()
             element.state = property;
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
-    //Check if type has been changed
-    if (oldType != newType) {
-        var newKind = element.kind;
-        newKind = newKind.replace(oldType, newType);
-        //Update element kind
-        element.kind = newKind;
-        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
-    }
-    //Update element type
-    element.type = newType;
-    stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
-    
+        //Check if type has been changed
+        if (oldType != newType) {
+            var newKind = element.kind;
+            newKind = newKind.replace(oldType, newType);
+            //Update element kind
+            element.kind = newKind;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
+        //Update element type
+        element.type = newType;
+        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
     else if(element.type=='IE') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2916,22 +2916,22 @@ function changeState()
     else if(element.type=='UML') {
         //Save the current property if not an UML or IE entity since niether entities does have variants.
         if (element.kind != 'UMLEntity') {
-            var property = document.getElementById("propertySelect").value;
-            element.state = property;
-            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
-        }
 
-        //Check if type has been changed
-        if (oldType != newType) {
-            var newKind = element.kind;
-            newKind = newKind.replace(oldType, newType);
-            //Update element kind
-            element.kind = newKind;
-            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+            //Check if type has been changed
+            if (oldType != newType) {
+                var newKind = element.kind;
+                newKind = newKind.replace(oldType, newType);
+                //Update element kind
+                element.kind = newKind;
+                stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+            }
+            //Update element type
+            element.type = newType;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
-        //Update element type
-        element.type = newType;
-        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        var property = document.getElementById("propertySelect").value;
+        element.state = property;
+        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { state: property }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
     else if(element.type=='IE') {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2854,8 +2854,7 @@ function constructElementOfType(type)
  * @param {Element} element
  * @returns {array} result
  */
-function getElementLines(element) {
-    //console.log(getElementLines(element));
+function getElementLines(element) { 
     return element.bottom.concat(element.right, element.top, element.left);
 }
 
@@ -2865,7 +2864,6 @@ function getElementLines(element) {
  * @returns {boolean} result
  */
 function elementHasLines(element) {
-    //console.log(elementHasLines(element));
     return (getElementLines(element).length > 0);
 }
 /** TODO: elementHasLines() seems to not work for UML, SD, IE elements, this needs to be fixed/investigated!!

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2856,7 +2856,7 @@ function constructElementOfType(type)
  */
 function getElementLines(element) {
     //console.log(getElementLines(element));
-    return element.top.concat(element.right, element.bottom, element.left);
+    return element.bottom.concat(element.right, element.top, element.left);
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2855,7 +2855,7 @@ function constructElementOfType(type)
  * @returns {array} result
  */
 function getElementLines(element) {
-    console.log(getElementLines(element));
+    //console.log(getElementLines(element));
     return element.top.concat(element.right, element.bottom, element.left);
 }
 
@@ -2865,7 +2865,7 @@ function getElementLines(element) {
  * @returns {boolean} result
  */
 function elementHasLines(element) {
-    console.log(elementHasLines(element));
+    //console.log(elementHasLines(element));
     return (getElementLines(element).length > 0);
 }
 /** TODO: elementHasLines() seems to not work for UML, SD, IE elements, this needs to be fixed/investigated!!

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2856,7 +2856,7 @@ function constructElementOfType(type)
  */
 function getElementLines(element) {
     //console.log(getElementLines(element));
-    return element.right.concat(element.top, element.bottom, element.left);
+    return element.left.concat(element.right, element.bottom, element.top);
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2856,7 +2856,7 @@ function constructElementOfType(type)
  */
 function getElementLines(element) {
     //console.log(getElementLines(element));
-    return element.left.concat(element.right, element.bottom, element.top);
+    return element.top.concat(element.right, element.bottom, element.left);
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2855,6 +2855,7 @@ function constructElementOfType(type)
  * @returns {array} result
  */
 function getElementLines(element) {
+    console.log("GotELementLines");
     return element.top.concat(element.right, element.bottom, element.left);
 }
 
@@ -2864,6 +2865,7 @@ function getElementLines(element) {
  * @returns {boolean} result
  */
 function elementHasLines(element) {
+    console.log("HasLines");
     return (getElementLines(element).length > 0);
 }
 /** TODO: elementHasLines() seems to not work for UML, SD, IE elements, this needs to be fixed/investigated!!

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2856,7 +2856,7 @@ function constructElementOfType(type)
  */
 function getElementLines(element) {
     //console.log(getElementLines(element));
-    return element.top.concat(element.right, element.bottom, element.left);
+    return element.left.concat(element.right, element.bottom, element.top);
 }
 
 /**


### PR DESCRIPTION
getElementLines used to only work for ER this seems to be due to how the other types tops are defined. element.top.concat was undefined for the other types but changing top with left, right or bottom worked just fine, so i changed element.top.concat to element.bottom.concat and it should now work for all types.