### PR TITLE
G3 2023 v7 issue#13934

### DIFF
--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -709,7 +709,7 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->execute();
 
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE ':fileName';"); 
+							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
 							$query->bindParam(':cid', $courseid);
 							$query->bindParam(':fileName', $likePattern);
 							$query->execute();

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -756,7 +756,7 @@ if($gradesys=="UNK") $gradesys=0;
 								}
 
 									
-								}
+							
 							}
 
 							//Check if adding box

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -703,7 +703,7 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->execute();
 
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
+							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE ':fileName';"); 
 							$query->bindParam(':cid', $cid);
 							$query->bindParam(':fileName', $likePattern);
 							$query->execute();
@@ -722,14 +722,14 @@ if($gradesys=="UNK") $gradesys=0;
 								$varname="TESTING INSIDE COUNT == 0";	
 								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 								$query3->bindParam(":examplename", $varname); 
-								$query3->bindParam(":sectionname", $examplename); 
+								$query3->bindParam(":sectionname", $exampleName); 
 								$query3->execute();
 
 								$visible=0;
 								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname;");
 								$query->bindParam(":cid", $courseid);
 								$query->bindParam(":cvs", $coursevers);
-								$query->bindParam(":entryname", $examplename);
+								$query->bindParam(":entryname", $exampleName);
 								$query->bindParam(":visible", $visible);
 								$query->execute();
 							}

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -687,6 +687,13 @@ if($gradesys=="UNK") $gradesys=0;
 						} else {
 							//Check for update
 							//TODO: Implement update for already existing code-examples.
+
+							$varname="TESTING ELSE";	
+							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+							$query3->bindParam(":examplename", $varname); 
+							$query3->bindParam(":sectionname", $exampleName); 
+							$query3->execute();
+
 							$likePattern = $exampleName .'%';
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
@@ -695,7 +702,26 @@ if($gradesys=="UNK") $gradesys=0;
 							$query->execute();
 							//Check if to be hidden
 							$e = $query->fetchAll();
+
+							$varname="TESTING E";	
+							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+							$query3->bindParam(":examplename", $varname); 
+							$query3->bindParam(":sectionname", $e); 
+							$query3->execute();
+							$f = count($e);
+							$varname="TESTING count E";	
+							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+							$query3->bindParam(":examplename", $varname); 
+							$query3->bindParam(":sectionname", $f); 
+							$query3->execute();
+
 							if(count($e)==0){
+								$varname="TESTING INSIDE e";	
+								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+								$query3->bindParam(":examplename", $varname); 
+								$query3->bindParam(":sectionname", $e); 
+								$query3->execute();
+
 								$visible=0;
 								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname;");
 								$query->bindParam(":cid", $courseid);

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -714,10 +714,13 @@ if($gradesys=="UNK") $gradesys=0;
 							$query->bindParam(':fileName', $likePattern);
 							$query->execute();
 							//Check if to be hidden
-							$exampleCount = $query->rowCount();
+
+							$rows = $query->fetchAll();
+							$exampleCount = count($rows);
+							
 
 
-							$varname="TESTING rowCount";	
+							$varname="TESTING exampleCount";	
 							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 							$query3->bindParam(":examplename", $varname); 
 							$query3->bindParam(":sectionname", $exampleCount); 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -688,7 +688,7 @@ if($gradesys=="UNK") $gradesys=0;
 							//Check for update
 							//TODO: Implement update for already existing code-examples.
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-							$query = $pdolite->prepare("SELECT gitFiles WHERE cid = :cid AND fileName=:fileName;"); 
+							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName=:fileName;"); 
 							$query->bindParam(':cid', $cid);
 							$query->bindParam(':fileName', $exampleName);
 							$query->execute();

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -705,12 +705,12 @@ if($gradesys=="UNK") $gradesys=0;
 							$varname="TESTING cid";	
 							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 							$query3->bindParam(":examplename", $varname); 
-							$query3->bindParam(":sectionname", $cid); 
+							$query3->bindParam(":sectionname", $courseid); 
 							$query3->execute();
 
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
-							$query->bindParam(':cid', $cid);
+							$query->bindParam(':cid', $courseid);
 							$query->bindParam(':fileName', $likePattern);
 							$query->execute();
 							//Check if to be hidden

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -694,7 +694,7 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->bindParam(":sectionname", $exampleName); 
 							$query3->execute();
 
-							$likePattern = $exampleName .'%';
+							$likePattern = '\''.$exampleName .'%'.'\'';
 
 							$varname="TESTING likePattern";	
 							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
@@ -703,7 +703,7 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->execute();
 
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE ':fileName';"); 
+							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
 							$query->bindParam(':cid', $cid);
 							$query->bindParam(':fileName', $likePattern);
 							$query->execute();

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -736,7 +736,7 @@ if($gradesys=="UNK") $gradesys=0;
 
 								
 								$visible = 0;
-								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname");
+								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname;");
 								$query->bindParam(":cid", $courseid);
 								$query->bindParam(":cvs", $coursevers);
 								$query->bindParam(":entryname", $exampleName);

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -687,10 +687,11 @@ if($gradesys=="UNK") $gradesys=0;
 						} else {
 							//Check for update
 							//TODO: Implement update for already existing code-examples.
+							$likePattern = $exampleName .'%';
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName=:fileName;"); 
+							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
 							$query->bindParam(':cid', $cid);
-							$query->bindParam(':fileName', $exampleName);
+							$query->bindParam(':fileName', $likePattern);
 							$query->execute();
 							//Check if to be hidden
 							$e = $query->fetchAll();

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -499,14 +499,14 @@ if($gradesys=="UNK") $gradesys=0;
 					
 				} else if(strcmp($opt,"CREGITEX")===0) {
 					//Get cid
-					$query = $pdo->prepare("SELECT cid FROM listentries WHERE lid=:lid");
+					$query = $pdo->prepare("SELECT cid FROM listentries WHERE lid=:lid;");
 					$query->bindParam(":lid", $lid);
 					$query->execute();
 					$e = $query->fetchAll();
 					$courseid = $e[0]['cid'];
 
 					//Get dir from the listentrie that was clicked
-					$query = $pdo->prepare("SELECT githubDir FROM listentries WHERE lid=:lid");
+					$query = $pdo->prepare("SELECT githubDir FROM listentries WHERE lid=:lid;");
 					$query->bindParam(":lid", $lid);
 					$query->execute();
 					$e = $query->fetchAll();
@@ -545,7 +545,7 @@ if($gradesys=="UNK") $gradesys=0;
 						//if no codeexample exist create a new one
 						if ($counted == 0) {
 							//Get active version of the course
-							$query = $pdo->prepare("SELECT activeversion FROM course WHERE cid=:cid");
+							$query = $pdo->prepare("SELECT activeversion FROM course WHERE cid=:cid;");
 							$query->bindParam(":cid", $courseid);
 							$query->execute();
 							$e = $query->fetchAll();
@@ -668,7 +668,7 @@ if($gradesys=="UNK") $gradesys=0;
 								$groupkind = null;
 								//add the codeexample to listentries
 								$query = $pdo->prepare("INSERT INTO listentries (cid,vers, entryname, link, kind, pos, visible,creator,comments, gradesystem, highscoremode, groupKind) 
-																									VALUES(:cid,:cvs,:entryname,:link,:kind,:pos,:visible,:usrid,:comment, :gradesys, :highscoremode, :groupkind)");
+																									VALUES(:cid,:cvs,:entryname,:link,:kind,:pos,:visible,:usrid,:comment, :gradesys, :highscoremode, :groupkind);");
 								$query->bindParam(":cid", $courseid);
 								$query->bindParam(":cvs", $coursevers);
 								$query->bindParam(":entryname", $examplename);
@@ -687,6 +687,30 @@ if($gradesys=="UNK") $gradesys=0;
 						} else {
 							//Check for update
 							//TODO: Implement update for already existing code-examples.
+							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+							$query = $pdolite->prepare("SELECT gitFiles WHERE cid = :cid AND fileName=:fileName;"); 
+							$query->bindParam(':cid', $cid);
+							$query->bindParam(':fileName', $exampleName);
+							$query->execute();
+							//Check if to be hidden
+							$e = $query->fetchAll();
+							if(count($e)==0){
+								$visible=0;
+								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname;");
+								$query->bindParam(":cid", $courseid);
+								$query->bindParam(":cvs", $coursevers);
+								$query->bindParam(":entryname", $examplename);
+								$query->bindParam(":visible", $visible);
+								$query->execute();
+							}
+
+							//Check if adding box
+
+							//Check if remove box
+							
+							
+							
+						
 						} 
 					}
 				

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -714,9 +714,15 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->bindParam(":examplename", $varname); 
 							$query3->bindParam(":sectionname", $f); 
 							$query3->execute();
+							$g=$e[0];
+							$varname="TESTING what is inside E";	
+							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+							$query3->bindParam(":examplename", $varname); 
+							$query3->bindParam(":sectionname", $g); 
+							$query3->execute();
 
 							if(count($e)==0){
-								$varname="TESTING INSIDE e";	
+								$varname="TESTING INSIDE e count 0";	
 								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 								$query3->bindParam(":examplename", $varname); 
 								$query3->bindParam(":sectionname", $e); 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -694,7 +694,7 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->bindParam(":sectionname", $exampleName); 
 							$query3->execute();
 
-							$likePattern = $exampleName .'%';
+							$likePattern = $exampleName .'.%';
 
 							$varname="TESTING likePattern";	
 							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -695,6 +695,13 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->execute();
 
 							$likePattern = $exampleName .'%';
+
+							$varname="TESTING likePattern";	
+							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+							$query3->bindParam(":examplename", $varname); 
+							$query3->bindParam(":sectionname", $likePattern); 
+							$query3->execute();
+
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
 							$query->bindParam(':cid', $cid);
@@ -715,7 +722,7 @@ if($gradesys=="UNK") $gradesys=0;
 								$varname="TESTING INSIDE COUNT == 0";	
 								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 								$query3->bindParam(":examplename", $varname); 
-								$query3->bindParam(":sectionname", $e); 
+								$query3->bindParam(":sectionname", $examplename); 
 								$query3->execute();
 
 								$visible=0;

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -701,28 +701,18 @@ if($gradesys=="UNK") $gradesys=0;
 							$query->bindParam(':fileName', $likePattern);
 							$query->execute();
 							//Check if to be hidden
-							$e = $query->fetchAll();
+							$exampleCount = $query->rowCount();
 
-							$varname="TESTING E";	
-							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-							$query3->bindParam(":examplename", $varname); 
-							$query3->bindParam(":sectionname", $e); 
-							$query3->execute();
-							$f = count($e);
-							$varname="TESTING count E";	
-							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-							$query3->bindParam(":examplename", $varname); 
-							$query3->bindParam(":sectionname", $f); 
-							$query3->execute();
-							$g=$e[0];
-							$varname="TESTING what is inside E";	
-							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-							$query3->bindParam(":examplename", $varname); 
-							$query3->bindParam(":sectionname", $g); 
-							$query3->execute();
 
-							if(count($e)==0){
-								$varname="TESTING INSIDE e count 0";	
+							$varname="TESTING rowCount";	
+							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+							$query3->bindParam(":examplename", $varname); 
+							$query3->bindParam(":sectionname", $exampleCount); 
+							$query3->execute();
+							
+
+							if($exampleCount==0){
+								$varname="TESTING INSIDE COUNT == 0";	
 								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 								$query3->bindParam(":examplename", $varname); 
 								$query3->bindParam(":sectionname", $e); 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -734,21 +734,28 @@ if($gradesys=="UNK") $gradesys=0;
 								$query3->bindParam(":sectionname", $exampleName); 
 								$query3->execute();
 
-								try {
-									$visible = 0;
-									$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname");
-									$query->bindParam(":cid", $courseid);
-									$query->bindParam(":cvs", $coursevers);
-									$query->bindParam(":entryname", $exampleName);
-									$query->bindParam(":visible", $visible);
-									$query->execute();
-								} catch (PDOException $e) {
-									$e->getMessage();
-									$varname="TESTING UPDATE";	
+								
+								$visible = 0;
+								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname");
+								$query->bindParam(":cid", $courseid);
+								$query->bindParam(":cvs", $coursevers);
+								$query->bindParam(":entryname", $exampleName);
+								$query->bindParam(":visible", $visible);
+								if (!$query->execute()) {
+									$error = $query->errorInfo();							
+									$varname="TESTING UPDATE ERROR";	
 									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
 									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $e); 
+									$query3->bindParam(":sectionname", $error); 
 									$query3->execute();
+									$varname="TESTING UPDATE ERROR[2]";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $error[2]); 
+									$query3->execute();
+								}
+
+									
 								}
 							}
 

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -528,6 +528,7 @@ if($gradesys=="UNK") $gradesys=0;
 							array_push($allFiles, $temp);
 						}
 					}
