### PR TITLE
G1 2023 v7 #14180

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -115,6 +115,7 @@ class StateChangeFactory
 
         // Get the keys of the values that is unique from default
         var uniqueKeysArr = Object.keys(element).filter(key => {
+            if (key === 'x' || key === 'y') return true;
             return (Object.keys(defaults[element.kind]).filter(value => {
                 return defaults[element.kind][value] === element[key];
             }).length === 0);
@@ -292,6 +293,7 @@ class StateChangeFactory
             var values = { kind: elem.kind };
 
             var uniqueKeysArr = Object.keys(elem).filter(key => {
+                if (key === 'x' || key === 'y') return true;
                 return (Object.keys(defaults[elem.kind]).filter(value => {
                     return defaults[elem.kind][value] == elem[key];
                 }).length == 0);


### PR DESCRIPTION
Fixed the issue with missing `x` and `y` coordinates in `historylog`.

Added an if-statement inside the filter function that basically ignores the filtering for the keys: `x` and `y`, where it was possible for the issue to occur. Now the coordinates should always be present in the historylog and as such the system should no longer crash.

The following code snippet is created by  the `exportWithHistory()` function. 
*Notice that the value for x is equal to 200 as this was not possible before.*
```JSON
{
	"historyLog": [{
		"id": "9DF74D",
		"kind": "EREntity",
		"x": 200,
		"y": 553,
		"time": 1684850801336
	}],
	"initialState": {
		"elements": [],
		"lines": []
	}
}
```