### PR TITLE
aligned instructions and canvas #12886

### DIFF
--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -32,6 +32,7 @@
             overflow: auto;
             margin-left: 0px;
             border: 1px solid #ccc;
+            padding-bottom: 2px;
         }
         
         .canvas_right {


### PR DESCRIPTION
Added `padding-bottom: 2px;` to the instructions window so they line up