### PR TITLE
G3 2024 v2 #14450 Dark mode for course schedule

### DIFF
--- a/DuggaSys/darkmodeToggle.js
+++ b/DuggaSys/darkmodeToggle.js
@@ -33,8 +33,8 @@ document.addEventListener('DOMContentLoaded', () => {
       themeStylesheet.href = "../Shared/css/blackTheme.css";
       localStorage.setItem('themeBlack',themeStylesheet.href);
     }
-	// Redraw course calendar / planner SVG to get the appropriate color scheme
-	// Course calendar = the SVG that displays the weeks and how far into a course we are (not sure what to call it)
+	// Redraw course schedule / planner SVG to get the appropriate color scheme
+	// Course schedule = the SVG that displays the weeks and how far into a course we are
 	drawSwimlanes();		
   })
 })

--- a/DuggaSys/darkmodeToggle.js
+++ b/DuggaSys/darkmodeToggle.js
@@ -12,7 +12,7 @@ if (!localStorage.getItem('themeBlack')) {
 /*/ The code below is waitng for the page to load, and check when the user changes his/her 
 operative system to either black or white mode . /*/
 
-
+// This is an event listener that toggles the theme of the page (dark or light)
 document.addEventListener('DOMContentLoaded', () => {
 	const storedTheme = localStorage.getItem('themeBlack');
 	if(storedTheme){
@@ -26,13 +26,16 @@ document.addEventListener('DOMContentLoaded', () => {
     // if it's light -> go dark
     if(themeStylesheet.href.includes('blackTheme')){
       themeStylesheet.href = "../Shared/css/style.css";
-      localStorage.setItem('themeBlack',themeStylesheet.href)
+      localStorage.setItem('themeBlack',themeStylesheet.href);
     } 
     else if(themeStylesheet.href.includes('style')) {
       // if it's dark -> go light
       themeStylesheet.href = "../Shared/css/blackTheme.css";
-      localStorage.setItem('themeBlack',themeStylesheet.href)
-    }		
+      localStorage.setItem('themeBlack',themeStylesheet.href);
+    }
+	// Redraw course calendar / planner SVG to get the appropriate color scheme
+	// Course calendar = the SVG that displays the weeks and how far into a course we are (not sure what to call it)
+	drawSwimlanes();		
   })
 })
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -70,9 +70,6 @@ function burgerToggleDarkmode(operation = 'click') {
     localStorage.setItem('themeBlack', themeStylesheet.href)
     backgroundColorTheme = "#fff";
   }
-  // Redraw course schedule / planner SVG to get the appropriate color scheme
-  // Course schedule = the SVG that displays the weeks and how far into a course we are
-  drawSwimlanes();
 
   //const themeToggle = document.getElementById('theme-toggle');
   //themeToggle.addEventListener('click', () => {});
@@ -2235,31 +2232,20 @@ function drawSwimlanes() {
   const storedTheme = localStorage.getItem('themeBlack');
 
   for (var i = 0; i < weekLength; i++) {
-    str += "<rect x='" + (i * weekwidth) + "' y='" + (15) + "' width='" +
-      (weekwidth) + "' height='" + (weekheight * (deadlineEntries.length + 1)) + "' ";
-    // The following code decides the color scheme of the course timeline 
-    // (The svg showing how far into a course we are and assignment deadlines)
-    if ((i % 2) == 0 && !(storedTheme.includes("blackTheme.css"))) { // All even columns should be light gray in white theme
-      str += "fill='#ededed' />";
-    } else if((i % 2) != 0 && !(storedTheme.includes("blackTheme.css"))){ // All uneven columns should be white in white theme
-      str += "fill='#ffffff' />";
-    } else if((i % 2) == 0 && (storedTheme.includes("blackTheme.css"))){ // All even columns should be dark gray in black theme
-      str += "fill='#121212' />";
-    }else{ // All uneven columns should be a lighter gray in white theme
-      str += "fill='#434343' />";
-    }
+    // Draws the columns in the course schedule
+    if ((i % 2) == 0){ str += "<rect class='evenScheduleColumn'";} // Even columns get the class "evenScheduleColumn"
+    else{ str += "<rect class='oddScheduleColumn'"; } // Odd columns get the class "oddScheduleColumn"
 
-    //Changes text colors of week numbers in course SVG (course schedule with deadlines)
-    if(storedTheme.includes("blackTheme.css")){ //If theme is black then week numbers in the course schedule should be white
-      str += `<text x='${((i * weekwidth) + (weekwidth * 0.5))}' y='${(33)}'
-      font-family='Arial' font-size='12px' fill='white' text-anchor='middle'>${(i + 1)}</text>`;
-    }else{ //If theme is white then week numbers in the course schedule should be black
-      str += `<text x='${((i * weekwidth) + (weekwidth * 0.5))}' y='${(33)}'
-      font-family='Arial' font-size='12px' fill='black' text-anchor='middle'>${(i + 1)}</text>`;
-    }
+    str += " x='" + (i * weekwidth) + "' y='" + (15) + "' width='" +
+    (weekwidth) + "' height='" + (weekheight * (deadlineEntries.length + 1)) + "' />";
+
+    // Draws the week of the column (For example "1" or "7" ...)
+    str += `<text class='scheduleWeeks' x='${((i * weekwidth) + (weekwidth * 0.5))}' y='${(33)}'
+      font-family='Arial' font-size='12px' text-anchor='middle'>${(i + 1)}</text>`;
 
   }
 
+  // Draws a row line in the course schedule
   for (var i = 1; i < (deadlineEntries.length + 2); i++) {
     str += `<line x1='0' y1='${((i * weekheight) + 15)}' x2='
     ${(weekLength * weekwidth)}' y2='${((i * weekheight) + 15)}' stroke='black' />`;
@@ -2296,20 +2282,11 @@ function drawSwimlanes() {
         } else if ((fillcol == "#FFEB3B") && (entry.deadline - current < 0) && (entry.submitted != null)) {
           textcol = `url("#fadeTextRed")`;
         }
+        // Draws the progress bar for a dugga in the schedule
+        str += `<rect class='progressBar' x='${(startday * daywidth)}' y='${(weeky)}' width='${(duggalength * daywidth)}' height='${weekheight}'/>`;
 
-        if(storedTheme.includes("blackTheme.css")){ //If theme is black then dugga progress should be more pigmented
-          str += `<rect opacity='0.9' x='${(startday * daywidth)}' y='${(weeky)}' width='${(duggalength * daywidth)}' height='${weekheight}' fill='${fillcol}' />`;
-        }else{ //If theme is white then week numbers in the course schedule should be less pigmented
-          str += `<rect opacity='0.7' x='${(startday * daywidth)}' y='${(weeky)}' width='${(duggalength * daywidth)}' height='${weekheight}' fill='${fillcol}' />`;
-        }
-
-        //Changes text colors of assignments/duggor in course SVG (course schedule with deadlines)
-        if(storedTheme.includes("blackTheme.css")){ //If theme is black then duggor-text in the course schedule should be white
-          str += `<text x='${(12)}' y='${(weeky + 18)}' font-family='Arial' font-size='12px' fill='#ffffff' text-anchor='left'> <title> ${entry.text} </title>${entry.text}</text>`;
-        }else{ //If theme is white then duggor-text in the course schedule should be black
-          str += `<text x='${(12)}' y='${(weeky + 18)}' font-family='Arial' font-size='12px' fill='${textcol}' text-anchor='left'> <title> ${entry.text} </title>${entry.text}</text>`;
-        }
-        
+        // Draws the dugga name in the schedule
+        str += `<text x='${(12)}' y='${(weeky + 18)}' font-family='Arial' font-size='12px' text-anchor='left' class='scheduleDugga'> <title> ${entry.text} </title>${entry.text}</text>`;
       }
     }
   }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2154,8 +2154,6 @@ function returnedHighscore(data) {
   $("#HighscoreBox").css("display", "block");
 }
 
