### PR TITLE
G3 2023 v7 issue#13549

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3086,14 +3086,14 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
 }
 
 //Creates all examples from github that doesnt exists yet
-function createExamples(dir,momentID) {//TODO HERE
+function createExamples(momentID) {//TODO HERE
   lid= momentID;
   dirname = dir;
   console.log("* AJAX START ");
   $.ajax({
     url: "sectionedservice.php",
     type: "POST",
-    data: {'lid':lid,'dirname':dirname , 'opt':'CREGITEX'},
+    data: {'lid':lid,'opt':'CREGITEX'},
     dataType: "json",
     //TODO: reload back to coursepage
   });
@@ -3689,8 +3689,7 @@ function refreshMoment(momentID){
   //TODO: take input from column/dropdownlist and iterate through and create the codeexample
   //for each codeexample in the moment dir, do create examples on those code-example dir
   //for loop not yet implemented, waiting for other issues to be completed before
-  dirname="../courses/1895/Github/Demo/Code-example1/"
-  createExamples(dirname,momentID)
+  createExamples(momentID);
 }
 
 //------------------------------------------------------------------------------

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3088,7 +3088,6 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
 //Creates all examples from github that doesnt exists yet
 function createExamples(momentID) {//TODO HERE
   lid= momentID;
-  dirname = dir;
   console.log("* AJAX START ");
   $.ajax({
     url: "sectionedservice.php",

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -528,14 +528,15 @@ if($gradesys=="UNK") $gradesys=0;
 							array_push($allFiles, $temp);
 						}
 					}
-					$countAllFiles = count($allFiles);
-					$varname="countFiles";	
-					$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-					$query3->bindParam(":examplename", $varname); 
-					$query3->bindParam(":sectionname", $countAllFiles); 
-					$query3->execute();	
+					
 
 					foreach($allFiles as $groupedFiles){
+						$countAllFiles = count($groupedFiles);
+						$varname="countGroupedFiles";	
+						$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+						$query3->bindParam(":examplename", $varname); 
+						$query3->bindParam(":sectionname", $countAllFiles); 
+						$query3->execute();	
 						//get the correct examplename
 						$explodeFiles = explode('.',$groupedFiles[0]);
 						$exampleName = $explodeFiles[0];

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -654,7 +654,22 @@ if($gradesys=="UNK") $gradesys=0;
 									$query->bindParam(":settings", $setting);
 									$query->bindParam(":wordlistid", $wlid);
 									$query->bindParam(":fontsize", $fontsize);
-									$query->execute();
+									if($query->execute()){
+										$varname="boxCreated";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $varname); 
+										$query3->execute();	
+										
+									}else {
+										$varname="boxNotCreated";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $varname); 
+										$query3->execute();	
+										
+									}
+							
 										
 									$varname="boxid";	
 									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -598,8 +598,8 @@ if($gradesys=="UNK") $gradesys=0;
 								$exampleid = $result->LatestExID;
 
 								//Add each file to a box and add that box to the codeexample and set the box to its correct content.
-								for ($i = 0; $i < count($groupedFiles); $i++) {
-									$filename = $groupedFiles[$i];
+								foreach($groupedFiles as $gFile){
+									$filename = $gFile;
 									$parts = explode('.', $filename);
 									$filetype = "CODE";
 									$wlid = 0;

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -656,11 +656,6 @@ if($gradesys=="UNK") $gradesys=0;
 									$query->bindParam(":fontsize", $fontsize);
 									$query->execute();
 
-									$varname="fileName";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $filename); 
-									$query3->execute();
 								}
 
 								$link = "UNK";

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -513,6 +513,13 @@ if($gradesys=="UNK") $gradesys=0;
 					$githubDir = $e[0]['githubDir'];
 					$dirPath = "../courses/".$courseid."/Github/" . $githubDir;
 
+						
+					$varname="dirpath";	
+					$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+					$query3->bindParam(":examplename", $varname); 
+					$query3->bindParam(":sectionname", $dirPath); 
+					$query3->execute();		
+
 					$allFiles = array();
 					foreach($files as $file) {
 						if(is_file($dirPath."/".$file)) {

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -667,35 +667,46 @@ if($gradesys=="UNK") $gradesys=0;
 										$query3->bindParam(":examplename", $varname); 
 										$query3->bindParam(":sectionname", $varname); 
 										$query3->execute();	
+										$varname="boxid";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $boxid); 
+										$query3->execute();	
+										$varname="exampleid";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $exampleid); 
+										$query3->execute();	
+										$varname="filename";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $filename); 
+										$query3->execute();	
+										$varname="filetype";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $filetype); 
+										$query3->execute();	
+										$varname="wlid";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $wlid); 
+										$query3->execute();	
+										$varname="fontsize";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $fontsize); 
+										$query3->execute();	
+										$varname="setting";	
+										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+										$query3->bindParam(":examplename", $varname); 
+										$query3->bindParam(":sectionname", $setting); 
+										$query3->execute();	
 										
 									}
 							
 										
-									$varname="boxid";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $boxid); 
-									$query3->execute();	
-									$varname="exampleid";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $exampleid); 
-									$query3->execute();	
-									$varname="filename";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $filename); 
-									$query3->execute();	
-									$varname="filetype";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $filetype); 
-									$query3->execute();	
-									$varname="wlid";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $wlid); 
-									$query3->execute();		
+										
 
 								}
 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -527,10 +527,11 @@ if($gradesys=="UNK") $gradesys=0;
 							array_push($allFiles, $temp);
 						}
 					}
-					$varname="arrayFiles";	
+					$countAllFiles = count($allFiles);
+					$varname="countFiles";	
 					$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 					$query3->bindParam(":examplename", $varname); 
