### PR TITLE
Now not possible to bring up context menu when on diagram page.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1362,6 +1362,11 @@ function showDiagramTypes(){
 //#endregion ===================================================================================
 //#region ================================ EVENTS               ================================
 // --------------------------------------- Window Events    --------------------------------
+document.addEventListener('contextmenu', event =>
+{
+    event.preventDefault();
+});
+
 document.addEventListener('keydown', function (e)
 {
     if (isKeybindValid(e, keybinds.LEFT_CONTROL) && ctrlPressed !== true) ctrlPressed = true;


### PR DESCRIPTION
Tested on Chrome, Edge and Firefox.