### PR TITLE
Added column for separate filename in lenasys for gitFiles

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1392,7 +1392,6 @@ function returnedSection(data) {
 
             }
           }
-
           if (retdata['writeaccess']) {
           if (itemKind === 3) {
             if(isLoggedIn){

--- a/Shared/SQL/init_db.sql
+++ b/Shared/SQL/init_db.sql
@@ -18,7 +18,7 @@ CREATE TABLE user(
 	securityquestionanswer	VARCHAR(256) DEFAULT NULL,
 	requestedpasswordchange	TINYINT(1) UNSIGNED NOT NULL DEFAULT 0,
 	PRIMARY KEY (uid)
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
 
 INSERT INTO user(username,password,newpassword,creator,superuser) values ("Grimling","$2y$12$stG4CWU//NCdnbAQi.KTHO2V0UVDVi89Lx5ShDvIh/d8.J4vO8o8m",0,1,1);
 INSERT INTO user(username,password,newpassword,creator) values ("Toddler","$2y$12$IHb86c8/PFyI5fa9r8B0But7rugtGKtogyp/2X0OuB3GJl9l0iJ.q",0,1); /* Password is Kong */
@@ -34,7 +34,7 @@ CREATE TABLE git_user(
 	addedtime  				DATETIME,
 	lastvisit				DATETIME,
 	PRIMARY KEY (git_uid)
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
 
 
 /**
@@ -59,7 +59,7 @@ CREATE TABLE course(
 	courseGitURL				VARCHAR(1024),
 	PRIMARY KEY (cid),
 	FOREIGN KEY (creator) REFERENCES user (uid)
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
 
 /* This table represents a many-to-many relation between courses, to illustrate pre-requirements for courses. */
 CREATE TABLE course_req(
@@ -68,7 +68,7 @@ CREATE TABLE course_req(
 	PRIMARY KEY (cid, req_cid),
 	FOREIGN KEY (cid) REFERENCES course(cid),
 	FOREIGN KEY (req_cid) REFERENCES course(cid)
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
 
 /**
  * This table represents a many-to-many relation between users and courses. That is,
@@ -94,7 +94,7 @@ CREATE TABLE user_course(
 	PRIMARY KEY (uid, cid),
 	FOREIGN KEY (uid) REFERENCES user (uid),
 	FOREIGN KEY (cid) REFERENCES course (cid)
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
 
 CREATE TABLE listentries (
 	lid 					INT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -261,6 +261,7 @@ $sql3 = '
 		cid INTEGER,
 		fileName VARCHAR(50), 
     fileType VARCHAR(50),
+		lenasysFileName VARCHAR(50),
 		fileURL VARCHAR(255),
     downloadURL VARCHAR(255), 
     fileSHA VARCHAR(255), 

--- a/recursivetesting/FetchGithubRepo.php
+++ b/recursivetesting/FetchGithubRepo.php
@@ -60,10 +60,11 @@ function insertToFileLink($cid, $item)
 function insertToMetaData($cid, $item) 
 {
     global $pdoLite;
-    $query = $pdoLite->prepare('INSERT INTO gitFiles (cid, fileName, fileType, fileURL, downloadURL, fileSHA, filePath) VALUES (:cid, :fileName, :fileType, :fileURL, :downloadURL, :fileSHA, :filePath)');
+    $query = $pdoLite->prepare('INSERT INTO gitFiles (cid, fileName, fileType, lenasysFileName, fileURL, downloadURL, fileSHA, filePath) VALUES (:cid, :fileName, :fileType, :lenasysFileName, :fileURL, :downloadURL, :fileSHA, :filePath)');
     $query->bindParam(':cid', $cid);
     $query->bindParam(':fileName', $item['name']);
     $query->bindParam(':fileType', $item['type']);
+    $query->bindParam(':lenasysFileName', $item['name']);
     $query->bindParam(':fileURL', $item['url']);
     $query->bindParam(':downloadURL', $item['download_url']);
     $query->bindParam(':fileSHA', $item['sha']);


### PR DESCRIPTION
The table gitFiles now contains a new field which is to be used for the actual name displayed in LenaSys, since the feature to be able to change the name which is displayed was to be added and the previous fileName is a primary key.

Co-authored by b21leowa