### PR TITLE
 Even more deprecated arguments #14089 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1402,8 +1402,8 @@ function getData()
     container = document.getElementById("container");
     DiagramResponse = fetchDiagram();
 
-    document.getElementById("diagram-toolbar").addEventListener("onmousedown", mdown(this));
-    document.getElementById("diagram-toolbar").addEventListener("onmouseup", tup());
+    document.getElementById("diagram-toolbar").addEventListener("onmousedown", mdown);
+    document.getElementById("diagram-toolbar").addEventListener("onmouseup", tup);
     // onSetup();
     //debugDrawSDEntity(); // <-- debugfunc to show an sd entity
     generateToolTips();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1402,8 +1402,13 @@ function getData()
     container = document.getElementById("container");
     DiagramResponse = fetchDiagram();
 
+    //add event listeners 
     document.getElementById("diagram-toolbar").addEventListener("onmousedown", mdown);
     document.getElementById("diagram-toolbar").addEventListener("onmouseup", tup);
+    document.getElementById("container").addEventListener("onmousedown", mdown);
+    document.getElementById("container").addEventListener("onmouseup", mup);
+    document.getElementById("container").addEventListener("onmousemove", mmoving);
+    document.getElementById("container").addEventListener("onwheel", mwheel);
     // onSetup();
     //debugDrawSDEntity(); // <-- debugfunc to show an sd entity
     generateToolTips();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1401,6 +1401,9 @@ function getData()
 { 
     container = document.getElementById("container");
     DiagramResponse = fetchDiagram();
+
+    document.getElementById("diagram-toolbar").addEventListener("onmousedown", mdown(this));
+    document.getElementById("diagram-toolbar").addEventListener("onmouseup", tup());
     // onSetup();
     //debugDrawSDEntity(); // <-- debugfunc to show an sd entity
     generateToolTips();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1403,12 +1403,12 @@ function getData()
     DiagramResponse = fetchDiagram();
 
     //add event listeners 
-    document.getElementById("diagram-toolbar").addEventListener("onmousedown", mdown);
-    document.getElementById("diagram-toolbar").addEventListener("onmouseup", tup);
-    document.getElementById("container").addEventListener("onmousedown", mdown);
-    document.getElementById("container").addEventListener("onmouseup", mup);
-    document.getElementById("container").addEventListener("onmousemove", mmoving);
-    document.getElementById("container").addEventListener("onwheel", mwheel);
+    document.getElementById("diagram-toolbar").addEventListener("mousedown", mdown);
+    document.getElementById("diagram-toolbar").addEventListener("mouseup", tup);
+    document.getElementById("container").addEventListener("mousedown", mdown);
+    document.getElementById("container").addEventListener("mouseup", mup);
+    document.getElementById("container").addEventListener("mousemove", mmoving);
+    document.getElementById("container").addEventListener("wheel", mwheel);
     // onSetup();
     //debugDrawSDEntity(); // <-- debugfunc to show an sd entity
     generateToolTips();

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -879,7 +879,8 @@
     
     <!-- Diagram drawing system canvas. -->
     <svg id="svgoverlay" preserveAspectRatio="none"></svg>
-    <div id="container" onmousedown='mdown(event)' onmouseup='mup(event)' onmousemove='mmoving(event)' onwheel='mwheel(event)'></div> <!-- Contains all elements (items) -->
+    <!-- <div id="container" onmousedown='mdown(event)' onmouseup='mup(event)' onmousemove='mmoving(event)' onwheel='mwheel(event)'></div> --> <!-- Contains all elements (items) -->
+    <div id="container"></div>
      <!-- One svg layer for background stuff and one for foreground stuff -->
     <svg id="svgbacklayer" preserveAspectRatio="none"></svg>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -44,7 +44,6 @@
     <div id="pixellength" style="width:1000mm;;padding:0px;visibility:hidden;"></div>
 
     <!-- Toolbar for diagram -->
-    <!-- <div id="diagram-toolbar" onmousedown='mdown(event)' onmouseup='tup();'> -->
     <div id="diagram-toolbar">
         <fieldset>
             <legend aria-hidden="true" aria-hidden="true">Modes</legend>
@@ -879,8 +878,7 @@
     
     <!-- Diagram drawing system canvas. -->
     <svg id="svgoverlay" preserveAspectRatio="none"></svg>
-    <!-- <div id="container" onmousedown='mdown(event)' onmouseup='mup(event)' onmousemove='mmoving(event)' onwheel='mwheel(event)'></div> --> <!-- Contains all elements (items) -->
-    <div id="container"></div>
+    <div id="container"></div><!-- Contains all elements (items) -->
      <!-- One svg layer for background stuff and one for foreground stuff -->
     <svg id="svgbacklayer" preserveAspectRatio="none"></svg>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -44,7 +44,8 @@
     <div id="pixellength" style="width:1000mm;;padding:0px;visibility:hidden;"></div>
 
     <!-- Toolbar for diagram -->
-    <div id="diagram-toolbar" onmousedown='mdown(event)' onmouseup='tup();'>
+    <!-- <div id="diagram-toolbar" onmousedown='mdown(event)' onmouseup='tup();'> -->
+    <div id="diagram-toolbar">
         <fieldset>
             <legend aria-hidden="true" aria-hidden="true">Modes</legend>
                 <div id="mouseMode0" class="diagramIcons toolbarMode active" onclick='setMouseMode(0);'>


### PR DESCRIPTION
Replaced all HTML type adding of event listeners like "onmousewheel...." that used event as argument with javascript addEventListener, thereby removing use of the deprecated 'event' argument and also replacing use of the deprecated 'mousewheel' with the proper argument; 'wheel'.