### PR TITLE
 Name of lifeline elements #14059 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9816,7 +9816,7 @@ function drawElement(element, ghosted = false)
                 }
             }
 
-            let text = element.name.map(line => {
+            let text = element.name(line => {
                 return splitLengthyLine(line, maxCharactersPerLine);
             }).flat();
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9807,20 +9807,20 @@ function drawElement(element, ghosted = false)
         />`;
         //actor or object is determined via the buttons in the context menu. the default is actor.
         if (element.actorOrObject == "actor") {
-            const maxCharactersPerLine = Math.floor((boxw / texth) * 1.75);
+            let maxLengthOfActorName = Math.floor((boxw / texth)*1.75);
 
-            let splitLengthyLine = (str, max) => {
+            /* let splitLengthyLine = (str, max) => {
                 if (str.length <= max) return str;
                 else {
                     return [str.substring(0, max)].concat(splitLengthyLine(str.substring(max), max));
                 }
             }
 
-            let text = element.name(line => {
+            let text = element.attributes.map(line => {
                 return splitLengthyLine(line, maxCharactersPerLine);
-            }).flat();
+            }).flat(); */
 
-            elemAttri = text.length;
+            //elemAttri = text.length;
             //svg for actor.
             str += `<g>`
             str += `<circle cx="${(boxw/2)+linew}" cy="${(boxw/8)+linew}" r="${boxw/8}px" fill='${element.fill}' stroke='${element.stroke}' stroke-width='${linew}'/>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9785,7 +9785,7 @@ function drawElement(element, ghosted = false)
     else if (element.kind == 'sequenceActorAndObject') {
         //div to encapsulate sequence lifeline.
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;`;
+        style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9824,6 +9824,19 @@ function drawElement(element, ghosted = false)
                 stroke-width='${linew}'
                 stroke='${element.stroke}'
                 fill='transparent'
+            />`;
+            //canvasContext.measureText(element.name).width;
+            //textWidth
+            //rect for sitting behind the actor text
+            str += `<rect class='text'
+                x='${xAnchor-(textWidth/2)}'
+                y='${boxw}'
+                width='${textWidth}'
+                height='${texth}'
+                rx='${sequenceCornerRadius}'
+                stroke-width='${linew}'
+                stroke='${element.stroke}'
+                fill='${element.fill}' 
             />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
             str += `</g>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9863,7 +9863,7 @@ function drawElement(element, ghosted = false)
                     stroke='none'
                     fill='${element.fill}' 
                 />`;
-                str += `<text class='text' x='${linew}' y='${boxw+texth+(linew*2)}'>${element.name}</text>`;
+                str += `<text class='text' x='${linew}' y='${boxw+texth+linew}'>${element.name}</text>`;
             }
             //fill='${element.fill}' 
             str += `</g>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9833,8 +9833,7 @@ function drawElement(element, ghosted = false)
                 y='${boxw}'
                 width='${textWidth}'
                 height='${texth}'
-                stroke-width='${linew}'
-                stroke='${element.stroke}'
+                stroke='none'
                 fill='${element.fill}' 
             />`;
             str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9828,7 +9828,7 @@ function drawElement(element, ghosted = false)
             //rect for sitting behind the actor text
             str += `<rect class='text'
                 x='${xAnchor-(textWidth/2)}'
-                y='${boxw}'
+                y='${boxw+linew}'
                 width='${textWidth}'
                 height='${texth}'
                 stroke='none'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9807,20 +9807,6 @@ function drawElement(element, ghosted = false)
         />`;
         //actor or object is determined via the buttons in the context menu. the default is actor.
         if (element.actorOrObject == "actor") {
-            let maxLengthOfActorName = Math.floor((boxw / texth)*1.75);
-
-            /* let splitLengthyLine = (str, max) => {
-                if (str.length <= max) return str;
-                else {
-                    return [str.substring(0, max)].concat(splitLengthyLine(str.substring(max), max));
-                }
-            }
-
-            let text = element.attributes.map(line => {
-                return splitLengthyLine(line, maxCharactersPerLine);
-            }).flat(); */
-
-            //elemAttri = text.length;
             //svg for actor.
             str += `<g>`
             str += `<circle cx="${(boxw/2)+linew}" cy="${(boxw/8)+linew}" r="${boxw/8}px" fill='${element.fill}' stroke='${element.stroke}' stroke-width='${linew}'/>`;
@@ -9839,17 +9825,17 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-
-            //rect for sitting behind the actor text
-            //make the box fit the text if the text isnt too big
+            //svg for the actor name text
+            //make the rect fit the text if the text isnt too big
             if (!tooBig) {
+                //rect for sitting behind the actor text
                 str += `<rect class='text'
                     x='${xAnchor-(textWidth/2)}'
                     y='${boxw+(linew*2)}'
                     width='${textWidth}'
                     height='${texth-linew}'
                     stroke='none'
-                    fill='${element.fill}' 
+                    fill='${element.fill}'
                 />`;
                 str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             }
@@ -9861,7 +9847,7 @@ function drawElement(element, ghosted = false)
                     width='${boxw-linew}'
                     height='${texth-linew}'
                     stroke='none'
-                    fill='${element.fill}' 
+                    fill='${element.fill}'
                 />`;
                 str += `<text class='text' x='${linew}' y='${boxw+texth}'>${element.name}</text>`;
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9783,9 +9783,9 @@ function drawElement(element, ghosted = false)
     //=============================================== <-- Start Sequnece functionality
     //sequence actor and its life line and also the object since they can be switched via options pane.
     else if (element.kind == 'sequenceActorAndObject') {
-        //div to encapsulate sequence lifeline.
-        str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;`;
+        //div to encapsulate sequence actor/object and its lifeline.
+        str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'`;
+        str += `style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9849,17 +9849,18 @@ function drawElement(element, ghosted = false)
                     width='${textWidth}'
                     height='${texth}'
                     stroke='none'
-                    fill='red' 
+                    fill='${element.fill}' 
                 />`;
-            } 
+            }
+            //else just make a boxw width rect.
             else {
                 str += `<rect class='text'
                     x='${linew}'
                     y='${boxw+(linew*2)}'
-                    width='${boxw}'
+                    width='${boxw-linew}'
                     height='${texth}'
                     stroke='none'
-                    fill='red' 
+                    fill='${element.fill}' 
                 />`;
             }
             //fill='${element.fill}' 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9784,8 +9784,8 @@ function drawElement(element, ghosted = false)
     //sequence actor and its life line and also the object since they can be switched via options pane.
     else if (element.kind == 'sequenceActorAndObject') {
         //div to encapsulate sequence actor/object and its lifeline.
-        str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'`;
-        str += `style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;`;
+        str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'
+        style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9847,7 +9847,7 @@ function drawElement(element, ghosted = false)
                     x='${xAnchor-(textWidth/2)}'
                     y='${boxw+(linew*2)}'
                     width='${textWidth}'
-                    height='${texth}'
+                    height='${texth-linew}'
                     stroke='none'
                     fill='${element.fill}' 
                 />`;
@@ -9859,7 +9859,7 @@ function drawElement(element, ghosted = false)
                     x='${linew}'
                     y='${boxw+(linew*2)}'
                     width='${boxw-linew}'
-                    height='${texth}'
+                    height='${texth-linew}'
                     stroke='none'
                     fill='${element.fill}' 
                 />`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9825,8 +9825,8 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            //svg for the actor name text
-            //make the rect fit the text if the text isnt too big
+            //svg for the actor name text, it has a background rect for ease of readability.
+            //make the rect fit the text if the text isn't too big
             if (!tooBig) {
                 //rect for sitting behind the actor text
                 str += `<rect class='text'
@@ -9839,8 +9839,9 @@ function drawElement(element, ghosted = false)
                 />`;
                 str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             }
-            //else just make a boxw width rect. and move the text slightly to fit this new rect better
+            //else just make a boxw width rect and adjust the text to fit this new rect better
             else {
+                //rect for sitting behind the actor text
                 str += `<rect class='text'
                     x='${linew}'
                     y='${boxw+(linew*2)}'
@@ -9851,7 +9852,6 @@ function drawElement(element, ghosted = false)
                 />`;
                 str += `<text class='text' x='${linew}' y='${boxw+texth}'>${element.name}</text>`;
             }
-            //fill='${element.fill}' 
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9832,8 +9832,9 @@ function drawElement(element, ghosted = false)
                 width='${textWidth}'
                 height='${texth}'
                 stroke='none'
-                fill='${element.fill}' 
+                fill='red' 
             />`;
+            //fill='${element.fill}' 
             str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
             str += `</g>`;
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9841,14 +9841,27 @@ function drawElement(element, ghosted = false)
             />`;
 
             //rect for sitting behind the actor text
-            str += `<rect class='text'
-                x='${xAnchor-(textWidth/2)}'
-                y='${boxw+(linew*2)}'
-                width='${textWidth}'
-                height='${texth}'
-                stroke='none'
-                fill='red' 
-            />`;
+            //make the box fit the text if the text isnt too big
+            if (!tooBig) {
+                str += `<rect class='text'
+                    x='${xAnchor-(textWidth/2)}'
+                    y='${boxw+(linew*2)}'
+                    width='${textWidth}'
+                    height='${texth}'
+                    stroke='none'
+                    fill='red' 
+                />`;
+            } 
+            else {
+                str += `<rect class='text'
+                    x='${linew}'
+                    y='${boxw+(linew*2)}'
+                    width='${boxw}'
+                    height='${texth}'
+                    stroke='none'
+                    fill='red' 
+                />`;
+            }
             //fill='${element.fill}' 
             str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
             str += `</g>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9821,7 +9821,6 @@ function drawElement(element, ghosted = false)
             }).flat();
 
             elemAttri = text.length;
-            }
             //svg for actor.
             str += `<g>`
             str += `<circle cx="${(boxw/2)+linew}" cy="${(boxw/8)+linew}" r="${boxw/8}px" fill='${element.fill}' stroke='${element.stroke}' stroke-width='${linew}'/>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9828,14 +9828,14 @@ function drawElement(element, ghosted = false)
             //rect for sitting behind the actor text
             str += `<rect class='text'
                 x='${xAnchor-(textWidth/2)}'
-                y='${boxw+linew}'
+                y='${boxw+(linew*2)}'
                 width='${textWidth}'
                 height='${texth}'
                 stroke='none'
                 fill='red' 
             />`;
             //fill='${element.fill}' 
-            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9863,7 +9863,7 @@ function drawElement(element, ghosted = false)
                     stroke='none'
                     fill='${element.fill}' 
                 />`;
-                str += `<text class='text' x='${linew}' y='${boxw+texth+linew}'>${element.name}</text>`;
+                str += `<text class='text' x='${linew}' y='${boxw+texth}'>${element.name}</text>`;
             }
             //fill='${element.fill}' 
             str += `</g>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9864,7 +9864,7 @@ function drawElement(element, ghosted = false)
                 />`;
             }
             //fill='${element.fill}' 
-            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9851,8 +9851,9 @@ function drawElement(element, ghosted = false)
                     stroke='none'
                     fill='${element.fill}' 
                 />`;
+                str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             }
-            //else just make a boxw width rect.
+            //else just make a boxw width rect. and move the text slightly to fit this new rect better
             else {
                 str += `<rect class='text'
                     x='${linew}'
@@ -9862,9 +9863,9 @@ function drawElement(element, ghosted = false)
                     stroke='none'
                     fill='${element.fill}' 
                 />`;
+                str += `<text class='text' x='${linew}' y='${boxw+(texth/2)+(linew*2)}'>${element.name}</text>`;
             }
             //fill='${element.fill}' 
-            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9839,19 +9839,18 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            for (let i = 0; i < text.length; i++) {
-                //rect for sitting behind the actor text
-                str += `<rect class='text'
-                    x='${xAnchor-(textWidth/2)}'
-                    y='${boxw+(linew*2)+((boxw+(linew*2))*i)}'
-                    width='${textWidth}'
-                    height='${texth}'
-                    stroke='none'
-                    fill='red' 
-                />`;
-                //fill='${element.fill}' 
-                str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)+((boxw+(texth/2)+(linew*2))*i)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
-            }
+
+            //rect for sitting behind the actor text
+            str += `<rect class='text'
+                x='${xAnchor-(textWidth/2)}'
+                y='${boxw+(linew*2)+((boxw+(linew*2))*i)}'
+                width='${textWidth}'
+                height='${texth}'
+                stroke='none'
+                fill='red' 
+            />`;
+            //fill='${element.fill}' 
+            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)+((boxw+(texth/2)+(linew*2))*i)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9825,8 +9825,6 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            //canvasContext.measureText(element.name).width;
-            //textWidth
             //rect for sitting behind the actor text
             str += `<rect class='text'
                 x='${xAnchor-(textWidth/2)}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9843,14 +9843,14 @@ function drawElement(element, ghosted = false)
             //rect for sitting behind the actor text
             str += `<rect class='text'
                 x='${xAnchor-(textWidth/2)}'