+					//Get active version of the course
 					//temp fix since this branch was created after the bugfix pr 14130
 					$query = $pdo->prepare("SELECT activeversion FROM course WHERE cid=:cid;");
 					$query->bindParam(":cid", $courseid);
@@ -550,7 +551,6 @@ if($gradesys=="UNK") $gradesys=0;
 
 						//if no codeexample exist create a new one
 						if ($counted == 0) {
-							//Get active version of the course
 							
 
 							//Get the last position in the listenries to add new course at the bottom
@@ -689,101 +689,24 @@ if($gradesys=="UNK") $gradesys=0;
 						} else {
 							//Check for update
 							//TODO: Implement update for already existing code-examples.
-
-							$varname="TESTING ELSE";	
-							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-							$query3->bindParam(":examplename", $varname); 
-							$query3->bindParam(":sectionname", $exampleName); 
-							$query3->execute();
-
+							//Check if to be hidden
 							$likePattern = $exampleName .'.%';
-
-							$varname="TESTING likePattern";	
-							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-							$query3->bindParam(":examplename", $varname); 
-							$query3->bindParam(":sectionname", $likePattern); 
-							$query3->execute();
-
-							$varname="TESTING cid";	
-							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-							$query3->bindParam(":examplename", $varname); 
-							$query3->bindParam(":sectionname", $courseid); 
-							$query3->execute();
-
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
 							$query->bindParam(':cid', $courseid);
 							$query->bindParam(':fileName', $likePattern);
-							$query->execute();
-							//Check if to be hidden
-
+							$query->execute();				
 							$rows = $query->fetchAll();
 							$exampleCount = count($rows);
 							
-
-
-							$varname="TESTING exampleCount";	
-							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-							$query3->bindParam(":examplename", $varname); 
-							$query3->bindParam(":sectionname", $exampleCount); 
-							$query3->execute();
-							
-
 							if($exampleCount==0){
-								$varname="TESTING INSIDE COUNT == 0";	
-								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-								$query3->bindParam(":examplename", $varname); 
-								$query3->bindParam(":sectionname", $exampleName); 
-								$query3->execute();
-
-								$varname="TESTING cid";	
-								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-								$query3->bindParam(":examplename", $varname); 
-								$query3->bindParam(":sectionname", $courseid); 
-								$query3->execute();
-
-								$varname="TESTING coursevers";	
-								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-								$query3->bindParam(":examplename", $varname); 
-								$query3->bindParam(":sectionname", $coursevers); 
-								$query3->execute();
-
-								$varname="TESTING exampleName";	
-								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-								$query3->bindParam(":examplename", $varname); 
-								$query3->bindParam(":sectionname", $exampleName); 
-								$query3->execute();
-
-								$visible = 0;
-								$varname="TESTING visible";	
-								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-								$query3->bindParam(":examplename", $varname); 
-								$query3->bindParam(":sectionname", $visible); 
-								$query3->execute();
-
-								
-								
+								$visible = 0;																								
 								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname;");
 								$query->bindParam(":cid", $courseid);
 								$query->bindParam(":cvs", $coursevers);
 								$query->bindParam(":entryname", $exampleName);
 								$query->bindParam(":visible", $visible);
-								if (!$query->execute()) {
-									$error = $query->errorInfo();							
-									$varname="TESTING UPDATE ERROR";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $error); 
-									$query3->execute();
-									$varname="TESTING UPDATE ERROR[2]";	
-									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
-									$query3->bindParam(":examplename", $varname); 
-									$query3->bindParam(":sectionname", $error[2]); 
-									$query3->execute();
-								}
-
-									
-							
+								$query->execute();
 							}
 
 							//Check if adding box

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -734,13 +734,22 @@ if($gradesys=="UNK") $gradesys=0;
 								$query3->bindParam(":sectionname", $exampleName); 
 								$query3->execute();
 
