### PR TITLE
Master g1 context pane fix | Null checking element.type being reassigned

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1173,7 +1173,7 @@ var defaults = {
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "SE", canChangeTo: null }, // Sequence Activation.
     sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "SE", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt", canChangeTo: null }, // Sequence Loop or Alternative.
 
-    note: { name: "Note", kind: "note", fill: "#FFFFFF", stroke: "#000000", width: 200, height: 50, type: "NOTE", attributes: ['Note'],},  // Note.
+    note: { name: "Note", kind: "NOTE", fill: "#FFFFFF", stroke: "#000000", width: 200, height: 50, type: "NOTE", attributes: ['Note'],},  // Note.
 }
 var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
@@ -9976,7 +9976,7 @@ function drawElement(element, ghosted = false)
     }
     //=============================================== <-- End of Sequnece functionality
     //=============================================== <-- Start Note functionality
-    else if (element.kind == "note") {
+    else if (element.kind == "NOTE") {
         const maxCharactersPerLine = Math.floor((boxw / texth) * 1.75);
         const theme = document.getElementById("themeBlack");
         const splitLengthyLine = (str, max) => {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2780,8 +2780,10 @@ function changeState()
             }
 
             //Update element type
-            element.type = newType;
-            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+            if (newType != undefined) {
+                element.type = newType;
+                stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+            }
         }
 
         var property = document.getElementById("propertySelect").value;
@@ -2806,8 +2808,10 @@ function changeState()
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         //Update element type
-        element.type = newType;
-        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        if (newType != undefined) {
+            element.type = newType;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
 
     }
     else if(element.type=='IE') {
@@ -2827,8 +2831,10 @@ function changeState()
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         //Update element type
-        element.type = newType;
-        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        if (newType != undefined) {
+            element.type = newType;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
 
     }
 
@@ -2843,8 +2849,10 @@ function changeState()
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         //Update element type
-        element.type = newType;
-        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        if (newType != undefined) {
+            element.type = newType;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
 
     }
     
@@ -2859,8 +2867,10 @@ function changeState()
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         //Update element type
-        element.type = newType;
-        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        if (newType != undefined) {
+            element.type = newType;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
 
     }
     else if (element.type == 'NOTE') {
@@ -2873,8 +2883,10 @@ function changeState()
             stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { kind: newKind }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         }
         //Update element type
-        element.type = newType;
-        stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        if (newType != undefined) {
+            element.type = newType;
+            stateMachine.save(StateChangeFactory.ElementAttributesChanged(element.id, { type: newType }), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        }
 
     }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -836,7 +836,7 @@ const elementTypesNames = {
     sequenceActorAndObject: "sequenceActorAndObject",
     sequenceActivation: "sequenceActivation",
     sequenceLoopOrAlt: "sequenceLoopOrAlt",
-    note: "Note",
+    note: "NOTE",
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -836,7 +836,7 @@ const elementTypesNames = {
     sequenceActorAndObject: "sequenceActorAndObject",
     sequenceActivation: "sequenceActivation",
     sequenceLoopOrAlt: "sequenceLoopOrAlt",
-    note: "NOTE",
+    note: "Note",
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1173,7 +1173,7 @@ var defaults = {
     sequenceActivation: {name: "Activation", kind: "sequenceActivation", fill: "#FFFFFF", stroke: "#000000", width: 30, height: 300, type: "SE", canChangeTo: null }, // Sequence Activation.
     sequenceLoopOrAlt: {kind: "sequenceLoopOrAlt", fill: "#FFFFFF", stroke: "#000000", width: 750, height: 300, type: "SE", alternatives: ["alternative1","alternative2","alternative3"], altOrLoop: "Alt", canChangeTo: null }, // Sequence Loop or Alternative.
 
-    note: { name: "Note", kind: "NOTE", fill: "#FFFFFF", stroke: "#000000", width: 200, height: 50, type: "NOTE", attributes: ['Note'],},  // Note.
+    note: { name: "Note", kind: "note", fill: "#FFFFFF", stroke: "#000000", width: 200, height: 50, type: "NOTE", attributes: ['Note'],},  // Note.
 }
 var defaultLine = { kind: "Normal" };
 //#endregion ===================================================================================
@@ -9988,7 +9988,7 @@ function drawElement(element, ghosted = false)
     }
     //=============================================== <-- End of Sequnece functionality
     //=============================================== <-- Start Note functionality
-    else if (element.kind == "NOTE") {
+    else if (element.kind == "note") {
         const maxCharactersPerLine = Math.floor((boxw / texth) * 1.75);
         const theme = document.getElementById("themeBlack");
         const splitLengthyLine = (str, max) => {


### PR DESCRIPTION
There was a problem of not being able to change any attributes, like name etc to anything. This completely broke the context pane. This was fixed by surrounding the reassigning of element.type with an if statement making sure its not undefined first

Please look at files changed, there is only if statements added that checks its not null

This was done together with me (@a21aldsa), the group leader (@b21eriho), the issue leader (@b21phiro) and also @a19clasv 