### PR TITLE
Better indication for loading-button (if there's nothing to load) #14120

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -582,10 +582,6 @@
     background-color: #DF2727 !important;
 }
 
-#localLoadField{
-    display: none;
-}
-
 .deleteLocalDiagram:hover {
     background-color: #961a1a !important;
 }

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -582,6 +582,10 @@
     background-color: #DF2727 !important;
 }
 
+#localLoadField{
+    display: none;
+}
+
 .deleteLocalDiagram:hover {
     background-color: #961a1a !important;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12980,17 +12980,17 @@ function exportWithHistory()
         };
 
         // Sets the autosave diagram first, if it is not already set.
-        //if (!localStorage.getItem("diagrams")) {
-        //    let s = `{"AutoSave": ${JSON.stringify(objToSave)}}`
-        //    localStorage.setItem("diagrams", s);
-        //}
+        if (!localStorage.getItem("diagrams")) {
+            let s = `{"AutoSave": ${JSON.stringify(objToSave)}}`
+            localStorage.setItem("diagrams", s);
+        }
         // Gets the string thats contains all the local diagram saves and updates an existing entry or creates a new entry based on the value of 'key'.
-        //let local = localStorage.getItem("diagrams");
-        //local = (local[0] == "{") ? local : `{${local}}`;
+        let local = localStorage.getItem("diagrams");
+        local = (local[0] == "{") ? local : `{${local}}`;
 
