### PR TITLE
G2 2024 v2 issue#14504

### DIFF
--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -155,6 +155,7 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid) || has
 //------------------------------------------------------------------------------------------------
 $mass=array();
 $entries=array();
+$variants=array();
 $files=array();
 $duggaPages = array();
 
@@ -212,6 +213,7 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid) || has
 				"trashcanVariant" => $rowz["vid"]
 				);
 
+			array_push($variants, html_entity_decode($rowz["variantanswer"]));
 			array_push($mass, $entryz);
 		}
 
@@ -252,8 +254,8 @@ $array = array(
 	'files' => $files,
 	'duggaPages' => $duggaPages,
 	'coursecode' => $coursecode,
-	'coursename' => $coursename
-
+	'coursename' => $coursename,
+	'variants' => $variants
 );
 
 echo json_encode($array);

--- a/DuggaSys/tests/duggaedservice-tests.php
+++ b/DuggaSys/tests/duggaedservice-tests.php
@@ -116,7 +116,7 @@ $testsData = array(
     //Test works, but it is not possible to gather the correct expected output since the array is within an array, and the api is currently unable to handle it properly. (,"entries":[{"variantanswer":"Test text"}])
     //Test works meaning that a variant is added correctly when checked without following deletes..
     'add variant' => array(
-    'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik"}',
+    'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","","","Test text"]}',
         'service' => 'http://localhost/LenaSYS/DuggaSys/duggaedservice.php',
         'service-data' => serialize(
             array(
@@ -148,7 +148,7 @@ $testsData = array(
     //Test works, but it is not possible to gather the correct expected output since the array is within an array, and the api is currently unable to handle it properly.
     //Test works meaning that a variant is updated correctly when checked without following deletes.
     'update a variant' => array(
-        'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik"}',
+        'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","","","Test text updated"]}',
         'query-before-test-1' => "SELECT vid FROM variant WHERE variantanswer = 'Test text'",
         'service' => 'http://localhost/LenaSYS/DuggaSys/duggaedservice.php',
         'service-data' => serialize(
@@ -180,7 +180,7 @@ $testsData = array(
     //Test works, but it is not possible to gather the correct expected output since the array is within an array, and the api is currently unable to handle it properly.
     //Test works meaning that a variant is deleted correctly when checked. All previous tests have been tested thoroughly so we now that they were added to begin with.
     'delete variant' => array(
-        'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik"}',
+        'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","",""]}',
         'query-before-test-1' => "SELECT vid FROM variant WHERE variantanswer = 'Test text updated'",
         'service' => 'http://localhost/LenaSYS/DuggaSys/duggaedservice.php',
         'service-data' => serialize(

--- a/DuggaSys/tests/duggaedservice-tests.php
+++ b/DuggaSys/tests/duggaedservice-tests.php
@@ -138,7 +138,8 @@ $testsData = array(
                 'debug',
                 'writeaccess',
                 'coursename',
-                'coursecode'
+                'coursecode',
+                'variants',
                 
             )
         ),
@@ -170,7 +171,8 @@ $testsData = array(
                 'debug',
                 'writeaccess',
                 'coursename',
-                'coursecode'
+                'coursecode',
+                'variants',
             )
         ),
     ),
@@ -198,7 +200,8 @@ $testsData = array(
                 'debug',
                 'writeaccess',
                 'coursename',
-                'coursecode'
+                'coursecode',
+                'variants',
             )
         ),
     ),

--- a/DuggaSys/tests/duggaedservice-tests.php
+++ b/DuggaSys/tests/duggaedservice-tests.php
@@ -113,8 +113,6 @@ $testsData = array(
         ),
     ),
 
-    //Test works, but it is not possible to gather the correct expected output since the array is within an array, and the api is currently unable to handle it properly. (,"entries":[{"variantanswer":"Test text"}])
-    //Test works meaning that a variant is added correctly when checked without following deletes..
     'add variant' => array(
     'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","","","Test text"]}',
         'service' => 'http://localhost/LenaSYS/DuggaSys/duggaedservice.php',
@@ -145,8 +143,6 @@ $testsData = array(
         ),
     ),
 
-    //Test works, but it is not possible to gather the correct expected output since the array is within an array, and the api is currently unable to handle it properly.
-    //Test works meaning that a variant is updated correctly when checked without following deletes.
     'update a variant' => array(
         'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","","","Test text updated"]}',
         'query-before-test-1' => "SELECT vid FROM variant WHERE variantanswer = 'Test text'",
@@ -177,8 +173,6 @@ $testsData = array(
         ),
     ),
 
-    //Test works, but it is not possible to gather the correct expected output since the array is within an array, and the api is currently unable to handle it properly.
-    //Test works meaning that a variant is deleted correctly when checked. All previous tests have been tested thoroughly so we now that they were added to begin with.
     'delete variant' => array(
         'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","",""]}',
         'query-before-test-1' => "SELECT vid FROM variant WHERE variantanswer = 'Test text updated'",


### PR DESCRIPTION
**Fix bugs in dugggaedservice-tests.php**
File: duggaedservice-tests.php

Issue: Variant tests passes even when the variant id is not retrieved correctly, causing the operations tested to not take place.


all "Test 3 (assertEqual)" tests should now fail when faulty values are entered.

Important for testing:
If you have made changes to the variant table before, you might need to reinstall your database or remove any new rows so that the expected outputs are correct.

If you make the "update variant" or "delete variant" tests fail on purpose, make sure to manually delete the newly created variants in the variants table before testing again (delete the last rows where variantanswer = 'Test text' or 'Test text updated').