### PR TITLE
Don't allow clicking on save button if there's nothing to save #14113

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -833,7 +833,7 @@
 }
 
 .disabledIcon{
-    background-color: white;
+    background-color: #cbb1e0;
 }
 
 #a4options {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -832,6 +832,10 @@
     font-weight: bold;
 }
 
+.disabled{
+    background-color: #888;
+}
+
 #a4options {
     display: flex;
 }

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -833,7 +833,7 @@
 }
 
 .disabledIcon{
-    border-color: #da2727;
+    background-color: white;
 }
 
 #a4options {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -833,7 +833,7 @@
 }
 
 .disabled{
-    background-color: #888;
+    color: red;
 }
 
 #a4options {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -833,7 +833,7 @@
 }
 
 .disabledIcon{
-    background-color: #a382bd;
+    background-color: #8d68ab;
 }
 
 #a4options {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -833,7 +833,7 @@
 }
 
 .disabledIcon{
-    background-color: #cbb1e0;
+    background-color: #a382bd;
 }
 
 #a4options {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -832,8 +832,8 @@
     font-weight: bold;
 }
 
-.disabled{
-    color: red;
+.disabledIcon{
+    border-color: #da2727;
 }
 
 #a4options {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1952,7 +1952,6 @@ function mdown(event)
             startY = event.clientY;
         }
     }
-    disableIfDataEmpty();
     dblPreviousTime = new Date().getTime();
     wasDblClicked = false;
 }
@@ -2212,6 +2211,8 @@ function mup(event)
     // Restore pointer state to normal
     pointerState = pointerStates.DEFAULT;
     deltaExceeded = false;
