### PR TITLE
G2 2024 v13 issue#14156

### DIFF
--- a/DuggaSys/microservices/courseedService/createCourseVersion_ms.php
+++ b/DuggaSys/microservices/courseedService/createCourseVersion_ms.php
@@ -1,5 +1,10 @@
 <?php
 
+//---------------------------------------------------------------------------------------------------------------
+// The microservice createCourseVersion_ms.php creates a new version of an existing course
+// by inserting a new row into the vers table
+//---------------------------------------------------------------------------------------------------------------
+
 date_default_timezone_set("Europe/Stockholm");
 include_once "../Shared/basic.php";
 include_once "../Shared/sessions.php";
@@ -8,8 +13,6 @@ include ('../shared_microservices/getUid_ms.php');
 // Connect to database and start session.
 pdoConnect();
 session_start();
-
-getUid();
 
 $opt=getOP('opt');
 $cid=getOP('cid');
@@ -20,19 +23,43 @@ $versname=getOP('versname');
 $versid=getOP('versid');
 $motd=getOP('motd');
 
-if(strcmp($opt,"NEWVRS")===0){
+
+if(checklogin() && isSuperUser(getUid()) == true) {
     $query = $pdo->prepare("INSERT INTO vers(cid,coursecode,vers,versname,coursename,coursenamealt,startdate,enddate,motd) values(:cid,:coursecode,:vers,:versname,:coursename,:coursenamealt,:startdate,:enddate,:motd);");
 
-    $query->bindParam(':cid', $cid);
-    $query->bindParam(':coursecode', $coursecode);
-    $query->bindParam(':vers', $versid);
-    $query->bindParam(':versname', $versname);
-    $query->bindParam(':coursename', $coursename);
-    $query->bindParam(':coursenamealt', $coursenamealt);
+	$query->bindParam(':cid', $cid);
+	$query->bindParam(':coursecode', $coursecode);
+	$query->bindParam(':vers', $versid);
+	$query->bindParam(':versname', $versname);
+	$query->bindParam(':coursename', $coursename);
+	$query->bindParam(':coursenamealt', $coursenamealt);
     $query->bindParam(':motd', $motd);
 
+    // if start and end dates are null, insert mysql null value into database
+	if($startdate=="null") $query->bindValue(':startdate', null,PDO::PARAM_INT);
+	else $query->bindParam(':startdate', $startdate);
+	if($enddate=="null") $query->bindValue(':enddate', null,PDO::PARAM_INT);
+	else $query->bindParam(':enddate', $enddate);
+
+	if(!$query->execute()) {
+		$error=$query->errorInfo();
+		$debug="Error inserting entries\n".$error[2];
+	} 
+
+    // if specified, sets the course as active
+    if($makeactive==3){
+		$query = $pdo->prepare("UPDATE course SET activeversion=:vers WHERE cid=:cid");
+		$query->bindParam(':cid', $cid);
+		$query->bindParam(':vers', $versid);
+		if(!$query->execute()) {
+				$error=$query->errorInfo();
+				$debug="Error updating entries\n".$error[2];
+		}	
+	}
+
+	// Logging for create a fresh course version
+	$description=$cid." ".$versid;
+	logUserEvent($userid, $username, EventTypes::AddCourseVers, $description);
 }
 
-
-            
 ?>   

--- a/DuggaSys/microservices/courseedService/createCourseVersion_ms.php
+++ b/DuggaSys/microservices/courseedService/createCourseVersion_ms.php
@@ -1,8 +1,13 @@
 <?php
 
+date_default_timezone_set("Europe/Stockholm");
 include_once "../Shared/basic.php";
 include_once "../Shared/sessions.php";
 include ('../shared_microservices/getUid_ms.php');
+
+// Connect to database and start session.
+pdoConnect();
+session_start();
 
 getUid();
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1017,13 +1017,23 @@ function AJAXService(opt,apara,kind)
 	}
 
 	if(kind=="COURSE"){
-		$.ajax({
-			url : "courseedservice.php",
-			type: "POST",
-			data: "opt="+opt+para,
-			dataType: "json",
-			success: returnedCourse
-		});
+		if (opt === "NEWVRS") {
+            $.ajax({
+                url: "../DuggaSys/microservices/courseedService/createCourseVersion_ms.php",
+				type: "POST",
+				data: "opt="+opt+para,
+				dataType: "json",
+				success: returnedCourse
+            });
+        } else {
+			$.ajax({
+				url : "courseedservice.php",
+				type: "POST",
+				data: "opt="+opt+para,
+				dataType: "json",
+				success: returnedCourse
+			});
+        }
 	}else if(kind=="VARIANTPDUGGA"){
 		$.ajax({
 			url: "showDuggaservice.php",

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1017,6 +1017,7 @@ function AJAXService(opt,apara,kind)
 	}
 
 	if(kind=="COURSE"){
+		//for testing of the microservice, delete the if/else and uncomment the original ajax call below before merge
 		if (opt === "NEWVRS") {
             $.ajax({
                 url: "../DuggaSys/microservices/courseedService/createCourseVersion_ms.php",
@@ -1034,6 +1035,13 @@ function AJAXService(opt,apara,kind)
 				success: returnedCourse
 			});
         }
+		/*$.ajax({
+			url : "courseedservice.php",
+			type: "POST",
+			data: "opt="+opt+para,
+			dataType: "json",
+			success: returnedCourse
+		});*/
 	}else if(kind=="VARIANTPDUGGA"){
 		$.ajax({
 			url: "showDuggaservice.php",


### PR DESCRIPTION
This microservice is used to create new versions of courses.

![Skärmbild 2024-04-02 145158](https://github.com/HGustavs/LenaSYS/assets/129263151/56bfeeee-2a1d-4b37-a5e3-bd9aa1a43d34)
enter a course while logged in as a superuser and press the plus button to create a new version.

![Skärmbild 2024-04-04 171731](https://github.com/HGustavs/LenaSYS/assets/129263151/3adf957b-a241-4a4d-8915-25b02a455993)
Input the data here. It is important to set "copy content from" to "None" since that functionality will be handled by a different microservice and doesn't work in its current state.

issue #14156 has more information if needed

before merging after testing has been done, dugga.js should be restored to use the monolith service by changing the code on line 1019 back to its original state: 

```
if(kind=="COURSE"){
	$.ajax({
	url : "courseedservice.php",
	type: "POST",
	data: "opt="+opt+para,
	dataType: "json",
	success: returnedCourse
	});
}else if(kind=="VARIANTPDUGGA"){
```
