### PR TITLE
Solved the 'keybind for note' bug

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1649,7 +1649,7 @@ document.addEventListener('keyup', function (e) {
     }
 
     if (isKeybindValid(e, keybinds.NOTE_ENTITY)) {
-        setElementPlacementType(elementTypes.NOTE);
+        setElementPlacementType(elementTypes.note);
         setMouseMode(mouseModes.PLACING_ELEMENT);
     }
 


### PR DESCRIPTION
Note was spelled NOTE, IDE did not give an error for this. this is now fixed.