-                y='${boxw+(linew*2)+((boxw+(linew*2))*i)}'
+                y='${boxw+(linew*2)}'
                 width='${textWidth}'
                 height='${texth}'
                 stroke='none'
                 fill='red' 
             />`;
             //fill='${element.fill}' 
-            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)+((boxw+(texth/2)+(linew*2))*i)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9833,12 +9833,11 @@ function drawElement(element, ghosted = false)
                 y='${boxw}'
                 width='${textWidth}'
                 height='${texth}'
-                rx='${sequenceCornerRadius}'
                 stroke-width='${linew}'
                 stroke='${element.stroke}'
                 fill='${element.fill}' 
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9863,7 +9863,7 @@ function drawElement(element, ghosted = false)
                     stroke='none'
                     fill='${element.fill}' 
                 />`;
-                str += `<text class='text' x='${linew}' y='${boxw+(texth/2)+(linew*2)}'>${element.name}</text>`;
+                str += `<text class='text' x='${linew}' y='${boxw+texth+(linew*2)}'>${element.name}</text>`;
             }
             //fill='${element.fill}' 
             str += `</g>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9807,6 +9807,21 @@ function drawElement(element, ghosted = false)
         />`;
         //actor or object is determined via the buttons in the context menu. the default is actor.
         if (element.actorOrObject == "actor") {
+            const maxCharactersPerLine = Math.floor((boxw / texth) * 1.75);
+
+            let splitLengthyLine = (str, max) => {
+                if (str.length <= max) return str;
+                else {
+                    return [str.substring(0, max)].concat(splitLengthyLine(str.substring(max), max));
+                }
+            }
+
+            let text = element.name.map(line => {
+                return splitLengthyLine(line, maxCharactersPerLine);
+            }).flat();
+
+            elemAttri = text.length;
+            }
             //svg for actor.
             str += `<g>`
             str += `<circle cx="${(boxw/2)+linew}" cy="${(boxw/8)+linew}" r="${boxw/8}px" fill='${element.fill}' stroke='${element.stroke}' stroke-width='${linew}'/>`;
