### PR TITLE
G3 2023 v7 issue#14002

### DIFF
--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -96,6 +96,7 @@
 	//--------------------------------------------------------------------------------------------------
 
 	function refreshCheck($cid, $user) {
+		global $shortdeadline, $longdeadline;
 		// Connect to database and start session
 		pdoConnect();
 		session_start();

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -1,6 +1,10 @@
 <?php 
 	// -------------==============######## Setup ###########==============-------------
 
+	// Variables for the refresh button, deadlines specified in seconds
+	$shortdeadline = 300; // 300 = 5 minutes
+	$longdeadline = 600; // 600 = 10 minutes
+
 	// Used to display errors on screen since PHP doesn't do that automatically.
 	ini_set('display_errors', 1);
 	ini_set('display_startup_errors', 1);
@@ -92,10 +96,6 @@
 	//--------------------------------------------------------------------------------------------------
 
 	function refreshCheck($cid, $user) {
-		// Specify deadlines in seconds
-		$shortdeadline = 300; // 300 = 5 minutes
-		$longdeadline = 600; // 600 = 10 minutes
-
 		// Connect to database and start session
 		pdoConnect();
 		session_start();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -28,6 +28,11 @@ var numberOfItems;
 var backgroundColorTheme;
 var isLoggedIn = false;
 
+// Globals for the automatic refresh (github)
+var isActivelyFocused = false; // If the user is actively focusing on the course page
+var lastUpdatedCodeExampes = null; // Last time code examples was updated
+const UPDATE_INTERVAL = 600 * 100; // Timerintervall for code to be updated (10 minutes)
+
 
 function IsLoggedIn(bool){
   bool ? isLoggedIn = true : isLoggedIn = false ;
@@ -3088,10 +3093,6 @@ function hasGracetimeExpired(deadline, dateTimeSubmitted) {
     return false;
   }
 }
-
-var isActivelyFocused = false; // If the user is actively focusing on the course page
-var lastUpdatedCodeExampes = null; // Last time code examples was updated
-const UPDATE_INTERVAL = 600 * 100; // Timerintervall for code to be updated (10 minutes)
 
 // Function to fetch code examples for a specific lecture/moment
 function createExamples(momentID, isManual) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -28,10 +28,7 @@ var numberOfItems;
 var backgroundColorTheme;
 var isLoggedIn = false;
 
-// Globals for the automatic refresh (github)
-var isActivelyFocused = false; // If the user is actively focusing on the course page
-var lastUpdatedCodeExampes = null; // Last time code examples was updated
-const UPDATE_INTERVAL = 600 * 100; // Timerintervall for code to be updated (10 minutes)
+
 
 
 function IsLoggedIn(bool){
@@ -3134,6 +3131,11 @@ $(window).on('blur', function() {
 
 // Create an interval that checks if the window is focused and the updateInterval has passed, 
 // then updates the code examples if the conditions are met.
+
+// Globals for the automatic refresh (github)
+var isActivelyFocused = false; // If the user is actively focusing on the course page
+var lastUpdatedCodeExampes = null; // Last time code examples was updated
+const UPDATE_INTERVAL = 600 * 100; // Timerintervall for code to be updated (10 minutes)
 
 setInterval(function() {
   if (isActivelyFocused) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -28,7 +28,10 @@ var numberOfItems;
 var backgroundColorTheme;
 var isLoggedIn = false;
 
-
+// Globals for the automatic refresh (github)
+var isActivelyFocused = false; // If the user is actively focusing on the course page
+var lastUpdatedCodeExampes = null; // Last time code examples was updated
+const UPDATE_INTERVAL = 600 * 100; // Timerintervall for code to be updated (10 minutes)
 
 
 function IsLoggedIn(bool){
@@ -3131,11 +3134,6 @@ $(window).on('blur', function() {
 
 // Create an interval that checks if the window is focused and the updateInterval has passed, 
 // then updates the code examples if the conditions are met.
-
-// Globals for the automatic refresh (github)
-var isActivelyFocused = false; // If the user is actively focusing on the course page
-var lastUpdatedCodeExampes = null; // Last time code examples was updated
-const UPDATE_INTERVAL = 600 * 100; // Timerintervall for code to be updated (10 minutes)
 
 setInterval(function() {
   if (isActivelyFocused) {


### PR DESCRIPTION
for issue #14002 

Made the variables for the refresh button into global ones and stored them at the top of the files. 
This is for both automatic (sectioned.js) and the manual (gitcommitService.php).

We noticed while adding this that the automatic refresh runs every 60 seconds unless you do a hard reload of the page, only then does it run every 10 minutes. 

To test this just check that the functionality for the refresh timer (the code for oversaturating github) works both automatically and manually.

co-author @g21emmka 