### PR TITLE
 Better loadscreen #14121 

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -15,15 +15,8 @@
     align-items: center;
 }
 #spinnerTMPPlaceholder{
-    /* width: 50vh;
-    height: 50vh;
-    background-color: #FFFFFF; */
     animation: 1s linear 0s infinite loadingSpin;
 }
-/* #loadingSpinner img{
-    width: 50vh;
-    height: 50vh;
-} */
 
 #container {
     position:absolute;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -2,7 +2,7 @@
     width: 100vw;
     height: 100vh;
     z-index: 9999;
-    background-color: blue;
+    background-color: #222222;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -5,6 +5,7 @@
     background-color: blue;
     display: flex;
     justify-content: center;
+    align-items: center;
 }
 #loadingSpinner img{
     width: 50vh;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1,3 +1,9 @@
+#loadingSpinner{
+    width: 100vw;
+    height: 100vh;
+    z-index: 5001;
+}
+
 #container {
     position:absolute;
     left:0;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -13,7 +13,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: var(--color-background-4);
 }
 #spinnerTMPPlaceholder{
     width: 50vh;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -2,6 +2,7 @@
     width: 100vw;
     height: 100vh;
     z-index: 5001;
+    background-color: blue;
 }
 
 #container {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -11,6 +11,8 @@
     height: 100vh;
     z-index: 9999;
     display: flex;
+    justify-content: center;
+    align-items: center;
 }
 #spinneTMPPlaceholder{
     width: 50vh;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -3,7 +3,7 @@
     height: 100vh;
     z-index: 9999;
     display: flex;
-    background: no-repeat center/80% url("../Shared/icons/diagram_lifeline.svg");
+    background: no-repeat center center url("../Shared/icons/diagram_lifeline.svg");
 }
 /* #loadingSpinner img{
     width: 50vh;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -14,7 +14,7 @@
     justify-content: center;
     align-items: center;
 }
-#spinneTMPPlaceholder{
+#spinnerTMPPlaceholder{
     width: 50vh;
     height: 50vh;
     background-color: #FFFFFF;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1,9 +1,22 @@
+@keyframes loadingSpin {
+    0%{
+        rotate: 0deg;
+    }
+    100%{
+        rotate: 360deg;
+    }
+}
 #loadingSpinner{
     width: 100vw;
     height: 100vh;
     z-index: 9999;
     display: flex;
-    background: no-repeat center center url("../Shared/icons/diagram_lifeline.svg");
+}
+#spinneTMPPlaceholder{
+    width: 50vh;
+    height: 50vh;
+    background-color: #FFFFFF;
+    animation: 4s linear 0s infinite loadingSpin;
 }
 /* #loadingSpinner img{
     width: 50vh;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -3,6 +3,12 @@
     height: 100vh;
     z-index: 9999;
     background-color: blue;
+    display: flex;
+    justify-content: center;
+}
+#loadingSpinner img{
+    width: 50vh;
+    height: 50vh;
 }
 
 #container {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -3,14 +3,12 @@
     height: 100vh;
     z-index: 9999;
     display: flex;
-    background-color: var(--color-primary);
-    justify-content: center;
-    align-items: center;
+    background: no-repeat center/80% url("../Shared/icons/diagram_entity.svg");
 }
-#loadingSpinner img{
+/* #loadingSpinner img{
     width: 50vh;
     height: 50vh;
-}
+} */
 
 #container {
     position:absolute;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -3,7 +3,7 @@
     height: 100vh;
     z-index: 9999;
     display: flex;
-    background: no-repeat center/80% url("../Shared/icons/diagram_entity.svg");
+    background: no-repeat center/80% url("../Shared/icons/diagram_lifeline.svg");
 }
 /* #loadingSpinner img{
     width: 50vh;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -13,6 +13,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    background-color: var(--color-background-4);
 }
 #spinnerTMPPlaceholder{
     width: 50vh;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -18,7 +18,7 @@
     /* width: 50vh;
     height: 50vh;
     background-color: #FFFFFF; */
