### PR TITLE
Fixed issue where states could not be accessed inside superstates. (#14304).

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9381,7 +9381,7 @@ function drawElement(element, ghosted = false)
 
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.5))}px; width:${boxw}px;font-size:${texth}px;z-index:1;`;
+        style='left:0px; top:0px;margin-top:${((boxh * -0.5))}px; width:${boxw}px;font-size:${texth}px; z-index:1;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;


### PR DESCRIPTION
Added fixed Z-index for elements created in diagram container. States can now be accessed when they are inside super states.