### PR TITLE
Strange behaviour when both template and example diagrams are toggled on #14233

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -955,6 +955,10 @@
                 <button id="rulerSnapToGrid" class="saveButton" style="background-color: transparent; border:#614875; border-width:3px; border-style:solid; color:#614875; font-weight: bold;" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
                 <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Ruler</button><br><br>
                 <button id="a4TemplateToggle" class="saveButton" style="background-color: transparent; border:#614875; border-width:3px; border-style:solid; color:#614875; font-weight: bold;" onclick="toggleA4Template()">A4 template</button><br><br>
+                <div id="a4Options" style="display:flex;">
+                    <button id="a4VerticalButton" style="display:none; width:76px; margin-right:45%;" onclick="toggleA4Vertical()">Vertical</button>
+                    <button id="a4HorizontalButton" style="display:none;" onclick="toggleA4Horizontal()">Horizontal</button>
+                </div>
                 <button id="darkmodeToggle" class="saveButton" style="background-color: transparent; border:#614875; border-width:3px; border-style:solid; color:#614875; font-weight: bold;" onclick="toggleDarkmode()">Darkmode</button><br><br>
                 <button id="diagramDropDownToggle" class="saveButton" style="background-color: transparent; border:#614875; border-width:3px; border-style:solid; color:#614875; font-weight: bold;" onclick="toggleDiagramDropdown()">Example diagrams </button><br><br>
                 <div class="dropdownContent">
@@ -965,11 +969,6 @@
                         <option value="JSON/ERDiagramMockup.json">ER diagrams </option>
                     </select>
                     <button class="saveButton" id="diagramLoad" onclick="loadMockupDiagram();">Load</button>
-                </div>
-
-                <div id="a4Options" style="display:flex;">
-                    <button id="a4VerticalButton" style="display:none; width:76px; margin-right:45%;" onclick="toggleA4Vertical()">Vertical</button>
-                    <button id="a4HorizontalButton" style="display:none;" onclick="toggleA4Horizontal()">Horizontal</button>
                 </div>
             </fieldset>
             <fieldset class='options-fieldset options-section'>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1017,9 +1017,9 @@
                 <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
                 <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Ruler</button><br><br>
                 <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">A4 template</button><br><br>
-                <div id="a4Options" style="display:flex;">
-                    <button id="a4VerticalButton" style="display:none; width:76px; margin-right:45%;" onclick="toggleA4Vertical()">Vertical</button>
-                    <button id="a4HorizontalButton" style="display:none;" onclick="toggleA4Horizontal()">Horizontal</button>
+                <div id="a4Options">
+                    <button id="a4VerticalButton" onclick="toggleA4Vertical()">Vertical</button>
+                    <button id="a4HorizontalButton" onclick="toggleA4Horizontal()">Horizontal</button>
                 </div>
                 <button id="darkmodeToggle" class="saveButton" onclick="toggleDarkmode()">Darkmode</button><br><br>
                 <button id="diagramDropDownToggle" class="saveButton" onclick="toggleDiagramDropdown()">Example diagrams </button><br><br>


### PR DESCRIPTION
Placed Vertical and Horizontal buttons under A4 template.
So it looks like this:
![image](https://github.com/HGustavs/LenaSYS/assets/57549915/bf7d0a79-4d2e-4c21-a83e-5aec091948de)
Instead of this:
![image](https://github.com/HGustavs/LenaSYS/assets/57549915/00afdda2-4e88-499c-8352-d4e385585283)