@@ -9825,17 +9840,19 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='transparent'
             />`;
-            //rect for sitting behind the actor text
-            str += `<rect class='text'
-                x='${xAnchor-(textWidth/2)}'
-                y='${boxw+(linew*2)}'
-                width='${textWidth}'
-                height='${texth}'
-                stroke='none'
-                fill='red' 
-            />`;
-            //fill='${element.fill}' 
-            str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
+            for (let i = 0; i < text.length; i++) {
+                //rect for sitting behind the actor text
+                str += `<rect class='text'
+                    x='${xAnchor-(textWidth/2)}'
+                    y='${boxw+(linew*2)+((boxw+(linew*2))*i)}'
+                    width='${textWidth}'
+                    height='${texth}'
+                    stroke='none'
+                    fill='red' 
+                />`;
+                //fill='${element.fill}' 
+                str += `<text class='text' x='${xAnchor}' y='${boxw+(texth/2)+(linew*2)+((boxw+(texth/2)+(linew*2))*i)}' dominant-baseline='middle' text-anchor='${vAlignment}' fill='${nonFilledElementPartStrokeColor}'>${element.name}</text>`;
+            }
             str += `</g>`;
         }
         else if (element.actorOrObject == "object") {


### PR DESCRIPTION
I added a svg rect that sits behind the actors name, this caused an unexpected bug though where this rect would be immensely offset if the name of the actor was too long to fit the designated box.

As shown in the comments on issue #14059 there was a discussion between me and the group leader about how this problem should be resolved. I ultimately decided on method two: "A similar method as the name for ER entities; simply have the name cut off into nowhere if its too long."