### PR TITLE
Fixed deleted FAB returning

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1928,6 +1928,11 @@ function returnedSection(data) {
     addClasses();
     showMOTD();
   }
+
+  //Force elements that are deletet to not show up unless pressing undo delete or reloading the page
+  for(var i = delArr.length-1; i == 0; --i){
+    document.getElementById("lid"+delArr[i]).style.display="none";
+  }
 }
 
 function openCanvasLink(btnobj){


### PR DESCRIPTION
To fix
- #14358 

I added a for loop in returnedSection() because it redrew all elements that still were in the database as if they werent deleted. 