-								$visible=0;
-								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname;");
-								$query->bindParam(":cid", $courseid);
-								$query->bindParam(":cvs", $coursevers);
-								$query->bindParam(":entryname", $exampleName);
-								$query->bindParam(":visible", $visible);
-								$query->execute();
+								try {
+									$visible = 0;
+									$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname");
+									$query->bindParam(":cid", $courseid);
+									$query->bindParam(":cvs", $coursevers);
+									$query->bindParam(":entryname", $exampleName);
+									$query->bindParam(":visible", $visible);
+									$query->execute();
+								} catch (PDOException $e) {
+									$e->getMessage();
+									$varname="TESTING UPDATE";	
+									$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+									$query3->bindParam(":examplename", $varname); 
+									$query3->bindParam(":sectionname", $e); 
+									$query3->execute();
+								}
 							}
 
 							//Check if adding box

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -702,6 +702,12 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->bindParam(":sectionname", $likePattern); 
 							$query3->execute();
 
+							$varname="TESTING cid";	
+							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+							$query3->bindParam(":examplename", $varname); 
+							$query3->bindParam(":sectionname", $cid); 
+							$query3->execute();
+
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
 							$query->bindParam(':cid', $cid);

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -734,8 +734,33 @@ if($gradesys=="UNK") $gradesys=0;
 								$query3->bindParam(":sectionname", $exampleName); 
 								$query3->execute();
 