-					$query3->bindParam(":sectionname", $allFiles[0][0]); 
+					$query3->bindParam(":sectionname", $countAllFiles); 
 					$query3->execute();	
 
 					foreach($allFiles as $groupedFiles){

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -531,8 +531,8 @@ if($gradesys=="UNK") $gradesys=0;
 					
 
 					foreach($allFiles as $groupedFiles){
-						$countAllFiles = count($groupedFiles);
-						$varname="countGroupedFiles";	
+						$countAllFiles = $groupedFiles[0];
+						$varname="nameGroupedFiles";	
 						$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 						$query3->bindParam(":examplename", $varname); 
 						$query3->bindParam(":sectionname", $countAllFiles); 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -603,12 +603,6 @@ if($gradesys=="UNK") $gradesys=0;
 									$parts = explode('.', $filename);
 									$filetype = "CODE";
 									$wlid = 0;
-									
-									$varname="fileName";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $filename); 
-									$query3->execute();
 									switch ($parts[1]) {
 										case "js":
 											$filetype = "CODE";
@@ -661,6 +655,12 @@ if($gradesys=="UNK") $gradesys=0;
 									$query->bindParam(":wordlistid", $wlid);
 									$query->bindParam(":fontsize", $fontsize);
 									$query->execute();
+
+									$varname="fileName";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $filename); 
+									$query3->execute();
 								}
 
 								$link = "UNK";

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -521,7 +521,7 @@ if($gradesys=="UNK") $gradesys=0;
 							foreach($files as $file2) {
 								$n1 = explode(".", $file);
 								$n2 = explode(".", $file2);
-								if(is_file($dirpath."/".$file2) && $n1[0] == $n2[0]) {
+								if(is_file($dirPath."/".$file2) && $n1[0] == $n2[0]) {
 									array_push($temp, $file2);
 								}
 							}

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -553,152 +553,143 @@ if($gradesys=="UNK") $gradesys=0;
 							$e = $query->fetchAll();
 							$pos = $e[0]['pos'] + 1; //Gets the last filled position+1 to put the new codexample at
 
-							//connect to SQLite
-							$metadata_db = null;
-							$success = false;
-							try {
-								$metadata_db = new PDO('sqlite:../../githubMetadata/metadata' . $metadataDbVersion . '.db');
-								$success = true;
-							} catch (PDOException $e) {
-								echo "Failed to connect to the database";
-								throw $e;
-							}
-
 							//select the files that has should be in the codeexample
-							if ($success) {
-								//Count files in the directory for the codeexample
-								$fileCount = 0;
-								$files = scandir($dirPath);
-								foreach ($files as $file) {
-									if (is_file($dirPath . '/' . $file)) {
-										$fileCount++;
-									}
+							
+							//Count files in the directory for the codeexample
+							//$fileCount = 0;
+							//$files = scandir($dirPath);
+							//foreach ($files as $file) {
+							//	if (is_file($dirPath . '/' . $file)) {
+							//		$fileCount++;
+							//	}
+							//}
+
+							$fileCount = count($groupedFiles);
+							//If we find files that should be in the codeexample, create the codeexample
+							//Only template for 1 up to 5 files
+							if ($fileCount > 0 && $fileCount < 6) {
+								// There are at least two boxes, create two boxes to start with
+								switch ($fileCount) {
+									case 1:
+										$templateNumber = 10;
+										break;
+									case 2:
+										$templateNumber = 1;
+										break;
+									case 3:
+										$templateNumber = 3;
+										break;
+									case 4:
+										$templateNumber = 5;
+										break;
+									case 5:
+										$templateNumber = 9;
+										break;
 								}
-								//If we find files that should be in the codeexample, create the codeexample
-								//Only template for 1 up to 5 files
-								if ($fileCount > 0 && $fileCount < 6) {
-									// There are at least two boxes, create two boxes to start with
-									switch ($fileCount) {
-										case 1:
-											$templateNumber = 10;
+								$examplename = $exampleName;
+								$sectionname = $exampleName;
+								//create codeexample
+								$query = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (:cid,:ename,:sname,1,:cversion,:templateid);");
+								$query->bindParam(":cid", $courseid);
+								$query->bindParam(":ename", $examplename);
+								$query->bindParam(":sname", $sectionname);
+								$query->bindParam(":cversion", $coursevers);
+								$query->bindParam(":templateid", $templateNumber);
+								$query->execute();
+
+								//select the latest codeexample created to link boxes to this codeexample
+								$query = $pdo->prepare("SELECT MAX(exampleid) as LatestExID FROM codeexample;");
+								$query->execute();
+								$result = $query->fetch(PDO::FETCH_OBJ);
+								$exampleid = $result->LatestExID;
+
+								//Add each file to a box and add that box to the codeexample and set the box to its correct content.
+								for ($i = 0; $i < count($groupedFiles); $i++) {
+									$filename = $groupedFiles[$i];
+									$parts = explode('.', $filename);
+									$filetype = "CODE";
+									$wlid = 0;
+
+									switch ($parts[1]) {
+										case "js":
+											$filetype = "CODE";
+											$wlid = 1;
 											break;
-										case 2:
-											$templateNumber = 1;
+										case "php":
+											$filetype = "CODE";
+											$wlid = 2;
 											break;
-										case 3:
-											$templateNumber = 3;
+										case "html":
+											$filetype = "CODE";
+											$wlid = 3;
 											break;
-										case 4:
-											$templateNumber = 5;
+										case "txt":
+											$filetype = "DOCUMENT";
+											$wlid = 4;
 											break;
-										case 5:
-											$templateNumber = 9;
+										case "md":
+											$filetype = "DOCUMENT";
+											$wlid = 4;
+											break;
+										case "java":
+											$filetype = "CODE";
+											$wlid = 5;
+											break;
+										case "sr":
+											$filetype = "CODE";
+											$wlid = 6;
+											break;
+										case "sql":
+											$filetype = "CODE";
+											$wlid = 7;
+											break;
+										default:
+											$filetype = "DOCUMENT";
+											$wlid = 4;
 											break;
 									}
-									$examplename = $dirname;
-									$sectionname = $dirname;
-									//create codeexample
-									$query = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (:cid,:ename,:sname,1,:cversion,:templateid);");
-									$query->bindParam(":cid", $courseid);
-									$query->bindParam(":ename", $examplename);
-									$query->bindParam(":sname", $sectionname);
-									$query->bindParam(":cversion", $coursevers);
-									$query->bindParam(":templateid", $templateNumber);
-									$query->execute();
 
-									//select the latest codeexample created to link boxes to this codeexample
-									$query = $pdo->prepare("SELECT MAX(exampleid) as LatestExID FROM codeexample;");
-									$query->execute();
-									$result = $query->fetch(PDO::FETCH_OBJ);
-									$exampleid = $result->LatestExID;
-
-									//Add each file to a box and add that box to the codeexample and set the box to its correct content.
-									for ($i = 2; $i < count($files); $i++) {
-										$filename = $files[$i];
-										$parts = explode('.', $filename);
-										$filetype = "CODE";
-										$wlid = 0;
-
-										switch ($parts[1]) {
-											case "js":
-												$filetype = "CODE";
-												$wlid = 1;
-												break;
-											case "php":
-												$filetype = "CODE";
-												$wlid = 2;
-												break;
-											case "html":
-												$filetype = "CODE";
-												$wlid = 3;
-												break;
-											case "txt":
-												$filetype = "DOCUMENT";
-												$wlid = 4;
-												break;
-											case "md":
-												$filetype = "DOCUMENT";
-												$wlid = 4;
-												break;
-											case "java":
-												$filetype = "CODE";
-												$wlid = 5;
-												break;
-											case "sr":
-												$filetype = "CODE";
-												$wlid = 6;
-												break;
-											case "sql":
-												$filetype = "CODE";
-												$wlid = 7;
-												break;
-											default:
-												$filetype = "DOCUMENT";
-												$wlid = 4;
-												break;
-										}
-
-										$boxid = $i - 1;
-										$fontsize = 9;
-										$setting = "[viktig=1]";
-										$query = $pdo->prepare("INSERT INTO box (boxid, exampleid, boxtitle, boxcontent, filename, settings, wordlistid, fontsize) VALUES (:boxid, :exampleid, :boxtitle, :boxcontent, :filename, :settings, :wordlistid, :fontsize);");
-										$query->bindParam(":boxid", $boxid);
-										$query->bindParam(":exampleid", $exampleid);
-										$query->bindParam(":boxtitle", $filename);
-										$query->bindParam(":boxcontent", $filetype);
-										$query->bindParam(":filename", $filename);
-										$query->bindParam(":settings", $setting);
-										$query->bindParam(":wordlistid", $wlid);
-										$query->bindParam(":fontsize", $fontsize);
-										$query->execute();
-									}
-
-									$link = "UNK";
-									$kind = 2;
-									$visible = 1;
-									$uid = 1;
-									$comment = null;
-									$gradesys = null;
-									$highscoremode = 0;
-									$groupkind = null;
-									//add the codeexample to listentries
-									$query = $pdo->prepare("INSERT INTO listentries (cid,vers, entryname, link, kind, pos, visible,creator,comments, gradesystem, highscoremode, groupKind) 
-																										VALUES(:cid,:cvs,:entryname,:link,:kind,:pos,:visible,:usrid,:comment, :gradesys, :highscoremode, :groupkind)");
-									$query->bindParam(":cid", $courseid);
-									$query->bindParam(":cvs", $coursevers);
-									$query->bindParam(":entryname", $examplename);
-									$query->bindParam(":link", $exampleid);
-									$query->bindParam(":kind", $kind);
-									$query->bindParam(":pos", $pos);
-									$query->bindParam(":visible", $visible);
-									$query->bindParam(":usrid", $uid);
-									$query->bindParam(":comment", $comment);
-									$query->bindParam(":gradesys", $gradesys);
-									$query->bindParam(":highscoremode", $highscoremode);
-									$query->bindParam(":groupkind", $groupkind);
+									$boxid = $i + 1;
+									$fontsize = 9;
+									$setting = "[viktig=1]";
+									$query = $pdo->prepare("INSERT INTO box (boxid, exampleid, boxtitle, boxcontent, filename, settings, wordlistid, fontsize) VALUES (:boxid, :exampleid, :boxtitle, :boxcontent, :filename, :settings, :wordlistid, :fontsize);");
+									$query->bindParam(":boxid", $boxid);
+									$query->bindParam(":exampleid", $exampleid);
+									$query->bindParam(":boxtitle", $filename);
+									$query->bindParam(":boxcontent", $filetype);
+									$query->bindParam(":filename", $filename);
+									$query->bindParam(":settings", $setting);
+									$query->bindParam(":wordlistid", $wlid);
+									$query->bindParam(":fontsize", $fontsize);
 									$query->execute();
 								}
+
+								$link = "UNK";
+								$kind = 2;
+								$visible = 1;
+								$uid = 1;
+								$comment = null;
+								$gradesys = null;
+								$highscoremode = 0;
+								$groupkind = null;
+								//add the codeexample to listentries
+								$query = $pdo->prepare("INSERT INTO listentries (cid,vers, entryname, link, kind, pos, visible,creator,comments, gradesystem, highscoremode, groupKind) 
+																									VALUES(:cid,:cvs,:entryname,:link,:kind,:pos,:visible,:usrid,:comment, :gradesys, :highscoremode, :groupkind)");
+								$query->bindParam(":cid", $courseid);
+								$query->bindParam(":cvs", $coursevers);
+								$query->bindParam(":entryname", $examplename);
+								$query->bindParam(":link", $exampleid);
+								$query->bindParam(":kind", $kind);
+								$query->bindParam(":pos", $pos);
+								$query->bindParam(":visible", $visible);
+								$query->bindParam(":usrid", $uid);
+								$query->bindParam(":comment", $comment);
+								$query->bindParam(":gradesys", $gradesys);
+								$query->bindParam(":highscoremode", $highscoremode);
+								$query->bindParam(":groupkind", $groupkind);
+								$query->execute();
 							}
+							
 						} else {
 							//Check for update
 							//TODO: Implement update for already existing code-examples.

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -598,8 +598,8 @@ if($gradesys=="UNK") $gradesys=0;
 								$exampleid = $result->LatestExID;
 
 								//Add each file to a box and add that box to the codeexample and set the box to its correct content.
-								foreach($groupedFiles as $gFile){
-									$filename = $gFile;
+								for ($i = 0; $i < count($groupedFiles); $i++) {
+									$filename = $groupedFiles[$i];
 									$parts = explode('.', $filename);
 									$filetype = "CODE";
 									$wlid = 0;
@@ -655,6 +655,32 @@ if($gradesys=="UNK") $gradesys=0;
 									$query->bindParam(":wordlistid", $wlid);
 									$query->bindParam(":fontsize", $fontsize);
 									$query->execute();
+										
+									$varname="boxid";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $boxid); 
+									$query3->execute();	
+									$varname="exampleid";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $exampleid); 
+									$query3->execute();	
+									$varname="filename";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $filename); 
+									$query3->execute();	
+									$varname="filetype";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $filetype); 
+									$query3->execute();	
+									$varname="wlid";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $wlid); 
+									$query3->execute();		
 
 								}
 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -522,11 +522,7 @@ if($gradesys=="UNK") $gradesys=0;
 					}
 
 					foreach($allFiles as $groupedFiles){
-						//get the correct examplename from the dirname and set the dir path
-						//$dirPath = $dirname;
-						//$dirnameArray = explode('/', $dirname);
-						//$dirname = $dirnameArray[count($dirnameArray) - 2];
-
+						//get the correct examplename
 						$explodeFiles = explode('.',$groupedFiles[0]);
 						$exampleName = $explodeFiles[0];
 						//count if there is already a codeexample or if we should create a new one.
@@ -554,21 +550,10 @@ if($gradesys=="UNK") $gradesys=0;
 							$pos = $e[0]['pos'] + 1; //Gets the last filled position+1 to put the new codexample at
 
 							//select the files that has should be in the codeexample
-							
-							//Count files in the directory for the codeexample
-							//$fileCount = 0;
-							//$files = scandir($dirPath);
-							//foreach ($files as $file) {
-							//	if (is_file($dirPath . '/' . $file)) {
-							//		$fileCount++;
-							//	}
-							//}
-
 							$fileCount = count($groupedFiles);
-							//If we find files that should be in the codeexample, create the codeexample
-							//Only template for 1 up to 5 files
+							//Start create the codeexample
 							if ($fileCount > 0 && $fileCount < 6) {
-								// There are at least two boxes, create two boxes to start with
+								//Select the correct template, only template for 1 up to 5 files exist
 								switch ($fileCount) {
 									case 1:
 										$templateNumber = 10;

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -645,23 +645,17 @@ if($gradesys=="UNK") $gradesys=0;
 									$boxid = $i + 1;
 									$fontsize = 9;
 									$setting = "[viktig=1]";
+									$boxtitle = substr($filename, 0, 20);
 									$query = $pdo->prepare("INSERT INTO box (boxid, exampleid, boxtitle, boxcontent, filename, settings, wordlistid, fontsize) VALUES (:boxid, :exampleid, :boxtitle, :boxcontent, :filename, :settings, :wordlistid, :fontsize);");
 									$query->bindParam(":boxid", $boxid);
 									$query->bindParam(":exampleid", $exampleid);
-									$query->bindParam(":boxtitle", $filename);
+									$query->bindParam(":boxtitle", $boxtitle);
 									$query->bindParam(":boxcontent", $filetype);
 									$query->bindParam(":filename", $filename);
 									$query->bindParam(":settings", $setting);
 									$query->bindParam(":wordlistid", $wlid);
 									$query->bindParam(":fontsize", $fontsize);
-									if($query->execute()){
-										$varname="boxCreated";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $varname); 
-										$query3->execute();	
-										
-									}else {
+									if(!$query->execute()){																				
 										if ($query->errorCode() !== '00000') {
 											$errorInfo = $query->errorInfo();
 											$errorCode = $errorInfo[0];
@@ -677,14 +671,9 @@ if($gradesys=="UNK") $gradesys=0;
 											$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 											$query3->bindParam(":examplename", $varname); 
 											$query3->bindParam(":sectionname", $errorMessage); 
-											$query3->execute();	
-																					
+											$query3->execute();																						
 										}																			
-									}
-							
-										
-										
-
+									}	
 								}
 
 								$link = "UNK";

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -514,6 +514,7 @@ if($gradesys=="UNK") $gradesys=0;
 					$dirPath = "../courses/".$courseid."/Github/" . $githubDir;	
 
 					$allFiles = array();
+					$files = scandir($dirPath);
 					foreach($files as $file) {
 						if(is_file($dirPath."/".$file)) {
 							$temp = array();

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -662,6 +662,25 @@ if($gradesys=="UNK") $gradesys=0;
 										$query3->execute();	
 										
 									}else {
+										if ($query->errorCode() !== '00000') {
+											$errorInfo = $query->errorInfo();
+											$errorCode = $errorInfo[0];
+											$errorMessage = $errorInfo[2];
+											
+											// Handle or display the error message as needed
+											$varname="errorCode";	
+											$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+											$query3->bindParam(":examplename", $varname); 
+											$query3->bindParam(":sectionname", $errorCode); 
+											$query3->execute();	
+											$varname="errorMessage";	
+											$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+											$query3->bindParam(":examplename", $varname); 
+											$query3->bindParam(":sectionname", $errorMessage); 
+											$query3->execute();	
+											
+											//echo "Error [{$errorCode}]: {$errorMessage}";
+										}
 										$varname="boxNotCreated";	
 										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 										$query3->bindParam(":examplename", $varname); 
@@ -702,6 +721,7 @@ if($gradesys=="UNK") $gradesys=0;
 										$query3->bindParam(":examplename", $varname); 
 										$query3->bindParam(":sectionname", $setting); 
 										$query3->execute();	
+
 										
 									}
 							

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -530,13 +530,7 @@ if($gradesys=="UNK") $gradesys=0;
 					}
 					
 
-					foreach($allFiles as $groupedFiles){
-						$countAllFiles = $groupedFiles[0];
-						$varname="nameGroupedFiles";	
-						$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-						$query3->bindParam(":examplename", $varname); 
-						$query3->bindParam(":sectionname", $countAllFiles); 
-						$query3->execute();	
+					foreach($allFiles as $groupedFiles){	
 						//get the correct examplename
 						$explodeFiles = explode('.',$groupedFiles[0]);
 						$exampleName = $explodeFiles[0];
@@ -609,7 +603,12 @@ if($gradesys=="UNK") $gradesys=0;
 									$parts = explode('.', $filename);
 									$filetype = "CODE";
 									$wlid = 0;
-
+									
+									$varname="fileName";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $filename); 
+									$query3->execute();
 									switch ($parts[1]) {
 										case "js":
 											$filetype = "CODE";

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -67,7 +67,6 @@ $tabs=getOP('tabs');
 $exampelid=getOP('exampleid');
 $url=getOP('url');
 
-$dirname=getOP('dirname');
 $lid=getOP('lid');
 $visbile = 0;
 $avgfeedbackscore = 0;
@@ -505,6 +504,14 @@ if($gradesys=="UNK") $gradesys=0;
 					$query->execute();
 					$e = $query->fetchAll();
 					$courseid = $e[0]['cid'];
+
+					//Get dir from the listentrie that was clicked
+					$query = $pdo->prepare("SELECT githubDir FROM listentries WHERE lid=:lid");
+					$query->bindParam(":lid", $lid);
+					$query->execute();
+					$e = $query->fetchAll();
+					$githubDir = $e[0]['githubDir'];
+					$dirPath = "../courses/".$courseid."/Github/" . $githubDir;
 
 					$allFiles = array();
 					foreach($files as $file) {

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -678,51 +678,8 @@ if($gradesys=="UNK") $gradesys=0;
 											$query3->bindParam(":examplename", $varname); 
 											$query3->bindParam(":sectionname", $errorMessage); 
 											$query3->execute();	
-											
-											//echo "Error [{$errorCode}]: {$errorMessage}";
-										}
-										$varname="boxNotCreated";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $varname); 
-										$query3->execute();	
-										$varname="boxid";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $boxid); 
-										$query3->execute();	
-										$varname="exampleid";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $exampleid); 
-										$query3->execute();	
-										$varname="filename";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $filename); 
-										$query3->execute();	
-										$varname="filetype";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $filetype); 
-										$query3->execute();	
-										$varname="wlid";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $wlid); 
-										$query3->execute();	
-										$varname="fontsize";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $fontsize); 
-										$query3->execute();	
-										$varname="setting";	
-										$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-										$query3->bindParam(":examplename", $varname); 
-										$query3->bindParam(":sectionname", $setting); 
-										$query3->execute();	
-
-										
+																					
+										}																			
 									}
 							
 										

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -506,184 +506,204 @@ if($gradesys=="UNK") $gradesys=0;
 					$e = $query->fetchAll();
 					$courseid = $e[0]['cid'];
 
