### PR TITLE
Unable to group-select sequence objects #14026

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3531,7 +3531,7 @@ function getRectFromElement (element)
             console.log("resizedY "+resizedY[i].y);
             return {
                 x: element.x,
-                y: resizedY[i].y,
+                y: resizedY[i].y * 2 - element.x - resizedY[i].resizedDifference,
                 width: element.width,
                 height: element.height
             };

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange * 0.45;
+                    resizedElement.y = elementData.y - heightChange * 0.48;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange * 0.45;
+                            resizedY[i].y -= heightChange * 0.48;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange * 0.45;
+                        resizedElement.y = elementData.y - heightChange * 0.48;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3614,7 +3614,7 @@ function getRectFromElement (element)
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
             if(element.type == "SE"){
-                resizedY += (element.height - preResizeHeight[i].height)/2
+                resizedY -= (element.height - preResizeHeight[i].height)/4
                 resizedY += 100;
             }
             return {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2636,6 +2636,14 @@ function mmoving(event)
 
                 // Deduct the new height, giving us the total change
                 const heightChange = -(tmp - elementData.height);
+
+                // Fetch original y-position
+                // "+ 15" hardcoded, for some reason the superstate jumps up 15 pixels when using this node.
+                tmp = elementData.y;
+                elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
+                
+                // Deduct the new position, giving us the total change
+                const yChange = -(tmp - elementData.y);
                 
                 let foundID = false;
                 let resizedElement = elementData;
@@ -2655,7 +2663,7 @@ function mmoving(event)
                     }
                 }
 
-                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, 0, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
+                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             }
 
             document.getElementById(context[0].id).remove();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y + heightChange;
+                    resizedElement.y = elementData.y + heightChange/4;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y += heightChange;
+                            resizedY[i].y += heightChange/4;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y + heightChange;
+                        resizedElement.y = elementData.y + heightChange/4;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2636,14 +2636,6 @@ function mmoving(event)
 
                 // Deduct the new height, giving us the total change
                 const heightChange = -(tmp - elementData.height);
-
-                // Fetch original y-position
-                // "+ 15" hardcoded, for some reason the superstate jumps up 15 pixels when using this node.
-                tmp = elementData.y;
-                elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
-                
-                // Deduct the new position, giving us the total change
-                const yChange = -(tmp - elementData.y);
                 
                 let foundID = false;
                 let resizedElement = elementData;
@@ -2663,7 +2655,7 @@ function mmoving(event)
                     }
                 }
 
-                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
+                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, 0, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             }
 
             document.getElementById(context[0].id).remove();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange/2;
+                    resizedElement.y = elementData.y - heightChange * 0.4;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange/2;
+                            resizedY[i].y -= heightChange * 0.4;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange/2;
+                        resizedElement.y = elementData.y - heightChange * 0.4;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2640,10 +2640,7 @@ function mmoving(event)
                 // Fetch original y-position
                 // "+ 15" hardcoded, for some reason the superstate jumps up 15 pixels when using this node.
                 tmp = elementData.y;
-                let screenTmp = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
-                
-                // Deduct the new position, giving us the total change
-                const yChange = -(tmp - screenTmp);
+                let screenY = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
                 
                 let foundID = false;
                 let resizedElement = elementData;
@@ -2663,7 +2660,7 @@ function mmoving(event)
                     }
                 }
 
