### PR TITLE
G1 2023 v7 #14049

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1728,7 +1728,7 @@ document.addEventListener('keyup', function (e)
         if(isKeybindValid(e, keybinds.CENTER_CAMERA)) centerCamera();
         if(isKeybindValid(e, keybinds.TOGGLE_REPLAY_MODE)) toggleReplay();
         if (isKeybindValid(e, keybinds.TOGGLE_ER_TABLE)) toggleErTable();
-        if (isKeybindValid(e, keybinds.SAVE_DIAGRAM)) storeDiagramInLocalStorage("CurrentlyActiveDiagram");
+        if (isKeybindValid(e, keybinds.SAVE_DIAGRAM)) showSavePopout();
         //if(isKeybindValid(e, keybinds.TOGGLE_ERROR_CHECK)) toggleErrorCheck(); Note that this functionality has been moved to hideErrorCheck(); because special conditions apply.
 
         if (isKeybindValid(e, keybinds.COPY)){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13031,6 +13031,16 @@ function saveDiagramBeforeUnload() {
     })
 }
 
+function showSavePopout()
+{
+    $("#savePopoutContainer").css("display", "flex");
+}
+
+function hideSavePopout()
+{
+    $("#savePopoutContainer").css("display", "none");
+}
+
 function loadDiagramFromString(temp, shouldDisplayMessage = true)
 {
     if(temp.historyLog && temp.initialState){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1609,7 +1609,12 @@ document.addEventListener('keydown', function (e)
                 var propField = document.getElementById("elementProperty_name");
                 if(!!document.getElementById("lineLabel")){
                     changeLineProperties();
-                }else{
+                }
+                else if (document.activeElement.id == "saveDiagramAs") {
+                    saveDiagramAs();
+                    hideSavePopout();
+                }
+                else {
                     changeState();
                     saveProperties(); 
                     propField.blur();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13039,6 +13039,7 @@ function saveDiagramBeforeUnload() {
 function showSavePopout()
 {
     $("#savePopoutContainer").css("display", "flex");
+    document.getElementById("saveDiagramAs").focus();
 }
 
 function hideSavePopout()

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13041,6 +13041,19 @@ function hideSavePopout()
     $("#savePopoutContainer").css("display", "none");
 }
 
+function saveDiagramAs()
+{
+    let elem = document.getElementById("saveDiagramAs");
+    let fileName = elem.value;
+    elem.value = "";
+    if (fileName.trim() == "") {
+        // fileName = "Untitled"
+        fileName = "CurrentlyActiveDiagram"; // Since it is currently not possible to load any other diagram, it must default to "CurrentlyActiveDiagram".
+    }
+
+    storeDiagramInLocalStorage(fileName);
+}
+
 function loadDiagramFromString(temp, shouldDisplayMessage = true)
 {
     if(temp.historyLog && temp.initialState){

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -851,7 +851,7 @@
         </fieldset>
         <fieldset id = "localSaveField">
             <legend aria-hidden="true">Save</legend>
-            <div id="localSave" class="diagramIcons" onclick="storeDiagramInLocalStorage('CurrentlyActiveDiagram')">
+            <div id="localSave" class="diagramIcons" onclick="showSavePopout()">
                 <img src="../Shared/icons/diagram_save_icon.svg" alt="Save diagram"/>
                 <span class="toolTipText"><b>Save current diagram</b><br>
                     <p>Click to save current diagram</p>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1026,6 +1026,27 @@
         <h2>Replay mode</h2>
         <p>Press "ESCAPE" to exit the replay-mode.</p>
     </div>
+    <div id="savePopoutContainer" class="loginBoxContainer" style="display:flex">
+        <div class="loginBox">
+            <div class="loginBoxheader">
+                <h3>
+                    Save current diagram as
+                </h3>
+                <div class="cursorPointer" onclick="">
+                    x
+                </div>
+            </div>
+            <div id="savePopout" style="margin-top:15px;display:block">
+                <div class="inputwrapper">
+                    <span style="margin-right:5px">Filename:</span>
+                    <input class="textinput" type="text" id="saveDiagramAs" placeholder="Untitled" value='' autocomplete="off"/>
+                </div>
+                <div class="button-row">
+                    <input type="submit" class="submit-button" onclick="" value="Save"/>
+                </div>
+            </div>
+        </div>
+    </div>
     <!-- content END -->
     <?php
         include '../Shared/loginbox.php';

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1042,7 +1042,7 @@
                     <input class="textinput" type="text" id="saveDiagramAs" placeholder="Untitled" value='' autocomplete="off"/>
                 </div>
                 <div class="button-row">
-                    <input type="submit" class="submit-button" onclick="" value="Save"/>
+                    <input type="submit" class="submit-button" onclick="saveDiagramAs(), hideSavePopout()" value="Save"/>
                 </div>
             </div>
         </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1032,7 +1032,7 @@
                 <h3>
                     Save current diagram as
                 </h3>
-                <div class="cursorPointer" onclick="">
+                <div class="cursorPointer" onclick="hideSavePopout()">
                     x
                 </div>
             </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1026,7 +1026,7 @@
         <h2>Replay mode</h2>
         <p>Press "ESCAPE" to exit the replay-mode.</p>
     </div>
-    <div id="savePopoutContainer" class="loginBoxContainer" style="display:flex">
+    <div id="savePopoutContainer" class="loginBoxContainer" style="display:none">
         <div class="loginBox">
             <div class="loginBoxheader">
                 <h3>


### PR DESCRIPTION
Saving the current diagram by either 'ctrl+s' or the save button in the toolbar, now brings up a menu to where you can enter a name for the diagram.

![image of the save popout, with an inputfield for the name of the save](https://github.com/HGustavs/LenaSYS/assets/102599161/49206fc9-3e50-4446-b0fc-709325f438ce)

Here you can either enter a name or leave it empty, and once the save button is pressed the diagram is added to localStorage with the given name.

**Note:** Leaving the input field empty is the only way to load that specific diagram. This is because it is currently not possible to load diagrams by name.