### PR TITLE
changeState() misbehaving #14067

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2902,7 +2902,6 @@ function getElementLines(element) {
  * @returns {boolean} result
  */
 function elementHasLines(element) {
-    console.log(getElementLines(element))
     return (getElementLines(element).length > 0);
 }
 /** TODO: elementHasLines() seems to not work for UML, SD, IE elements, this needs to be fixed/investigated!!
@@ -2918,7 +2917,7 @@ function changeState()
     var newRelation = document.getElementById("propertySelect")?.value || undefined;
     
     // If we are changing types and the element has lines, we should not change
-    if (oldType !== newType && elementHasLines(element)){
+    if (oldType !== newType && newType !== undefined && oldType !== undefined && elementHasLines(element)){
         displayMessage("error", `
             Can't change type from \"${oldType}\" to \"${newType}\" as
             different diagrams should not be able to connect to each other.`

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2874,16 +2874,6 @@ function elementHasLines(element) {
  */
 function changeState() 
 {
-    //"from" and "to" elements
-    /* let fromElem = context[0][findIndex(context[0], line.fromID)];
-    let toElem = context[0][findIndex(context[0], line.toID)]; */
-    /* let newTypetemp;
-    if (document.getElementById("typeSelect").value != undefined) {
-        newTypetemp = document.getElementById("typeSelect").value;
-    } */
-
-    //console.log(fromElem, toElem);
-
     const element =  context[0],
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || undefined;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2895,7 +2895,7 @@ function changeState()
         
         //If not attribute, also save the current type and check if kind also should be updated
         if (element.kind != 'ERAttr') {
-            
+
             //Check if type has been changed
             if (oldType != newType) {
                 var newKind = element.kind;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -461,7 +461,7 @@ class StateMachine
 
                         currentChangedType = changeTypes[index];
 
-                        switch (currentChangeType) {
+                        switch (currentChangedType) {
                             case StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED:
                             case StateChange.ChangeTypes.ELEMENT_MOVED:
                             case StateChange.ChangeTypes.ELEMENT_RESIZED:

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2884,18 +2884,18 @@ function changeState()
 
     //console.log(fromElem, toElem);
 
-    const element =  context[0],
+    /* const element =  context[0],
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || undefined;
           //newType = newTypetemp;
           var oldRelation = element.state;
-          var newRelation = document.getElementById("propertySelect")?.value || undefined
+          var newRelation = document.getElementById("propertySelect")?.value || undefined */
 
-    /* let element = context[0];
+    let element = context[0];
     let oldType = element.type;
     let newType = document.getElementById("typeSelect")?.value || undefined;
     let oldRelation = element.state;
-    let newRelation = document.getElementById("propertySelect")?.value || undefined; */
+    let newRelation = document.getElementById("propertySelect")?.value || undefined;
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
         for (let i = 0; i < lines.length; i++) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2882,7 +2882,7 @@ function changeState()
         newTypetemp = document.getElementById("typeSelect").value;
     }
 
-    console.log(fromElem, toElem);
+    //console.log(fromElem, toElem);
 
     const element =  context[0],
           oldType = element.type,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2936,6 +2936,7 @@ function changeState()
         }
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
     } else if (oldType == newType && oldRelation == newRelation){
+        console.log("its ok");
         return;
     }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2874,6 +2874,12 @@ function elementHasLines(element) {
  */
 function changeState() 
 {
+    //"from" and "to" elements
+    let fromElem = context[0][findIndex(context[0], line.fromID)];
+    let toElem = context[0][findIndex(context[0], line.toID)];
+
+    console.log(fromElem, toElem);
+
     const element =  context[0],
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || undefined;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2895,6 +2895,7 @@ function changeState()
         
         //If not attribute, also save the current type and check if kind also should be updated
         if (element.kind != 'ERAttr') {
+            
             //Check if type has been changed
             if (oldType != newType) {
                 var newKind = element.kind;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2884,18 +2884,18 @@ function changeState()
 
     //console.log(fromElem, toElem);
 
-    /* const element =  context[0],
+    const element =  context[0],
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || undefined;
           //newType = newTypetemp;
           var oldRelation = element.state;
-          var newRelation = document.getElementById("propertySelect")?.value || undefined */
+          var newRelation = document.getElementById("propertySelect")?.value || undefined
 
-    let element = context[0];
+    /* let element = context[0];
     let oldType = element.type;
     let newType = document.getElementById("typeSelect")?.value || undefined;
     let oldRelation = element.state;
-    let newRelation = document.getElementById("propertySelect")?.value || undefined;
+    let newRelation = document.getElementById("propertySelect")?.value || undefined; */
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
         for (let i = 0; i < lines.length; i++) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2877,19 +2877,25 @@ function changeState()
     //"from" and "to" elements
     /* let fromElem = context[0][findIndex(context[0], line.fromID)];
     let toElem = context[0][findIndex(context[0], line.toID)]; */
-    let newTypetemp;
+    /* let newTypetemp;
     if (document.getElementById("typeSelect").value != undefined) {
         newTypetemp = document.getElementById("typeSelect").value;
-    }
+    } */
 
     //console.log(fromElem, toElem);
 
-    const element =  context[0],
+    /* const element =  context[0],
           oldType = element.type,
-          //newType = document.getElementById("typeSelect")?.value || undefined;
-          newType = newTypetemp;
+          newType = document.getElementById("typeSelect")?.value || undefined;
+          //newType = newTypetemp;
           var oldRelation = element.state;
-          var newRelation = document.getElementById("propertySelect")?.value || undefined
+          var newRelation = document.getElementById("propertySelect")?.value || undefined */
+
+    let element = context[0];
+    let oldType = element.type;
+    let newType = document.getElementById("typeSelect")?.value || undefined;
+    let oldRelation = element.state;
+    let newRelation = document.getElementById("propertySelect")?.value || undefined;
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
         displayMessage("error", `

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2898,7 +2898,6 @@ function changeState()
         return;
     }
     else if (element.type == 'ER') {
-        console.log("er")
         //If not attribute, also save the current type and check if kind also should be updated
         if (element.kind != 'ERAttr') {
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2911,6 +2911,7 @@ function changeState()
                             Can't change type from \"${oldType}\" to \"${newType}\" as
                             different diagrams should not be able to connect to each other.`
                             )
+                            return;
                         }
                     }
                 }
@@ -2927,15 +2928,12 @@ function changeState()
                             Can't change type from \"${oldType}\" to \"${newType}\" as
                             different diagrams should not be able to connect to each other.`
                             )
+                            return;
                         }
                     }
                 }
             }
-            //else reversed
-            
         }
-        
-        return;
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
     } else if (oldType == newType && oldRelation == newRelation){
         return;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2877,52 +2877,15 @@ function changeState()
     const element =  context[0],
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || undefined;
-          //newType = newTypetemp;
           var oldRelation = element.state;
           var newRelation = document.getElementById("propertySelect")?.value || undefined
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
-        for (let i = 0; i < lines.length; i++) {
-            if (lines[i].fromID == element.id) {
-                //find the element the line is going to
-                for (let j = 0; j < data.length; j++) {
-                    if (data[j].id == lines[i].toID) {
-                        if (data[j].type == element.type) {
-                            return;
-                        }
-                        else{
-                            displayMessage("error", `
-                            Can't change type from \"${oldType}\" to \"${newType}\" as
-                            different diagrams should not be able to connect to each other.`
-                            )
-                            return;
-                        }
-                    }
-                }
-            }
-            else if (lines[i].toID == element.id) {
-                //find the element the line is going to
-                for (let j = 0; j < data.length; j++) {
-                    if (data[j].id == lines[i].fromID) {
-                        if (data[j].type == element.type) {
-                            return;
-                        }
-                        else{
-                            displayMessage("error", `
-                            Can't change type from \"${oldType}\" to \"${newType}\" as
-                            different diagrams should not be able to connect to each other.`
-                            )
-                            return;
-                        }
-                    }
-                }
-            }
-        }
+        https://www.hyundai.se/bilar/ioniq-6
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
     } else if (oldType == newType && oldRelation == newRelation){
         return;
     }
-
     else if (element.type == 'ER') {
         
         //If not attribute, also save the current type and check if kind also should be updated

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2875,14 +2875,19 @@ function elementHasLines(element) {
 function changeState() 
 {
     //"from" and "to" elements
-    let fromElem = context[0][findIndex(context[0], line.fromID)];
-    let toElem = context[0][findIndex(context[0], line.toID)];
+    /* let fromElem = context[0][findIndex(context[0], line.fromID)];
+    let toElem = context[0][findIndex(context[0], line.toID)]; */
+    let newTypetemp;
+    if (document.getElementById("typeSelect").value != undefined) {
+        newTypetemp = document.getElementById("typeSelect").value;
+    }
 
     console.log(fromElem, toElem);
 
     const element =  context[0],
           oldType = element.type,
-          newType = document.getElementById("typeSelect")?.value || undefined;
+          //newType = document.getElementById("typeSelect")?.value || undefined;
+          newType = newTypetemp;
           var oldRelation = element.state;
           var newRelation = document.getElementById("propertySelect")?.value || undefined
     // If we are changing types and the element has lines, we should not change

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2884,24 +2884,57 @@ function changeState()
 
     //console.log(fromElem, toElem);
 
-    /* const element =  context[0],
+    const element =  context[0],
           oldType = element.type,
           newType = document.getElementById("typeSelect")?.value || undefined;
           //newType = newTypetemp;
           var oldRelation = element.state;
-          var newRelation = document.getElementById("propertySelect")?.value || undefined */
+          var newRelation = document.getElementById("propertySelect")?.value || undefined
 
-    let element = context[0];
+    /* let element = context[0];
     let oldType = element.type;
     let newType = document.getElementById("typeSelect")?.value || undefined;
     let oldRelation = element.state;
-    let newRelation = document.getElementById("propertySelect")?.value || undefined;
+    let newRelation = document.getElementById("propertySelect")?.value || undefined; */
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
-        displayMessage("error", `
-        Can't change type from \"${oldType}\" to \"${newType}\" as
-        different diagrams should not be able to connect to each other.`
-        )
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].fromID == element.id) {
+                //find the element the line is going to
+                for (let j = 0; j < data.length; j++) {
+                    if (data[j].id == lines[i].toID) {
+                        if (data[j].type == element.type) {
+                            return;
+                        }
+                        else{
+                            displayMessage("error", `
+                            Can't change type from \"${oldType}\" to \"${newType}\" as
+                            different diagrams should not be able to connect to each other.`
+                            )
+                        }
+                    }
+                }
+            }
+            else if (lines[i].toID == element.id) {
+                //find the element the line is going to
+                for (let j = 0; j < data.length; j++) {
+                    if (data[j].id == lines[i].fromID) {
+                        if (data[j].type == element.type) {
+                            return;
+                        }
+                        else{
+                            displayMessage("error", `
+                            Can't change type from \"${oldType}\" to \"${newType}\" as
+                            different diagrams should not be able to connect to each other.`
+                            )
+                        }
+                    }
+                }
+            }
+            //else reversed
+            
+        }
+        
         return;
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
     } else if (oldType == newType && oldRelation == newRelation){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2890,12 +2890,6 @@ function changeState()
           //newType = newTypetemp;
           var oldRelation = element.state;
           var newRelation = document.getElementById("propertySelect")?.value || undefined
-
-    /* let element = context[0];
-    let oldType = element.type;
-    let newType = document.getElementById("typeSelect")?.value || undefined;
-    let oldRelation = element.state;
-    let newRelation = document.getElementById("propertySelect")?.value || undefined; */
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
         for (let i = 0; i < lines.length; i++) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2881,7 +2881,6 @@ function changeState()
           var newRelation = document.getElementById("propertySelect")?.value || undefined
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
-        https://www.hyundai.se/bilar/ioniq-6
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
     } else if (oldType == newType && oldRelation == newRelation){
         return;
@@ -2890,7 +2889,6 @@ function changeState()
         
         //If not attribute, also save the current type and check if kind also should be updated
         if (element.kind != 'ERAttr') {
-
             //Check if type has been changed
             if (oldType != newType) {
                 var newKind = element.kind;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2871,6 +2871,7 @@ function getElementLines(element) {
  * @returns {boolean} result
  */
 function elementHasLines(element) {
+    console.log(getElementLines(element))
     return (getElementLines(element).length > 0);
 }
 /** TODO: elementHasLines() seems to not work for UML, SD, IE elements, this needs to be fixed/investigated!!
@@ -2880,24 +2881,24 @@ function elementHasLines(element) {
 function changeState() 
 {
     const element =  context[0],
-          oldType = element.type,
-          newType = document.getElementById("typeSelect")?.value || undefined;
-          var oldRelation = element.state;
-          var newRelation = document.getElementById("propertySelect")?.value || undefined
+        oldType = element.type,
+        newType = document.getElementById("typeSelect")?.value || undefined;
+    var oldRelation = element.state;
+    var newRelation = document.getElementById("propertySelect")?.value || undefined;
+    
     // If we are changing types and the element has lines, we should not change
-    if ((elementHasLines(element))){
+    if (oldType !== newType && elementHasLines(element)){
         displayMessage("error", `
-        Can't change type from \"${oldType}\" to \"${newType}\" as
-        different diagrams should not be able to connect to each other.`
+            Can't change type from \"${oldType}\" to \"${newType}\" as
+            different diagrams should not be able to connect to each other.`
         )
         return;
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
     } else if (oldType == newType && oldRelation == newRelation){
         return;
     }
-
     else if (element.type == 'ER') {
-        
+        console.log("er")
         //If not attribute, also save the current type and check if kind also should be updated
         if (element.kind != 'ERAttr') {
 
@@ -2994,8 +2995,7 @@ function changeState()
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
 
     }
-    
-    generateContextProperties();
+
     displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
 
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2936,7 +2936,6 @@ function changeState()
         }
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
     } else if (oldType == newType && oldRelation == newRelation){
-        console.log("its ok");
         return;
     }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2881,10 +2881,16 @@ function changeState()
           var newRelation = document.getElementById("propertySelect")?.value || undefined
     // If we are changing types and the element has lines, we should not change
     if ((elementHasLines(element))){
+        displayMessage("error", `
+        Can't change type from \"${oldType}\" to \"${newType}\" as
+        different diagrams should not be able to connect to each other.`
+        )
+        return;
     // If we are changing to the same type, (simply pressed save without changes), do nothing.
     } else if (oldType == newType && oldRelation == newRelation){
         return;
     }
+
     else if (element.type == 'ER') {
         
         //If not attribute, also save the current type and check if kind also should be updated


### PR DESCRIPTION
Fixed an issue where the changeState() function displayed an error message even though the changes were applied. 

Removed a function call `generateContextProperties()` as the propertySet was overridden by it, causing the changes not to be saved and applied properly. Solves issue #14067