### PR TITLE
G3 2024 v1 #14322

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -40,25 +40,27 @@ function updateCourse()
 	// Show dialog
 	$("#editCourse").css("display", "none");
 	
+	// Updates the course (except the course GitHub repo. 
+	// Course GitHub repo is updated in the next block of code)
+	$("#overlay").css("display", "none");
+	AJAXService("UPDATE", {	cid : cid, coursename : coursename, visib : visib, coursecode : coursecode, courseGitURL : courseGitURL }, "COURSE");
+	localStorage.setItem('courseid', courseid);
+	localStorage.setItem('updateCourseName', true);
+
 	//Check if courseGitURL has a value
 	if(courseGitURL) {
 		//Check if fetchGitHubRepo returns true
 		if(fetchGitHubRepo(courseGitURL)) {
-			$("#overlay").css("display", "none");
-			AJAXService("UPDATE", {	cid : cid, coursename : coursename, visib : visib, coursecode : coursecode, courseGitURL : courseGitURL }, "COURSE");
-			localStorage.setItem('courseid', courseid);
-			localStorage.setItem('updateCourseName', true);
+			localStorage.setItem('courseGitHubRepo', courseGitURL);
+			//If courseGitURL has a value, display a message stating the update (with github-link) worked
 			alert("Course " + coursename + " updated with new GitHub-link!"); 
 			updateGithubRepo(courseGitURL, cid);
 		}
 		//Else: get error message from the fetchGitHubRepo function.
 
 	} else {
-		//If courseGitURL has no value, update the course as usual.
-		$("#overlay").css("display", "none");
-		AJAXService("UPDATE", {	cid : cid, coursename : coursename, visib : visib, coursecode : coursecode, courseGitURL : courseGitURL }, "COURSE");
-		localStorage.setItem('courseid', courseid);
-		localStorage.setItem('updateCourseName', true);
+		localStorage.setItem('courseGitHubRepo', " ");
+		//If courseGitURL has no value, display an update message
 		alert("Course " + coursename + " updated!"); 
 	}
 }