-					//get the correct examplename from the dirname and set the dir path
-					$dirPath = $dirname;
-					$dirnameArray = explode('/', $dirname);
-					$dirname = $dirnameArray[count($dirnameArray)-2];								
-					//count if there is already a codeexample or if we should create a new one.
-					$query1 = $pdo->prepare("SELECT COUNT(*) AS count FROM codeexample  WHERE cid=:cid AND examplename=:examplename;");
-					$query1->bindParam(":cid", $courseid);
-					$query1->bindParam(":examplename", $dirname); 
-					$query1->execute();					
-					$result = $query1->fetch(PDO::FETCH_OBJ);
-					$counted = $result->count;
-
-					//if no codeexample exist create a new one
-					if($counted == 0) {
-						//Get active version of the course
-						$query = $pdo->prepare("SELECT activeversion FROM course WHERE cid=:cid");
-						$query->bindParam(":cid", $courseid);
-						$query->execute();
-						$e = $query->fetchAll();
-						$coursevers = $e[0]['activeversion'];
-	
-						//Get the last position in the listenries to add new course at the bottom
-						$query = $pdo->prepare("SELECT pos FROM listentries WHERE cid=:cid ORDER BY pos DESC;");
-						$query->bindParam(":cid", $courseid);
-						$query->execute();
-						$e = $query->fetchAll();
-						$pos = $e[0]['pos']+1;//Gets the last filled position+1 to put the new codexample at
-						
-						//connect to SQLite
-						$metadata_db = null;
-						$success = false;
-						try {
-							$metadata_db = new PDO('sqlite:../../githubMetadata/metadata'.$metadataDbVersion.'.db');
-							$success = true;							
-						} catch (PDOException $e) {
-							echo "Failed to connect to the database";
-							throw $e;
-						}
-						
-						//select the files that has should be in the codeexample
-						if($success) {							
-							//Count files in the directory for the codeexample
-							$fileCount = 0;
-							$files = scandir($dirPath);
-							foreach ($files as $file) {
-								if (is_file($dirPath . '/' . $file)) {
-									$fileCount++;
+					$allFiles = array();
+					foreach($files as $file) {
+						if(is_file($dirPath."/".$file)) {
+							$temp = array();
+							foreach($files as $file2) {
+								$n1 = explode(".", $file);
+								$n2 = explode(".", $file2);
+								if(is_file($dirpath."/".$file2) && $n1[0] == $n2[0]) {
+									array_push($temp, $file2);
 								}
 							}
-							//If we find files that should be in the codeexample, create the codeexample
-							//Only template for 1 up to 5 files
-							if($fileCount > 0 && $fileCount<6) {					
-								// There are at least two boxes, create two boxes to start with
-								switch ($fileCount) {
-									case 1:
-										$templateNumber = 10;
-										break;
-									case 2:
-										$templateNumber = 1;
-										break;
-									case 3:
-										$templateNumber = 3;
-										break;
-									case 4:
-										$templateNumber = 5;
-										break;
-									case 5:
-										$templateNumber = 9;
-										break;	
-								}			
-								$examplename = $dirname;
-								$sectionname = $dirname;
-								//create codeexample
-								$query = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (:cid,:ename,:sname,1,:cversion,:templateid);");
-								$query->bindParam(":cid", $courseid);
-								$query->bindParam(":ename", $examplename);
-								$query->bindParam(":sname", $sectionname);
-								$query->bindParam(":cversion", $coursevers);
-								$query->bindParam(":templateid", $templateNumber);
-								$query->execute();
-							
-								//select the latest codeexample created to link boxes to this codeexample
-								$query = $pdo->prepare("SELECT MAX(exampleid) as LatestExID FROM codeexample;");
-								$query->execute();
-								$result = $query->fetch(PDO::FETCH_OBJ);
-								$exampleid = $result->LatestExID;
-								
-								//Add each file to a box and add that box to the codeexample and set the box to its correct content.
-								for($i = 2; $i < count($files); $i++) {
-									$filename = $files[$i];
-									$parts = explode('.', $filename);
-									$filetype = "CODE";
-									$wlid = 0;
-									
-									switch ($parts[1]) {
-										case "js":
-											$filetype = "CODE";
-											$wlid = 1;
+							array_push($allFiles, $temp);
+						}
+					}
+
+					foreach($allFiles as $groupedFiles){
+						//get the correct examplename from the dirname and set the dir path
+						//$dirPath = $dirname;
+						//$dirnameArray = explode('/', $dirname);
+						//$dirname = $dirnameArray[count($dirnameArray) - 2];
+
+						$explodeFiles = explode('.',$groupedFiles[0]);
+						$exampleName = $explodeFiles[0];
+						//count if there is already a codeexample or if we should create a new one.
+						$query1 = $pdo->prepare("SELECT COUNT(*) AS count FROM codeexample  WHERE cid=:cid AND examplename=:examplename;");
+						$query1->bindParam(":cid", $courseid);
+						$query1->bindParam(":examplename", $exampleName);
+						$query1->execute();
+						$result = $query1->fetch(PDO::FETCH_OBJ);
+						$counted = $result->count;
+
+						//if no codeexample exist create a new one
+						if ($counted == 0) {
+							//Get active version of the course
+							$query = $pdo->prepare("SELECT activeversion FROM course WHERE cid=:cid");
+							$query->bindParam(":cid", $courseid);
+							$query->execute();
+							$e = $query->fetchAll();
+							$coursevers = $e[0]['activeversion'];
+
+							//Get the last position in the listenries to add new course at the bottom
+							$query = $pdo->prepare("SELECT pos FROM listentries WHERE cid=:cid ORDER BY pos DESC;");
+							$query->bindParam(":cid", $courseid);
+							$query->execute();
+							$e = $query->fetchAll();
+							$pos = $e[0]['pos'] + 1; //Gets the last filled position+1 to put the new codexample at
+
+							//connect to SQLite
+							$metadata_db = null;
+							$success = false;
+							try {
+								$metadata_db = new PDO('sqlite:../../githubMetadata/metadata' . $metadataDbVersion . '.db');
+								$success = true;
+							} catch (PDOException $e) {
+								echo "Failed to connect to the database";
+								throw $e;
+							}
+
+							//select the files that has should be in the codeexample
+							if ($success) {
+								//Count files in the directory for the codeexample
+								$fileCount = 0;
+								$files = scandir($dirPath);
+								foreach ($files as $file) {
+									if (is_file($dirPath . '/' . $file)) {
+										$fileCount++;
+									}
+								}
+								//If we find files that should be in the codeexample, create the codeexample
+								//Only template for 1 up to 5 files
+								if ($fileCount > 0 && $fileCount < 6) {
+									// There are at least two boxes, create two boxes to start with
+									switch ($fileCount) {
+										case 1:
+											$templateNumber = 10;
 											break;
-										case "php":
-											$filetype = "CODE";
-											$wlid = 2;
+										case 2:
+											$templateNumber = 1;
 											break;
-										case "html":
-											$filetype = "CODE";
-											$wlid = 3;
+										case 3:
+											$templateNumber = 3;
 											break;
-										case "txt":
-											$filetype = "DOCUMENT";
-											$wlid = 4;
+										case 4:
+											$templateNumber = 5;
 											break;
-										case "md":
-											$filetype = "DOCUMENT";
-											$wlid = 4;
-											break;
-										case "java":
-											$filetype = "CODE";
-											$wlid = 5;
-											break;
-										case "sr":
-											$filetype = "CODE";
-											$wlid = 6;
-											break;
-										case "sql":
-											$filetype = "CODE";
-											$wlid = 7;
-											break;
-										default:
-											$filetype = "DOCUMENT";
-											$wlid = 4;
+										case 5:
+											$templateNumber = 9;
 											break;
 									}
+									$examplename = $dirname;
+									$sectionname = $dirname;
+									//create codeexample
+									$query = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (:cid,:ename,:sname,1,:cversion,:templateid);");
+									$query->bindParam(":cid", $courseid);
+									$query->bindParam(":ename", $examplename);
+									$query->bindParam(":sname", $sectionname);
+									$query->bindParam(":cversion", $coursevers);
+									$query->bindParam(":templateid", $templateNumber);
+									$query->execute();
 
-									$boxid=$i-1;
-									$fontsize= 9;
-									$setting = "[viktig=1]";
-									$query = $pdo->prepare("INSERT INTO box (boxid, exampleid, boxtitle, boxcontent, filename, settings, wordlistid, fontsize) VALUES (:boxid, :exampleid, :boxtitle, :boxcontent, :filename, :settings, :wordlistid, :fontsize);");
-									$query->bindParam(":boxid", $boxid);
-									$query->bindParam(":exampleid", $exampleid);
-									$query->bindParam(":boxtitle", $filename);
-									$query->bindParam(":boxcontent", $filetype); 
-									$query->bindParam(":filename", $filename);
-									$query->bindParam(":settings", $setting);
-									$query->bindParam(":wordlistid", $wlid);
-									$query->bindParam(":fontsize", $fontsize);
+									//select the latest codeexample created to link boxes to this codeexample
+									$query = $pdo->prepare("SELECT MAX(exampleid) as LatestExID FROM codeexample;");
+									$query->execute();
+									$result = $query->fetch(PDO::FETCH_OBJ);
+									$exampleid = $result->LatestExID;
+
+									//Add each file to a box and add that box to the codeexample and set the box to its correct content.
+									for ($i = 2; $i < count($files); $i++) {
+										$filename = $files[$i];
+										$parts = explode('.', $filename);
+										$filetype = "CODE";
+										$wlid = 0;
+
+										switch ($parts[1]) {
+											case "js":
+												$filetype = "CODE";
+												$wlid = 1;
+												break;
+											case "php":
+												$filetype = "CODE";
+												$wlid = 2;
+												break;
+											case "html":
+												$filetype = "CODE";
+												$wlid = 3;
+												break;
+											case "txt":
+												$filetype = "DOCUMENT";
+												$wlid = 4;
+												break;
+											case "md":
+												$filetype = "DOCUMENT";
+												$wlid = 4;
+												break;
+											case "java":
+												$filetype = "CODE";
+												$wlid = 5;
+												break;
+											case "sr":
+												$filetype = "CODE";
+												$wlid = 6;
+												break;
+											case "sql":
+												$filetype = "CODE";
+												$wlid = 7;
+												break;
+											default:
+												$filetype = "DOCUMENT";
+												$wlid = 4;
+												break;
+										}
+
+										$boxid = $i - 1;
+										$fontsize = 9;
+										$setting = "[viktig=1]";
+										$query = $pdo->prepare("INSERT INTO box (boxid, exampleid, boxtitle, boxcontent, filename, settings, wordlistid, fontsize) VALUES (:boxid, :exampleid, :boxtitle, :boxcontent, :filename, :settings, :wordlistid, :fontsize);");
+										$query->bindParam(":boxid", $boxid);
+										$query->bindParam(":exampleid", $exampleid);
+										$query->bindParam(":boxtitle", $filename);
+										$query->bindParam(":boxcontent", $filetype);
+										$query->bindParam(":filename", $filename);
+										$query->bindParam(":settings", $setting);
+										$query->bindParam(":wordlistid", $wlid);
+										$query->bindParam(":fontsize", $fontsize);
+										$query->execute();
+									}
+
+									$link = "UNK";
+									$kind = 2;
+									$visible = 1;
+									$uid = 1;
+									$comment = null;
+									$gradesys = null;
+									$highscoremode = 0;
+									$groupkind = null;
+									//add the codeexample to listentries
+									$query = $pdo->prepare("INSERT INTO listentries (cid,vers, entryname, link, kind, pos, visible,creator,comments, gradesystem, highscoremode, groupKind) 
+																										VALUES(:cid,:cvs,:entryname,:link,:kind,:pos,:visible,:usrid,:comment, :gradesys, :highscoremode, :groupkind)");
+									$query->bindParam(":cid", $courseid);
+									$query->bindParam(":cvs", $coursevers);
+									$query->bindParam(":entryname", $examplename);
+									$query->bindParam(":link", $exampleid);
+									$query->bindParam(":kind", $kind);
+									$query->bindParam(":pos", $pos);
+									$query->bindParam(":visible", $visible);
+									$query->bindParam(":usrid", $uid);
+									$query->bindParam(":comment", $comment);
+									$query->bindParam(":gradesys", $gradesys);
+									$query->bindParam(":highscoremode", $highscoremode);
+									$query->bindParam(":groupkind", $groupkind);
 									$query->execute();
 								}
-								
-								$link = "UNK";
-								$kind = 2;
-								$visible = 1;
-								$uid = 1;
-								$comment = null;
-								$gradesys = null;
-								$highscoremode = 0;
-								$groupkind = null;
-								//add the codeexample to listentries
-								$query = $pdo->prepare("INSERT INTO listentries (cid,vers, entryname, link, kind, pos, visible,creator,comments, gradesystem, highscoremode, groupKind) 
-																		VALUES(:cid,:cvs,:entryname,:link,:kind,:pos,:visible,:usrid,:comment, :gradesys, :highscoremode, :groupkind)");
-								$query->bindParam(":cid", $courseid);
-								$query->bindParam(":cvs", $coursevers);
-								$query->bindParam(":entryname", $examplename);
-								$query->bindParam(":link", $exampleid); 
-								$query->bindParam(":kind", $kind);
-								$query->bindParam(":pos", $pos);
-								$query->bindParam(":visible", $visible);
-								$query->bindParam(":usrid", $uid);
-								$query->bindParam(":comment", $comment);
-								$query->bindParam(":gradesys", $gradesys);
-								$query->bindParam(":highscoremode", $highscoremode);
-								$query->bindParam(":groupkind", $groupkind);
-								$query->execute();	
 							}
-						}
-					} else {
-						//Check for update
-						//TODO: Implement update for already existing code-examples.
-					} 
+						} else {
+							//Check for update
+							//TODO: Implement update for already existing code-examples.
+						} 
+					}
 				
 				} else if (strcmp($coursevers, "null")!==0) {
 					// Get every coursevers of courses so we seed groups to every courseversion

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -655,25 +655,7 @@ if($gradesys=="UNK") $gradesys=0;
 									$query->bindParam(":settings", $setting);
 									$query->bindParam(":wordlistid", $wlid);
 									$query->bindParam(":fontsize", $fontsize);
-									if(!$query->execute()){																				
-										if ($query->errorCode() !== '00000') {
-											$errorInfo = $query->errorInfo();
-											$errorCode = $errorInfo[0];
-											$errorMessage = $errorInfo[2];
-											
-											// Handle or display the error message as needed
-											$varname="errorCode";	
-											$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-											$query3->bindParam(":examplename", $varname); 
-											$query3->bindParam(":sectionname", $errorCode); 
-											$query3->execute();	
-											$varname="errorMessage";	
-											$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-											$query3->bindParam(":examplename", $varname); 
-											$query3->bindParam(":sectionname", $errorMessage); 
-											$query3->execute();																						
-										}																			
-									}	
+									$query->execute();																																																
 								}
 
 								$link = "UNK";

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -511,14 +511,7 @@ if($gradesys=="UNK") $gradesys=0;
 					$query->execute();
 					$e = $query->fetchAll();
 					$githubDir = $e[0]['githubDir'];
-					$dirPath = "../courses/".$courseid."/Github/" . $githubDir;
-
-						
-					$varname="dirpath";	
-					$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-					$query3->bindParam(":examplename", $varname); 
-					$query3->bindParam(":sectionname", $dirPath); 
-					$query3->execute();		
+					$dirPath = "../courses/".$courseid."/Github/" . $githubDir;	
 
 					$allFiles = array();
 					foreach($files as $file) {
@@ -534,6 +527,11 @@ if($gradesys=="UNK") $gradesys=0;
 							array_push($allFiles, $temp);
 						}
 					}
+					$varname="arrayFiles";	
+					$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+					$query3->bindParam(":examplename", $varname); 
+					$query3->bindParam(":sectionname", $allFiles[0][0]); 
+					$query3->execute();	
 
 					foreach($allFiles as $groupedFiles){
 						//get the correct examplename


### PR DESCRIPTION
Redone the previous version of creating code-examples to fit the new version of how files,dir and moment is located on the webbserver and repo, see https://github.com/LenaSYS/Webbprogrammering-Examples/tree/master/Examples%20Html for moment "Examples Html".
This now creates a code example based on the file name. If multiple files have same name they are created as the same codeexample. Meaning: 
Canvas Animate.html = 1 code-example
Canvas Draw Objects.html =1 code-example
Canvas Gradient.html =1 code-example
Canvas Immediate.html =1 code-example
And 
Canvas Animate.html + Canvas Animate.css 	=1 code-example

This verision does currently not support the possibility to have two files of the same type in a code example because two files cannot have the same type and name. But maybe two or more .sql, .js, .html or any other files type is never used within the same example so this might not even be an problem? @HGustavs 

You select a dir in the github setting in the dropdown and press submit.
![image](https://github.com/HGustavs/LenaSYS/assets/102595788/be6d77cc-ef1b-4652-8483-bb2146bb54bd)

Then you press the refreshbutton on that moment.
![image](https://github.com/HGustavs/LenaSYS/assets/102595788/bf0ffb5c-e9e9-409c-ab42-a06c126a5aad)


Refresh the page and all code examples is created with their files.
![image](https://github.com/HGustavs/LenaSYS/assets/102595788/b307339b-e146-45a8-80bf-9747d04690f2)
