### PR TITLE
Enlarge section that opens the option

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -117,6 +117,7 @@
     transform: translate(20px,0px) rotate(90deg);
     cursor: pointer;
     width: 780px;
+    padding: 6px;
 }
 
 #options-pane-content {


### PR DESCRIPTION
I've modified line 120 as I fixed the button issue where it wasn't able to click on it at the left side (Issue #14367). I added some extra space at the bottom of the button by using a "padding 6px". Now it works better and you can click on the button even on the edge. I checked to make sure it looks good on all the full option screen sizes.