+								$varname="TESTING cid";	
+								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+								$query3->bindParam(":examplename", $varname); 
+								$query3->bindParam(":sectionname", $courseid); 
+								$query3->execute();
+
+								$varname="TESTING coursevers";	
+								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+								$query3->bindParam(":examplename", $varname); 
+								$query3->bindParam(":sectionname", $coursevers); 
+								$query3->execute();
+
+								$varname="TESTING exampleName";	
+								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+								$query3->bindParam(":examplename", $varname); 
+								$query3->bindParam(":sectionname", $exampleName); 
+								$query3->execute();
 								
 								$visible = 0;
+								$varname="TESTING visible";	
+								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
+								$query3->bindParam(":examplename", $varname); 
+								$query3->bindParam(":sectionname", $visible); 
+								$query3->execute();
+
+								
+								
 								$query = $pdo->prepare("UPDATE listentries SET visible=:visible WHERE cid=:cid AND vers=:cvs AND entryname=:entryname;");
 								$query->bindParam(":cid", $courseid);
 								$query->bindParam(":cvs", $coursevers);

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -528,6 +528,12 @@ if($gradesys=="UNK") $gradesys=0;
 							array_push($allFiles, $temp);
 						}
 					}
+					//temp fix since this branch was created after the bugfix pr 14130
+					$query = $pdo->prepare("SELECT activeversion FROM course WHERE cid=:cid;");
+					$query->bindParam(":cid", $courseid);
+					$query->execute();
+					$e = $query->fetchAll();
+					$coursevers = $e[0]['activeversion'];
 					
 
 					foreach($allFiles as $groupedFiles){	
@@ -545,11 +551,7 @@ if($gradesys=="UNK") $gradesys=0;
 						//if no codeexample exist create a new one
 						if ($counted == 0) {
 							//Get active version of the course
-							$query = $pdo->prepare("SELECT activeversion FROM course WHERE cid=:cid;");
-							$query->bindParam(":cid", $courseid);
-							$query->execute();
-							$e = $query->fetchAll();
-							$coursevers = $e[0]['activeversion'];
+							
 
 							//Get the last position in the listenries to add new course at the bottom
 							$query = $pdo->prepare("SELECT pos FROM listentries WHERE cid=:cid ORDER BY pos DESC;");
@@ -751,7 +753,7 @@ if($gradesys=="UNK") $gradesys=0;
 								$query3->bindParam(":examplename", $varname); 
 								$query3->bindParam(":sectionname", $exampleName); 
 								$query3->execute();
-								
+
 								$visible = 0;
 								$varname="TESTING visible";	
 								$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -694,7 +694,7 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->bindParam(":sectionname", $exampleName); 
 							$query3->execute();
 
-							$likePattern = '\''.$exampleName .'%'.'\'';
+							$likePattern = $exampleName .'%';
 
 							$varname="TESTING likePattern";	
 							$query3 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (1,:examplename,:sectionname,1,45656,1);");
@@ -709,7 +709,7 @@ if($gradesys=="UNK") $gradesys=0;
 							$query3->execute();
 
 							$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE :fileName;"); 
+							$query = $pdolite->prepare("SELECT * FROM gitFiles WHERE cid = :cid AND fileName LIKE ':fileName';"); 
 							$query->bindParam(':cid', $courseid);
 							$query->bindParam(':fileName', $likePattern);
 							$query->execute();


### PR DESCRIPTION
This is part one to solve issue  #13934 wich is the update part of existing code-examples auto create function.

We divided the update into three parts:
1. Hide an example when all files are deleted to that codeexample in the github repo.
2. Remove/unlink one or more boxes if one or more file (but not all) are removed from the github repi
3. Add boxes to the codeexample if more files are added to the githubrepo and those files should be added onto an existing code-example.

This PR will solve part 1. 
We decided to make a PR for the first part since we created this branch after we did the PR for https://github.com/HGustavs/LenaSYS/pull/14130 but before it was merged and would like this fix for part 1 (and 2 and 3).

We use the previous selection of coursevers here in this branch based on the "activeversion" so a tester must make sure to click the checkbox when creating/update a course:
![image](https://github.com/HGustavs/LenaSYS/assets/102595788/8945e18a-43c8-4e7e-a07f-80ca67b6772f)
![image](https://github.com/HGustavs/LenaSYS/assets/102595788/f2c92232-da6b-4796-843f-d7938510fe84)

We had an issue that when removing a file from the repo, clicking refresh the SQLite database did not recognize that the file was deleted. A fix for this is in place by issue https://github.com/HGustavs/LenaSYS/issues/14139 and PR https://github.com/HGustavs/LenaSYS/pull/14158 and would also like this fix before we start working on part 2 and 3.

There is a manual way around this "remove" problem.
So to test the functionality of this PR which is to hide examples when they are removed from github repo/sqlite:
sudo sqlite3 metadata2.db 
delete from gitFiles where fileName = 'FILENAME.FILETYPE' AND CID=XXXX;
This will remove the file "you deleted from the repo" in the sqlite db.
To trigger the hide part of the codeexample click the refresh button on the moment and reload the page.


This was done together with @b21sebgr .
