### PR TITLE
Fixed savebutton in diagrams.php (#13984)

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1103,7 +1103,7 @@
                     <input class="textinput" type="text" id="saveDiagramAs" placeholder="Untitled" value='' autocomplete="off"/>
                 </div>
                 <div class="button-row">
-                    <input type="submit" class="submit-button" onclick="saveDiagramAs();hideSavePopout();" value="Save"/>
+                    <input type="submit" class="submit-button" onclick="saveDiagramAs(); hideSavePopout();" value="Save"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Changed from comma to semicolon in 'onclick' on line 1106 in diagram.php as the functions were already implemented but did not work. The semicolon allows multiple functions to be entered inside 'onclick'.