### PR TITLE
G3 2024 v2 #14550

### DIFF
--- a/dockerenv/.gitattributes
+++ b/dockerenv/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/dockerenv/.gitignore
+++ b/dockerenv/.gitignore
@@ -1,0 +1,3 @@
+mysql-data
+githubMetadata
+

--- a/dockerenv/Dockerfile
+++ b/dockerenv/Dockerfile
@@ -25,11 +25,14 @@ RUN echo '<Directory /var/www/html>' > /etc/apache2/conf-available/custom-direct
     && echo '</Directory>' >> /etc/apache2/conf-available/custom-directory-listing.conf \
     && a2enconf custom-directory-listing
 
-# Change permissions
-RUN chown -R www-data:www-data /var/www/
+# Copy the initialization script
+COPY init.sh /usr/local/bin/init.sh
 
-# Create directory for github metadata
-RUN mkdir /var/www/html/githubMetadata
+# Make sure the script is executable
+RUN chmod +x /usr/local/bin/init.sh
+
+# Set the script as the entrypoint
+ENTRYPOINT [ "/usr/local/bin/init.sh" ]
 
 # Default command
 CMD [ "apache2-foreground" ]

--- a/dockerenv/Dockerfile
+++ b/dockerenv/Dockerfile
@@ -1,0 +1,35 @@
+FROM php:8.0-apache
+
+# Update package list and install system dependencies required for PHP extensions
+RUN apt-get update && \
+    apt-get install -y \
+    libaio1 \
+    git \
+    libsqlite3-dev \
+    libcurl4-openssl-dev \
+    && docker-php-ext-install pdo_mysql pdo_sqlite curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Increase PHP upload size
+RUN { \
+        echo 'upload_max_filesize=128M'; \
+        echo 'post_max_size=128M'; \
+    } > /usr/local/etc/php/conf.d/uploads.ini
+
+# Enable Apache Directory Listing
+RUN a2enmod autoindex
+RUN echo '<Directory /var/www/html>' > /etc/apache2/conf-available/custom-directory-listing.conf \
+    && echo '    Options Indexes FollowSymLinks' >> /etc/apache2/conf-available/custom-directory-listing.conf \
+    && echo '    AllowOverride None' >> /etc/apache2/conf-available/custom-directory-listing.conf \
+    && echo '    Require all granted' >> /etc/apache2/conf-available/custom-directory-listing.conf \
+    && echo '</Directory>' >> /etc/apache2/conf-available/custom-directory-listing.conf \
+    && a2enconf custom-directory-listing
+
+# Change permissions
+RUN chown -R www-data:www-data /var/www/
+
+# Create directory for github metadata
+RUN mkdir /var/www/html/githubMetadata
+
+# Default command
+CMD [ "apache2-foreground" ]

--- a/dockerenv/Dockerfile
+++ b/dockerenv/Dockerfile
@@ -26,10 +26,11 @@ RUN echo '<Directory /var/www/html>' > /etc/apache2/conf-available/custom-direct
     && a2enconf custom-directory-listing
 
 # Copy the initialization script
-COPY init.sh /usr/local/bin/init.sh
+COPY ./init.sh /usr/local/bin/init.sh
 
 # Make sure the script is executable
 RUN chmod +x /usr/local/bin/init.sh
+RUN sed -i 's/\r$//' /usr/local/bin/init.sh
 
 # Set the script as the entrypoint
 ENTRYPOINT [ "/usr/local/bin/init.sh" ]

--- a/dockerenv/Dockerfile
+++ b/dockerenv/Dockerfile
@@ -32,8 +32,12 @@ COPY ./init.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 RUN sed -i 's/\r$//' /usr/local/bin/init.sh
 
+USER root
+
 # Set the script as the entrypoint
 ENTRYPOINT [ "/usr/local/bin/init.sh" ]
+
+USER www-data
 
 # Default command
 CMD [ "apache2-foreground" ]

--- a/dockerenv/coursesyspw.php
+++ b/dockerenv/coursesyspw.php
@@ -1,0 +1,7 @@
+<?php
+          define("DB_USER","lenasys");
+          define("DB_PASSWORD","password");
+          define("DB_HOST","db");
+          define("DB_NAME","lenasysdb");
+          define("DB_USING_DOCKER","on");
+        ?>

--- a/dockerenv/docker-compose.yml
+++ b/dockerenv/docker-compose.yml
@@ -2,16 +2,17 @@ version: '3.9'
 services:
   web:
     build: .
+    platform: linux/amd64
     container_name: apache-php
     ports:
       - "80:80"
     volumes:
-      - "../:/var/www/html/LenaSYS"
-      - "./coursesyspw.php:/var/www/html/coursesyspw.php"
-      - "./githubMetadata:/var/www/html/githubMetadata"
+      - "../:/var/www/html/LenaSYS:delegated"
+      - "./coursesyspw.php:/var/www/html/coursesyspw.php:delegated"
+      - "./githubMetadata:/var/www/html/githubMetadata:delegated"
     restart: no
   db:
-    image: mysql:5.7.42
+    image: mysql:latest
     container_name: mysql-server
     environment:
       MYSQL_ROOT_PASSWORD: password
@@ -23,6 +24,7 @@ services:
     restart: no
   dbadmin:
     image: phpmyadmin/phpmyadmin
+    platform: linux/amd64
     container_name: phpmyadmin
     environment:
       PMA_HOST: db

--- a/dockerenv/docker-compose.yml
+++ b/dockerenv/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    container_name: apache-php
+    ports:
+      - "80:80"
+    volumes:
+      - "../:/var/www/html/LenaSYS"
+      - "./coursesyspw.php:/var/www/html/coursesyspw.php"
+      - "./githubMetadata:/var/www/html/githubMetadata"
+    restart: no
+  db:
+    image: mysql:5.7.42
+    container_name: mysql-server
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: db
+      MYSQL_USER: dbuser
+      MYSQL_PASSWORD: password
+    volumes:
+      - "./mysql-data:/var/lib/mysql"
+    restart: no
+  dbadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin
+    environment:
+      PMA_HOST: db
+      PMA_USER: root
+      PMA_PASSWORD: password
+    ports:
+      - "8080:80"
+    restart: no

--- a/dockerenv/docker_install_instructions.md
+++ b/dockerenv/docker_install_instructions.md
@@ -1,0 +1,7 @@
+# Docker installation instructions
+
+1. Install [docker desktop](https://www.docker.com/products/docker-desktop/).
+2. Open the `LenaSYS/dockerenv` directory/folder in the terminal.
+3. Run the command: `docker compose up -d` to setup and start the containers.
+4. Navigate to [localhost/LenaSYS/install/install.php](http://localhost/LenaSYS/install/install.php).
+5. Navigate through the installer (On the first page the correct info should be present). `password` is the default mysql root password in this config.

--- a/dockerenv/init.sh
+++ b/dockerenv/init.sh
@@ -6,9 +6,13 @@ if ! id "www-data" &>/dev/null; then
     useradd -u 33 -g www-data -s /bin/false www-data
 fi
 
-chown www-data:1000 /var/www/html/coursesyspw.php
+# Set appropriate user rights
+umask 000
+chown www-data:www-data /var/www/html/coursesyspw.php
 mkdir /var/www/html/githubMetadata
+chown www-data:www-data /var/www/html/LenaSYS
 chown -R www-data:www-data /var/www/html/githubMetadata
+chmod -R 777 /var/www/html
 
 git config core.fileMode false
 

--- a/dockerenv/init.sh
+++ b/dockerenv/init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+chown www-data:1000 /var/www/html/coursesyspw.php
+mkdir /var/www/html/githubMetadata
+chown -R www-data:www-data /var/www/html/githubMetadata
+
+git config core.fileMode false
+
+# Execute the main container command
+exec "$@"

--- a/dockerenv/init.sh
+++ b/dockerenv/init.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Add user and group if not exists
+if ! id "www-data" &>/dev/null; then
+    groupadd -g 33 www-data
+    useradd -u 33 -g www-data -s /bin/false www-data
+fi
+
 chown www-data:1000 /var/www/html/coursesyspw.php
 mkdir /var/www/html/githubMetadata
 chown -R www-data:www-data /var/www/html/githubMetadata

--- a/install/install.php
+++ b/install/install.php
@@ -56,7 +56,7 @@
     //---------------------------------------------------------------------------------------------------
     function isPermissionsSat($crntFilePath){
       $permissionsSat = false;
-      if(!mkdir("{$crntFilePath}/testPermissionsForInstallationToStartDir", 0060)) {
+      if(!mkdir("{$crntFilePath}/testPermissionsForInstallationToStartDir", 0755)) {
         $permissionsSat = false;
       }
       else {


### PR DESCRIPTION
Implemented a docker environment config, that should let users from various systems easily setup a development environment. View the instructions in `dockerenv/docker_install_instructions.md` to test it. I have tested it on windows and linux, where it works. But I have not tested it on mac os. 

When testing, please specify your platform. If it did not work specify error messages. 