### PR TITLE
 Name of sequence object cuts of a little too late #14115 

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9890,7 +9890,7 @@ function drawElement(element, ghosted = false)
                 fill='${element.fill}' 
             />`;
             //define a clip path for text cutoff
-            str += `<clipPath id="objectTextCutOff" clipPathUnits="objectBoundingBox">
+            str += `<clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
                     <rect y='${linew}' x='${linew}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' />
                 </clipPath>`
             if (!tooBig) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9879,10 +9879,11 @@ function drawElement(element, ghosted = false)
         else if (element.actorOrObject == "object") {
             //svg for object.
             str += `<g>`;
+            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `<rect class='text'
-                x='${linew}'
-                y='${linew}'
-                width='${boxw - (linew * 2)}'
+                x='${linew/2}'
+                y='${linew/2}'
+                width='${boxw - (linew/2)}'
                 height='${(boxw/2) - linew}'
                 rx='${sequenceCornerRadius}'
                 stroke-width='${linew}'
@@ -9902,7 +9903,6 @@ function drawElement(element, ghosted = false)
                 str += `<text class='text' id='objectNameClipped' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'/>">${element.name}</text>`;
                 str += `<use clip-path="url(#objectTextCutOff)" xlink:href="#objectNameClipped" fill="red" />`;
             } */
-            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9889,11 +9889,17 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}' 
             />`;
+            //define a clip path for text cutoff
+            str += `<clipPath id="objectTextCutOff">
+                    <rect y="'${linew}'" x="'${linew}'" width="'${boxw - (linew * 2)}'" height="'${(boxw/2) - linew}'" />
+                </clipPath></defs>`;
             if (!tooBig) {
                 str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             }
             else{
-                str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
+                //str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
+                //the text has a clip path of the avaliable area, this ensures that it cuts off properly when its too big.
+                str += `<text class='text' id='objectClippedName' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' clip-path=<rect y="'${linew}'" x="'${linew}'" width="'${boxw - (linew * 2)}'" height="'${(boxw/2) - linew}'" />">${element.name}</text>`;
             }
             str += `</g>`;   
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9899,7 +9899,8 @@ function drawElement(element, ghosted = false)
             else{
                 //str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
                 //the text has a clip path of the avaliable area, this ensures that it cuts off properly when its too big.
-                str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' clip-path="url(#objectTextCutOff)" />">${element.name}</text>`;
+                str += `<text class='text' id='objectNameClipped' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'/>">${element.name}</text>`;
+                str += `<use clip-path="url(#objectTextCutOff)" xlink:href="#objectNameClipped" fill="red" />`;
             }
             str += `</g>`;   
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9890,7 +9890,7 @@ function drawElement(element, ghosted = false)
                 fill='${element.fill}' 
             />`;
             //define a clip path for text cutoff
-            str += `<defs><clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
+            /* str += `<defs><clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
                     <rect y='${linew}' x='${linew}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' />
                 </clipPath></defs>`;
             if (!tooBig) {
@@ -9901,7 +9901,8 @@ function drawElement(element, ghosted = false)
                 //the text has a clip path of the avaliable area, this ensures that it cuts off properly when its too big.
                 str += `<text class='text' id='objectNameClipped' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'/>">${element.name}</text>`;
                 str += `<use clip-path="url(#objectTextCutOff)" xlink:href="#objectNameClipped" fill="red" />`;
-            }
+            } */
+            str += `<text class='text' id='objectNameClipped' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'/>">${element.name}</text>`;
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9314,6 +9314,7 @@ function drawElement(element, ghosted = false)
     if (isDarkTheme()) nonFilledElementPartStrokeColor = '#FFFFFF';
     else nonFilledElementPartStrokeColor = '#383737';
 
+    //TODO, replace all actorFontColor with nonFilledElementPartStrokeColor
     //this is a silly way of changing the color for the text for actor, I couldnt think of a better one though. Currently it is also used for sequenceLoopOrAlt
     //replace this with nonFilledElementPartStroke when it gets merged.
     var actorFontColor;
@@ -9888,7 +9889,12 @@ function drawElement(element, ghosted = false)
                 stroke='${element.stroke}'
                 fill='${element.fill}' 
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+            if (!tooBig) {
+                str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+            }
+            else{
+                str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
+            }
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9889,8 +9889,13 @@ function drawElement(element, ghosted = false)
             stroke='${element.stroke}'
             fill='${element.fill}' 
             />`;
-            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
-            //define a clip path for text cutoff
+            if (!tooBig) {
+                str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+            }
+            else{
+                str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
+            }
+                //define a clip path for text cutoff
             /* str += `<defs><clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
                     <rect y='${linew}' x='${linew}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' />
                 </clipPath></defs>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9880,14 +9880,14 @@ function drawElement(element, ghosted = false)
             //svg for object.
             str += `<g>`;
             str += `<rect class='text'
-            x='${linew/2}'
-            y='${linew/2}'
-            width='${boxw - linew}'
-            height='${(boxw/2) - linew}'
-            rx='${sequenceCornerRadius}'
-            stroke-width='${linew}'
-            stroke='${element.stroke}'
-            fill='${element.fill}' 
+                x='${linew/2}'
+                y='${linew/2}'
+                width='${boxw - linew}'
+                height='${(boxw/2) - linew}'
+                rx='${sequenceCornerRadius}'
+                stroke-width='${linew}'
+                stroke='${element.stroke}'
+                fill='${element.fill}' 
             />`;
             str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `</g>`;   

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9890,9 +9890,9 @@ function drawElement(element, ghosted = false)
                 fill='${element.fill}' 
             />`;
             //define a clip path for text cutoff
-            str += `<clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
+            str += `<defs><clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
                     <rect y='${linew}' x='${linew}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' />
-                </clipPath>`
+                </clipPath></defs>`;
             if (!tooBig) {
                 str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9889,12 +9889,7 @@ function drawElement(element, ghosted = false)
             stroke='${element.stroke}'
             fill='${element.fill}' 
             />`;
