### PR TITLE
Improve consistency in dark mode for course planning svg

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -538,7 +538,7 @@ body {
 }
 
 /* Course schedule styling */
-#swimlaneSVG rect:nth-child(odd){
+#swimlaneSVG rect:nth-child(n of .progressBar){
     opacity: 0.9;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -917,7 +917,7 @@ p {
   font-size: 10px;
 }
 
-#swimlaneSVG rect:nth-child(odd){
+#swimlaneSVG rect:nth-child(n of .progressBar){
   fill: #620C5B80; 
   opacity: 0.7;
 }


### PR DESCRIPTION
The issue appeared to be the styling of the progressbars being applied by simply applying styling to every odd child of swimlaneSVG.

as the demo course has 9 columns instead of 10 like webbutveckling, the styling got "desynced". Simply changing it to apply specifically to children of swimlaneSVG that also have the class progressbar appears to have fixed it well.

the progressbars themselves still span the entirety of the demo course schedule, but we believe that to be intentional.