+
+    disableIfDataEmpty();
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13118,10 +13118,10 @@ function saveDiagramBeforeUnload() {
 function disableIfDataEmpty(){
     console.log("hello");
     if (stateMachine.currentHistoryIndex === -1 || data.length === 0){
-        document.getElementById('localSaveField').disabled = true;
+        document.getElementById('localSaveField').classList.add('disabled');
     }
     else{
-        document.getElementById('localSaveField').disabled = false;
+        document.getElementById('localSaveField').classList.remove('disabled');
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13116,6 +13116,7 @@ function saveDiagramBeforeUnload() {
 }
 
 function disableIfDataEmpty(){
+    console.log("hello");
     if (stateMachine.currentHistoryIndex === -1 || data.length === 0){
         document.getElementById('localSaveField').disabled = true;
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -515,7 +515,8 @@ class StateMachine
         showdata();
         this.scrubHistory(this.currentHistoryIndex);
         updatepos(0, 0);
-        displayMessage(messageTypes.SUCCESS, "Changes reverted!")
+        displayMessage(messageTypes.SUCCESS, "Changes reverted!");
+        disableIfDataEmpty();
     }
     stepForward()
     {
@@ -13117,7 +13118,6 @@ function saveDiagramBeforeUnload() {
 }
 
 function disableIfDataEmpty(){
-    console.log("hello");
     if (stateMachine.currentHistoryIndex === -1 || data.length === 0){
         document.getElementById('localSaveField').classList.add('disabledIcon');
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13127,15 +13127,21 @@ function hideSavePopout()
 
 function saveDiagramAs()
 {
-    let elem = document.getElementById("saveDiagramAs");
-    let fileName = elem.value;
-    elem.value = "";
-    if (fileName.trim() == "") {
-        // fileName = "Untitled"
-        fileName = "CurrentlyActiveDiagram"; // Since it is currently not possible to load any other diagram, it must default to "CurrentlyActiveDiagram".
-    }
 
-    storeDiagramInLocalStorage(fileName);
+    if (stateMachine.currentHistoryIndex === -1){
+        displayMessage(messageTypes.ERROR, "You don't have anything to save!");
+    }
+    else{
+        let elem = document.getElementById("saveDiagramAs");
+        let fileName = elem.value;
+        elem.value = "";
+        if (fileName.trim() == "") {
+            // fileName = "Untitled"
+            fileName = "CurrentlyActiveDiagram"; // Since it is currently not possible to load any other diagram, it must default to "CurrentlyActiveDiagram".
+        }
+    
+        storeDiagramInLocalStorage(fileName);
+    }
 }
 
 function loadDiagramFromString(temp, shouldDisplayMessage = true)

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13119,10 +13119,10 @@ function saveDiagramBeforeUnload() {
 function disableIfDataEmpty(){
     console.log("hello");
     if (stateMachine.currentHistoryIndex === -1 || data.length === 0){
-        document.getElementById('localSaveField').classList.add('disabled');
+        document.getElementById('localSaveField').classList.add('disabledIcon');
     }
     else{
-        document.getElementById('localSaveField').classList.remove('disabled');
+        document.getElementById('localSaveField').classList.remove('disabledIcon');
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13116,8 +13116,13 @@ function saveDiagramBeforeUnload() {
 
 function showSavePopout()
 {
-    $("#savePopoutContainer").css("display", "flex");
-    document.getElementById("saveDiagramAs").focus();
+    if (stateMachine.currentHistoryIndex === -1){
+        displayMessage(messageTypes.ERROR, "You don't have anything to save!");
+    }
+    else{
+        $("#savePopoutContainer").css("display", "flex");
+        document.getElementById("saveDiagramAs").focus();
+    }
 }
 
 function hideSavePopout()
@@ -13127,21 +13132,14 @@ function hideSavePopout()
 
 function saveDiagramAs()
 {
-
-    if (stateMachine.currentHistoryIndex === -1){
-        displayMessage(messageTypes.ERROR, "You don't have anything to save!");
+    let elem = document.getElementById("saveDiagramAs");
+    let fileName = elem.value;
+    elem.value = "";
+    if (fileName.trim() == "") {
+        // fileName = "Untitled"
+        fileName = "CurrentlyActiveDiagram"; // Since it is currently not possible to load any other diagram, it must default to "CurrentlyActiveDiagram".
     }
-    else{
-        let elem = document.getElementById("saveDiagramAs");
-        let fileName = elem.value;
-        elem.value = "";
-        if (fileName.trim() == "") {
-            // fileName = "Untitled"
-            fileName = "CurrentlyActiveDiagram"; // Since it is currently not possible to load any other diagram, it must default to "CurrentlyActiveDiagram".
-        }
-    
-        storeDiagramInLocalStorage(fileName);
-    }
+    storeDiagramInLocalStorage(fileName);
 }
 
 function loadDiagramFromString(temp, shouldDisplayMessage = true)

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13114,6 +13114,12 @@ function saveDiagramBeforeUnload() {
     })
 }
 
+function disableIfDataEmpty(){
+    if (stateMachine.currentHistoryIndex === -1 || data.length === 0){
+        document.getElementById('localSaveField').disabled = true;
+    }
+}
+
 function showSavePopout()
 {
     if (stateMachine.currentHistoryIndex === -1 || data.length === 0){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13116,7 +13116,7 @@ function saveDiagramBeforeUnload() {
 
 function showSavePopout()
 {
-    if (stateMachine.currentHistoryIndex === -1 || (stateMachine.ElementsDeleted).length === (stateMachine.ElementsAndLinesCreated).length){
+    if (stateMachine.currentHistoryIndex === -1 || data === 0){
         displayMessage(messageTypes.ERROR, "You don't have anything to save!");
     }
     else{

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13116,7 +13116,7 @@ function saveDiagramBeforeUnload() {
 
 function showSavePopout()
 {
-    if (stateMachine.currentHistoryIndex === -1){
+    if (stateMachine.currentHistoryIndex === -1 || (stateMachine.ElementsDeleted).length === (stateMachine.ElementsAndLinesCreated).length){
         displayMessage(messageTypes.ERROR, "You don't have anything to save!");
     }
     else{

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1952,6 +1952,7 @@ function mdown(event)
             startY = event.clientY;
         }
     }
+    disableIfDataEmpty();
     dblPreviousTime = new Date().getTime();
     wasDblClicked = false;
 }
@@ -13117,6 +13118,9 @@ function saveDiagramBeforeUnload() {
 function disableIfDataEmpty(){
     if (stateMachine.currentHistoryIndex === -1 || data.length === 0){
         document.getElementById('localSaveField').disabled = true;
+    }
+    else{
+        document.getElementById('localSaveField').disabled = false;
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13116,7 +13116,7 @@ function saveDiagramBeforeUnload() {
 
 function showSavePopout()
 {
-    if (stateMachine.currentHistoryIndex === -1 || data === 0){
+    if (stateMachine.currentHistoryIndex === -1 || data.length === 0){
         displayMessage(messageTypes.ERROR, "You don't have anything to save!");
     }
     else{

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -504,7 +504,6 @@ class StateMachine
         if (this.currentHistoryIndex == -1) {return;}
         else {
             this.currentHistoryIndex--;
-            console.log(this.currentHistoryIndex);
         }
 
         // Remove ghost only if stepBack while creating edge

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13105,6 +13105,7 @@ function closeModal(){
         // Failed to load content
         console.error("No content to load")
     }
+    disableIfDataEmpty();
 } 
 
 // Save current diagram when user leaves the page

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -849,7 +849,7 @@
                 </span>
             </div>
         </fieldset>
-        <fieldset id="localSaveField">
+        <fieldset id="localSaveField" class="disabledIcon">
             <legend aria-hidden="true">Save</legend>
             <div id="localSave" class="diagramIcons" onclick="showSavePopout()">
                 <img src="../Shared/icons/diagram_save_icon.svg" alt="Save diagram"/>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -860,7 +860,7 @@
                 </span>
             </div>
         </fieldset>
-        <fieldset id = "localLoadField">
+        <fieldset id="localLoadField">
             <legend aria-hidden="true">Load</legend>
             <div id="localLoad" class="diagramIcons" onclick="showModal();">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -849,7 +849,7 @@
                 </span>
             </div>
         </fieldset>
-        <fieldset id="localSaveField" onload="disableIfDataEmpty()">
+        <fieldset id="localSaveField">
             <legend aria-hidden="true">Save</legend>
             <div id="localSave" class="diagramIcons" onclick="showSavePopout()">
                 <img src="../Shared/icons/diagram_save_icon.svg" alt="Save diagram"/>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -849,7 +849,7 @@
                 </span>
             </div>
         </fieldset>
-        <fieldset id = "localSaveField">
+        <fieldset id="localSaveField" onload="disableIfDataEmpty()">
             <legend aria-hidden="true">Save</legend>
             <div id="localSave" class="diagramIcons" onclick="showSavePopout()">
                 <img src="../Shared/icons/diagram_save_icon.svg" alt="Save diagram"/>


### PR DESCRIPTION
The function I made checks if data[] == 0 which means the container is empty or if the historyindex is -1. It is called whenever the mouseUp event is triggered. It should work with both ctrl+z and removing elements. The buttons is set to "disabled" (only by css) by default.