-        //let localDiagrams = JSON.parse(local);
-        //localDiagrams[key] = objToSave;
-        //localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
+        let localDiagrams = JSON.parse(local);
+        localDiagrams[key] = objToSave;
+        localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
 
         displayMessage(messageTypes.SUCCESS, "You have saved the current diagram");
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13243,7 +13243,7 @@ function checkAndShowModal() {
     if (diagramKeys.length >= 2) {
         showModal();
     } else {
-        displayMessage(messageTypes.SUCCESS, "You have no saves");
+        displayMessage(messageTypes.SUCCESS, "You have no saves (1 by default)");
         return;
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13241,7 +13241,7 @@ function checkAndShowModal() {
     if (diagramKeys.length >= 2) {
         showModal();
     } else {
-        console.log("You have no saves");
+        displayMessage(messageTypes.SUCCESS, "You have saved the current diagram");
         return;
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13174,7 +13174,7 @@ function showModal(){
     var modal = document.querySelector('.loadModal');
     var overlay = document.querySelector('.loadModalOverlay');
     var container = document.querySelector('#loadContainer');
-    let diagramKeys = 0;
+    let diagramKeys;
     let localDiagrams;
 
     let local = localStorage.getItem("diagrams");
@@ -13191,7 +13191,7 @@ function showModal(){
     }
 
     // If no items were found for loading in 
-    if (diagramKeys === undefined || diagramKeys.length === 0){
+    if (diagramKeys === undefined || diagramKeys.length === 1){
         var p = document.createElement('p');
         var pText = document.createTextNode('No saves could be found');
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13174,7 +13174,7 @@ function showModal(){
     var modal = document.querySelector('.loadModal');
     var overlay = document.querySelector('.loadModalOverlay');
     var container = document.querySelector('#loadContainer');
-    let diagramKeys;
+    let diagramKeys = 0;
     let localDiagrams;
 
     let local = localStorage.getItem("diagrams");
@@ -13182,11 +13182,6 @@ function showModal(){
         local = (local[0] == "{") ? local : `{${local}}`;
         localDiagrams = JSON.parse(local);
         diagramKeys = Object.keys(localDiagrams);
-    }
-
-    if (diagramKeys == undefined || diagramKeys-length == 0) {
-        console.log("No saves found!")
-        return;
     }
 
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12980,10 +12980,11 @@ function exportWithHistory()
         };
 
         // Sets the autosave diagram first, if it is not already set.
-        if (!localStorage.getItem("diagrams")) {
-            let s = `{"AutoSave": ${JSON.stringify(objToSave)}}`
-            localStorage.setItem("diagrams", s);
-        }
+        //if (!localStorage.getItem("diagrams")) {
+        //    let s = `{"AutoSave": ${JSON.stringify(objToSave)}}`
+        //    localStorage.setItem("diagrams", s);
+        //}
+        
         // Gets the string thats contains all the local diagram saves and updates an existing entry or creates a new entry based on the value of 'key'.
         let local = localStorage.getItem("diagrams");
         local = (local[0] == "{") ? local : `{${local}}`;
@@ -13191,7 +13192,7 @@ function showModal(){
     }
 
     // If no items were found for loading in 
-    if (diagramKeys === undefined || diagramKeys.length === 1){
+    if (diagramKeys === undefined || diagramKeys.length === 0){
         var p = document.createElement('p');
         var pText = document.createTextNode('No saves could be found');
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13238,7 +13238,7 @@ function checkAndShowModal() {
         diagramKeys = Object.keys(localDiagrams);
     }
 
-    if (diagramKeys.length >= 1) {
+    if (diagramKeys.length >= 2) {
         showModal();
     } else {
         console.log("You have no saves");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13241,7 +13241,7 @@ function checkAndShowModal() {
     if (diagramKeys.length >= 2) {
         showModal();
     } else {
-        displayMessage(messageTypes.SUCCESS, "You have saved the current diagram");
+        displayMessage(messageTypes.SUCCESS, "You have no saves");
         return;
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13238,7 +13238,7 @@ function checkAndShowModal() {
         diagramKeys = Object.keys(localDiagrams);
     }
 
-    if (diagramKeys.length === 0) {
+    if (diagramKeys.length >= 1) {
         showModal();
     } else {
         console.log("You have no saves");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12968,6 +12968,8 @@ function exportWithHistory()
  */
  function storeDiagramInLocalStorage(key){
 
+    let diagramCount = 0; // Variable to keep track of the count of saved diagrams
+
     if (stateMachine.currentHistoryIndex == -1) {
         displayMessage(messageTypes.ERROR, "You don't have anything to save!");
     } else {
@@ -12991,6 +12993,10 @@ function exportWithHistory()
         let localDiagrams = JSON.parse(local);
         localDiagrams[key] = objToSave;
         localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
+
+        // Update and show the count of diagrams on the button "Load"
+        diagramCount++;
+        document.getElementById("diagramCountButton").innerText = "Saved Diagrams: " + diagramCount;
 
         displayMessage(messageTypes.SUCCESS, "You have saved the current diagram");
     }
@@ -13327,7 +13333,6 @@ function getCurrentFileName()
 
 function saveDiagramAs()
 {
-    let diagramCount = 0; // Variable to keep track of the count of saved diagrams
     let elem = document.getElementById("saveDiagramAs");
     let fileName = elem.value;
     const currentDate=new Date();
@@ -13349,7 +13354,7 @@ function saveDiagramAs()
     if (local != null) {
         local = (local[0] == "{") ? local : `{${local}}`;
         localDiagrams = JSON.parse(local);
-     names = Object.keys(localDiagrams);
+        names = Object.keys(localDiagrams);
     }
 
     for(let i=0; i<names.length; i++)
@@ -13362,10 +13367,6 @@ function saveDiagramAs()
         }
     }
     storeDiagramInLocalStorage(fileName);
-
-    // Update and show the count of diagrams on the button "Load"
-    diagramCount++;
-    document.getElementById("diagramCountButton").innerText = "Saved Diagrams: " + diagramCount;
 }
 
 function loadDiagramFromString(temp, shouldDisplayMessage = true)

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13238,7 +13238,7 @@ function checkAndShowModal() {
         diagramKeys = Object.keys(localDiagrams);
     }
 
-    if (diagramKeys.length === 1) {
+    if (diagramKeys.length === 0) {
         showModal();
     } else {
         console.log("You have no saves");

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12968,8 +12968,6 @@ function exportWithHistory()
  */
  function storeDiagramInLocalStorage(key){
 
-    let diagramCount = 0; // Variable to keep track of the count of saved diagrams
-
     if (stateMachine.currentHistoryIndex == -1) {
         displayMessage(messageTypes.ERROR, "You don't have anything to save!");
     } else {
@@ -12994,9 +12992,6 @@ function exportWithHistory()
         localDiagrams[key] = objToSave;
         localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
 
-        // Update and show the count of diagrams on the button "Load"
-        diagramCount++;
-        document.getElementById("diagramCountButton").innerText = "Saved Diagrams: " + diagramCount;
 
         displayMessage(messageTypes.SUCCESS, "You have saved the current diagram");
     }
@@ -13225,6 +13220,7 @@ function showModal(){
             }
             container.appendChild(wrapper);
 
+            document.getElementById('diagramCountSaves').innerHTML = diagramKeys.length;
             document.getElementById('loadCounter').innerHTML = diagramKeys.length;
         }
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13184,6 +13184,11 @@ function showModal(){
         diagramKeys = Object.keys(localDiagrams);
     }
 
+    if (diagramKeys == undefined || diagramKeys-length == 0) {
+        console.log("No saves found!")
+        return;
+    }
+
 
     // Remove all elements
     while (container.firstElementChild){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13227,6 +13227,25 @@ function showModal(){
     overlay.classList.remove('hiddenLoad');
 }
 
+function checkAndShowModal() {
+    let diagramKeys;
+    let localDiagrams;
+
+    let local = localStorage.getItem("diagrams");
+    if (local != null) {
+        local = (local[0] == "{") ? local : `{${local}}`;
+        localDiagrams = JSON.parse(local);
+        diagramKeys = Object.keys(localDiagrams);
+    }
+
+    if (diagramKeys.length === 1) {
+        showModal();
+    } else {
+        console.log("You have no saves");
+        return;
+    }
+}
+
 function closeModal(){
     var modal = document.querySelector('.loadModal');
     var overlay = document.querySelector('.loadModalOverlay');

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -13327,6 +13327,7 @@ function getCurrentFileName()
 
 function saveDiagramAs()
 {
+    let diagramCount = 0; // Variable to keep track of the count of saved diagrams
     let elem = document.getElementById("saveDiagramAs");
     let fileName = elem.value;
     const currentDate=new Date();
@@ -13361,6 +13362,10 @@ function saveDiagramAs()
         }
     }
     storeDiagramInLocalStorage(fileName);
+
+    // Update and show the count of diagrams on the button "Load"
+    diagramCount++;
+    document.getElementById("diagramCountButton").innerText = "Saved Diagrams: " + diagramCount;
 }
 
 function loadDiagramFromString(temp, shouldDisplayMessage = true)

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -12984,14 +12984,13 @@ function exportWithHistory()
         //    let s = `{"AutoSave": ${JSON.stringify(objToSave)}}`
         //    localStorage.setItem("diagrams", s);
         //}
-        
         // Gets the string thats contains all the local diagram saves and updates an existing entry or creates a new entry based on the value of 'key'.
-        let local = localStorage.getItem("diagrams");
-        local = (local[0] == "{") ? local : `{${local}}`;
+        //let local = localStorage.getItem("diagrams");
+        //local = (local[0] == "{") ? local : `{${local}}`;
 
-        let localDiagrams = JSON.parse(local);
-        localDiagrams[key] = objToSave;
-        localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
+        //let localDiagrams = JSON.parse(local);
+        //localDiagrams[key] = objToSave;
+        //localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
 
         displayMessage(messageTypes.SUCCESS, "You have saved the current diagram");
     }

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -887,7 +887,7 @@
         </fieldset>
         <fieldset id="localLoadField">
             <legend aria-hidden="true">Load</legend>
-            <legend id="diagramCountSaves">Saved Diagrams: 0</legend>
+            <legend id="diagramCountSaves">0</legend>
             <div id="localLoad" class="diagramIcons" onclick="checkAndShowModal();">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
                 <span class="toolTipText"><b>Load diagram</b><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -886,7 +886,10 @@
             </div>
         </fieldset>
         <fieldset id="localLoadField">
-            <legend aria-hidden="true">Load</legend>
+            <div>
+                <legend aria-hidden="true">Load</legend>
+                <p id="diagramCountSaves">Saved Diagrams: 0</p>
+            </div>
             <div id="localLoad" class="diagramIcons" onclick="checkAndShowModal();">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
                 <span class="toolTipText"><b>Load diagram</b><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -887,7 +887,7 @@
         </fieldset>
         <fieldset id="localLoadField">
             <legend aria-hidden="true">Load</legend>
-            <div id="localLoad" class="diagramIcons" onclick="showModal();">
+            <div id="localLoad" class="diagramIcons" onclick="checkAndShowModal();">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
                 <span class="toolTipText"><b>Load diagram</b><br>
                     <p>Click to load a diagram</p>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -886,10 +886,8 @@
             </div>
         </fieldset>
         <fieldset id="localLoadField">
-            <div>
-                <legend aria-hidden="true">Load</legend>
-                <p id="diagramCountSaves">Saved Diagrams: 0</p>
-            </div>
+            <legend aria-hidden="true">Load</legend>
+            <legend id="diagramCountSaves">Saved Diagrams: 0</legend>
             <div id="localLoad" class="diagramIcons" onclick="checkAndShowModal();">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
                 <span class="toolTipText"><b>Load diagram</b><br>


### PR DESCRIPTION
Added function to check if there isnt any saved diagrams, if its not then the load button doesnt show any modal and if there is saved diagrams the modal is shown. Added a count on the "load" button as a clue to users to see how many diagrams they have saved.