### PR TITLE
Fixed issue where resizing elements caused the position to change. #14383

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2492,7 +2492,9 @@ function mmoving(event) {
             } else if (startNodeDown && (startHeight - (deltaY / zoomfact)) > minHeight) {
                 // Fetch original height
                 var tmp = elementData.height;
+
                 elementData.height = (startHeight - (deltaY / zoomfact));
+
 
                 // Deduct the new height, giving us the total change
                 const heightChange = -(tmp - elementData.height);
@@ -2513,22 +2515,29 @@ function mmoving(event) {
                         preResizeHeight.push(resizedElement);
                     }
                 }
+
+
                 stateMachine.save(StateChangeFactory.ElementResized([elementData.id], 0, heightChange), StateChange.ChangeTypes.ELEMENT_RESIZED);
             } else if (startNodeUp && (startHeight + (deltaY / zoomfact)) > minHeight) {
                 // Fetch original height
                 var tmp = elementData.height;
+
                 elementData.height = (startHeight + (deltaY / zoomfact));
+
 
                 // Deduct the new height, giving us the total change
                 const heightChange = -(tmp - elementData.height);
+
 
                 // Fetch original y-position
                 // "+ 14" hardcoded, for some reason the superstate jumps up 14 pixels when using this node.
                 tmp = elementData.y;
                 elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 14)).y;
 
+
                 // Deduct the new position, giving us the total change
                 const yChange = -(tmp - elementData.y);
+
 
                 // Adds a deep clone of the element to preResizeHeight if it isn't in it
                 let foundID = false;
@@ -2546,6 +2555,8 @@ function mmoving(event) {
                         preResizeHeight.push(resizedElement);
                     }
                 }
+                console.log("yChange: ", yChange);
+                console.log("heightChange: ", heightChange);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             }
             document.getElementById(context[0].id).remove();
@@ -9030,7 +9041,7 @@ function drawElement(element, ghosted = false) {
 
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.5))}px; width:${boxw}px;font-size:${texth}px;z-index:1;`;
+        style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;z-index:1;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9202,7 +9213,7 @@ function drawElement(element, ghosted = false) {
 
         //div to encapuslate SD element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.15))}px; width:${boxw}px;font-size:${texth}px;z-index:1;`;
+        style='left:0px; top:0px; width:${boxw}px;font-size:${texth}px;z-index:1;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9293,7 +9304,7 @@ function drawElement(element, ghosted = false) {
     else if (element.kind == 'UMLRelation') {
         //div to encapuslate UML element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px; margin-top:${((boxh / 3))}px;z-index:1;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh}px;z-index:1;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9353,7 +9364,7 @@ function drawElement(element, ghosted = false) {
 
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element uml-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' 
-        style='left:0px; top:0px;margin-top:${((boxh * -0.15))}px; width:${boxw}px;font-size:${texth}px;z-index:1;`;
+        style='left:0px; top:0px;width:${boxw}px;font-size:${texth}px;z-index:1;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9405,7 +9416,7 @@ function drawElement(element, ghosted = false) {
     else if (element.kind == 'IERelation') {
         //div to encapuslate IE element
         str += `<div id='${element.id}'	class='element ie-element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave();'
-        style='left:0px; top:0px; margin-top:${((boxh / 1.5))}px; width:${boxw}px;height:${boxh / 2}px;z-index:1;`;
+        style='left:0px; top:0px; width:${boxw}px;height:${boxh / 2}px;z-index:1;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9657,7 +9668,7 @@ function drawElement(element, ghosted = false) {
         }
         //div to encapuslate note element
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'
-        style='left:0px; top:0px;margin-top:${((boxh * -0.4))}px; width:${boxw}px;font-size:${texth}px;`;
+        style='left:0px; top:0px;width:${boxw}px;font-size:${texth}px;`;
         if (context.includes(element)) {
             str += `z-index: 1;`;
         }
@@ -9741,7 +9752,6 @@ function drawElement(element, ghosted = false) {
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxh / 2))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;
@@ -9749,7 +9759,6 @@ function drawElement(element, ghosted = false) {
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxh / 2))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;
@@ -9757,7 +9766,6 @@ function drawElement(element, ghosted = false) {
             str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';' style='
                             left:0px;
                             top:0px;
-                            margin-top:${((boxh / 2.75))}px;;
                             width:${boxw}px;
                             height:${boxh}px;
                             font-size:${texth}px;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2492,9 +2492,7 @@ function mmoving(event) {
             } else if (startNodeDown && (startHeight - (deltaY / zoomfact)) > minHeight) {
                 // Fetch original height
                 var tmp = elementData.height;
-
                 elementData.height = (startHeight - (deltaY / zoomfact));
-
 
                 // Deduct the new height, giving us the total change
                 const heightChange = -(tmp - elementData.height);
@@ -2515,29 +2513,22 @@ function mmoving(event) {
                         preResizeHeight.push(resizedElement);
                     }
                 }
-
-
                 stateMachine.save(StateChangeFactory.ElementResized([elementData.id], 0, heightChange), StateChange.ChangeTypes.ELEMENT_RESIZED);
             } else if (startNodeUp && (startHeight + (deltaY / zoomfact)) > minHeight) {
                 // Fetch original height
                 var tmp = elementData.height;
-
                 elementData.height = (startHeight + (deltaY / zoomfact));
-
 
                 // Deduct the new height, giving us the total change
                 const heightChange = -(tmp - elementData.height);
-
 
                 // Fetch original y-position
                 // "+ 14" hardcoded, for some reason the superstate jumps up 14 pixels when using this node.
                 tmp = elementData.y;
                 elementData.y = screenToDiagramCoordinates(0, (startY - deltaY + 14)).y;
 
-
                 // Deduct the new position, giving us the total change
                 const yChange = -(tmp - elementData.y);
-
 
                 // Adds a deep clone of the element to preResizeHeight if it isn't in it
                 let foundID = false;
@@ -2555,8 +2546,6 @@ function mmoving(event) {
                         preResizeHeight.push(resizedElement);
                     }
                 }
