### PR TITLE
G1 2023 v7 #14110

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13106,18 +13106,22 @@ function closeModal(){
     modal.classList.add('hiddenLoad');
     overlay.classList.add('hiddenLoad');
 }
-
+/**
+ * @description Check whether there is a diagram saved in localstorage and load it.
+ * @param {string} key The name/key of the diagram to load.
+ */
  function loadDiagramFromLocalStorage(key)
 {
-    // Check whether there is a diagram saved in localstorage and load it. key for current diagram is CurrentlyActiveDiagram
     if (localStorage.getItem("diagrams")) {
         var diagramFromLocalStorage = localStorage.getItem("diagrams");
         diagramFromLocalStorage = (diagramFromLocalStorage[0] == "{") ? diagramFromLocalStorage: `{${diagramFromLocalStorage}}`;
         let obj = JSON.parse(diagramFromLocalStorage);
         if (obj[key] === undefined) {
-            return;
+            console.error("Undefined key")
         }
-        loadDiagramFromString(obj[key]);
+        else {
+            loadDiagramFromString(obj[key]);
+        }
     } else {
         // Failed to load content
         console.error("No content to load")

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12849,6 +12849,7 @@ function exportWithHistory()
 }
 /**
  * @description Stores the current diagram as JSON in localstorage
+ * @param {string} key The name/key of the diagram
  */
  function storeDiagramInLocalStorage(key){
 
@@ -12868,27 +12869,13 @@ function exportWithHistory()
             let s = `{"AutoSave": ${JSON.stringify(objToSave)}}`
             localStorage.setItem("diagrams", s);
         }
+        // Gets the string thats contains all the local diagram saves and updates an existing entry or creates a new entry based on the value of 'key'.
+        let local = localStorage.getItem("diagrams");
+        local = (local[0] == "{") ? local : `{${local}}`;
 
-        if (localStorage.getItem("diagrams")) {
-            let local = localStorage.getItem("diagrams");
-            local = (local[0] == "{") ? local : `{${local}}`;
-
-            let localDiagrams = JSON.parse(local);
-            let keys = Object.keys(localDiagrams);
-            for (let i = 0; i < keys.length; i++) {
-                if (key == keys[i]) {
-                    localDiagrams[keys[i]] = objToSave;
-                    localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
-                    return;
-                }
-            }
-            localDiagrams[key] = objToSave;
-            localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
-        }
-        else {
-            let t = `"${key}": ${JSON.stringify(objToSave)}`;
-            localStorage.setItem("diagrams", t);
-        }
+        let localDiagrams = JSON.parse(local);
+        localDiagrams[key] = objToSave;
+        localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
 
         displayMessage(messageTypes.SUCCESS, "You have saved the current diagram");
     }


### PR DESCRIPTION
Reworked the current system to store and map multiple JSON strings to their own key, while they are all in the same string (localstorage). Used this system to connect the saving and loading functions for local diagrams.

You can either save a diagram with the same name to overwrite it, or a new name to save it as a seperate diagram.
AutoSave is called the first time a diagram is saved, and then it is called by the function `saveDiagramBeforeUnload()`