### PR TITLE
G3 2023 v7 issue#13987

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3137,7 +3137,7 @@ $(window).on('focus', function() {
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
-      autoRefreshCodeExample(dir, momentID);
+      autoRefreshCodeExample();
   }
 // When the user stops watching course page, set isActivelyFocused to false
 }).on('blur', function() {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3127,7 +3127,7 @@ $(window).on('focus', function( ) {
 
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
-  // If the user has been focusing on the course page for more than **UPDATEINTERVAL** minute (data can be found above createCodeExamples function), 
+  // If the user has been focusing on the course page for more than **UPDATEINTERVAL** minute (data varieable can be found above createCodeExamples function), 
   //update the code examples or if its first time
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3136,16 +3136,15 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function(dir, momentID) {
   isActivelyFocused = true;
+  let momentID = lid;
+  let dir = "../courses/1895/Github/Demo/Code-example1/";
 
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
       createExamples(dir, momentID);
-      console.log(momentID);
-      console.log(dir);
-      console.log(lid);
-      console.log(dirname);
+
   }
 // When the user stops watching course page, set isActivelyFocused to false
 }).on('blur', function() {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3141,7 +3141,7 @@ $(window).on('focus', function( ) {
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
-      createExamples(dir, lid);
+      createExamples(dir);
 
   }
 // When the user stops watching course page, set isActivelyFocused to false

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3130,7 +3130,7 @@ function autoRefreshCodeExample(dir, momentID) {
     } else {
       console.log("No dir and momentID set yet.");
     }
-  }, 10 * 60 * 1000); // set to 10 minutes
+  },  60 * 100); // set to 1 minutes currently
 }
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3105,6 +3105,7 @@ function createExamples(dir,momentID) {
     success: function(response) {
       console.log("AJAX request succeeded. Response:", response);
       lastUpdatedCodeExampes = Date.now();
+      console.log("Last time code examples updated was: ", lastUpdatedCodeExampes);
     },
     error: function(xhr, status, error) {
       console.log("AJAX request failed. Status:", status);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3130,7 +3130,7 @@ function autoRefreshCodeExample(dir, momentID) {
   },  600 * 100); // set to 1 minutes currently
 }
 