-                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
+                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, screenY, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             }
 
             document.getElementById(context[0].id).remove();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3614,8 +3614,8 @@ function getRectFromElement (element)
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
             if(element.type == "SE"){
-                resizedY -= (element.height - preResizeHeight[i].height)/4
-                resizedY += 30;
+                resizedY += (element.height - preResizeHeight[i].height)
+                resizedY += 300;
             }
             return {
                 x: element.x,
@@ -3628,7 +3628,7 @@ function getRectFromElement (element)
     let elementY = element.y;
     if(element.type == "SE"){
         let elementY = element.y;
-        elementY += 30;
+        elementY += 300;
     }
     return {
         x: element.x,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y + heightChange/10;
+                    resizedElement.y = elementData.y + heightChange/14;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y += heightChange/10;
+                            resizedY[i].y += heightChange/14;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y + heightChange/10;
+                        resizedElement.y = elementData.y + heightChange/14;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3614,8 +3614,8 @@ function getRectFromElement (element)
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
             if(element.type == "SE"){
-                resizedY += (element.height - preResizeHeight[i].height)
-                resizedY += 300;
+                resizedY += (element.height - preResizeHeight[i].height)/4
+                resizedY += 800;
             }
             return {
                 x: element.x,
@@ -3628,7 +3628,7 @@ function getRectFromElement (element)
     let elementY = element.y;
     if(element.type == "SE"){
         let elementY = element.y;
-        elementY += 300;
+        elementY += 800;
     }
     return {
         x: element.x,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2640,7 +2640,10 @@ function mmoving(event)
                 // Fetch original y-position
                 // "+ 15" hardcoded, for some reason the superstate jumps up 15 pixels when using this node.
                 tmp = elementData.y;
-                let screenY = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
+                let screenTmp = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
+                
+                // Deduct the new position, giving us the total change
+                const yChange = -(tmp - screenTmp);
                 
                 let foundID = false;
                 let resizedElement = elementData;
@@ -2660,7 +2663,7 @@ function mmoving(event)
                     }
                 }
 
-                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, screenY, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
+                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             }
 
             document.getElementById(context[0].id).remove();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,12 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
+                    resizedElement.y = elementData.y - heightChange/14;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
+                            resizedY[i].y -= heightChange/14;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2662,6 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
+                        resizedElement.y = elementData.y - heightChange/14;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3521,7 +3521,7 @@ function getRectFromElement (element)
         if (element.id == preResizeHeight[i].id) {
             let resizedY = element.y;
             if(preResizeHeight[i].height < element.height){
-                resizedY += (element.height - preResizeHeight[i].height)/4
+                resizedY -= (element.height - preResizeHeight[i].height)/4
             }
             return {
                 x: element.x,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2646,8 +2646,8 @@ function mmoving(event)
                 const yChange = -(tmp - elementData.y);
                 
                 let foundID = false;
-                let resizedElement = elementData;
                 if(resizedY == undefined){
+                    let resizedElement = structuredClone(elementData);
                     resizedElement.y = elementData.y + heightChange;
                     resizedY.push(resizedElement);
                 }else{
@@ -2661,6 +2661,7 @@ function mmoving(event)
                         }
                     }
                     if(!foundID){
+                        let resizedElement = structuredClone(elementData);
                         resizedElement.y = elementData.y + heightChange;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2656,7 +2656,7 @@ function mmoving(event)
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
                             resizedY[i].y += heightChange;
-                            resizedY[i].resizedDifference = resizedY[i].y - elementData.y - resizedDifference;
+                            resizedY[i].resizedDifference = resizedY[i].y - elementData.y - resizedY[i].resizedDifference;
                             console.log(resizedY[i].y);
                             foundID = true;
                             console.log("found ID"+ foundID);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2649,12 +2649,14 @@ function mmoving(event)
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
                     resizedElement.y = elementData.y + heightChange;
+                    resizedElement['resizedDifference'] = resizedElement.y - elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
                             resizedY[i].y += heightChange;
+                            resizedY[i].resizedDifference = resizedY[i].y - elementData.y - resizedDifference;
                             console.log(resizedY[i].y);
                             foundID = true;
                             console.log("found ID"+ foundID);
@@ -2663,6 +2665,7 @@ function mmoving(event)
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
                         resizedElement.y = elementData.y + heightChange;
+                        resizedElement['resizedDifference'] = resizedElement.y - elementData.y;
                         resizedY.push(resizedElement);
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2675,6 +2675,7 @@ function mmoving(event)
                 // Deduct the new height, giving us the total change
                 const heightChange = -(tmp - elementData.height);
 
+                // Adds a deep clone of the element to preResizeHeight if it isn't in it
                 let foundID = false;
                 if(preResizeHeight == undefined){
                     let resizedElement = structuredClone(elementData);
@@ -2710,6 +2711,7 @@ function mmoving(event)
                 // Deduct the new position, giving us the total change
                 const yChange = -(tmp - elementData.y);
                 
+                // Adds a deep clone of the element to preResizeHeight if it isn't in it
                 let foundID = false;
                 if(preResizeHeight == undefined){
                     let resizedElement = structuredClone(elementData);
@@ -3607,15 +3609,16 @@ function getRectFromPoints(topLeft, bottomRight)
  */
 function getRectFromElement (element)
 {
+    // Corrects returned y position due to problems with resizing vertically
     for (let i = 0; i < preResizeHeight.length; i++) {
         if (element.id == preResizeHeight[i].id) {
             let resizedY = element.y;
             if(preResizeHeight[i].height < element.height){
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
+            // Corrects returned y position due to problems with SE types
             let elementY = resizedY;
             if(element.type == "SE"){
-                console.log("SE resized");
                 elementY += preResizeHeight[i].height/3;
             }
             return {
@@ -3626,9 +3629,10 @@ function getRectFromElement (element)
             };
         }
     }
+    
+    // Corrects returned y position due to problems with resizing vertically
     let elementY = element.y;
     if(element.type == "SE"){
-        console.log("SE normal");
         elementY += element.height/3;
     }
     return {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1124,7 +1124,7 @@ var errorData = []; // List of all elements with an error in diagram
 var UMLHeight = []; // List with UML Entities' real height
 var IEHeight = []; // List with IE Entities' real height
 var SDHeight = []; // List with SD Entities' real height
-var resizedY = []; // List with elements' different y position for box selection due to problems with resizing height
+var preResizeHeight = []; // List with elements' and their starting height for box selection due to problems with resizing height
 
 
 // Ghost element is used for placing new elements. DO NOT PLACE GHOST ELEMENTS IN DATA ARRAY UNTILL IT IS PRESSED!
@@ -2646,27 +2646,18 @@ function mmoving(event)
                 const yChange = -(tmp - elementData.y);
                 
                 let foundID = false;
-                if(resizedY == undefined){
+                if(preResizeHeight == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange * 0.49;
-                    resizedElement['elementY'] = elementData.y;
-                    resizedY.push(resizedElement);
+                    preResizeHeight.push(resizedElement);
                 }else{
-                    for (var i = 0; i < resizedY.length; i++) {
-                        if (elementData.id == resizedY[i].id) {
-                            console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange * 0.49;
-                            resizedY[i].elementY = elementData.y;
-                            console.log(resizedY[i].y);
+                    for (var i = 0; i < preResizeHeight.length; i++) {
+                        if (elementData.id == preResizeHeight[i].id) {
                             foundID = true;
-                            console.log("found ID"+ foundID);
                         }
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange * 0.49;
-                        resizedElement['elementY'] = elementData.y;
-                        resizedY.push(resizedElement);
+                        preResizeHeight.push(resizedElement);
                     }
                 }
 
@@ -3526,12 +3517,15 @@ function getRectFromPoints(topLeft, bottomRight)
 function getRectFromElement (element)
 {
     console.log("getRectFromElement");
-    for (var i = 0; i < resizedY.length; i++) {
-        if (element.id == resizedY[i].id) {
-            console.log("resizedY "+resizedY[i].y);
+    for (var i = 0; i < preResizeHeight.length; i++) {
+        if (element.id == preResizeHeight[i].id) {
+            let resizedY = element.y;
+            if(preResizeHeight[i].height < element.height){
+                resizedY -= (element.height - preResizeHeight[i].height)/4
+            }
             return {
                 x: element.x,
-                y: resizedY[i].y + element.y - resizedY[i].elementY,
+                y: resizedY,
                 width: element.width,
                 height: element.height
             };

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3614,8 +3614,7 @@ function getRectFromElement (element)
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
             if(element.type == "SE"){
-                resizedY -= (element.height - preResizeHeight[i].height)/8
-                resizedY += 1500;
+                resizedY += (element.height - preResizeHeight[i].height)/8
             }
             return {
                 x: element.x,
@@ -3625,14 +3624,9 @@ function getRectFromElement (element)
             };
         }
     }
-    let elementY = element.y;
-    if(element.type == "SE"){
-        let elementY = element.y;
-        elementY += 1500;
-    }
     return {
         x: element.x,
-        y: elementY,
+        y: element.y,
         width: element.width,
         height: element.height,
     };

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9213,10 +9213,6 @@ function addNodes(element)
     nodes += "<span id='ml' class='node ml'></span>";
     nodes += "<span id='md' class='node md'></span>";
     nodes += "<span id='mu' class='node mu'></span>";
-    //vertical resizing
-    if ((element.kind == "sequenceActorAndObject") || (element.kind == "sequenceLoopOrAlt") || (element.kind == "sequenceActivation")) {
-        nodes += "<span id='md' class='node md'></span>";
-    }
 
     if (element.kind == "UMLSuperState") {
         nodes += "<span id='md' class='node md'></span>";

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2646,9 +2646,10 @@ function mmoving(event)
                 const yChange = -(tmp - elementData.y);
                 
                 let foundID = false;
+                let resizedElement = elementData;
                 if(resizedY == undefined){
-                    elementData.y -= heightChange/2;
-                    resizedY.push(elementData);
+                    resizedElement.y = elementData.y - heightChange/2;
+                    resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
@@ -2657,8 +2658,8 @@ function mmoving(event)
                         }
                     }
                     if(!foundID){
-                        elementData.y -= heightChange/2;
-                        resizedY.push(elementData);
+                        resizedElement.y -= heightChange/2;
+                        resizedY.push(resizedElement.y);
                     }
                 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9536,7 +9536,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.5))}px; width:${boxw}px;font-size:${texth}px;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -10263,6 +10263,7 @@ function drawElement(element, ghosted = false)
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
+                            margin-top:${((boxh / 2))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange/3;
+                    resizedElement.y = elementData.y - heightChange/2;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange/3;
+                            resizedY[i].y -= heightChange/2;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange/3;
+                        resizedElement.y = elementData.y - heightChange/2;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2646,8 +2646,8 @@ function mmoving(event)
                 const yChange = -(tmp - elementData.y);
                 
                 let foundID = false;
-                let resizedElement = elementData;
                 if(resizedY == undefined){
+                    let resizedElement = elementData.slice(0);
                     resizedElement.y = elementData.y + heightChange;
                     resizedY.push(resizedElement);
                 }else{
@@ -2661,6 +2661,7 @@ function mmoving(event)
                         }
                     }
                     if(!foundID){
+                        let resizedElement = elementData.slice(0);
                         resizedElement.y = elementData.y + heightChange;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3614,7 +3614,8 @@ function getRectFromElement (element)
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
             if(element.type == "SE"){
-                resizedY += 300;
+                resizedY -= (element.height - preResizeHeight[i].height)/4
+                resizedY += 30;
             }
             return {
                 x: element.x,
@@ -3624,9 +3625,14 @@ function getRectFromElement (element)
             };
         }
     }
+    let elementY = element.y;
+    if(element.type == "SE"){
+        let elementY = element.y;
+        elementY += 30;
+    }
     return {
         x: element.x,
-        y: element.y,
+        y: elementY,
         width: element.width,
         height: element.height,
     };

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange * 0.4;
+                    resizedElement.y = elementData.y - heightChange * 0.45;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange * 0.4;
+                            resizedY[i].y -= heightChange * 0.45;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange * 0.4;
+                        resizedElement.y = elementData.y - heightChange * 0.45;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3532,7 +3532,6 @@ function getRectFromPoints(topLeft, bottomRight)
  */
 function getRectFromElement (element)
 {
-    console.log("getRectFromElement");
     for (var i = 0; i < preResizeHeight.length; i++) {
         if (element.id == preResizeHeight[i].id) {
             let resizedY = element.y;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2680,7 +2680,7 @@ function mmoving(event)
                     let resizedElement = structuredClone(elementData);
                     preResizeHeight.push(resizedElement);
                 }else{
-                    for (var i = 0; i < preResizeHeight.length; i++) {
+                    for (let i = 0; i < preResizeHeight.length; i++) {
                         if (elementData.id == preResizeHeight[i].id) {
                             foundID = true;
                         }
@@ -2715,7 +2715,7 @@ function mmoving(event)
                     let resizedElement = structuredClone(elementData);
                     preResizeHeight.push(resizedElement);
                 }else{
-                    for (var i = 0; i < preResizeHeight.length; i++) {
+                    for (let i = 0; i < preResizeHeight.length; i++) {
                         if (elementData.id == preResizeHeight[i].id) {
                             foundID = true;
                         }
@@ -3607,15 +3607,14 @@ function getRectFromPoints(topLeft, bottomRight)
  */
 function getRectFromElement (element)
 {
-    for (var i = 0; i < preResizeHeight.length; i++) {
+    for (let i = 0; i < preResizeHeight.length; i++) {
         if (element.id == preResizeHeight[i].id) {
             let resizedY = element.y;
             if(preResizeHeight[i].height < element.height){
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
             if(element.type == "SE"){
-                resizedY -= (element.height - preResizeHeight[i].height)/4
-                resizedY += 100;
+                resizedY += 300;
             }
             return {
                 x: element.x,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange * 0.48;
+                    resizedElement.y = elementData.y - heightChange * 0.49;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange * 0.48;
+                            resizedY[i].y -= heightChange * 0.49;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange * 0.48;
+                        resizedElement.y = elementData.y - heightChange * 0.49;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange/14;
+                    resizedElement.y = elementData.y - heightChange/3;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange/14;
+                            resizedY[i].y -= heightChange/3;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange/14;
+                        resizedElement.y = elementData.y - heightChange/3;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3519,6 +3519,7 @@ function getRectFromElement (element)
 {
     for (var i = 0; i < resizedY.length; i++) {
         if (element.id == resizedY[i].id) {
+            console.log("resizedY "+resizedY[i].y);
             return {
                 x: element.x,
                 y: resizedY[i].y,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,17 +2648,17 @@ function mmoving(event)
                 let foundID = false;
                 let resizedElement = elementData;
                 if(resizedY == undefined){
-                    resizedElement.y = elementData.y - heightChange/2;
+                    resizedElement.y = elementData.y - heightChange;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
-                            resizedY[i].y -= heightChange/2;
+                            resizedY[i].y -= heightChange;
                             foundID = true;
                         }
                     }
                     if(!foundID){
-                        resizedElement.y = elementData.y - heightChange/2;
+                        resizedElement.y = elementData.y - heightChange;
                         resizedY.push(resizedElement);
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3521,7 +3521,7 @@ function getRectFromElement (element)
         if (element.id == preResizeHeight[i].id) {
             let resizedY = element.y;
             if(preResizeHeight[i].height < element.height){
-                resizedY += (element.height - preResizeHeight[i].height)/4
+                resizedY += (element.height - preResizeHeight[i].height)/2
             }
             return {
                 x: element.x,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y + heightChange/4;
+                    resizedElement.y = elementData.y + heightChange/10;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y += heightChange/4;
+                            resizedY[i].y += heightChange/10;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y + heightChange/4;
+                        resizedElement.y = elementData.y + heightChange/10;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3613,9 +3613,6 @@ function getRectFromElement (element)
             if(preResizeHeight[i].height < element.height){
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
-            if(element.type == "SE"){
-                resizedY += (element.height - preResizeHeight[i].height)/8
-            }
             return {
                 x: element.x,
                 y: resizedY,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2638,7 +2638,7 @@ function mmoving(event)
                 const heightChange = -(tmp - elementData.height);
 
                 // Fetch original y-position
-                // "+ 15" hardcoded, for some reason the superstate jumps up 14 pixels when using this node.
+                // "+ 14" hardcoded, for some reason the superstate jumps up 14 pixels when using this node.
                 tmp = elementData.y;
                 elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 14)).y;
                 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3517,6 +3517,7 @@ function getRectFromPoints(topLeft, bottomRight)
  */
 function getRectFromElement (element)
 {
+    console.log("getRectFromElement");
     for (var i = 0; i < resizedY.length; i++) {
         if (element.id == resizedY[i].id) {
             console.log("resizedY "+resizedY[i].y);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,17 +2648,17 @@ function mmoving(event)
                 let foundID = false;
                 let resizedElement = elementData;
                 if(resizedY == undefined){
-                    resizedElement.y = elementData.y - heightChange;
+                    resizedElement.y = elementData.y + heightChange;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
-                            resizedY[i].y -= heightChange;
+                            resizedY[i].y += heightChange;
                             foundID = true;
                         }
                     }
                     if(!foundID){
-                        resizedElement.y = elementData.y - heightChange;
+                        resizedElement.y = elementData.y + heightChange;
                         resizedY.push(resizedElement);
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3614,8 +3614,8 @@ function getRectFromElement (element)
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
             if(element.type == "SE"){
-                resizedY += (element.height - preResizeHeight[i].height)/4
-                resizedY += 800;
+                resizedY -= (element.height - preResizeHeight[i].height)/8
+                resizedY += 1500;
             }
             return {
                 x: element.x,
@@ -3628,7 +3628,7 @@ function getRectFromElement (element)
     let elementY = element.y;
     if(element.type == "SE"){
         let elementY = element.y;
-        elementY += 800;
+        elementY += 1500;
     }
     return {
         x: element.x,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3684,7 +3684,6 @@ function rectsIntersect (left, right)
              // Set the new snap point to center of element
              obj.x -= obj.width / 2;
              obj.y -= obj.height / 2;
-             console.log(obj.width, obj.height, "tester");
 
            } else {
              obj.x += (targetDelta.x / zoomfact);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,17 +2648,17 @@ function mmoving(event)
                 let foundID = false;
                 let resizedElement = elementData;
                 if(resizedY == undefined){
-                    resizedElement.y = elementData.y + heightChange * 1000;
+                    resizedElement.y = elementData.y + heightChange;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
-                            resizedY[i].y += heightChange * 1000;
+                            resizedY[i].y += heightChange;
                             foundID = true;
                         }
                     }
                     if(!foundID){
-                        resizedElement.y = elementData.y + heightChange * 1000;
+                        resizedElement.y = elementData.y + heightChange;
                         resizedY.push(resizedElement);
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2649,14 +2649,14 @@ function mmoving(event)
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
                     resizedElement.y = elementData.y + heightChange;
-                    resizedElement['resizedDifference'] = resizedElement.y - elementData.y;
+                    resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
                             resizedY[i].y += heightChange;
-                            resizedY[i].resizedDifference = resizedY[i].y - elementData.y - resizedY[i].resizedDifference;
+                            resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
                             console.log("found ID"+ foundID);
@@ -2665,7 +2665,7 @@ function mmoving(event)
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
                         resizedElement.y = elementData.y + heightChange;
-                        resizedElement['resizedDifference'] = resizedElement.y - elementData.y;
+                        resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }
                 }
@@ -3531,7 +3531,7 @@ function getRectFromElement (element)
             console.log("resizedY "+resizedY[i].y);
             return {
                 x: element.x,
-                y: resizedY[i].y * 2 - element.y - resizedY[i].resizedDifference,
+                y: resizedY[i].y + element.y - resizedY[i].elementY,
                 width: element.width,
                 height: element.height
             };

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2655,6 +2655,7 @@ function mmoving(event)
                         if (elementData.id == resizedY[i].id) {
                             resizedY[i].y += heightChange;
                             foundID = true;
+                            console.log("found ID"+ foundID);
                         }
                     }
                     if(!foundID){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3613,6 +3613,9 @@ function getRectFromElement (element)
             if(preResizeHeight[i].height < element.height){
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
+            if(element.type == "SE"){
+                resizedY += 30;
+            }
             return {
                 x: element.x,
                 y: resizedY,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3613,17 +3613,27 @@ function getRectFromElement (element)
             if(preResizeHeight[i].height < element.height){
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
+            let elementY = resizedY;
+            if(element.type == "SE"){
+                console.log("SE resized");
+                elementY += preResizeHeight[i].height/3;
+            }
             return {
                 x: element.x,
-                y: resizedY,
+                y: elementY,
                 width: element.width,
                 height: element.height
             };
         }
     }
+    let elementY = element.y;
+    if(element.type == "SE"){
+        console.log("SE normal");
+        elementY += element.height/3;
+    }
     return {
         x: element.x,
-        y: element.y,
+        y: elementY,
         width: element.width,
         height: element.height,
     };

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2653,7 +2653,9 @@ function mmoving(event)
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
+                            console.log(resizedY[i].y);
                             resizedY[i].y += heightChange;
+                            console.log(resizedY[i].y);
                             foundID = true;
                             console.log("found ID"+ foundID);
                         }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange/14;
+                    resizedElement.y = elementData.y - heightChange/100;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange/14;
+                            resizedY[i].y -= heightChange/100;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange/14;
+                        resizedElement.y = elementData.y - heightChange/100;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange/100;
+                    resizedElement.y = elementData.y - heightChange/33;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange/100;
+                            resizedY[i].y -= heightChange/33;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange/100;
+                        resizedElement.y = elementData.y - heightChange/33;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange/20;
+                    resizedElement.y = elementData.y - heightChange/14;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange/20;
+                            resizedY[i].y -= heightChange/14;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange/20;
+                        resizedElement.y = elementData.y - heightChange/14;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2646,8 +2646,8 @@ function mmoving(event)
                 const yChange = -(tmp - elementData.y);
                 
                 let foundID = false;
+                let resizedElement = elementData;
                 if(resizedY == undefined){
-                    let resizedElement = elementData.slice(0);
                     resizedElement.y = elementData.y + heightChange;
                     resizedY.push(resizedElement);
                 }else{
@@ -2661,7 +2661,6 @@ function mmoving(event)
                         }
                     }
                     if(!foundID){
-                        let resizedElement = elementData.slice(0);
                         resizedElement.y = elementData.y + heightChange;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2625,6 +2625,22 @@ function mmoving(event)
 
                 // Deduct the new height, giving us the total change
                 const heightChange = -(tmp - elementData.height);
+
+                let foundID = false;
+                if(preResizeHeight == undefined){
+                    let resizedElement = structuredClone(elementData);
+                    preResizeHeight.push(resizedElement);
+                }else{
+                    for (var i = 0; i < preResizeHeight.length; i++) {
+                        if (elementData.id == preResizeHeight[i].id) {
+                            foundID = true;
+                        }
+                    }
+                    if(!foundID){
+                        let resizedElement = structuredClone(elementData);
+                        preResizeHeight.push(resizedElement);
+                    }
+                }
                 
                 stateMachine.save(StateChangeFactory.ElementResized([elementData.id], 0, heightChange), StateChange.ChangeTypes.ELEMENT_RESIZED);
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3531,7 +3531,7 @@ function getRectFromElement (element)
             console.log("resizedY "+resizedY[i].y);
             return {
                 x: element.x,
-                y: resizedY[i].y * 2 - element.x - resizedY[i].resizedDifference,
+                y: resizedY[i].y * 2 - element.y - resizedY[i].resizedDifference,
                 width: element.width,
                 height: element.height
             };

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3614,6 +3614,7 @@ function getRectFromElement (element)
                 resizedY += (element.height - preResizeHeight[i].height)/2
             }
             if(element.type == "SE"){
+                resizedY += (element.height - preResizeHeight[i].height)/2
                 resizedY += 30;
             }
             return {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,12 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y + heightChange/14;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y += heightChange/14;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2662,6 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y + heightChange/14;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3615,7 +3615,7 @@ function getRectFromElement (element)
             }
             if(element.type == "SE"){
                 resizedY += (element.height - preResizeHeight[i].height)/2
-                resizedY += 30;
+                resizedY += 100;
             }
             return {
                 x: element.x,

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,17 +2648,17 @@ function mmoving(event)
                 let foundID = false;
                 let resizedElement = elementData;
                 if(resizedY == undefined){
-                    resizedElement.y = elementData.y + heightChange;
+                    resizedElement.y = elementData.y + heightChange * 1000;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
-                            resizedY[i].y += heightChange;
+                            resizedY[i].y += heightChange * 1000;
                             foundID = true;
                         }
                     }
                     if(!foundID){
-                        resizedElement.y = elementData.y + heightChange;
+                        resizedElement.y = elementData.y + heightChange * 1000;
                         resizedY.push(resizedElement);
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2638,9 +2638,9 @@ function mmoving(event)
                 const heightChange = -(tmp - elementData.height);
 
                 // Fetch original y-position
-                // "+ 15" hardcoded, for some reason the superstate jumps up 15 pixels when using this node.
+                // "+ 15" hardcoded, for some reason the superstate jumps up 14 pixels when using this node.
                 tmp = elementData.y;
-                elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
+                elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 14)).y;
                 
                 // Deduct the new position, giving us the total change
                 const yChange = -(tmp - elementData.y);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2658,8 +2658,8 @@ function mmoving(event)
                         }
                     }
                     if(!foundID){
-                        resizedElement.y -= heightChange/2;
-                        resizedY.push(resizedElement.y);
+                        resizedElement.y = elementData.y - heightChange/2;
+                        resizedY.push(resizedElement);
                     }
                 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2648,14 +2648,14 @@ function mmoving(event)
                 let foundID = false;
                 if(resizedY == undefined){
                     let resizedElement = structuredClone(elementData);
-                    resizedElement.y = elementData.y - heightChange/33;
+                    resizedElement.y = elementData.y - heightChange/20;
                     resizedElement['elementY'] = elementData.y;
                     resizedY.push(resizedElement);
                 }else{
                     for (var i = 0; i < resizedY.length; i++) {
                         if (elementData.id == resizedY[i].id) {
                             console.log(resizedY[i].y);
-                            resizedY[i].y -= heightChange/33;
+                            resizedY[i].y -= heightChange/20;
                             resizedY[i].elementY = elementData.y;
                             console.log(resizedY[i].y);
                             foundID = true;
@@ -2664,7 +2664,7 @@ function mmoving(event)
                     }
                     if(!foundID){
                         let resizedElement = structuredClone(elementData);
-                        resizedElement.y = elementData.y - heightChange/33;
+                        resizedElement.y = elementData.y - heightChange/20;
                         resizedElement['elementY'] = elementData.y;
                         resizedY.push(resizedElement);
                     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2640,10 +2640,10 @@ function mmoving(event)
                 // Fetch original y-position
                 // "+ 15" hardcoded, for some reason the superstate jumps up 15 pixels when using this node.
                 tmp = elementData.y;
-                elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
+                let screenTmp = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
                 
                 // Deduct the new position, giving us the total change
-                const yChange = -(tmp - elementData.y);
+                const yChange = -(tmp - screenTmp);
                 
                 let foundID = false;
                 let resizedElement = elementData;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2640,10 +2640,10 @@ function mmoving(event)
                 // Fetch original y-position
                 // "+ 15" hardcoded, for some reason the superstate jumps up 15 pixels when using this node.
                 tmp = elementData.y;
-                let screenTmp = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
+                elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 15)).y;
                 
                 // Deduct the new position, giving us the total change
-                const yChange = -(tmp - screenTmp);
+                const yChange = -(tmp - elementData.y);
                 
                 let foundID = false;
                 let resizedElement = elementData;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3521,7 +3521,7 @@ function getRectFromElement (element)
         if (element.id == preResizeHeight[i].id) {
             let resizedY = element.y;
             if(preResizeHeight[i].height < element.height){
-                resizedY -= (element.height - preResizeHeight[i].height)/4
+                resizedY += (element.height - preResizeHeight[i].height)/4
             }
             return {
                 x: element.x,


### PR DESCRIPTION
The title is misleading, you can group-select sequence objects. The problem is that resizing an element vertically changes the y position detected when group-selecting and makes it so that the visual location doesn't match up to the actual location needed to include in Box Selection. 

I've fixed that by storing the height when first resizing an element and changing the compared y position based on the difference with their current height. You still need the Box Selection box to be a bit above them, but that has nothing to do with resizing and was both there before I started and was possibly intended.