### PR TITLE
Extra functionality for "reset view" button #14235

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13444,9 +13444,9 @@ function resetDiagram(){
     zoomfact = 1;
 
     // Reset the scroll coordinates to center the camera at 0, 0
-    scrollx = -(window.innerWidth / 2);
-    scrolly = -(window.innerHeight / 2);
-    
+    scrollx = -(window.innerWidth / (2 * zoomfact));
+    scrolly = -(window.innerHeight / (2 * zoomfact));
+
     // Update the elements of the screen
     showdata();
     updatepos();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13439,14 +13439,8 @@ function resetDiagram(){
     //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
     //fetchDiagramFileContentOnLoad();
     */
-    // Goto the beginning of the diagram
-    stateMachine.gotoInitialState();
 
-    // Remove the previous history
-    stateMachine.currentHistoryIndex = -1;
-    stateMachine.lastFlag = {};
-    stateMachine.removeFutureStates();
-
+    centerCamera();
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13443,30 +13443,10 @@ function resetDiagram(){
     // Reset the zoom factor and the scroll coordinates to its default value
     zoomfact = 1;
 
-
-    // Center of screen in pixels
-    var centerScreen = {
-        x: window.innerWidth / 2,
-        y: window.innerHeight / 2
-    };
-
-    // Center of diagram in coordinates
-    var centerDiagram = {
-        x: minX + (maxX - minX) / 2,
-        y: minY + (maxY - minY) / 2
-    };
-
-    // Move camera to center of diagram
-    scrollx = centerDiagram.x * zoomfact;
-    scrolly = centerDiagram.y * zoomfact;
-
-    var middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
-    document.getElementById("zoom-message").innerHTML = zoomfact + "x";
-
-
-    scrollx = middleCoordinate.x;
-    scrolly = middleCoordinate.y;
-
+    // Reset the scroll coordinates to center the camera at 0, 0
+    scrollx = -(window.innerWidth / 2);
+    scrolly = -(window.innerHeight / 2);
+    
     // Update the elements of the screen
     showdata();
     updatepos();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13440,18 +13440,12 @@ function resetDiagram(){
     //fetchDiagramFileContentOnLoad();
     */
 
-    // Reset the zoom factor to its default value
+    // Reset the zoom factor and the scroll coordinates to its default value
     zoomfact = 1;
 
-    // Calculate the center of the diagram
-    var centerDiagram = {
-        x: (minX + maxX) / 2,
-        y: (minY + maxY) / 2
-    };
-
-    // Move camera to center of diagram
-    scrollx = centerDiagram.x * zoomfact;
-    scrolly = centerDiagram.y * zoomfact;
+    // Reset the scroll coordinates to (0, 0)
+    scrollx = window.innerWidth / (2 * zoomfact);
+    scrolly = window.innerHeight / (2 * zoomfact);
 
     // Update the elements of the screen
     showdata();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12865,10 +12865,10 @@ function showdata()
 function centerCamera()
 {
     // Stops execution if there are no elements to center the camera around.
-    //if (data.length == 0) {
-    //    displayMessage(messageTypes.ERROR, "Error: There are no elements to center to!");
-    //  return;
-    //}
+    if (data.length == 0) {
+        displayMessage(messageTypes.ERROR, "Error: There are no elements to center to!");
+        return;
+    }
 
     //desiredZoomfact = zoomfact;
     zoomfact = 1;
@@ -13439,8 +13439,32 @@ function resetDiagram(){
     //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
     //fetchDiagramFileContentOnLoad();
     */
+   
+    // Set the default zoom factor
+    var defaultZoomFactor = 1;
 
-    centerCamera();
+    // Set the default scroll coordinates
+    var defaultScrollX = 0;
+    var defaultScrollY = 0;
+
+    // Reset the zoom factor
+    zoomfact = defaultZoomFactor;
+
+    // Reset the scroll coordinates
+    scrollx = defaultScrollX;
+    scrolly = defaultScrollY;
+
+    // Update screen elements
+    showdata();
+    updatepos();
+    updateGridPos();
+    updateGridSize();
+    drawRulerBars(scrollx, scrolly);
+    updateA4Pos();
+    updateA4Size();
+    zoomCenter(); // Assuming this function is responsible for handling zoom centering
+    displayMessage(messageTypes.SUCCESS, "Camera view reset to default.");
+
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13439,6 +13439,12 @@ function resetDiagram(){
     //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
     //fetchDiagramFileContentOnLoad();
     */
+   
+
+ 
+
+    // Update screen elements
+    drawRulerBars(scrollx, scrolly);
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13439,8 +13439,9 @@ function resetDiagram(){
     //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
     //fetchDiagramFileContentOnLoad();
     */
-    zoomreset()
-    
+    zoomreset();
+    zoomCenter();
+
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13442,11 +13442,10 @@ function resetDiagram(){
 
     // Reset the zoom factor and the scroll coordinates to its default value
     zoomfact = 1;
-    scrollY = 0;
-    scrollx = 0;
+
     // Reset the scroll coordinates to center the camera at 0, 0
-    //scrollx = -(window.innerWidth / (2 * zoomfact));
-    //scrolly = -(window.innerHeight / (2 * zoomfact));
+    scrollx = 0;
+    scrolly = 0;
 
 
     // Update the elements of the screen
@@ -13459,7 +13458,7 @@ function resetDiagram(){
     updateA4Size();
 
     //Reset the zoomCenter
-    zoomCenter(centerDiagram);
+    zoomCenter({ x: 0, y: 0 });
 
     // Display success message
     displayMessage(messageTypes.SUCCESS, "Diagram reset to default.");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12865,10 +12865,10 @@ function showdata()
 function centerCamera()
 {
     // Stops execution if there are no elements to center the camera around.
-    if (data.length == 0) {
-        displayMessage(messageTypes.ERROR, "Error: There are no elements to center to!");
-        return;
-    }
+    //if (data.length == 0) {
+    //    displayMessage(messageTypes.ERROR, "Error: There are no elements to center to!");
+    //  return;
+    //}
 
     //desiredZoomfact = zoomfact;
     zoomfact = 1;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13446,6 +13446,7 @@ function resetDiagram(){
     // Reset the scroll coordinates to center the camera at 0, 0
     scrollx = 0;
     scrolly = 0;
+    centerDiagram = 0;
 
 
     // Update the elements of the screen
@@ -13456,9 +13457,7 @@ function resetDiagram(){
     drawRulerBars(scrollx, scrolly);
     updateA4Pos();
     updateA4Size();
-
-    //Reset the zoomCenter
-    zoomCenter({ x: 0, y: 0 });
+    zoomCenter(centerDiagram);
 
     // Display success message
     displayMessage(messageTypes.SUCCESS, "Diagram reset to default.");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13451,12 +13451,7 @@ function resetDiagram(){
     scrolly = defaultScrollY;
 
     // Update screen elements
-    updatepos();
-    updateGridPos();
-    updateGridSize();
     drawRulerBars(scrollx, scrolly);
-    updateA4Pos();
-    updateA4Size();
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13439,19 +13439,6 @@ function resetDiagram(){
     //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
     //fetchDiagramFileContentOnLoad();
     */
-   
-
-    // Set the default scroll coordinates
-    var defaultScrollX = 0;
-    var defaultScrollY = 0;
-
-
-    // Reset the scroll coordinates
-    scrollx = defaultScrollX;
-    scrolly = defaultScrollY;
-
-    // Update screen elements
-    drawRulerBars(scrollx, scrolly);
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13429,18 +13429,15 @@ function resetDiagram(){
     // Goto the beginning of the diagram
         // NOTE: stateMachine should be StateMachine, but this had no effect
         // on functionality.
-    /*
+    
     stateMachine.gotoInitialState();
 
     // Remove the previous history
     stateMachine.currentHistoryIndex = -1;
     stateMachine.lastFlag = {};
     stateMachine.removeFutureStates();
-    //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
-    //fetchDiagramFileContentOnLoad();
-    */
-    zoomreset();
-    zoomCenter();
+    localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
+    fetchDiagramFileContentOnLoad();
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13439,17 +13439,9 @@ function resetDiagram(){
     //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
     //fetchDiagramFileContentOnLoad();
     */
-   
+    loadDiagram();
 
-    // Set the default scroll coordinates
-    toggleGrid();
-    updateGridPos();
-    updateA4Pos();
-    updateGridSize();
-    showdata();
-    drawRulerBars(scrollx,scrolly);
-
-    loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
+    //loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13439,9 +13439,25 @@ function resetDiagram(){
     //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
     //fetchDiagramFileContentOnLoad();
     */
-    loadDiagram();
 
-    //loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
+    // Reset the zoom factor and the scroll coordinates to its default value
+    zoomfact = 1;
+    scrollx = 0;
+    scrolly = 0;
+
+    // Update the elements of the screen
+    showdata();
+    updatepos();
+    updateGridPos();
+    updateGridSize();
+    drawRulerBars(scrollx, scrolly);
+    updateA4Pos();
+    updateA4Size();
+
+    // Display success message
+    displayMessage(messageTypes.SUCCESS, "Camera view reset to default.");
+
+    loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13444,8 +13444,12 @@ function resetDiagram(){
     zoomfact = 1;
 
     // Reset the scroll coordinates to (0, 0)
-    scrollx = window.innerWidth / (2 * zoomfact);
-    scrolly = window.innerHeight / (2 * zoomfact);
+    centerX = 0;
+    centery = 0;
+    centerScreenX = window.innerWidth / (2 * zoomfact);
+    centerScreenY = window.innerHeight / (2 * zoomfact);
+    scrollx = (centerX * zoomfact) - centerScreenX;
+    scrolly = (centerY * zoomfact) - centerScreenY;
 
     // Update the elements of the screen
     showdata();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -29,7 +29,7 @@ class Point {
 
 /** 
  * @description Represents a change stored in the StateMachine. StateChange contains a list of StateChange.ChangeTypes in the local property stateChanges, that in turn contains a flag to describe each change. The getFlags() can be used to get the sum of all these stateChanges. 
- */
+ */ 
 class StateChange {
     /**
      * @description ChangeType containing all information about a certain change. Several instances of ChangeType can exist inside a StateChange.
@@ -13442,16 +13442,9 @@ function resetDiagram(){
    
 
     // Set the default scroll coordinates
-    var defaultScrollX = 0;
-    var defaultScrollY = 0;
-
-
-    // Reset the scroll coordinates
-    scrollx = defaultScrollX;
-    scrolly = defaultScrollY;
-
-    // Update screen elements
-    drawRulerBars(scrollx, scrolly);
+    clearContext();
+    showdata();
+    updatepos(0, 0);
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13443,14 +13443,6 @@ function resetDiagram(){
     // Reset the zoom factor and the scroll coordinates to its default value
     zoomfact = 1;
 
-    // Reset the scroll coordinates to (0, 0)
-    centerX = 0;
-    centery = 0;
-    centerScreenX = window.innerWidth / (2 * zoomfact);
-    centerScreenY = window.innerHeight / (2 * zoomfact);
-    scrollx = (centerX * zoomfact) - centerScreenX;
-    scrolly = (centerY * zoomfact) - centerScreenY;
-
     // Update the elements of the screen
     showdata();
     updatepos();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13429,15 +13429,23 @@ function resetDiagram(){
     // Goto the beginning of the diagram
         // NOTE: stateMachine should be StateMachine, but this had no effect
         // on functionality.
-    
+    /*
     stateMachine.gotoInitialState();
 
     // Remove the previous history
     stateMachine.currentHistoryIndex = -1;
     stateMachine.lastFlag = {};
     stateMachine.removeFutureStates();
-    localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
-    fetchDiagramFileContentOnLoad();
+    //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
+    //fetchDiagramFileContentOnLoad();
+    */
+    // Goto the beginning of the diagram
+    stateMachine.gotoInitialState();
+
+    // Remove the previous history
+    stateMachine.currentHistoryIndex = -1;
+    stateMachine.lastFlag = {};
+    stateMachine.removeFutureStates();
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13441,7 +13441,14 @@ function resetDiagram(){
     */
    
 
- 
+    // Set the default scroll coordinates
+    var defaultScrollX = 0;
+    var defaultScrollY = 0;
+
+
+    // Reset the scroll coordinates
+    scrollx = defaultScrollX;
+    scrolly = defaultScrollY;
 
     // Update screen elements
     drawRulerBars(scrollx, scrolly);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13442,7 +13442,12 @@ function resetDiagram(){
    
 
     // Set the default scroll coordinates
-    centerCamera();
+    toggleGrid();
+    updateGridPos();
+    updateA4Pos();
+    updateGridSize();
+    showdata();
+    drawRulerBars(scrollx,scrolly);
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13426,18 +13426,20 @@ function resetDiagramAlert(){
  */
 function resetDiagram(){
     
-    //Goto the beginning of the diagram
-    //NOTE: stateMachine should be StateMachine, but this had no effect
-    //on functionality.
-    
+    // Goto the beginning of the diagram
+        // NOTE: stateMachine should be StateMachine, but this had no effect
+        // on functionality.
+    /*
     stateMachine.gotoInitialState();
 
-    //Remove the previous history
+    // Remove the previous history
     stateMachine.currentHistoryIndex = -1;
     stateMachine.lastFlag = {};
     stateMachine.removeFutureStates();
-    localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
-    fetchDiagramFileContentOnLoad();
+    //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
+    //fetchDiagramFileContentOnLoad();
+    */
+    zoomreset()
     
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13440,10 +13440,18 @@ function resetDiagram(){
     //fetchDiagramFileContentOnLoad();
     */
 
-    // Reset the zoom factor and the scroll coordinates to its default value
+    // Reset the zoom factor to its default value
     zoomfact = 1;
-    scrollx = 0;
-    scrolly = 0;
+
+    // Calculate the center of the diagram
+    var centerDiagram = {
+        x: (minX + maxX) / 2,
+        y: (minY + maxY) / 2
+    };
+
+    // Move camera to center of diagram
+    scrollx = centerDiagram.x * zoomfact;
+    scrolly = centerDiagram.y * zoomfact;
 
     // Update the elements of the screen
     showdata();
@@ -13454,6 +13462,7 @@ function resetDiagram(){
     updateA4Pos();
     updateA4Size();
 
+    //Reset the zoomCenter
     zoomCenter({ x: 0, y: 0 });
 
     // Display success message

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13426,19 +13426,19 @@ function resetDiagramAlert(){
  */
 function resetDiagram(){
     
-    // Goto the beginning of the diagram
-        // NOTE: stateMachine should be StateMachine, but this had no effect
-        // on functionality.
-    /*
+    //Goto the beginning of the diagram
+    //NOTE: stateMachine should be StateMachine, but this had no effect
+    //on functionality.
+    
     stateMachine.gotoInitialState();
 
-    // Remove the previous history
+    //Remove the previous history
     stateMachine.currentHistoryIndex = -1;
     stateMachine.lastFlag = {};
     stateMachine.removeFutureStates();
-    //localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
-    //fetchDiagramFileContentOnLoad();
-    */
+    localStorage.setItem("CurrentlyActiveDiagram","");// Emptying the currently active diagram
+    fetchDiagramFileContentOnLoad();
+    
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13442,9 +13442,7 @@ function resetDiagram(){
    
 
     // Set the default scroll coordinates
-    clearContext();
-    showdata();
-    updatepos(0, 0);
+    centerCamera();
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13457,7 +13457,7 @@ function resetDiagram(){
     updateA4Size();
 
     //Reset the zoomCenter
-    zoomCenter({ x: 0, y: 0 });
+    zoomCenter(centerDiagram);
 
     // Display success message
     displayMessage(messageTypes.SUCCESS, "Diagram reset to default.");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13462,7 +13462,6 @@ function resetDiagram(){
     drawRulerBars(scrollx, scrolly);
     updateA4Pos();
     updateA4Size();
-    zoomCenter(); // Assuming this function is responsible for handling zoom centering
     displayMessage(messageTypes.SUCCESS, "Camera view reset to default.");
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13446,7 +13446,6 @@ function resetDiagram(){
     // Reset the scroll coordinates to center the camera at 0, 0
     scrollx = 0;
     scrolly = 0;
-    centerDiagram = 0;
 
 
     // Update the elements of the screen
@@ -13457,7 +13456,9 @@ function resetDiagram(){
     drawRulerBars(scrollx, scrolly);
     updateA4Pos();
     updateA4Size();
-    zoomCenter(centerDiagram);
+
+    //Reset the zoomCenter
+    zoomCenter({ x: 0, y: 0 });
 
     // Display success message
     displayMessage(messageTypes.SUCCESS, "Diagram reset to default.");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13442,10 +13442,12 @@ function resetDiagram(){
 
     // Reset the zoom factor and the scroll coordinates to its default value
     zoomfact = 1;
-
+    scrollY = 0;
+    scrollx = 0;
     // Reset the scroll coordinates to center the camera at 0, 0
-    scrollx = -(window.innerWidth / (2 * zoomfact));
-    scrolly = -(window.innerHeight / (2 * zoomfact));
+    //scrollx = -(window.innerWidth / (2 * zoomfact));
+    //scrolly = -(window.innerHeight / (2 * zoomfact));
+
 
     // Update the elements of the screen
     showdata();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13443,6 +13443,30 @@ function resetDiagram(){
     // Reset the zoom factor and the scroll coordinates to its default value
     zoomfact = 1;
 
+
+    // Center of screen in pixels
+    var centerScreen = {
+        x: window.innerWidth / 2,
+        y: window.innerHeight / 2
+    };
+
+    // Center of diagram in coordinates
+    var centerDiagram = {
+        x: minX + (maxX - minX) / 2,
+        y: minY + (maxY - minY) / 2
+    };
+
+    // Move camera to center of diagram
+    scrollx = centerDiagram.x * zoomfact;
+    scrolly = centerDiagram.y * zoomfact;
+
+    var middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
+    document.getElementById("zoom-message").innerHTML = zoomfact + "x";
+
+
+    scrollx = middleCoordinate.x;
+    scrolly = middleCoordinate.y;
+
     // Update the elements of the screen
     showdata();
     updatepos();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13454,8 +13454,10 @@ function resetDiagram(){
     updateA4Pos();
     updateA4Size();
 
+    zoomCenter({ x: 0, y: 0 });
+
     // Display success message
-    displayMessage(messageTypes.SUCCESS, "Camera view reset to default.");
+    displayMessage(messageTypes.SUCCESS, "Diagram reset to default.");
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13440,29 +13440,23 @@ function resetDiagram(){
     //fetchDiagramFileContentOnLoad();
     */
    
-    // Set the default zoom factor
-    var defaultZoomFactor = 1;
 
     // Set the default scroll coordinates
     var defaultScrollX = 0;
     var defaultScrollY = 0;
 
-    // Reset the zoom factor
-    zoomfact = defaultZoomFactor;
 
     // Reset the scroll coordinates
     scrollx = defaultScrollX;
     scrolly = defaultScrollY;
 
     // Update screen elements
-    showdata();
     updatepos();
     updateGridPos();
     updateGridSize();
     drawRulerBars(scrollx, scrolly);
     updateA4Pos();
     updateA4Size();
-    displayMessage(messageTypes.SUCCESS, "Camera view reset to default.");
 
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }


### PR DESCRIPTION
Fixed issue when pressing "reset view" button. Before the camera didnt move when there was no entitites in the diagram. Now the camera moves back to the origin of the diagram when pressing "reset view" although there isnt some entities in the diagram.