### PR TITLE
Clear gitfiles from SQLite db on refresh #14139

### DIFF
--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -74,7 +74,6 @@
 		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid, repoURL) VALUES (:cid, :repoURL)"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoURL', $url);
-		$query->execute();
 		if (!$query->execute()) {
 			$error = $query->errorInfo();
 			echo "Error updating file entries" . $error[2];
@@ -93,6 +92,8 @@
 	//--------------------------------------------------------------------------------------------------
 
 	function refreshGithubRepo($cid){
+		clearGitFiles($cid); // Clear the gitfiles table before downloading repo
+
 		// Get old commit and URL from Sqlite 
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 		$query = $pdolite->prepare('SELECT lastCommit, repoURL FROM gitRepos WHERE cid = :cid');
@@ -146,7 +147,6 @@
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoURL', $repoURL);
 		$query->bindParam(':lastCommit', $lastCommit);
-		$query->execute();
 		if (!$query->execute()) {
 			$error = $query->errorInfo();
 			echo "Error updating file entries" . $error[2];
@@ -166,7 +166,6 @@
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 		$query = $pdolite->prepare("DELETE FROM gitFiles WHERE cid = :cid"); 
 		$query->bindParam(':cid', $cid);
-		$query->execute();
 		if (!$query->execute()) {
 			$error = $query->errorInfo();
 			echo "Error updating file entries" . $error[2];


### PR DESCRIPTION
Issue #14139 
Now the SQLite table gitFiles are cleared every time the course is refreshed. 
If you haven't run the install script yet today (22/5), please do so before testing.

To test this, create a new course (or use a course you already have with a github url) and download the files with the refresh button. Then check the SQLite database in CMD to see what files are in the gitFiles table (select * from gitFiles). 
Remove a file from your connected github repo and press the refresh button again (note: it is important that you make sure the change has gone through before pressing the button!).
Open the SQLite database again in CMD and see if the files are up to date with your github repo.

co-author @g21emmka 