### PR TITLE
It is now possible to move both lifeline and superstate without overlapp

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3762,11 +3762,11 @@ function entityIsOverlapping(id, x, y)
                 }
               }
               //if its overlapping with a super state, just break since that is allowed.
-              if (data[i].kind == "UMLSuperState") {
+                if (data[i].kind == "UMLSuperState" || element.kind == "UMLSuperState") {
                 break;
               }
               //if its overlapping with a sequence actor, just break since that is allowed.
-              if (data[i].kind == "sequenceActorAndObject") {
+                if (data[i].kind == "sequenceActorAndObject" || element.kind == "sequenceActorAndObject") {
                 break;
               }
               else if ((targetX < compX2) && (targetX + element.width) > data[i].x &&


### PR DESCRIPTION
The old checks never checked what kind of element you were moving with the mouse, so i added a element.kind check inside the if statment for both objects that check if you are holding the right kind of element