-
-
 //----------------------------------------------------------------------------------
 // drawSwimlanes: Draws schedule for deaadlines on all assignments is course
 //----------------------------------------------------------------------------------
@@ -2230,16 +2228,32 @@ function drawSwimlanes() {
     "<linearGradient gradientUnits='userSpaceOnUse' x1='0' x2='300' y1='0' y2='0' id='fadeTextRed'>" +
     "<stop offset='85%' stop-opacity='1' stop-color='#FF0000' /><stop offset='100%' stop-opacity='0'/> </linearGradient></defs>";
 
+  var storedTheme = localStorage.getItem('themeBlack');
+
   for (var i = 0; i < weekLength; i++) {
     str += "<rect x='" + (i * weekwidth) + "' y='" + (15) + "' width='" +
       (weekwidth) + "' height='" + (weekheight * (deadlineEntries.length + 1)) + "' ";
-    if ((i % 2) == 0) {
+    // The following code decides the color scheme of the course timeline 
+    // (The svg showing how far in we are in a course and assignment deadlines)
+    if ((i % 2) == 0 && !(storedTheme.includes("blackTheme.css"))) { // All even columns should be light gray in white theme
       str += "fill='#ededed' />";
-    } else {
+    } else if((i % 2) != 0 && !(storedTheme.includes("blackTheme.css"))){ // All uneven columns should be white in white theme
       str += "fill='#ffffff' />";
+    } else if((i % 2) == 0 && (storedTheme.includes("blackTheme.css"))){ // All even columns should be dark gray in black theme
+      str += "fill='#121212' />";
+    }else{ // All uneven columns should be a lighter gray in white theme
+      str += "fill='#434343' />";
     }
-    str += `<text x='${((i * weekwidth) + (weekwidth * 0.5))}' y='${(33)}'
-    font-family='Arial' font-size='12px' fill='black' text-anchor='middle'>${(i + 1)}</text>`;
+
+    //Changes text colors of week numbers in course SVG (course schedule with deadlines)
+    if(storedTheme.includes("blackTheme.css")){ //If theme is black then week numbers in the course schedule should be white
+      str += `<text x='${((i * weekwidth) + (weekwidth * 0.5))}' y='${(33)}'
+      font-family='Arial' font-size='12px' fill='white' text-anchor='middle'>${(i + 1)}</text>`;
+    }else{ //If theme is white then week numbers in the course schedule should be black
+      str += `<text x='${((i * weekwidth) + (weekwidth * 0.5))}' y='${(33)}'
+      font-family='Arial' font-size='12px' fill='black' text-anchor='middle'>${(i + 1)}</text>`;
+    }
+
   }
 
   for (var i = 1; i < (deadlineEntries.length + 2); i++) {
@@ -2279,8 +2293,19 @@ function drawSwimlanes() {
           textcol = `url("#fadeTextRed")`;
         }
 
-        str += `<rect opacity='0.7' x='${(startday * daywidth)}' y='${(weeky)}' width='${(duggalength * daywidth)}' height='${weekheight}' fill='${fillcol}' />`;
-        str += `<text x='${(12)}' y='${(weeky + 18)}' font-family='Arial' font-size='12px' fill='${textcol}' text-anchor='left'> <title> ${entry.text} </title>${entry.text}</text>`;
+        if(storedTheme.includes("blackTheme.css")){ //If theme is black then dugga progress should be more pigmented
+          str += `<rect opacity='0.9' x='${(startday * daywidth)}' y='${(weeky)}' width='${(duggalength * daywidth)}' height='${weekheight}' fill='${fillcol}' />`;
+        }else{ //If theme is white then week numbers in the course schedule should be less pigmented
+          str += `<rect opacity='0.7' x='${(startday * daywidth)}' y='${(weeky)}' width='${(duggalength * daywidth)}' height='${weekheight}' fill='${fillcol}' />`;
+        }
+
+        //Changes text colors of assignments/duggor in course SVG (course schedule with deadlines)
+        if(storedTheme.includes("blackTheme.css")){ //If theme is black then duggor-text in the course schedule should be white
+          str += `<text x='${(12)}' y='${(weeky + 18)}' font-family='Arial' font-size='12px' fill='#ffffff' text-anchor='left'> <title> ${entry.text} </title>${entry.text}</text>`;
+        }else{ //If theme is white then duggor-text in the course schedule should be black
+          str += `<text x='${(12)}' y='${(weeky + 18)}' font-family='Arial' font-size='12px' fill='${textcol}' text-anchor='left'> <title> ${entry.text} </title>${entry.text}</text>`;
+        }
+        
       }
     }
   }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2229,8 +2229,6 @@ function drawSwimlanes() {
     "<linearGradient gradientUnits='userSpaceOnUse' x1='0' x2='300' y1='0' y2='0' id='fadeTextRed'>" +
     "<stop offset='85%' stop-opacity='1' stop-color='#FF0000' /><stop offset='100%' stop-opacity='0'/> </linearGradient></defs>";
 
-  const storedTheme = localStorage.getItem('themeBlack');
-
   for (var i = 0; i < weekLength; i++) {
     // Draws the columns in the course schedule
     if ((i % 2) == 0){ str += "<rect class='evenScheduleColumn'";} // Even columns get the class "evenScheduleColumn"

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -70,8 +70,8 @@ function burgerToggleDarkmode(operation = 'click') {
     localStorage.setItem('themeBlack', themeStylesheet.href)
     backgroundColorTheme = "#fff";
   }
-  // Redraw course calendar / planner SVG to get the appropriate color scheme
-  // Course calendar = the SVG that displays the weeks and how far into a course we are (not sure what to call it)
+  // Redraw course schedule / planner SVG to get the appropriate color scheme
+  // Course schedule = the SVG that displays the weeks and how far into a course we are
   drawSwimlanes();
 
   //const themeToggle = document.getElementById('theme-toggle');

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -60,15 +60,17 @@ function burgerToggleDarkmode(operation = 'click') {
   const themeToggle = document.getElementById('theme-toggle');
   // if it's light -> go dark
   if (themeStylesheet.href.includes('blackTheme')) {
-    themeStylesheet.href = "../Shared/css/whiteTheme.css";
+    themeStylesheet.href = "../Shared/css/style.css";
     localStorage.setItem('themeBlack', themeStylesheet.href)
     backgroundColorTheme = "#121212";
+    drawSwimlanes();
   }
-  else if (themeStylesheet.href.includes('whiteTheme')) {
+  else if (!themeStylesheet.href.includes('blackTheme')) {
     // if it's dark -> go light
     themeStylesheet.href = "../Shared/css/blackTheme.css";
     localStorage.setItem('themeBlack', themeStylesheet.href)
     backgroundColorTheme = "#fff";
+    drawSwimlanes();
   }
 
   //const themeToggle = document.getElementById('theme-toggle');
@@ -2159,7 +2161,7 @@ function returnedHighscore(data) {
 //----------------------------------------------------------------------------------
 
 function drawSwimlanes() {
-
+  document.getElementById("swimlaneSVG").innerHTML = "";
   var startdate = new Date(retdata['startdate']);
   var enddate = new Date(retdata['enddate']);
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -63,15 +63,16 @@ function burgerToggleDarkmode(operation = 'click') {
     themeStylesheet.href = "../Shared/css/style.css";
     localStorage.setItem('themeBlack', themeStylesheet.href)
     backgroundColorTheme = "#121212";
-    drawSwimlanes();
   }
   else if (!themeStylesheet.href.includes('blackTheme')) {
     // if it's dark -> go light
     themeStylesheet.href = "../Shared/css/blackTheme.css";
     localStorage.setItem('themeBlack', themeStylesheet.href)
     backgroundColorTheme = "#fff";
-    drawSwimlanes();
   }
+  // Redraw course calendar / planner SVG to get the appropriate color scheme
+  // Course calendar = the SVG that displays the weeks and how far into a course we are (not sure what to call it)
+  drawSwimlanes();
 
   //const themeToggle = document.getElementById('theme-toggle');
   //themeToggle.addEventListener('click', () => {});
@@ -2161,6 +2162,7 @@ function returnedHighscore(data) {
 //----------------------------------------------------------------------------------
 
 function drawSwimlanes() {
+  // Resets the swimlane SVG
   document.getElementById("swimlaneSVG").innerHTML = "";
   var startdate = new Date(retdata['startdate']);
   var enddate = new Date(retdata['enddate']);
@@ -2230,13 +2232,13 @@ function drawSwimlanes() {
     "<linearGradient gradientUnits='userSpaceOnUse' x1='0' x2='300' y1='0' y2='0' id='fadeTextRed'>" +
     "<stop offset='85%' stop-opacity='1' stop-color='#FF0000' /><stop offset='100%' stop-opacity='0'/> </linearGradient></defs>";
 
-  var storedTheme = localStorage.getItem('themeBlack');
+  const storedTheme = localStorage.getItem('themeBlack');
 
   for (var i = 0; i < weekLength; i++) {
     str += "<rect x='" + (i * weekwidth) + "' y='" + (15) + "' width='" +
       (weekwidth) + "' height='" + (weekheight * (deadlineEntries.length + 1)) + "' ";
     // The following code decides the color scheme of the course timeline 
-    // (The svg showing how far in we are in a course and assignment deadlines)
+    // (The svg showing how far into a course we are and assignment deadlines)
     if ((i % 2) == 0 && !(storedTheme.includes("blackTheme.css"))) { // All even columns should be light gray in white theme
       str += "fill='#ededed' />";
     } else if((i % 2) != 0 && !(storedTheme.includes("blackTheme.css"))){ // All uneven columns should be white in white theme

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -76,10 +76,6 @@
 	background-color: var(--color-background-light-surface);
 }
 
-#picktemplate img{
-
-}
-
 #picktemplate h1{
 	text-align: center;
   font-family: Arial, Sans-Serif;
@@ -539,8 +535,25 @@ body {
 
 #statisticsSwimlanes{
     border: 2px solid var(--color-text-secondary);
-
 }
+
+/* Course schedule styling */
+#swimlaneSVG rect:nth-child(odd){
+    opacity: 0.9;
+}
+
+.scheduleWeeks, .scheduleDugga{
+   fill: white;
+}
+
+.evenScheduleColumn{
+    fill:#2d3133;
+}
+
+.oddScheduleColumn{
+    fill:#242729;
+}
+/* Course schedule styling END */
 
 .DateColorInDarkMode{
     cursor: pointer;

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1286,7 +1286,7 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 
 #a4Text {
     fill: white;
-
+}
 .date-interval-selector, #searchbar, #highlight-entry {
     background-color: #212121;
     color: white;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -917,6 +917,23 @@ p {
   font-size: 10px;
 }
 
+#swimlaneSVG rect:nth-child(odd){
+  fill: #620C5B80; 
+  opacity: 0.7;
+}
+
+.scheduleWeeks{
+  fill: black;
+}
+
+.evenScheduleColumn{
+  fill:#f0f0f0;
+}
+
+.oddScheduleColumn{
+  fill:#ffffff;
+}
+
 @media only screen and (max-width: 800px), only screen and (orientation:portrait) {
   #swimlaneSVG text {
       font-size: 14px;
@@ -4889,6 +4906,8 @@ rect[class*="activitymarker"]:hover {
   margin-bottom: 5px;
   margin-right: 2px;
 }
+
+
 
 #searchBar img,
 #testSearchContainer img {


### PR DESCRIPTION
My issue was that there was only a light theme for the course schedule (SVG). 
I made it so that the schedule SVG works in dark mode and light mode. The dark mode version now looks like this:
![Skärmavbild 2024-04-11 kl  13 18 20](https://github.com/HGustavs/LenaSYS/assets/129263915/f7fe91f6-451a-4a32-8e39-f620dc06de17)

The theme should also update without having to refresh the page. To update the theme, you should only have to press the moon button:
![Skärmavbild 2024-04-11 kl  13 19 18](https://github.com/HGustavs/LenaSYS/assets/129263915/515292a7-c7a0-4bd6-a7ca-6842b6ec7616)

Additionally, test that it also works when using the moon button from the burger menu (can be accessed with smaller devices). This button within the burger menu can be seen below: 
![Skärmavbild 2024-04-11 kl  13 20 22](https://github.com/HGustavs/LenaSYS/assets/129263915/e9f51cd0-d73a-4b72-be09-12a911ab59e9)

The SVG whould update without having to refresh the page, even when using the burger menu version of the button.

Pull request from issue #14450 