### PR TITLE
the used url for curl in test.php will use the service entry from eac…

### DIFF
--- a/DuggaSys/tests/showDuggaservice_test.php
+++ b/DuggaSys/tests/showDuggaservice_test.php
@@ -7,7 +7,7 @@ $testsData = array(
         'expected-output' => '{"debug":"[Guest] Missing hash\/password\/variant!","param":"{}","answer":"UNK","danswer":"UNK","score":0,"highscoremode":"","grade":"UNK","submitted":"","marked":"","deadline":"UNK","release":"UNK","files":[],"userfeedback":"UNK","feedbackquestion":"UNK","variant":"UNK","ishashindb":false,"variantsize":"UNK","variantvalue":"UNK","password":"UNK","hashvariant":"UNK","isFileSubmitted":"UNK","isTeacher":0,"variants":[],"duggaTitle":"UNK","hash":"UNK","hashpwd":"UNK","opt":"UNK","link":"UNK"}',
         'query-before-test-1' => "INSERT INTO groupdugga(hash, active_users) VALUES ('hnf3j58s', 5);",
         'query-after-test-1' => "DELETE FROM groupdugga WHERE hash = 'hnf3j58s';",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'opt' => 'UPDATEAU',
             'hash' => 'hnf3j58s'
@@ -20,7 +20,7 @@ $testsData = array(
         'expected-output' => '{"debug":"[Guest] Missing hash\/password\/variant!","param":"{}","answer":"UNK","danswer":"UNK","score":0,"highscoremode":"","grade":"UNK","submitted":"","marked":"","deadline":"UNK","release":"UNK","files":[],"userfeedback":"UNK","feedbackquestion":"UNK","variant":"UNK","ishashindb":false,"variantsize":"UNK","variantvalue":"UNK","password":"UNK","hashvariant":"UNK","isFileSubmitted":"UNK","isTeacher":0,"variants":[],"duggaTitle":"UNK","hash":"UNK","hashpwd":"UNK","opt":"UNK","link":"UNK"}',
         //Get newly added active users?
         'query-after-test-1' => "DELETE FROM groupdugga WHERE hash = 'tj7dh2nb';",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'opt' => 'UPDATEAU',
             'hash' => 'tj7dh2nb',
@@ -34,7 +34,7 @@ $testsData = array(
         'expected-output' => '{"debug":"[Guest] Missing hash\/password\/variant!","param":"{}","answer":"UNK","danswer":"UNK","score":0,"highscoremode":"","grade":"UNK","submitted":"","marked":"","deadline":"UNK","release":"UNK","files":[],"userfeedback":"UNK","feedbackquestion":"UNK","variant":"UNK","ishashindb":false,"variantsize":"UNK","variantvalue":"UNK","password":"UNK","hashvariant":"UNK","isFileSubmitted":"UNK","isTeacher":0,"variants":[],"duggaTitle":"UNK","hash":"UNK","hashpwd":"UNK","opt":"UNK","link":"UNK"}',
         'query-before-test-1' => "INSERT INTO groupdugga(hash,active_users) VALUES('hjk4ert6', 52);",
         'query-after-test-1' => "DELETE FROM groupdugga WHERE hash = 'hjk4ert6';",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'opt' => 'UPDATEAU',
             'hash' => 'hjk4ert6',
@@ -54,7 +54,7 @@ $testsData = array(
         'query-after-test-1' => "DELETE FROM userAnswer ORDER BY aid DESC LIMIT 1;",
         'query-after-test-2' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-3' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'opt' => 'SAVDU',
             'hash' => 'ghj1jfg2',
@@ -76,7 +76,7 @@ $testsData = array(
         'query-after-test-1' => "DELETE FROM userAnswer ORDER BY aid DESC LIMIT 1;",
         'query-after-test-2' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-3' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'opt' => 'SAVDU',
             'hash' => 'ghj1jfg2',
@@ -98,7 +98,7 @@ $testsData = array(
         'query-after-test-1' => "DELETE FROM userAnswer ORDER BY aid DESC LIMIT 1;",
         'query-after-test-2' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-3' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'opt' => 'SAVDU',
             'hash' => 'dfg4zxc5',
@@ -118,7 +118,7 @@ $testsData = array(
         'query-after-test-1' => "DELETE FROM userAnswer ORDER BY aid DESC LIMIT 1;",
         'query-after-test-2' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-3' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'opt' => 'SAVDU',
             'cid' => '9999',
@@ -144,7 +144,7 @@ $testsData = array(
         'query-after-test-1' => "DELETE FROM userAnswer ORDER BY aid DESC LIMIT 1;",
         'query-after-test-2' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-3' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'hash' => 'dfg4zxc5'
             'username' => 'stei',
@@ -162,7 +162,7 @@ $testsData = array(
         'query-before-test-3' => "SELECT MAX(lid) FROM listentries",
         'query-after-test-1' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-2' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'username' => 'stei',
             'password' => 'password',
@@ -179,7 +179,7 @@ $testsData = array(
         'query-before-test-3' => "SELECT MAX(lid) FROM listentries",
         'query-after-test-1' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-2' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'username' => 'stei',
             'password' => 'password',
@@ -199,7 +199,7 @@ $testsData = array(
         'query-after-test-1' => "DELETE FROM userAnswer ORDER BY aid DESC LIMIT 1;",
         'query-after-test-2' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-3' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'hash' => 'ghj1ghj2',
             'hashpwd' => 'asddasdd',
@@ -221,7 +221,7 @@ $testsData = array(
         'query-after-test-1' => "DELETE FROM userAnswer ORDER BY aid DESC LIMIT 1;",
         'query-after-test-2' => "DELETE FROM listentries WHERE cid = 9999;",
         'query-after-test-3' => "DELETE FROM course WHERE cid = 9999;",
-        'service' => 'showDuggaservice.php',
+        'service' => 'localhost/LenaSYS/DuggaSys/showDuggaservice.php',
         'service-data' => serialize(array( // Data that service needs to execute function
             'courseid' => '9999',
             'duggaid' => '1',

--- a/Shared/test.php
+++ b/Shared/test.php
@@ -158,15 +158,7 @@ function testHandler($testsData, $prettyPrint){
         // Output filter
         $filter = unserialize($testData['filter-output']);
 
-        if (!(strpos($testData['service'], "/"))) {
-            echo $testData['service'];
-            $dirname = dirname(dirname(__FILE__));
-            $urlpath = strstr($dirname, '/root');
-            $serviceURL = $dirname.$urlpath."/DuggaSys/".$testData['service'];
-        }
-        else{
-            $serviceURL = $testData['service'];
-        }
+        $serviceURL = $testData['service'];
 
         // Test 1 login
         $serviceData = unserialize($testData['service-data']);


### PR DESCRIPTION
The testing API will now use a url from the service entry of each test. Test.php will retrieve the url that is placed in the service entry of each test. 

Using for example a XAMPP/apache solution on port 80 would work without issues now. The service `sectionedservice.php` that is used in the tests in `sectionedservice_Test.php` will have the service entry `localhost/LenaSYS/DuggaSys/sectionedservice.php`. If the user uses another port for their local web server, they need to add it themselves like so:
`localhost:1337/LenaSYS/DuggaSys/sectionedservice.php`