-                console.log("yChange: ", yChange);
-                console.log("heightChange: ", heightChange);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             }
             document.getElementById(context[0].id).remove();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9041,7 +9041,7 @@ function drawElement(element, ghosted = false) {
         str += `'>`;
 
         //div to encapuslate UML header
-        str += `<div class='uml-header' style='width: ${boxw}; height: ${boxh};'>`;
+        str += `<div class='uml-header' style='width: ${boxw}; height: ${boxh - (linew * 2)}px;'>`;
         //svg for UML header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh - (linew * 2)}'
@@ -9053,7 +9053,7 @@ function drawElement(element, ghosted = false) {
         str += `</div>`;
 
         //div to encapuslate UML content
-        str += `<div class='uml-content' style='margin-top: -0.5em;'>`;
+        str += `<div class='uml-content' style='height:${boxh - (linew * 2)}px'>`;
         //Draw UML-content if there exist at least one attribute
         if (elemAttri != 0) {
             //svg for background
@@ -9081,7 +9081,7 @@ function drawElement(element, ghosted = false) {
         //Draw UML-footer if there exist at least one function
         if (elemFunc != 0) {
             //div for UML footer
-            str += `<div class='uml-footer' style='margin-top: -0.5em; height: ${boxh / 2 + (boxh * elemFunc / 2)}px;'>`;
+            str += `<div class='uml-footer' style='height: ${boxh / 2 + (boxh * elemFunc / 2)}px;'>`;
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemFunc / 2)}'>`;
             str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemFunc / 2) - (linew * 2)}'
@@ -9094,7 +9094,7 @@ function drawElement(element, ghosted = false) {
             // Draw UML-footer if there are no functions
         } else {
             //div for UML footer
-            str += `<div class='uml-footer' style='margin-top: -0.5em; height: ${boxh / 2 + (boxh / 2)}px;'>`;
+            str += `<div class='uml-footer' style='height: ${boxh / 2 + (boxh / 2)}px;'>`;
             //svg for background
             str += `<svg width='${boxw}' height='${boxh / 2 + (boxh / 2)}'>`;
             str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh / 2) - (linew * 2)}'
@@ -9213,7 +9213,7 @@ function drawElement(element, ghosted = false) {
         str += `'>`;
 
         //div to encapuslate SD header
-        str += `<div style='width: ${boxw}; height: ${boxh};'>`;
+        str += `<div style='width: ${boxw}; height: ${boxh - (linew * 2)}px;'>`;
         //svg for SD header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<path class="text" 
@@ -9238,7 +9238,7 @@ function drawElement(element, ghosted = false) {
         str += `</div>`;
 
         //div to encapuslate SD content
-        str += `<div style='margin-top: ${-8 * zoomfact}px;'>`;
+        str += `<div style='margin-top: ${-8 * zoomfact}px; height: ${boxh / 2 + (boxh * elemAttri / 2)}px'>`;
         //Draw SD-content if there exist at least one attribute
         if (elemAttri != 0) {
             /* find me let sdOption = document.getElementById("SDOption");
@@ -9267,7 +9267,7 @@ function drawElement(element, ghosted = false) {
             // Draw SD-content if there are no attributes.
         } else {
             //svg for background
-            str += `<svg width='${boxw}' height='${boxh / 2 + (boxh / 2)}'>`;
+            str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}'>`;
             str += `<path class="text"
                 d="M${linew},${(linew)}
                     h${(boxw - (linew * 2))}
@@ -9364,7 +9364,7 @@ function drawElement(element, ghosted = false) {
         str += `'>`;
 
         //div to encapuslate IE header
-        str += `<div class='uml-header' style='width: ${boxw}; height: ${boxh};'>`;
+        str += `<div class='uml-header' style='width: ${boxw}; height: ${boxh - (linew * 2)}px;'>`;
         //svg for IE header, background and text
         str += `<svg width='${boxw}' height='${boxh}'>`;
         str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh - (linew * 2)}'
@@ -9376,11 +9376,11 @@ function drawElement(element, ghosted = false) {
         str += `</div>`;
 
         //div to encapuslate IE content
-        str += `<div class='uml-content' style='margin-top: ${-8 * zoomfact}px;'>`;
+        str += `<div class='uml-content' style='height: ${boxh / 2 + (boxh * elemAttri / 2)}px;'>`;
         //Draw IE-content if there exist at least one attribute
         if (elemAttri != 0) {
             //svg for background
-            str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}'>`;
+            str += `<svg width='${boxw}' height='${boxh / 2 + (boxh * elemAttri / 2)}px'>`;
             str += `<rect class='text' x='${linew}' y='${linew}' width='${boxw - (linew * 2)}' height='${boxh / 2 + (boxh * elemAttri / 2) - (linew * 2)}'
             stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' />`;
             for (var i = 0; i < elemAttri; i++) {


### PR DESCRIPTION
Removed 'margin-top' property from all elements. The calculations for the height of the elements when resizing was incorrect due to the 'margin-top' property. 

Resizing elements now work as intended.