@@ -196,6 +198,7 @@ function updateGithubRepo(githubURL, cid) {
 		success: function() { 
 			//Returns true if the data and JSON is correct
 			dataCheck = true;
+			alert("Something went right! Supposedly the github url has been saved to the database!");
 		},
 		error: function(data){
 			//Check FetchGithubRepo for the meaning of the error code.

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -198,7 +198,6 @@ function updateGithubRepo(githubURL, cid) {
 		success: function() { 
 			//Returns true if the data and JSON is correct
 			dataCheck = true;
-			alert("Something went right! Supposedly the github url has been saved to the database!");
 		},
 		error: function(data){
 			//Check FetchGithubRepo for the meaning of the error code.
@@ -570,7 +569,6 @@ function returnedCourse(data)
 	str+="</div>";
 	// For now we only have two kinds of sections
 	if (data['entries'].length > 0) {
-		console.log(data['entries']);
 		for ( i = 0; i < data['entries'].length; i++) {
 			var item = data['entries'][i];
 			// Do not show courses the user does not have access to.

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -253,7 +253,7 @@ function createVersion()
 	resetinputs();
 }
 
-function selectCourse(cid, coursename, coursecode, visi, vers, edvers)
+function selectCourse(cid, coursename, coursecode, visi, vers, edvers, gitHubUrl)
 {
 	$(".item").css("border", "none");
 	$(".item").css("box-shadow", "none");
@@ -273,6 +273,8 @@ function selectCourse(cid, coursename, coursecode, visi, vers, edvers)
 	$("#cid").val(cid);
 	// Set Code
 	$("#coursecode").val(coursecode);
+	// Set github url
+	$("#editcoursegit-url").val(gitHubUrl);
 
 	//Give data attribute to course code input to check if input value is same as actual code for validation
 	$("#coursecode").attr("data-origincode", coursecode);
@@ -542,6 +544,7 @@ function createVersion(){
 
 function returnedCourse(data)
 {
+	console.log(data);
 	versions = data['versions'];
 	entries = data['entries'];
 	if(data['LastCourseCreated'][0] != undefined){
@@ -570,7 +573,7 @@ function returnedCourse(data)
 	if (data['entries'].length > 0) {
 		for ( i = 0; i < data['entries'].length; i++) {
 			var item = data['entries'][i];
-
+			console.log(data);
 			// Do not show courses the user does not have access to.
 			if (!data['writeaccess'] && !item['registered'] && uname !="Guest" && uname)
 				continue;
@@ -603,7 +606,8 @@ function returnedCourse(data)
         		str += "<div class='ellipsis' style='margin-right:15px;'><a class='"+textStyle+"' href='sectioned.php?courseid=" + item['cid'] + "&coursename=" + item['coursename'] + "&coursevers=" + item['activeversion'] + "' title='\"" + item['coursename'] + "\" [" + item['coursecode'] + "]'>" + courseBegin + courseEnd + "</a></div>";
         		str += "<span style='margin-bottom: 0px'>";
 
-				    str += "<span><img alt='course settings icon' tabindex='0' class='courseSettingIcon' id='dorf' style='position: relative; top: 2px;' src='../Shared/icons/Cogwheel.svg' onclick='selectCourse(\"" + item['cid'] + "\",\"" + htmlFix(item['coursename']) + "\",\"" + item['coursecode'] + "\",\"" + item['visibility'] + "\",\"" + item['activeversion'] + "\",\"" + item['activeedversion'] + "\");' title='Edit \"" + item['coursename'] + "\" '></span>";
+					str += "<span><img alt='course settings icon' tabindex='0' class='courseSettingIcon' id='dorf' style='position: relative; top: 2px;' src='../Shared/icons/Cogwheel.svg' onclick='selectCourse(\"" + item['cid'] + "\",\"" + htmlFix(item['coursename']) + "\",\"" + item['coursecode'] + "\",\"" + item['visibility'] + "\",\"" + item['activeversion'] + "\",\"" + item['activeedversion'] + "\",\"" + item['courseGitURL'] + "\");' title='Edit \"" + item['coursename'] + "\" '></span>";
+
         
         		str += "</span>";
       		} else {
@@ -896,5 +900,5 @@ function localStorageCourse(){
 }
 
 function glowNewCourse(courseid){
-    document.getElementById("C"+courseid).firstChild.setAttribute("class", "highlightChange");
+   // document.getElementById("C"+courseid).firstChild.setAttribute("class", "highlightChange");
 }

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -544,7 +544,6 @@ function createVersion(){
 
 function returnedCourse(data)
 {
-	console.log(data);
 	versions = data['versions'];
 	entries = data['entries'];
 	if(data['LastCourseCreated'][0] != undefined){
@@ -571,9 +570,9 @@ function returnedCourse(data)
 	str+="</div>";
 	// For now we only have two kinds of sections
 	if (data['entries'].length > 0) {
+		console.log(data['entries']);
 		for ( i = 0; i < data['entries'].length; i++) {
 			var item = data['entries'][i];
-			console.log(data);
 			// Do not show courses the user does not have access to.
 			if (!data['writeaccess'] && !item['registered'] && uname !="Guest" && uname)
 				continue;
@@ -710,7 +709,10 @@ function elementIsValid(element) {
 	element.classList.add("bg-color-change-invalid");
 	$(messageElement.firstChild.id).fadeIn();
 	//messageElement.style.display = "block";
-
+		// The inputs for the git URLs are valid even when they're empty, since they're optional
+		if(element.name === "courseGitURL") {
+			return true;
+		}
 	//Check if value of element matches regex based on name attribute same as key for regex object
 	if(element.value.match(regex[element.name])) {
 		//Seperate validation for coursecodes since it should not be possible to submit form if course code is in use
@@ -739,10 +741,7 @@ function elementIsValid(element) {
 		//messageElement.style.display = "none";
 		element.classList.remove("bg-color-change-invalid");
 
-		// The inputs for the git URLs are valid even when they're empty, since they're optional
-		if(element.name === "courseGitURL") {
-			return true;
-		}
+
 		return false;
 	}
 

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -95,7 +95,7 @@ if(checklogin()){
 			} 
 
 			// Logging for creating new course
-			$description=$coursename." ".$coursecode." "."Hidden";
+			$description=$coursename." ".$coursecode." ".$courseGitURL." "."Hidden";
 			logUserEvent($userid, $username, EventTypes::AddCourse, $description);
 
 			//////////////////////////////
@@ -487,7 +487,7 @@ if(checklogin()){
 			}
 			
 			// Logging for editing of course
-			$description=$coursename." ".$coursecode." ".$visibilityName;
+			$description=$coursename." ".$coursecode." ".$visibilityName." ".$courseGitURL;
 			logUserEvent($userid, $username, EventTypes::EditCourse, $description);
 
 		}else if(strcmp($opt,"SETTINGS")===0){
@@ -592,6 +592,8 @@ if(!$query->execute()) {
 	$error=$query->errorInfo();
 	$debug="Error reading courses\n".$error[2];
 }else{
+
+	
 	foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
 			$writeAccess = false;
 			if (isset ($userCourse[$row['cid']])){
@@ -617,7 +619,8 @@ if(!$query->execute()) {
 						'visibility' => $row['visibility'],
 						'activeversion' => $row['activeversion'],
 						'activeedversion' => $row['activeedversion'],
-						'registered' => $isRegisteredToCourse
+						'registered' => $isRegisteredToCourse,
+						'courseGitURL' => $row['courseGitURL']
 						)
 					);
 			}

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -577,7 +577,7 @@ if(!$query->execute()) {
 }
 
 
-$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion FROM course ORDER BY coursename");
+$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion,courseGitURL FROM course ORDER BY coursename");
 
 /*
 

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -57,7 +57,7 @@ while ($row = $query->fetch(PDO::FETCH_ASSOC)){
 }
 
 $log_uuid = getOP('log_uuid');
-$info="opt: ".$opt." cid: ".$cid." coursename: ".$coursename." versid: ".$versid." visibility: ".$visibility;
+$info="opt: ".$opt." cid: ".$cid." coursename: ".$coursename." versid: ".$versid." visibility: ".$visibility." courseGitUrl: ".$courseGitURL;
 logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "courseedservice.php",$userid,$info);
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixed bug where course GitHub URL was not saved nor displayed correctly when editing a course. With the current fix, the course GitHub URL will now be saved to the database and correctly fetched with a modification of a database query. OBS, if no GitHub URL was saved for a course then "null" will be displayed in its corresponding field. This has to be removed when updating a course. Additionally, when creating a course, the GitHub URL field will always be red regardless of input, although this does not affect the functionality of the whole process. 