-    animation: 4s linear 0s infinite loadingSpin;
+    animation: 1s linear 0s infinite loadingSpin;
 }
 /* #loadingSpinner img{
     width: 50vh;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -2,7 +2,6 @@
     width: 100vw;
     height: 100vh;
     z-index: 9999;
-    background-color: #222222;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -3,6 +3,7 @@
     height: 100vh;
     z-index: 9999;
     display: flex;
+    background-color: var(--color-primary);
     justify-content: center;
     align-items: center;
 }

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -15,9 +15,9 @@
     align-items: center;
 }
 #spinnerTMPPlaceholder{
-    width: 50vh;
+    /* width: 50vh;
     height: 50vh;
-    background-color: #FFFFFF;
+    background-color: #FFFFFF; */
     animation: 4s linear 0s infinite loadingSpin;
 }
 /* #loadingSpinner img{

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1,7 +1,7 @@
 #loadingSpinner{
     width: 100vw;
     height: 100vh;
-    z-index: 5001;
+    z-index: 9999;
     background-color: blue;
 }
 

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -13,8 +13,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-}
-#spinnerTMPPlaceholder{
     animation: 1s linear 0s infinite loadingSpin;
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1161,6 +1161,8 @@ var defaultLine = { kind: "Normal" };
 window.addEventListener("DOMContentLoaded", (event) => {
     console.log(event);
     document.getElementById("loadingSpinner").style.display="none";
+    getData();
+    addAlertOnUnload();
 });
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1157,7 +1157,7 @@ var defaults = {
 var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
 //#region ================================ INIT AND SETUP       ================================
-//an event listener for when the window is loaded, this hides the loading spinner.
+//an event listener for when the window is loaded, this hides the loading spinner and calls start up functions
 window.addEventListener("DOMContentLoaded", (event) => {
     getData();
     addAlertOnUnload();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1161,7 +1161,7 @@ var defaultLine = { kind: "Normal" };
 window.addEventListener("DOMContentLoaded", (event) => {
     getData();
     addAlertOnUnload();
-    document.getElementById("loadingSpinner").style.display="none";
+    //document.getElementById("loadingSpinner").style.display="none";
 });
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1157,6 +1157,10 @@ var defaults = {
 var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
 //#region ================================ INIT AND SETUP       ================================
+//an event listener for when the window is loaded, this hides the loading spinner.
+window.addEventListener("DOMContentLoaded", (event) => {
+    document.getElementById("loadingSpinner").style.display="none";
+});
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.
  * @see getData() For the VERY FIRST function called in the file.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1159,10 +1159,9 @@ var defaultLine = { kind: "Normal" };
 //#region ================================ INIT AND SETUP       ================================
 //an event listener for when the window is loaded, this hides the loading spinner.
 window.addEventListener("DOMContentLoaded", (event) => {
-    console.log(event);
-    document.getElementById("loadingSpinner").style.display="none";
     getData();
     addAlertOnUnload();
+    document.getElementById("loadingSpinner").style.display="none";
 });
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1,4 +1,11 @@
-    // =============================================================================================
+//an event listener for when the window is loaded, this hides the loading spinner.
+window.addEventListener("DOMContentLoaded", (event) => {
+    console.log(event);
+    document.getElementById("loadingSpinner").style.display="none";
+    getData();
+    addAlertOnUnload();
+});
+// =============================================================================================
 //#region ================================ CLASSES             ==================================
 /** 
  * @description Point contianing X & Y coordinates. Can also be used as a 2D-vector. */
