### PR TITLE
G3 2024 v1 #14352

### DIFF
--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -117,8 +117,12 @@
 		$updateTime = strtotime($updated); // Format the update-time as Unix timestamp
 
 		$_SESSION["lastFetchTime"] = date("Y-m-d H:i:s", $currentTime);
-		$_SESSION["fetchCooldown"] = $longdeadline - ($currentTime - $updateTime);
-
+		$fethCooldown = $longdeadline - (time() - $updateTime);
+		if($fethCooldown<0){
+			$_SESSION["fetchCooldown"]=0;
+		}else{
+			$_SESSION["fetchCooldown"]=$fethCooldown;
+		}
 		// Check if the user has superuser priviliges
 		if($user == 1) { // 1 = superuser
 			if(($currentTime - $updateTime) < $shortdeadline) { // If they to, use the short deadline

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -116,6 +116,9 @@
 		$currentTime = time(); // Get the current time as a Unix timestamp
 		$updateTime = strtotime($updated); // Format the update-time as Unix timestamp
 
+		$_SESSION["lastFetchTime"] = date("Y-m-d H:i:s", $currentTime);
+		$_SESSION["fetchCooldown"] = $longdeadline - ($currentTime - $updateTime);
+
 		// Check if the user has superuser priviliges
 		if($user == 1) { // 1 = superuser
 			if(($currentTime - $updateTime) < $shortdeadline) { // If they to, use the short deadline

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1262,6 +1262,7 @@ p {
 
 .tooltiptext {
   display: none;
+  width: 230px;
   background-color: var(--color-background);
   color: var(--color-text-primary);
   text-align: center;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1255,17 +1255,35 @@ p {
 }
 
 .tooltip {
+  position: relative;
+  display: inline-block;
   line-height: 32px;
 }
 
 .tooltiptext {
   display: none;
-  width: 160px;
-  background-color: var(--color-primary);
-  color: var(--color-text-header);
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
   text-align: center;
   border-radius: 6px;
-  margin: 0 5px;
+  padding: 4px 4px;
+  /* Position for tooltip */
+  position: absolute;
+  z-index: 1;
+  top: 125%;
+  left: -150%;
+  margin-left: -60px;
+}
+
+.tooltip .tooltiptext::after {
+  content: " ";
+  position: absolute;
+  bottom: 100%;  /* At the top of the tooltip */
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent var(--color-background) transparent;
 }
 
 .tooltip:hover .tooltiptext {

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -199,10 +199,11 @@
 
 							// Refresh button for Github repo in nav
 							echo "<td class='refresh' style='display: inline-block;'>";
-							echo "<div class='refresh menuButton'>";
-            	echo "<span id='refreshBTN' title='Download Github repo' value='Refresh' href='#'>";
-             	echo "<img alt='refresh icon' id='refreshIMG' class='navButt' onclick='refreshGithubRepo(".$_SESSION['courseid'].");' src='../Shared/icons/gitrefresh.svg'>";
-							echo "</span>";
+							echo "<div class='refresh menuButton tooltip'>";
+								echo "<span id='refreshBTN' value='Refresh' href='#'>";
+									echo "<img alt='refresh icon' id='refreshIMG' class='navButt' onclick='refreshGithubRepo(".$_SESSION['courseid'].")' src='../Shared/icons/gitrefresh.svg'>";
+								echo "</span>";
+								echo "<span class='tooltiptext'><b>Last Fetch:</b> ".$_SESSION['lastFetchTime']."<br><b>Cooldown:</b> ".$_SESSION['fetchCooldown']."</span>";
 							echo "</div>";
 							echo "</td>";
 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -204,6 +204,7 @@
 									echo "<img alt='refresh icon' id='refreshIMG' class='navButt' onclick='refreshGithubRepo(".$_SESSION['courseid'].")' src='../Shared/icons/gitrefresh.svg'>";
 								echo "</span>";
 								echo "<span class='tooltiptext'><b>Last Fetch:</b> ".$_SESSION['lastFetchTime']."<br><b>Cooldown:</b> ".$_SESSION['fetchCooldown']."</span>";
+								// echo "<span class='tooltiptext'><b>Last Fetch:</b> <br><b>Cooldown:</b> </span>";
 							echo "</div>";
 							echo "</td>";
 


### PR DESCRIPTION
Set a fixed width to the tooltip-box so it is centered underneath the gitRepo-button even if it has no date from last fetch. Set the cooldown to show "0" instead of a negative value if the cooldown in out of sync.