### PR TITLE
Removed filter filtering out maps that doesn't contain the keyword "Examples"

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -610,9 +610,7 @@
 								foreach ($dirs as $dir) {
 									$dirname = basename($dir);
 									// Creates an option for each directory containing the string "Examples". 
-									if(strstr($dirname, 'Examples')) {
-										echo "<option value='$dirname'>$dirname</option>";
-									}		
+									echo "<option value='$dirname'>$dirname</option>";	
 								}			
 							?>
 						</select>


### PR DESCRIPTION
Now the dropdown for choosing a directory after downloading form Github does not filter out for maps only containing the keyword "Examples", so it should now display all maps within the given directory and look something like this

![image](https://github.com/HGustavs/LenaSYS/assets/102578849/c682e82d-240a-4a5e-a1df-e4d9a6ccb299)

To test this, simply open sectioned.php, click on an individual github button on a moment to open the dropdown and see if the dropdown contains multiple options not containing the keyword "Examples"