@@ -1157,13 +1164,6 @@ var defaults = {
 var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
 //#region ================================ INIT AND SETUP       ================================
-//an event listener for when the window is loaded, this hides the loading spinner.
-window.addEventListener("DOMContentLoaded", (event) => {
-    console.log(event);
-    document.getElementById("loadingSpinner").style.display="none";
-    getData();
-    addAlertOnUnload();
-});
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.
  * @see getData() For the VERY FIRST function called in the file.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1161,7 +1161,7 @@ var defaultLine = { kind: "Normal" };
 window.addEventListener("DOMContentLoaded", (event) => {
     getData();
     addAlertOnUnload();
-    //document.getElementById("loadingSpinner").style.display="none";
+    document.getElementById("loadingSpinner").style.display="none";
 });
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1158,17 +1158,10 @@ var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
 //#region ================================ INIT AND SETUP       ================================
 //an event listener for when the window is loaded, this hides the loading spinner.
-/* window.addEventListener("DOMContentLoaded", (event) => {
+window.addEventListener("DOMContentLoaded", (event) => {
+    console.log(event);
     document.getElementById("loadingSpinner").style.display="none";
-}); */
-if (document.readyState == 'loading') {
-    // still loading, wait for the event
-    document.addEventListener('DOMContentLoaded', (event) => {
-        document.getElementById("loadingSpinner").style.display="none";
-    });
-  } else {
-    document.getElementById("loadingSpinner").style.display="none";
-  }
+});
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.
  * @see getData() For the VERY FIRST function called in the file.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1,11 +1,4 @@
-//an event listener for when the window is loaded, this hides the loading spinner.
-window.addEventListener("DOMContentLoaded", (event) => {
-    console.log(event);
-    document.getElementById("loadingSpinner").style.display="none";
-    getData();
-    addAlertOnUnload();
-});
-// =============================================================================================
+    // =============================================================================================
 //#region ================================ CLASSES             ==================================
 /** 
  * @description Point contianing X & Y coordinates. Can also be used as a 2D-vector. */