-            if (!tooBig) {
-                str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
-            }
-            else{
-                str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
-            }
+            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
                 //define a clip path for text cutoff
             /* str += `<defs><clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
                     <rect y='${linew}' x='${linew}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' />

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9899,7 +9899,7 @@ function drawElement(element, ghosted = false)
             else{
                 //str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
                 //the text has a clip path of the avaliable area, this ensures that it cuts off properly when its too big.
-                str += `<text class='text' id='objectClippedName' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' clip-path=<rect y="'${linew}'" x="'${linew}'" width="'${boxw - (linew * 2)}'" height="'${(boxw/2) - linew}'" />">${element.name}</text>`;
+                str += `<text class='text' id='objectClippedName' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' clip-path="url(#objectTextCutOff)" />">${element.name}</text>`;
             }
             str += `</g>`;   
         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9882,7 +9882,7 @@ function drawElement(element, ghosted = false)
             str += `<rect class='text'
             x='${linew/2}'
             y='${linew/2}'
-            width='${boxw - (linew/2)}'
+            width='${boxw - linew}'
             height='${(boxw/2) - linew}'
             rx='${sequenceCornerRadius}'
             stroke-width='${linew}'

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9891,8 +9891,8 @@ function drawElement(element, ghosted = false)
             />`;
             //define a clip path for text cutoff
             str += `<clipPath id="objectTextCutOff" clipPathUnits="objectBoundingBox">
-                    <rect y="'${linew}'" x="'${linew}'" width="'${boxw - (linew * 2)}'" height="'${(boxw/2) - linew}'" />
-                </clipPath>`;
+                    <rect y='${linew}' x='${linew}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' />
+                </clipPath>`
             if (!tooBig) {
                 str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9890,19 +9890,6 @@ function drawElement(element, ghosted = false)
             fill='${element.fill}' 
             />`;
             str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
-                //define a clip path for text cutoff
-            /* str += `<defs><clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
-                    <rect y='${linew}' x='${linew}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' />
-                </clipPath></defs>`;
-            if (!tooBig) {
-                str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
-            }
-            else{
-                //str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
-                //the text has a clip path of the avaliable area, this ensures that it cuts off properly when its too big.
-                str += `<text class='text' id='objectNameClipped' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'/>">${element.name}</text>`;
-                str += `<use clip-path="url(#objectTextCutOff)" xlink:href="#objectNameClipped" fill="red" />`;
-            } */
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9902,7 +9902,7 @@ function drawElement(element, ghosted = false)
                 str += `<text class='text' id='objectNameClipped' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'/>">${element.name}</text>`;
                 str += `<use clip-path="url(#objectTextCutOff)" xlink:href="#objectNameClipped" fill="red" />`;
             } */
-            str += `<text class='text' id='objectNameClipped' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'/>">${element.name}</text>`;
+            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `</g>`;   
         }
         str += `</svg>`;  

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9879,17 +9879,17 @@ function drawElement(element, ghosted = false)
         else if (element.actorOrObject == "object") {
             //svg for object.
             str += `<g>`;
-            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             str += `<rect class='text'
-                x='${linew/2}'
-                y='${linew/2}'
-                width='${boxw - (linew/2)}'
-                height='${(boxw/2) - linew}'
-                rx='${sequenceCornerRadius}'
-                stroke-width='${linew}'
-                stroke='${element.stroke}'
-                fill='${element.fill}' 
+            x='${linew/2}'
+            y='${linew/2}'
+            width='${boxw - (linew/2)}'
+            height='${(boxw/2) - linew}'
+            rx='${sequenceCornerRadius}'
+            stroke-width='${linew}'
+            stroke='${element.stroke}'
+            fill='${element.fill}' 
             />`;
+            str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             //define a clip path for text cutoff
             /* str += `<defs><clipPath id="objectTextCutOff" clipPathUnits="userSpaceOnUse">
                     <rect y='${linew}' x='${linew}' width='${boxw - (linew * 2)}' height='${(boxw/2) - linew}' />

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9890,16 +9890,16 @@ function drawElement(element, ghosted = false)
                 fill='${element.fill}' 
             />`;
             //define a clip path for text cutoff
-            str += `<clipPath id="objectTextCutOff">
+            str += `<clipPath id="objectTextCutOff" clipPathUnits="objectBoundingBox">
                     <rect y="'${linew}'" x="'${linew}'" width="'${boxw - (linew * 2)}'" height="'${(boxw/2) - linew}'" />
-                </clipPath></defs>`;
+                </clipPath>`;
             if (!tooBig) {
                 str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
             }
             else{
                 //str += `<text class='text' x='${linew}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle'>${element.name}</text>`;
                 //the text has a clip path of the avaliable area, this ensures that it cuts off properly when its too big.
-                str += `<text class='text' id='objectClippedName' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' clip-path="url(#objectTextCutOff)" />">${element.name}</text>`;
+                str += `<text class='text' x='${xAnchor}' y='${((boxw/2) - linew)/2}' dominant-baseline='middle' text-anchor='${vAlignment}' clip-path="url(#objectTextCutOff)" />">${element.name}</text>`;
             }
             str += `</g>`;   
         }


### PR DESCRIPTION
edited the sequence object svg to fit the avaliable space better, the extra free space made the text seem more broken than it was. The text now works just like all other element names.