### PR TITLE
G1 2023 v7 #14153

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -577,6 +577,15 @@
     border: 1px solid #000;
 }
 
+.deleteLocalDiagram{
+    margin-left: 10px;
+    background-color: #DF2727 !important;
+}
+
+.deleteLocalDiagram:hover {
+    background-color: #961a1a !important;
+}
+
 #amountOfLoads{
     text-align: center;
     font-size: 12px;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13285,7 +13285,7 @@ function showModal(){
             let wrapper = document.createElement('div');
             var btn = document.createElement('button');
             var btnText = document.createTextNode(diagramKeys[i]);
-
+            
             btn.setAttribute("onclick", `loadDiagramFromLocalStorage('${diagramKeys[i]}');closeModal();`);
             btn.appendChild(btnText);
             wrapper.appendChild(btn);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13452,6 +13452,22 @@ function loadDiagramFromString(temp, shouldDisplayMessage = true)
     }
 }
 
+function removeLocalDiagram(item)
+{
+    let local = localStorage.getItem("diagrams");
+    local = (local[0] == "{") ? local : `{${local}}`;
+    let localDiagrams = JSON.parse(local);
+
+    if (item !== 'AutoSave') {
+        delete localDiagrams[item];
+    }
+    else {
+        displayMessage(messageTypes.ERROR, "Error, unable to delete 'AutoSave'");
+    }
+
+    localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
+}
+
 //Alert function to give user a warning/choice before reseting diagram data.
 function resetDiagramAlert(){
     let refreshConfirm = confirm("Are you sure you want to reset to default state? All changes made to diagram will be lost");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13282,12 +13282,24 @@ function showModal(){
     }
     else{
         for (let i = 0; i < diagramKeys.length; i++){
+            let wrapper = document.createElement('div');
             var btn = document.createElement('button');
             var btnText = document.createTextNode(diagramKeys[i]);
 
             btn.setAttribute("onclick", `loadDiagramFromLocalStorage('${diagramKeys[i]}');closeModal();`);
             btn.appendChild(btnText);
-            container.appendChild(btn);
+            wrapper.appendChild(btn);
+            wrapper.style.display = "flex";
+            btn.style.width = '100%';
+
+            if (btnText.textContent !== 'AutoSave') {
+                let delBtn = document.createElement('button');
+                delBtn.classList.add('deleteLocalDiagram');
+                delBtn.setAttribute("onclick", `removeLocalDiagram('${diagramKeys[i]}');showModal();`);
+                delBtn.appendChild(document.createTextNode('Delete'));
+                wrapper.appendChild(delBtn);
+            }
+            container.appendChild(wrapper);
 
             document.getElementById('loadCounter').innerHTML = diagramKeys.length;
         }


### PR DESCRIPTION
Added functionality to remove a specific diagram from localstorage. You can now delete a save from the load diagram menu by pressing the delete button.

Since autosave almost always updates, there is no need for the user to be able to remove it.

![image](https://github.com/HGustavs/LenaSYS/assets/102599161/56142b09-d834-47b2-a308-f970be61c439)
