### PR TITLE
deleted height and weight from CSS

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -781,8 +781,6 @@
 }
 
 #a4Rect {
-    width: 794px;
-    height: 1122px;
     stroke:rgb(50, 50, 50);
     stroke-width:2;
     stroke-dasharray: 5 3;


### PR DESCRIPTION
Weight and height was defined in two places: CSS and javascript . I deleted wight and height from CSS file.