### PR TITLE
arrow is not broken anymore  #14292

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8023,7 +8023,7 @@ function drawLine(line, targetGhost = false) {
                 iconSizeStart = 20;
                 break;
             case UMLLineIcons.ARROW:
-                if (line.ctype == 'BT') {
+                if (line.ctype == 'TB') {
                     str += `<polyline id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact}' fill=none stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 } else if (line.ctype == 'TB') {
                     str += `<polyline id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact}' fill=none stroke='${lineColor}' stroke-width='${strokewidth}'/>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8023,7 +8023,7 @@ function drawLine(line, targetGhost = false) {
                 iconSizeStart = 20;
                 break;
             case UMLLineIcons.ARROW:
-                if (elemsAreClose) {
+                if (line.ctype == 'BT') {
                     str += `<polyline id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact}' fill=none stroke='${lineColor}' stroke-width='${strokewidth}'/>`;
                 } else if (line.ctype == 'TB') {
                     str += `<polyline id='${line.id + "IconOne"}' class='diagram-umlicon-darkmode' points='${fx - 10 * zoomfact} ${fy - 20 * zoomfact},${fx} ${fy},${fx + 10 * zoomfact} ${fy - 20 * zoomfact}' fill=none stroke='${lineColor}' stroke-width='${strokewidth}'/>`;


### PR DESCRIPTION
I changed the parameter (elemsAreClose) in swich case for startIcon with same parameters as there was for other icons.