@@ -1164,6 +1157,13 @@ var defaults = {
 var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
 //#region ================================ INIT AND SETUP       ================================
+//an event listener for when the window is loaded, this hides the loading spinner.
+window.addEventListener("DOMContentLoaded", (event) => {
+    console.log(event);
+    document.getElementById("loadingSpinner").style.display="none";
+    getData();
+    addAlertOnUnload();
+});
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.
  * @see getData() For the VERY FIRST function called in the file.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1158,7 +1158,7 @@ var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
 //#region ================================ INIT AND SETUP       ================================
 //an event listener for when the window is loaded, this hides the loading spinner and calls start up functions
-window.addEventListener("DOMContentLoaded", (event) => {
+window.addEventListener("DOMContentLoaded", () => {
     getData();
     addAlertOnUnload();
     document.getElementById("loadingSpinner").style.display="none";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1158,9 +1158,17 @@ var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
 //#region ================================ INIT AND SETUP       ================================
 //an event listener for when the window is loaded, this hides the loading spinner.
-window.addEventListener("DOMContentLoaded", (event) => {
+/* window.addEventListener("DOMContentLoaded", (event) => {
     document.getElementById("loadingSpinner").style.display="none";
-});
+}); */
+if (document.readyState == 'loading') {
+    // still loading, wait for the event
+    document.addEventListener('DOMContentLoaded', (event) => {
+        document.getElementById("loadingSpinner").style.display="none";
+    });
+  } else {
+    document.getElementById("loadingSpinner").style.display="none";
+  }
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.
  * @see getData() For the VERY FIRST function called in the file.

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -32,7 +32,8 @@
     <script src="diagram.js"></script>
     <script src="./assets/js/fetchDiagramInfo.js"></script>
 </head>
-<body onload="getData();addAlertOnUnload();" style="overflow: hidden;">
+<!-- <body onload="getData();addAlertOnUnload();" style="overflow: hidden;"> -->
+<body style="overflow: hidden;">
     
     <div id="loadingSpinner">
         <!-- temporary image -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -37,20 +37,7 @@
     
     <!-- loading spinner -->
     <div id="loadingSpinner">
-        <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
-        <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
-            <!-- <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/> -->
-            <!-- <path d="M 100,0 Q 0,200 200,50" fill="none" stroke="blue" stroke-width="5"/> -->
-            <mask id="spinnerMask">
-                <!-- Everything under a white pixel will be visible -->
-                <rect x="0" y="0" width="200" height="200" fill="white" />
-
-                <!-- Everything under a black pixel will be invisible -->
-                <rect x="100" y="-100" width="200" height="200" fill="black" />
-            </mask>
-            <!-- <circle cx="100" cy="100" r="100" mask="url(#spinnerMask)" /> -->
-            <circle cx="100" cy="100" r="90" fill="none" stroke="blue" stroke-width="10" mask="url(#spinnerMask)"/>
-        </svg>
+        <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/>
     </div>
 
     <!-- Markdown document with keybinds -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -35,9 +35,10 @@
 <!-- <body onload="getData();addAlertOnUnload();" style="overflow: hidden;"> -->
 <body style="overflow: hidden;">
     
+    <!-- loading spinner -->
     <div id="loadingSpinner">
         <!-- temporary image -->
-        <div id="spinneTMPPlaceholder"></div>
+        <div id="spinnerTMPPlaceholder"></div>
     </div>
 
     <!-- Markdown document with keybinds -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -38,9 +38,9 @@
     <!-- loading spinner -->
     <div id="loadingSpinner">
         <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
-        <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
             <!-- <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/> -->
-            <path d="M 0,0 A 0 0 0 0 0 14,10" fill="none" stroke="blue" stroke-width="5"/>
+            <path d="M 100,0 A 200 200 90 0 0 200,100" fill="none" stroke="blue" stroke-width="5"/>
         </svg>
     </div>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -40,7 +40,7 @@
         <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
         <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
             <!-- <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/> -->
-            <path d="M 100,0 A 200 200 90 0 0 200,100" fill="none" stroke="blue" stroke-width="5"/>
+            <path d="M 100,0 Q 0,200 200,50" fill="none" stroke="blue" stroke-width="5"/>
         </svg>
     </div>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -41,15 +41,15 @@
         <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
             <!-- <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/> -->
             <!-- <path d="M 100,0 Q 0,200 200,50" fill="none" stroke="blue" stroke-width="5"/> -->
-            <!-- <mask id="spinnerMask"> -->
+            <mask id="spinnerMask">
                 <!-- Everything under a white pixel will be visible -->
                 <!-- <rect x="0" y="0" width="200" height="200" fill="white" /> -->
 
                 <!-- Everything under a black pixel will be invisible -->
                 <rect x="100" y="-100" width="200" height="200" fill="black" />
-            <!-- </mask> -->
+            </mask>
             <!-- <circle cx="100" cy="100" r="100" mask="url(#spinnerMask)" /> -->
-            <circle cx="100" cy="100" r="100" fill="none" stroke="blue" stroke-width="5"/>
+            <circle cx="100" cy="100" r="90" fill="none" stroke="blue" stroke-width="10" mask="url(#spinnerMask)"/>
         </svg>
     </div>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -37,7 +37,10 @@
     
     <!-- loading spinner -->
     <div id="loadingSpinner">
-        <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/>
+        <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
+        <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/>
+        </svg>
     </div>
 
     <!-- Markdown document with keybinds -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -41,14 +41,15 @@
         <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
             <!-- <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/> -->
             <!-- <path d="M 100,0 Q 0,200 200,50" fill="none" stroke="blue" stroke-width="5"/> -->
-            <mask id="spinnerMask">
+            <!-- <mask id="spinnerMask"> -->
                 <!-- Everything under a white pixel will be visible -->
                 <!-- <rect x="0" y="0" width="200" height="200" fill="white" /> -->
 
                 <!-- Everything under a black pixel will be invisible -->
                 <rect x="100" y="-100" width="200" height="200" fill="black" />
-            </mask>
-            <circle cx="100" cy="100" r="100" mask="url(#spinnerMask)" />
+            <!-- </mask> -->
+            <!-- <circle cx="100" cy="100" r="100" mask="url(#spinnerMask)" /> -->
+            <circle cx="100" cy="100" r="100" fill="none" stroke="blue" stroke-width="5"/>
         </svg>
     </div>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -39,7 +39,8 @@
     <div id="loadingSpinner">
         <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
         <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
-            <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/>
+            <!-- <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/> -->
+            <path d="M 0,0 A 0 0 0 0 0 14,10" fill="none" stroke="blue" stroke-width="5"/>
         </svg>
     </div>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -37,8 +37,7 @@
     
     <!-- loading spinner -->
     <div id="loadingSpinner">
-        <!-- temporary image -->
-        <div id="spinnerTMPPlaceholder"></div>
+        <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/>
     </div>
 
     <!-- Markdown document with keybinds -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -40,7 +40,15 @@
         <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
         <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
             <!-- <rect x="10" y="10" width="30" height="30" stroke="white" fill="transparent" stroke-width="5"/> -->
-            <path d="M 100,0 Q 0,200 200,50" fill="none" stroke="blue" stroke-width="5"/>
+            <!-- <path d="M 100,0 Q 0,200 200,50" fill="none" stroke="blue" stroke-width="5"/> -->
+            <mask id="spinnerMask">
+                <!-- Everything under a white pixel will be visible -->
+                <!-- <rect x="0" y="0" width="200" height="200" fill="white" /> -->
+
+                <!-- Everything under a black pixel will be invisible -->
+                <rect x="100" y="-100" width="200" height="200" fill="black" />
+            </mask>
+            <circle cx="100" cy="100" r="100" mask="url(#spinnerMask)" />
         </svg>
     </div>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -37,14 +37,16 @@
     
     <!-- loading spinner -->
     <div id="loadingSpinner">
-        <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
-        <svg id="spinnerTMPPlaceholder" width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <!-- this svg is here instaed of in its own file since, during development, -->
+        <!-- this proved to load faster meaning the user spend less time staring at nothing -->
+        <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
             <mask id="spinnerMask">
                 <!-- Everything under a white pixel will be visible -->
                 <rect x="0" y="0" width="200" height="200" fill="white" />
                 <!-- Everything under a black pixel will be invisible -->
                 <rect x="100" y="-100" width="200" height="200" fill="black" />
             </mask>
+            <!-- its just a circle with a mask -->
             <circle cx="100" cy="100" r="90" fill="none" stroke="#775886" stroke-width="10" mask="url(#spinnerMask)"/>
         </svg>
     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -37,7 +37,7 @@
     
     <div id="loadingSpinner">
         <!-- temporary image -->
-        <img src="../Shared/icons/diagram_entity.svg"/>
+        <!-- <img src="../Shared/icons/diagram_entity.svg"/> -->
     </div>
 
     <!-- Markdown document with keybinds -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -32,7 +32,7 @@
     <script src="diagram.js"></script>
     <script src="./assets/js/fetchDiagramInfo.js"></script>
 </head>
-<!-- <body onload="getData();addAlertOnUnload();" style="overflow: hidden;"> -->
+<!-- instead of onload on body there is an event listener for loaded in diagram.js at the top of the INIT AND SETUP REGION -->
 <body style="overflow: hidden;">
     
     <!-- loading spinner -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -37,7 +37,16 @@
     
     <!-- loading spinner -->
     <div id="loadingSpinner">
-        <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/>
+        <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
+        <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <mask id="spinnerMask">
+                <!-- Everything under a white pixel will be visible -->
+                <rect x="0" y="0" width="200" height="200" fill="white" />
+                <!-- Everything under a black pixel will be invisible -->
+                <rect x="100" y="-100" width="200" height="200" fill="black" />
+            </mask>
+            <circle cx="100" cy="100" r="90" fill="none" stroke="#775886" stroke-width="10" mask="url(#spinnerMask)"/>
+        </svg>
     </div>
 
     <!-- Markdown document with keybinds -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -43,7 +43,7 @@
             <!-- <path d="M 100,0 Q 0,200 200,50" fill="none" stroke="blue" stroke-width="5"/> -->
             <mask id="spinnerMask">
                 <!-- Everything under a white pixel will be visible -->
-                <!-- <rect x="0" y="0" width="200" height="200" fill="white" /> -->
+                <rect x="0" y="0" width="200" height="200" fill="white" />
 
                 <!-- Everything under a black pixel will be invisible -->
                 <rect x="100" y="-100" width="200" height="200" fill="black" />

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -33,7 +33,12 @@
     <script src="./assets/js/fetchDiagramInfo.js"></script>
 </head>
 <body onload="getData();addAlertOnUnload();" style="overflow: hidden;">
-        
+    
+    <div id="loadingSpinner">
+        <!-- temporary image -->
+        <img src="../Shared/icons/diagram_entity.svg"/>
+    </div>
+
     <!-- Markdown document with keybinds -->
     <div id="markdownKeybinds" style="display: none">
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -37,7 +37,7 @@
     
     <div id="loadingSpinner">
         <!-- temporary image -->
-        <!-- <img src="../Shared/icons/diagram_entity.svg"/> -->
+        <div id="spinneTMPPlaceholder"></div>
     </div>
 
     <!-- Markdown document with keybinds -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -38,7 +38,7 @@
     <!-- loading spinner -->
     <div id="loadingSpinner">
         <!-- <img id="spinnerTMPPlaceholder" src="../Shared/icons/spinner.svg" alt="loading"/> -->
-        <svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <svg id="spinnerTMPPlaceholder" width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
             <mask id="spinnerMask">
                 <!-- Everything under a white pixel will be visible -->
                 <rect x="0" y="0" width="200" height="200" fill="white" />

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -51,7 +51,7 @@
       <g
          id="g1425">
         <path
-           style="fill:none;stroke:#000000;stroke-width:22.193;stroke-miterlimit:2;stroke-dasharray:none"
+           style="fill:none;stroke:#ffffff;stroke-width:22.193;stroke-miterlimit:2;stroke-dasharray:none"
            id="path373"
            sodipodi:type="arc"
            sodipodi:cx="104.56462"

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="48.0px"
-   height="48.0px"
-   viewBox="0 0 48.0 48.0"
+   width="200"
+   height="200"
+   viewBox="0 0 200 200"
    version="1.1"
    id="SVGRoot"
    sodipodi:docname="spinner.svg"
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="px"
      showgrid="true"
-     inkscape:zoom="12.138667"
-     inkscape:cx="28.545144"
-     inkscape:cy="18.453426"
+     inkscape:zoom="3.0346668"
+     inkscape:cx="76.614672"
+     inkscape:cy="115.99297"
      inkscape:window-width="1920"
      inkscape:window-height="1027"
      inkscape:window-x="-8"
@@ -36,7 +36,9 @@
      inkscape:lockguides="false">
     <inkscape:grid
        type="xygrid"
-       id="grid260" />
+       id="grid260"
+       originx="0"
+       originy="0" />
   </sodipodi:namedview>
   <defs
      id="defs132" />
@@ -49,17 +51,17 @@
       <g
          id="g1425">
         <path
-           style="fill:none;stroke:#ffffff;stroke-width:5.20889;stroke-miterlimit:2;stroke-dasharray:none"
+           style="fill:none;stroke:#000000;stroke-width:22.193;stroke-miterlimit:2;stroke-dasharray:none"
            id="path373"
            sodipodi:type="arc"
-           sodipodi:cx="23.999998"
-           sodipodi:cy="24.000002"
-           sodipodi:rx="21.395552"
-           sodipodi:ry="21.395554"
+           sodipodi:cx="104.56462"
+           sodipodi:cy="100.00826"
+           sodipodi:rx="93.485001"
+           sodipodi:ry="88.889175"
            sodipodi:start="0.4195548"
            sodipodi:end="5.2982331"
            sodipodi:arc-type="arc"
-           d="M 43.539922,32.715564 A 21.395552,21.395554 0 0 1 22.537085,45.345484 21.395552,21.395554 0 0 1 3.4537185,29.968254 21.395552,21.395554 0 0 1 11.328878,6.7601526 21.395552,21.395554 0 0 1 35.829661,6.1722496"
+           d="M 189.9417,136.21762 A 93.485001,88.889175 0 0 1 98.172616,188.68941 93.485001,88.889175 0 0 1 14.790401,124.80374 93.485001,88.889175 0 0 1 49.199858,28.384222 93.485001,88.889175 0 0 1 156.25275,25.941742"
            sodipodi:open="true" />
       </g>
     </g>

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -1,4 +1,9 @@
-<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
-
-   <path d="M0,0 a200,200,200,0,0" fill="transparent" stroke="white" stroke-width="5"/>
+<svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+   <mask id="spinnerMask">
+         <!-- Everything under a white pixel will be visible -->
+         <rect x="0" y="0" width="200" height="200" fill="white" />
+         <!-- Everything under a black pixel will be invisible -->
+         <rect x="100" y="-100" width="200" height="200" fill="black" />
+   </mask>
+   <circle cx="100" cy="100" r="90" fill="none" stroke="blue" stroke-width="10" mask="url(#spinnerMask)"/>
 </svg>

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48.0px"
+   height="48.0px"
+   viewBox="0 0 48.0 48.0"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="spinner.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview137"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     showgrid="true"
+     inkscape:zoom="12.138667"
+     inkscape:cx="28.545144"
+     inkscape:cy="18.453426"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="-8"
+     inkscape:window-y="222"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1425"
+     inkscape:lockguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid260" />
+  </sodipodi:namedview>
+  <defs
+     id="defs132" />
+  <g
+     inkscape:label="Lager 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1430">
+      <g
+         id="g1425">
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:5.20889;stroke-miterlimit:2;stroke-dasharray:none"
+           id="path373"
+           sodipodi:type="arc"
+           sodipodi:cx="23.999998"
+           sodipodi:cy="24.000002"
+           sodipodi:rx="21.395552"
+           sodipodi:ry="21.395554"
+           sodipodi:start="0.4195548"
+           sodipodi:end="5.2982331"
+           sodipodi:arc-type="arc"
+           d="M 43.539922,32.715564 A 21.395552,21.395554 0 0 1 22.537085,45.345484 21.395552,21.395554 0 0 1 3.4537185,29.968254 21.395552,21.395554 0 0 1 11.328878,6.7601526 21.395552,21.395554 0 0 1 35.829661,6.1722496"
+           sodipodi:open="true" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -1,9 +1,4 @@
-<svg version="1.1"
-   width="200" height="200"
-   baseProfile="full"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:ev="http://www.w3.org/2001/xml-events">
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
 
-   <path d="M0,0 a200,200,200,0,0" fill="transparent" stroke-width="5"/>
+   <path d="M0,0 a200,200,200,0,0" fill="transparent" stroke="white" stroke-width="5"/>
 </svg>

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -51,18 +51,18 @@
       <g
          id="g1425">
         <path
-           style="fill:none;stroke:#ffffff;stroke-width:22.193;stroke-miterlimit:2;stroke-dasharray:none"
+           style="fill:none;stroke:#ffffff;stroke-width:21.7865;stroke-miterlimit:2;stroke-dasharray:none"
            id="path373"
+           d="M 189.10678,99.232414 A 89.104721,89.872826 0 0 1 105.18304,188.95319 89.104721,89.872826 0 0 1 11.499833,109.66601 89.104721,89.872826 0 0 1 84.529191,10.724958"
            sodipodi:type="arc"
-           sodipodi:cx="104.56462"
-           sodipodi:cy="100.00826"
-           sodipodi:rx="93.485001"
-           sodipodi:ry="88.889175"
-           sodipodi:start="0.4195548"
-           sodipodi:end="5.2982331"
            sodipodi:arc-type="arc"
-           d="M 189.9417,136.21762 A 93.485001,88.889175 0 0 1 98.172616,188.68941 93.485001,88.889175 0 0 1 14.790401,124.80374 93.485001,88.889175 0 0 1 49.199858,28.384222 93.485001,88.889175 0 0 1 156.25275,25.941742"
-           sodipodi:open="true" />
+           sodipodi:open="true"
+           sodipodi:start="0"
+           sodipodi:end="4.5378561"
+           sodipodi:ry="89.872826"
+           sodipodi:rx="89.104721"
+           sodipodi:cy="99.232414"
+           sodipodi:cx="100.00206" />
       </g>
     </g>
   </g>

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -5,5 +5,5 @@
          <!-- Everything under a black pixel will be invisible -->
          <rect x="100" y="-100" width="200" height="200" fill="black" />
    </mask>
-   <circle cx="100" cy="100" r="90" fill="none" stroke="blue" stroke-width="10" mask="url(#spinnerMask)"/>
+   <circle cx="100" cy="100" r="90" fill="none" stroke="#775886" stroke-width="10" mask="url(#spinnerMask)"/>
 </svg>

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -1,69 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   width="200"
-   height="200"
-   viewBox="0 0 200 200"
-   version="1.1"
-   id="SVGRoot"
-   sodipodi:docname="spinner.svg"
-   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+<svg version="1.1"
+   width="200" height="200"
+   baseProfile="full"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview137"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="px"
-     showgrid="true"
-     inkscape:zoom="3.0346668"
-     inkscape:cx="76.614672"
-     inkscape:cy="115.99297"
-     inkscape:window-width="1920"
-     inkscape:window-height="1027"
-     inkscape:window-x="-8"
-     inkscape:window-y="222"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g1425"
-     inkscape:lockguides="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid260"
-       originx="0"
-       originy="0" />
-  </sodipodi:namedview>
-  <defs
-     id="defs132" />
-  <g
-     inkscape:label="Lager 1"
-     inkscape:groupmode="layer"
-     id="layer1">
-    <g
-       id="g1430">
-      <g
-         id="g1425">
-        <path
-           style="fill:none;stroke:#ffffff;stroke-width:21.7865;stroke-miterlimit:2;stroke-dasharray:none"
-           id="path373"
-           d="M 189.10678,99.232414 A 89.104721,89.872826 0 0 1 105.18304,188.95319 89.104721,89.872826 0 0 1 11.499833,109.66601 89.104721,89.872826 0 0 1 84.529191,10.724958"
-           sodipodi:type="arc"
-           sodipodi:arc-type="arc"
-           sodipodi:open="true"
-           sodipodi:start="0"
-           sodipodi:end="4.5378561"
-           sodipodi:ry="89.872826"
-           sodipodi:rx="89.104721"
-           sodipodi:cy="99.232414"
-           sodipodi:cx="100.00206" />
-      </g>
-    </g>
-  </g>
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:ev="http://www.w3.org/2001/xml-events">
+
+   <path d="M0,0 a200,200,200,0,0" fill="transparent" stroke-width="5"/>
 </svg>

--- a/Shared/icons/spinner.svg
+++ b/Shared/icons/spinner.svg
@@ -1,9 +1,0 @@
-<svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
-   <mask id="spinnerMask">
-         <!-- Everything under a white pixel will be visible -->
-         <rect x="0" y="0" width="200" height="200" fill="white" />
-         <!-- Everything under a black pixel will be invisible -->
-         <rect x="100" y="-100" width="200" height="200" fill="black" />
-   </mask>
-   <circle cx="100" cy="100" r="90" fill="none" stroke="#775886" stroke-width="10" mask="url(#spinnerMask)"/>
-</svg>


### PR DESCRIPTION
Created a loading spinner that disappears after the window is loaded and also calls the startup functions.

For the tester: you can use the networking tab of developer tools to artificially throttle your connection to be slower, this allows you to see the loading spinner better if you have fast internet. 