### PR TITLE
 Allow display of saved diagram when loaded #14045 

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -886,7 +886,7 @@
         </fieldset>
         <fieldset id = "localLoadField">
             <legend aria-hidden="true">Load</legend>
-            <div id="localLoad" class="diagramIcons" onclick="loadDiagramFromLocalStorage('CurrentyActiveDiagram');">
+            <div id="localLoad" class="diagramIcons" onclick="loadDiagramFromLocalStorage('CurrentlyActiveDiagram');">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
                 <span class="toolTipText"><b>Load diagram</b><br>
                     <p>Click to load a diagram</p>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -886,7 +886,7 @@
         </fieldset>
         <fieldset id = "localLoadField">
             <legend aria-hidden="true">Load</legend>
-            <div id="localLoad" class="diagramIcons" onclick="alert('No functionality set for load button');">
+            <div id="localLoad" class="diagramIcons" onclick="loadDiagramFromLocalStorage('CurrentyActiveDiagram');">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
                 <span class="toolTipText"><b>Load diagram</b><br>
                     <p>Click to load a diagram</p>


### PR DESCRIPTION
made it so the button calls loadDiagramFromLocalStorage onclick