-// When the window gains focus, set isActive to true
+// When the window gains focus, set isActivelyFocused to true
 $(window).on('focus', function() {
   isActivelyFocused = true;
   console.log('Window gained focus, isActive is now', isActive);
@@ -3139,7 +3139,7 @@ $(window).on('focus', function() {
       lastUpdated = now;
       createExamples(dir, momentID);
   }
-// When the window loses focus, set isActive to false
+// When the window loses focus, set isActivelyFocused to false
 }).on('blur', function() {
   isActivelyFocused = false;
   console.log('Window lost focus, isActive is now', isActive);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3137,7 +3137,7 @@ $(window).on('focus', function() {
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
-      autoRefreshCodeExample();
+      createExamples();
   }
 // When the user stops watching course page, set isActivelyFocused to false
 }).on('blur', function() {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3086,6 +3086,9 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
   }
 }
 
+let isActivelyFocused = false;
+let lastUpdatedCodeExampes = null;
+
 //Creates all examples from github that doesnt exists yet
 function createExamples(dir,momentID) {
   lid = momentID;
@@ -3111,6 +3114,8 @@ function createExamples(dir,momentID) {
   console.log("** AJAX DONE **");
 
 }
+
+
 
 
 // Function to start the interval, used to refresh without having to click the button

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3090,11 +3090,8 @@ function createExamples(dir,momentID) {
   lid = momentID;
   dirname = dir;
 
-  console.log("Function createExamples called with parameters:");
-  console.log("dir:", dir);
-  console.log("momentID:", momentID);
-
-  console.log("* AJAX START ");
+  console.log("Function createExamples called with parameters: " + dir + " and " + momentID);
+  console.log("** AJAX START **");
 
   $.ajax({
     url: "sectionedservice.php",
@@ -3120,7 +3117,7 @@ function createExamples(dir,momentID) {
     } else {
       console.log("No dir and momentID set yet.");
     }
-  }, 10 * 60 * 1000); //
+  }, 10 * 60 * 100); // set to 1 minutes currently
 }
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3135,7 +3135,7 @@ $(window).on('focus', function() {
   isActivelyFocused = true;
   let momentID;
   let dir;
-  console.log('Window gained focus, isActivelyFocused is now', isActivelyFocused);
+  console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
@@ -3144,7 +3144,7 @@ $(window).on('focus', function() {
 // When the window loses focus, set isActivelyFocused to false
 }).on('blur', function() {
   isActivelyFocused = false;
-  console.log('Window lost focus, isActivelyFocused is now', isActivelyFocused);
+  console.log('User lost focus on course page, isActivelyFocused is now', isActivelyFocused);
 });
 
 // ------ Validates all versionnames ------

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3089,6 +3089,9 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
 let isActivelyFocused = false;
 let lastUpdatedCodeExampes = null;
 const updateInterval = 600 * 100; // 1 minutes
+let momentID = lid;
+let dir = "../courses/1895/Github/Demo/Code-example1/";
+
 
 //Creates all examples from github that doesnt exists yet
 function createExamples(dir,momentID) {
@@ -3132,7 +3135,7 @@ function autoRefreshCodeExample(dir, momentID) {
 
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function() {
-  state.isActivelyFocused = true;
+  isActivelyFocused = true;
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
@@ -3141,7 +3144,7 @@ $(window).on('focus', function() {
   }
 // When the user stops watching course page, set isActivelyFocused to false
 }).on('blur', function() {
-  state.isActivelyFocused = false;
+  isActivelyFocused = false;
   console.log('User lost focus on course page, isActivelyFocused is now', isActivelyFocused);
 });
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3136,6 +3136,10 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function() {
   isActivelyFocused = true;
+  console.log(momentID);
+  console.log(dir);
+  console.log(lid);
+  
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3111,6 +3111,15 @@ function createExamples(dir,momentID) {
   });
 
   console.log("** AJAX DONE **");
+
+  // Call `createExamples()` every 10 minutes with the latest dir and momentID
+  setInterval(function() {
+    if (dir !== "" && momentID !== "") {
+      createExamples(dir, momentID);
+    } else {
+      console.log("No dir and momentID set yet.");
+    }
+  }, 10 * 60 * 1000); //
 }
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3122,28 +3122,32 @@ function createExamples(momentID) {
 }
 
 
-// When the user is watching course page, set isActivelyFocused to true
+// When the user is watching the course page, set isActivelyFocused to true
 $(window).on('focus', function( ) {
   isActivelyFocused = true;
-
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
-  const now = Date.now();
-  // If the user has been focusing on the course page for more than **UPDATEINTERVAL** minute (data variable can be found above createCodeExamples function), 
-  //update the code examples or if its first time
-  if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
-      lastUpdatedCodeExampes = now;
-      // Call the createExamples function for each lecture/moments
-      for (let i = 0; i < collectedLid.length; i++) {
-        createExamples(collectedLid[i]);
-      }
+});
 
-  }
-// When the user stops watching course page, set isActivelyFocused to false
-}).on('blur', function() {
+// When the user stops watching the course page, set isActivelyFocused to false
+$(window).on('blur', function() {
   isActivelyFocused = false;
   console.log('User lost focus on course page, isActivelyFocused is now', isActivelyFocused);
 });
 
+// Create an interval that checks if the window is focused and the updateInterval has passed, 
+// then updates the code examples if the conditions are met.
+setInterval(function() {
+    if (isActivelyFocused) {
+        const now = Date.now();
+        if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
+            lastUpdatedCodeExampes = now;
+            // Call the createExamples function for each lecture/moments
+            for (let i = 0; i < collectedLid.length; i++) {
+                createExamples(collectedLid[i]);
+            }
+        }
+    }
+}, 1000);
 // ------ Validates all versionnames ------
 function validateVersionName(versionName, dialogid) {
   //Regex for letters, numbers, and dashes

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3148,15 +3148,6 @@ $(window).on('focus', function() {
   console.log('Window lost focus, isActivelyFocused is now', isActivelyFocused);
 });
 
-
-
-$(document).ready(function(momentID) {
-  let dir = "../courses/1895/Github/Demo/Code-example1/";
-
-  // Start auto-refresh every 10 minutes
-  autoRefreshCodeExample(dir, momentID);
-});
-
 // ------ Validates all versionnames ------
 function validateVersionName(versionName, dialogid) {
   //Regex for letters, numbers, and dashes

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3088,6 +3088,7 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
 
 let isActivelyFocused = false;
 let lastUpdatedCodeExampes = null;
+const updateInterval = 600 * 100; // 1 minutes
 
 //Creates all examples from github that doesnt exists yet
 function createExamples(dir,momentID) {
@@ -3137,7 +3138,7 @@ $(window).on('focus', function() {
   isActivelyFocused = true;
   console.log('Window gained focus, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
-  if (lastUpdated === null || (now - lastUpdated) > updateInterval) {
+  if (lastUpdated === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdated = now;
       createExamples(dir, momentID);
   }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3132,7 +3132,7 @@ function autoRefreshCodeExample(dir, momentID) {
 
 // When the window gains focus, set isActive to true
 $(window).on('focus', function() {
-  isActive = true;
+  isActivelyFocused = true;
   console.log('Window gained focus, isActive is now', isActive);
   const now = Date.now();
   if (lastUpdated === null || (now - lastUpdated) > updateInterval) {
@@ -3141,7 +3141,7 @@ $(window).on('focus', function() {
   }
 // When the window loses focus, set isActive to false
 }).on('blur', function() {
-  isActive = false;
+  isActivelyFocused = false;
   console.log('Window lost focus, isActive is now', isActive);
 });
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3743,6 +3743,7 @@ function refreshMoment(momentID){
   //for loop not yet implemented, waiting for other issues to be completed before
   dirname="../courses/1895/Github/Demo/Code-example1/"
   createExamples(dirname,momentID)
+  
 
 }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3731,6 +3731,11 @@ function refreshMoment(momentID){
   //Iterate all entries in the sectionlist of the course
   console.log("RefreshButton Clicked!");
 
+  state.dir = "../courses/1895/Github/Demo/Code-example1/";
+  state.momentID = momentID;
+
+  console.log('State updated in refreshMoment:', state); 
+
   //TODO: take input from column/dropdownlist and iterate through and create the codeexample
   //for each codeexample in the moment dir, do create examples on those code-example dir
   //for loop not yet implemented, waiting for other issues to be completed before

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3086,9 +3086,9 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
   }
 }
 
-let isActivelyFocused = false;
-let lastUpdatedCodeExampes = null;
-const updateInterval = 600 * 100; // 1 minutes
+let isActivelyFocused = false; // If the user is actively focusing on the course page
+let lastUpdatedCodeExampes = null; // Last time code examples was updated
+const updateInterval = 600 * 1000; // Timerintervall for code to be updated (10 minutes)
 let momentID = lid;
 let dir = "../courses/1895/Github/Demo/Code-example1/";
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3127,7 +3127,7 @@ $(window).on('focus', function( ) {
 
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
-  // If the user has been focusing on the course page for more than **UPDATEINTERVAL** minute (data varieable can be found above createCodeExamples function), 
+  // If the user has been focusing on the course page for more than **UPDATEINTERVAL** minute (data variable can be found above createCodeExamples function), 
   //update the code examples or if its first time
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3100,7 +3100,7 @@ function createExamples(dir,momentID) {
   console.log("The value of all lids is: " + collectedLid);
   console.log("Function createExamples called with parameters: " + dir + " and " + momentID);
   console.log("** AJAX START **");
-
+  //AJAX Request to create all code examples
   $.ajax({
     url: "sectionedservice.php",
     type: "POST",
@@ -3128,8 +3128,11 @@ $(window).on('focus', function( ) {
 
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
+  // If the user has been focusing on the course page for more than **UPDATEINTERVAL** minute (data can be found above createCodeExamples function), 
+  //update the code examples or if its first time
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
+      // Call the createExamples function for each lecture/moments
       for (let i = 0; i < collectedLid.length; i++) {
         createExamples(dir, collectedLid[i]);
       }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3139,7 +3139,8 @@ $(window).on('focus', function() {
   console.log(momentID);
   console.log(dir);
   console.log(lid);
-  
+  console.log(dirname);
+
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3098,6 +3098,7 @@ function createExamples(momentID) {
   lid = momentID;
   console.log("The value of all lids is: " + collectedLid);
   console.log("Function createExamples called with parameters: " + dir + " and " + momentID);
+  console.log(lid);
   console.log("** AJAX START **");
   //AJAX Request to create all code examples
   $.ajax({

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3133,7 +3133,7 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the window gains focus, set isActivelyFocused to true
 $(window).on('focus', function() {
   isActivelyFocused = true;
-  console.log('Window gained focus, isActive is now', isActive);
+  console.log('Window gained focus, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdated === null || (now - lastUpdated) > updateInterval) {
       lastUpdated = now;
@@ -3142,7 +3142,7 @@ $(window).on('focus', function() {
 // When the window loses focus, set isActivelyFocused to false
 }).on('blur', function() {
   isActivelyFocused = false;
-  console.log('Window lost focus, isActive is now', isActive);
+  console.log('Window lost focus, isActivelyFocused is now', isActivelyFocused);
 });
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3118,9 +3118,6 @@ function createExamples(dir,momentID) {
 
 }
 
-
-
-
 // Function to start the interval, used to refresh without having to click the button
 function autoRefreshCodeExample(dir, momentID) {
   setInterval(function() {
@@ -3136,6 +3133,8 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the window gains focus, set isActivelyFocused to true
 $(window).on('focus', function() {
   isActivelyFocused = true;
+  let momentID;
+  let dir;
   console.log('Window gained focus, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3086,19 +3086,33 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
 }
 
 //Creates all examples from github that doesnt exists yet
-function createExamples(dir,momentID) {//TODO HERE
-  lid= momentID;
+function createExamples(dir,momentID) {
+  lid = momentID;
   dirname = dir;
+
+  console.log("Function createExamples called with parameters:");
+  console.log("dir:", dir);
+  console.log("momentID:", momentID);
+
   console.log("* AJAX START ");
+
   $.ajax({
     url: "sectionedservice.php",
     type: "POST",
     data: {'lid':lid,'dirname':dirname , 'opt':'CREGITEX'},
     dataType: "json",
-    //TODO: reload back to coursepage
+    success: function(response) {
+      console.log("AJAX request succeeded. Response:", response);
+    },
+    error: function(xhr, status, error) {
+      console.log("AJAX request failed. Status:", status);
+      console.log("Error:", error);
+    }
   });
+
   console.log("** AJAX DONE **");
 }
+
 
 // ------ Validates all versionnames ------
 function validateVersionName(versionName, dialogid) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3136,7 +3136,6 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function( ) {
   isActivelyFocused = true;
-  let dir = "../courses/1895/Github/Demo/Code-example1/";
 
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3109,7 +3109,7 @@ function createExamples(dir,momentID) {
 
   console.log("** AJAX DONE **");
 
-  // Call `createExamples()` every 10 minutes with the latest dir and momentID
+  // Call `createExamples()` every 1 minutes with the latest dir and momentID
   setInterval(function() {
     if (dir !== "" && momentID !== "") {
       createExamples(dir, momentID);
@@ -3117,7 +3117,7 @@ function createExamples(dir,momentID) {
     } else {
       console.log("No dir and momentID set yet.");
     }
-  }, 10 * 60 * 100); // set to 1 minutes currently
+  }, 600 * 100); // set to 1 minutes currently
 }
 
 
@@ -3126,12 +3126,14 @@ function autoRefreshCodeExample(dir, momentID) {
   setInterval(function() {
     if (dir !== "" && momentID !== "") {
       createExamples(dir, momentID);
-      console.log("createExamples() called in the setInterval function.");
+      console.log("createExamples() called in the autoRefreshCodeExample function.");
     } else {
       console.log("No dir and momentID set yet.");
     }
   }, 10 * 60 * 1000); // set to 10 minutes
 }
+
+
 
 // ------ Validates all versionnames ------
 function validateVersionName(versionName, dialogid) {
@@ -3724,6 +3726,11 @@ function refreshMoment(momentID){
   //for loop not yet implemented, waiting for other issues to be completed before
   dirname="../courses/1895/Github/Demo/Code-example1/"
   createExamples(dirname,momentID)
+
+
+  // Start auto-refresh every 10 minutes
+  autoRefreshCodeExample(dirname, momentID);
+
 }
 
 //------------------------------------------------------------------------------

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3088,7 +3088,7 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
 
 let isActivelyFocused = false; // If the user is actively focusing on the course page
 let lastUpdatedCodeExampes = null; // Last time code examples was updated
-const updateInterval = 600 * 1000; // Timerintervall for code to be updated (10 minutes)
+const updateInterval = 600 * 100; // Timerintervall for code to be updated (10 minutes)
 let dir = "../courses/1895/Github/Demo/Code-example1/";
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3098,7 +3098,6 @@ let lectureIDs = [];
 function createExamples(dir,momentID) {
   lid = momentID;
   dirname = dir;
-  console.log("The value of lid is: ", lid);
   console.log("The value of all lids is: " + collectedLid);
 
 
@@ -3145,7 +3144,9 @@ $(window).on('focus', function( ) {
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
-      createExamples();
+      for (let i = 0; i < collectedLid.length; i++) {
+        createExamples(dir, collectedLid[i]);
+      }
 
   }
 // When the user stops watching course page, set isActivelyFocused to false

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3736,11 +3736,6 @@ function refreshMoment(momentID){
   //Iterate all entries in the sectionlist of the course
   console.log("RefreshButton Clicked!");
 
-  state.dir = "../courses/1895/Github/Demo/Code-example1/";
-  state.momentID = momentID;
-
-  console.log('State updated in refreshMoment:', state); 
-
   //TODO: take input from column/dropdownlist and iterate through and create the codeexample
   //for each codeexample in the moment dir, do create examples on those code-example dir
   //for loop not yet implemented, waiting for other issues to be completed before

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3138,8 +3138,8 @@ $(window).on('focus', function() {
   isActivelyFocused = true;
   console.log('Window gained focus, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
-  if (lastUpdated === null || (now - lastUpdatedCodeExampes) > updateInterval) {
-      lastUpdated = now;
+  if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
+      lastUpdatedCodeExampes = now;
       createExamples(dir, momentID);
   }
 // When the window loses focus, set isActivelyFocused to false

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3130,7 +3130,7 @@ function autoRefreshCodeExample(dir, momentID) {
   },  600 * 100); // set to 1 minutes currently
 }
 
-// When the window gains focus, set isActivelyFocused to true
+// When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function() {
   isActivelyFocused = true;
   let momentID;
@@ -3139,9 +3139,9 @@ $(window).on('focus', function() {
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
-      createExamples(dir, momentID);
+      autoRefreshCodeExample(dir, momentID);
   }
-// When the window loses focus, set isActivelyFocused to false
+// When the user stops watching course page, set isActivelyFocused to false
 }).on('blur', function() {
   isActivelyFocused = false;
   console.log('User lost focus on course page, isActivelyFocused is now', isActivelyFocused);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3121,6 +3121,18 @@ function createExamples(dir,momentID) {
 }
 
 
+// Function to start the interval, used to refresh without having to click the button
+function autoRefreshCodeExample(dir, momentID) {
+  setInterval(function() {
+    if (dir !== "" && momentID !== "") {
+      createExamples(dir, momentID);
+      console.log("createExamples() called in the setInterval function.");
+    } else {
+      console.log("No dir and momentID set yet.");
+    }
+  }, 10 * 60 * 1000); // set to 10 minutes
+}
+
 // ------ Validates all versionnames ------
 function validateVersionName(versionName, dialogid) {
   //Regex for letters, numbers, and dashes

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3133,8 +3133,8 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function() {
   isActivelyFocused = true;
-  let momentID;
-  let dir;
+  lid = momentID;
+  dirname = dir;
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3097,6 +3097,8 @@ let dir = "../courses/1895/Github/Demo/Code-example1/";
 function createExamples(dir,momentID) {
   lid = momentID;
   dirname = dir;
+  console.log("The value of lid is: ", lid);
+
 
   console.log("Function createExamples called with parameters: " + dir + " and " + momentID);
   console.log("** AJAX START **");

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3091,6 +3091,7 @@ let lastUpdatedCodeExampes = null;
 const updateInterval = 600 * 100; // 1 minutes
 let momentID = lid;
 let dir = "../courses/1895/Github/Demo/Code-example1/";
+let lectureIDs = [];
 
 
 //Creates all examples from github that doesnt exists yet
@@ -3098,6 +3099,7 @@ function createExamples(dir,momentID) {
   lid = momentID;
   dirname = dir;
   console.log("The value of lid is: ", lid);
+  console.log(collectedLid);
 
 
   console.log("Function createExamples called with parameters: " + dir + " and " + momentID);
@@ -3743,7 +3745,7 @@ function refreshMoment(momentID){
   //for loop not yet implemented, waiting for other issues to be completed before
   dirname="../courses/1895/Github/Demo/Code-example1/"
   createExamples(dirname,momentID)
-  
+
 
 }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3134,7 +3134,7 @@ function autoRefreshCodeExample(dir, momentID) {
 }
 
 // When the user is watching course page, set isActivelyFocused to true
-$(window).on('focus', function(dir, momentID) {
+$(window).on('focus', function( ) {
   isActivelyFocused = true;
   let dir = "../courses/1895/Github/Demo/Code-example1/";
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3134,14 +3134,14 @@ function autoRefreshCodeExample(dir, momentID) {
 }
 
 // When the user is watching course page, set isActivelyFocused to true
-$(window).on('focus', function() {
+$(window).on('focus', function(dir, momentID) {
   isActivelyFocused = true;
 
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
-      createExamples();
+      createExamples(dir, momentID);
       console.log(momentID);
       console.log(dir);
       console.log(lid);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2417,6 +2417,7 @@ $(document).on('click', '#dorf', function (e) {
   e.stopPropagation();
 });
 
+
 // The event handler returns two elements. The following two if statements gets the element of interest.
 $(document).on('click', '.moment, .section, .statistics', function () {
 
@@ -3109,15 +3110,6 @@ function createExamples(dir,momentID) {
 
   console.log("** AJAX DONE **");
 
-  // Call `createExamples()` every 1 minutes with the latest dir and momentID
-  setInterval(function() {
-    if (dir !== "" && momentID !== "") {
-      createExamples(dir, momentID);
-      console.log("createExamples() called in the setInterval function.");
-    } else {
-      console.log("No dir and momentID set yet.");
-    }
-  }, 600 * 100); // set to 1 minutes currently
 }
 
 
@@ -3130,10 +3122,16 @@ function autoRefreshCodeExample(dir, momentID) {
     } else {
       console.log("No dir and momentID set yet.");
     }
-  },  60 * 100); // set to 1 minutes currently
+  },  600 * 100); // set to 1 minutes currently
 }
 
 
+$(document).ready(function(momentID) {
+  let dir = "../courses/1895/Github/Demo/Code-example1/";
+
+  // Start auto-refresh every 10 minutes
+  autoRefreshCodeExample(dir, momentID);
+});
 
 // ------ Validates all versionnames ------
 function validateVersionName(versionName, dialogid) {
@@ -3726,10 +3724,6 @@ function refreshMoment(momentID){
   //for loop not yet implemented, waiting for other issues to be completed before
   dirname="../courses/1895/Github/Demo/Code-example1/"
   createExamples(dirname,momentID)
-
-
-  // Start auto-refresh every 10 minutes
-  autoRefreshCodeExample(dirname, momentID);
 
 }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3116,6 +3116,7 @@ function createExamples(dir,momentID) {
   setInterval(function() {
     if (dir !== "" && momentID !== "") {
       createExamples(dir, momentID);
+      console.log("createExamples() called in the setInterval function.");
     } else {
       console.log("No dir and momentID set yet.");
     }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3089,7 +3089,6 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
 let isActivelyFocused = false; // If the user is actively focusing on the course page
 let lastUpdatedCodeExampes = null; // Last time code examples was updated
 const updateInterval = 600 * 1000; // Timerintervall for code to be updated (10 minutes)
-let momentID = lid;
 let dir = "../courses/1895/Github/Demo/Code-example1/";
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3133,8 +3133,6 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function() {
   isActivelyFocused = true;
-  lid = momentID;
-  dirname = dir;
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3141,7 +3141,7 @@ $(window).on('focus', function( ) {
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
-      createExamples(dir, momentID);
+      createExamples(dir, lid);
 
   }
 // When the user stops watching course page, set isActivelyFocused to false

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3141,7 +3141,7 @@ $(window).on('focus', function( ) {
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
-      createExamples(dir);
+      createExamples();
 
   }
 // When the user stops watching course page, set isActivelyFocused to false

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3091,7 +3091,6 @@ let lastUpdatedCodeExampes = null;
 const updateInterval = 600 * 100; // 1 minutes
 let momentID = lid;
 let dir = "../courses/1895/Github/Demo/Code-example1/";
-let lectureIDs = [];
 
 
 //Creates all examples from github that doesnt exists yet
@@ -3099,8 +3098,6 @@ function createExamples(dir,momentID) {
   lid = momentID;
   dirname = dir;
   console.log("The value of all lids is: " + collectedLid);
-
-
   console.log("Function createExamples called with parameters: " + dir + " and " + momentID);
   console.log("** AJAX START **");
 
@@ -3124,17 +3121,6 @@ function createExamples(dir,momentID) {
 
 }
 
-// Function to start the interval, used to refresh without having to click the button
-function autoRefreshCodeExample(dir, momentID) {
-  setInterval(function() {
-    if (dir !== "" && momentID !== "") {
-      createExamples(dir, momentID);
-      console.log("createExamples() called in the autoRefreshCodeExample function.");
-    } else {
-      console.log("No dir and momentID set yet.");
-    }
-  },  600 * 100); // set to 1 minutes currently
-}
 
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function( ) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3136,7 +3136,6 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function(dir, momentID) {
   isActivelyFocused = true;
-  let momentID = lid;
   let dir = "../courses/1895/Github/Demo/Code-example1/";
 
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3104,6 +3104,7 @@ function createExamples(dir,momentID) {
     dataType: "json",
     success: function(response) {
       console.log("AJAX request succeeded. Response:", response);
+      lastUpdatedCodeExampes = Date.now();
     },
     error: function(xhr, status, error) {
       console.log("AJAX request failed. Status:", status);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3136,16 +3136,16 @@ function autoRefreshCodeExample(dir, momentID) {
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function() {
   isActivelyFocused = true;
-  console.log(momentID);
-  console.log(dir);
-  console.log(lid);
-  console.log(dirname);
 
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
       lastUpdatedCodeExampes = now;
       createExamples();
+      console.log(momentID);
+      console.log(dir);
+      console.log(lid);
+      console.log(dirname);
   }
 // When the user stops watching course page, set isActivelyFocused to false
 }).on('blur', function() {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3132,7 +3132,7 @@ function autoRefreshCodeExample(dir, momentID) {
 
 // When the user is watching course page, set isActivelyFocused to true
 $(window).on('focus', function() {
-  isActivelyFocused = true;
+  state.isActivelyFocused = true;
   console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
   const now = Date.now();
   if (lastUpdatedCodeExampes === null || (now - lastUpdatedCodeExampes) > updateInterval) {
@@ -3141,7 +3141,7 @@ $(window).on('focus', function() {
   }
 // When the user stops watching course page, set isActivelyFocused to false
 }).on('blur', function() {
-  isActivelyFocused = false;
+  state.isActivelyFocused = false;
   console.log('User lost focus on course page, isActivelyFocused is now', isActivelyFocused);
 });
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3099,7 +3099,7 @@ function createExamples(dir,momentID) {
   lid = momentID;
   dirname = dir;
   console.log("The value of lid is: ", lid);
-  console.log(collectedLid);
+  console.log("The value of all lids is: " + collectedLid);
 
 
   console.log("Function createExamples called with parameters: " + dir + " and " + momentID);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3130,6 +3130,22 @@ function autoRefreshCodeExample(dir, momentID) {
   },  600 * 100); // set to 1 minutes currently
 }
 
+// When the window gains focus, set isActive to true
+$(window).on('focus', function() {
+  isActive = true;
+  console.log('Window gained focus, isActive is now', isActive);
+  const now = Date.now();
+  if (lastUpdated === null || (now - lastUpdated) > updateInterval) {
+      lastUpdated = now;
+      createExamples(dir, momentID);
+  }
+// When the window loses focus, set isActive to false
+}).on('blur', function() {
+  isActive = false;
+  console.log('Window lost focus, isActive is now', isActive);
+});
+
+
 
 $(document).ready(function(momentID) {
   let dir = "../courses/1895/Github/Demo/Code-example1/";


### PR DESCRIPTION
# Auto-refresh for code examples when user is on course page

This pull request introduces a feature that automatically refreshes code examples when a user is viewing the course page. This PR includes a countdown timer that runs for 10 minutes while the user viewing the course page. Once the timer reaches 0, all code examples for each moment/lecture are refreshed. When the user is not viewing the course page, the timer is paused. This is used by a boolean value 'isActivelyFocued' to ensure if the course page is viewed on by user. Also withthe function from jQuery 'blur' and 'focused' it was simple to implement. 

## New issues to add
* The createExamples function was updated in another issue with different parameters, meaning my function also will need to be updated so it has same parameters as that function
* A toaster/alert needs to be fixed so the user can get a feedback when clicking refresh button
* Perform code cleanup for the createExamples, focus function, and refreshMoment. This involves removing unnecessary console logs and comments (e.g., TODO:: comments).
