### PR TITLE
replaced break; with isOverlapping = false;

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3595,11 +3595,11 @@ function entityIsOverlapping(id, x, y) {
                 }
                 //if its overlapping with a super state, just break since that is allowed.
                 if (data[i].kind == "UMLSuperState" || element.kind == "UMLSuperState") {
-                    break;
+                    isOverlapping = false;
                 }
                 //if its overlapping with a sequence actor, just break since that is allowed.
                 if (data[i].kind == "sequenceActorAndObject" || element.kind == "sequenceActorAndObject") {
-                    break;
+                    isOverlapping = false;
                 } else if ((targetX < compX2) && (targetX + element.width) > data[i].x &&
                     (targetY < compY2) && (targetY + elementHeight) > data[i].y) {
                     isOverlapping = true;


### PR DESCRIPTION
I replaced the break; line with isOverlapping = false. If you draw a super state or sequence actor then you should not be able to overlap with other diagrams like ER diagrams.