### PR TITLE
A4 template in darkmode #14232

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1287,4 +1287,8 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 .boxSelectionLines {
     stroke:#fff;
 }
+
+#a4Text {
+    fill: white;
+}
 /*/ END /*/


### PR DESCRIPTION
Fixed color of a4 template text when in darkmode. Solves #14232 