### PR TITLE
g1-2023-v6-fix-3-#14022 changed x and y postion of label

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8837,8 +8837,8 @@ function drawLine(line, targetGhost = false)
 
         
         // Label position for recursive edges
-        const labelPositionX = labelPosX+lineLabel.labelMovedX+lineLabel.displacementX + 180 * zoomfact
-        const labelPositionY = labelPosY+lineLabel.labelMovedY+lineLabel.displacementY - 40 * zoomfact
+        const labelPositionX = labelPosX+lineLabel.labelMovedX+lineLabel.displacementX + 1 * zoomfact
+        const labelPositionY = labelPosY+lineLabel.labelMovedY+lineLabel.displacementY - 1 * zoomfact
 
         //Add background, position and size is determined by text and zoom factor <-- Consider replacing magic numbers
         str += `<rect class="text cardinalityLabel" id=${line.id + "Label"} x="${labelPositionX}" y="${labelPositionY}" width="${(textWidth + zoomfact * 4)}" height="${textheight * zoomfact + zoomfact * 3}"/>`;


### PR DESCRIPTION
changed the variables of the x and y positions of the labels so that its 1 times the zoomfact on both x and y