### PR TITLE
G3 2024 v2 #14357 Removed redundant AJAX calls and fixed the time interval

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3213,11 +3213,9 @@ setInterval(function () {
       console.log("Time to update the code examples.");
 
       let returnedPromises = [];
-      for (let i = 0; i < itemKinds.length; i++) {
+      for (let i = 0; i < collectedLid.length; i++) {
         if (itemKinds[i] === 4) {
-          for (let i = 0; i < collectedLid.length; i++) {
-            returnedPromises.push(createExamples(collectedLid[i], false));
-          }
+          returnedPromises.push(createExamples(collectedLid[i], false));
         }
       }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -31,7 +31,8 @@ var isLoggedIn = false;
 // Globals for the automatic refresh (github)
 var isActivelyFocused = false; // If the user is actively focusing on the course page
 var lastUpdatedCodeExampes = null; // Last time code examples was updated
-const UPDATE_INTERVAL = 600 * 100; // Timerintervall for code to be updated (10 minutes)
+var updateMins = 10; // Variable expressed in minutes for how often the code should be updated
+const UPDATE_INTERVAL = 60000 * updateMins; // Timerintervall for code to be updated (currently set to 10 minutes) (minute in millisecond * updateMins)
 
 
 function IsLoggedIn(bool) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -31,7 +31,7 @@ var isLoggedIn = false;
 // Globals for the automatic refresh (github)
 var isActivelyFocused = false; // If the user is actively focusing on the course page
 var lastUpdatedCodeExampes = null; // Last time code examples was updated
-var updateMins = 10; // Variable expressed in minutes for how often the code should be updated
+const updateMins = 10; // Variable expressed in minutes for how often the code should be updated
 const UPDATE_INTERVAL = 60000 * updateMins; // Timerintervall for code to be updated (currently set to 10 minutes) (minute in millisecond * updateMins)
 
 


### PR DESCRIPTION
Removed unnecessary for-loop to minimize AJAX-calls. Now there will only be one AJAX-call for every moment in a course. The content of the AJAX-call remains unchanged. 

Now the AJAX-calls are only executed in a 10 minute interval, additionally also when the user refreshes a moment.

We have noticed that within the AJAX-call, there is a `duggor` attribute which contains information unrelated to the course. Another issue might be to change the structure of the AJAX-call to contain less information, thus avoiding unnecessary repetition. 

Issue: 
#14357 