### PR TITLE
G1 2023 v7 #14117

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13138,7 +13138,15 @@ function saveDiagramAs()
     if (fileName.trim() == "") {
         fileName = "Untitled";
     }
-
+    const names=getAllLocalStorageKeys();
+    for(let i=0; i<names.length; i++)
+    {
+        if(names[i]==fileName)
+        {
+            alert("about to override");
+            break;
+        }
+    }
     storeDiagramInLocalStorage(fileName);
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13135,8 +13135,17 @@ function saveDiagramAs()
 {
     let elem = document.getElementById("saveDiagramAs");
     let fileName = elem.value;
+    const currentDate=new Date();
+    const year = currentDate.getFullYear();
+    const month = currentDate.getMonth() + 1; // Note: January is month 0
+    const day = currentDate.getDate();
+    const hours = currentDate.getHours();
+    const minutes = currentDate.getMinutes();
+    const seconds = currentDate.getSeconds();
+    const formattedDate = year + "-" + month + "-" + day+' ';
+    const formattedTime = hours + ":" + minutes + ":" + seconds;
     if (fileName.trim() == "") {
-        fileName = "Untitled";
+        fileName = "diagram "+formattedDate+formattedTime;
     }
     const names=getAllLocalStorageKeys();
     for(let i=0; i<names.length; i++)

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13047,7 +13047,7 @@ function showModal(){
     var container = document.querySelector('#loadContainer');
 
     // Array for testing visuals, remove this once once functionality has been finished
-    var testArray = ["ERDiagram - 2021-03-12", "StateDiagram - 2021-03-11", "SequenceDiagram - 2021-03-13", "IE Diagram - 2021-03-13"];
+    var testArray = [];
 
     // Remove all elements
     while (container.firstElementChild){
@@ -13091,6 +13091,13 @@ function closeModal(){
     modal.classList.add('hiddenLoad');
     overlay.classList.add('hiddenLoad');
 }
+function getAllLocalStorageKeys()
+{
+    let keys=[];
+    for(let i=0; i<localStorage.length; i++)
+    keys.push(localStorage.key(i));
+    return keys;
+}
 
  function loadDiagramFromLocalStorage(key)
 {
@@ -13128,10 +13135,8 @@ function saveDiagramAs()
 {
     let elem = document.getElementById("saveDiagramAs");
     let fileName = elem.value;
-    elem.value = "";
     if (fileName.trim() == "") {
-        // fileName = "Untitled"
-        fileName = "CurrentlyActiveDiagram"; // Since it is currently not possible to load any other diagram, it must default to "CurrentlyActiveDiagram".
+        fileName = "Untitled";
     }
 
     storeDiagramInLocalStorage(fileName);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13131,6 +13131,14 @@ function hideSavePopout()
     $("#savePopoutContainer").css("display", "none");
 }
 
+function showOverridePopout() {
+    $("#overrideContainer").css("display", "flex");
+}
+
+function closeOverridePopout() {
+    $("#overrideContainer").css("display", "none");
+}
+
 function saveDiagramAs()
 {
     let elem = document.getElementById("saveDiagramAs");
@@ -13152,8 +13160,8 @@ function saveDiagramAs()
     {
         if(names[i]==fileName)
         {
-            alert("about to override");
-            break;
+            hideSavePopout();
+            showOverridePopout()
         }
     }
     storeDiagramInLocalStorage(fileName);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13138,6 +13138,13 @@ function showOverridePopout() {
 function closeOverridePopout() {
     $("#overrideContainer").css("display", "none");
 }
+//get the current file name that the user wants to use for saving to local storage.
+function getCurrentFileName()
+{
+    let elem = document.getElementById("saveDiagramAs");
+    let fileName = elem.value;
+    return fileName;
+}
 
 function saveDiagramAs()
 {
@@ -13162,6 +13169,7 @@ function saveDiagramAs()
         {
             hideSavePopout();
             showOverridePopout()
+            return;
         }
     }
     storeDiagramInLocalStorage(fileName);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13047,7 +13047,7 @@ function showModal(){
     var container = document.querySelector('#loadContainer');
 
     // Array for testing visuals, remove this once once functionality has been finished
-    var testArray = [];
+let names=getAllLocalStorageKeys();
 
     // Remove all elements
     while (container.firstElementChild){
@@ -13055,7 +13055,7 @@ function showModal(){
     }
 
     // If no items were found for loading in 
-    if (testArray.length === 0){
+    if (names.length === 0){
         var p = document.createElement('p');
         var pText = document.createTextNode('No saves could be found');
 
@@ -13064,17 +13064,17 @@ function showModal(){
         console.log("no saves");
     }
     else{
-        for (let i = 0; i<testArray.length; i++){
+        for (let i = 0; i<names.length; i++){
             var btn = document.createElement('button');
-            var btnText = document.createTextNode(testArray[i]);
+            var btnText = document.createTextNode(names[i]);
+            btn.setAttribute("onclick", `(function(name) { loadDiagramFromLocalStorage(name); closeModal(); })('${names[i]}')`);
     
-            // NOTE: This needs to be changed to load in the correct diagramload-object i from localstorage, it is currently set to 'CurrentlyActiveDiagram'.
-            btn.setAttribute("onclick", "loadDiagramFromLocalStorage('CurrentlyActiveDiagram');closeModal();");
+            closeModal();
     
             btn.appendChild(btnText);
             container.appendChild(btn);
 
-            document.getElementById('loadCounter').innerHTML = testArray.length;
+            document.getElementById('loadCounter').innerHTML = names.length;
 
             console.log("saves");
         }

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -883,6 +883,28 @@
     </div>
     <div class="loadModalOverlay hiddenLoad"></div>
 
+    <div id="overrideContainer" class="loginBoxContainer" style="display:none">
+        <div class="loginBox">
+            <div class="loginBoxheader">
+                <h3>
+                    Filename already exists
+                </h3>
+                <div class="cursorPointer" onclick="closeOverridePopout()">
+                    x
+                </div>
+            </div>
+            <div id="savePopout" style="margin-top:15px;display:block">
+                <div>
+                    <p>Do you want to overwrite the existing file?</p>
+                </div>
+                <div class="button-row">
+                    <button class="submit-button" onclick="closeOverridePopout(), showSavePopout()">Cancel</button>
+                    <button class="submit-button" onclick="saveDiagramAs(), closeOverridePopout()">Overwrite</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Message prompt -->
     <div id="diagram-message"></div>
     

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -899,7 +899,7 @@
                 </div>
                 <div class="button-row">
                     <button class="submit-button" onclick="closeOverridePopout(), showSavePopout()">Cancel</button>
-                    <button class="submit-button" onclick="saveDiagramAs(), closeOverridePopout()">Overwrite</button>
+                    <button class="submit-button" onclick="    storeDiagramInLocalStorage(getCurrentFileName()), closeOverridePopout()">Overwrite</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
if a file has no name a file name will be generated containing the date and time it was saved.
Fixed the saving function not working at all. It previously would take user input and then just use the key for currently active diagrams. Files should now save properly.
Added a popout that informs the user if a duplicate name exists and gives the option to either save or cansel.