### PR TITLE
Fix grid breaking after opening inspection tool, issue #14327

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1374,7 +1374,6 @@ document.addEventListener('keydown', function (e)
         clearInterval(stateMachine.replayTimer);
     }
 
-
     // If the active element in DOM is not an "INPUT" "SELECT" "TEXTAREA"
     if( !/INPUT|SELECT|TEXTAREA/.test(document.activeElement.nodeName.toUpperCase())) {
         if (isKeybindValid(e, keybinds.ESCAPE) && escPressed != true) {
@@ -4319,7 +4318,6 @@ function toggleGrid()
    }
 }
 
-document.addEventListener()
 
 /**
  * @description Toggles the darkmode for svgbacklayer ON/OFF.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1374,6 +1374,7 @@ document.addEventListener('keydown', function (e)
         clearInterval(stateMachine.replayTimer);
     }
 
+
     // If the active element in DOM is not an "INPUT" "SELECT" "TEXTAREA"
     if( !/INPUT|SELECT|TEXTAREA/.test(document.activeElement.nodeName.toUpperCase())) {
         if (isKeybindValid(e, keybinds.ESCAPE) && escPressed != true) {
@@ -1612,7 +1613,8 @@ document.addEventListener('keyup', function (e)
 });
 
 window.addEventListener("resize", () => {
-    updateContainerBounds();
+    updateGridSize();
+    showdata()
     drawRulerBars(scrollx,scrolly);
 });
 
@@ -4316,6 +4318,8 @@ function toggleGrid()
         gridButton.style.border = "3px solid #614875";
    }
 }
+
+document.addEventListener()
 
 /**
  * @description Toggles the darkmode for svgbacklayer ON/OFF.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4318,7 +4318,6 @@ function toggleGrid()
    }
 }
 
-
 /**
  * @description Toggles the darkmode for svgbacklayer ON/OFF.
  */

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1103,7 +1103,7 @@
                     <input class="textinput" type="text" id="saveDiagramAs" placeholder="Untitled" value='' autocomplete="off"/>
                 </div>
                 <div class="button-row">
-                    <input type="submit" class="submit-button" onclick="saveDiagramAs();hideSavePopout();" value="Save"/>
+                    <input type="submit" class="submit-button" onclick="saveDiagramAs(), hideSavePopout()" value="Save"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The problem has been recognized as the web browser window not registering the resize of the window, which is what is happening when the inspector tool is opened. Proposed solution fixes this.

Changes made in the window EventListener now includes functions to update the grid, ruler and other relevant components to match window size when window is resized by dragging with mouse on the sides of the window browser or when opening up an "inner" window such as inspection tool.