### PR TITLE
Fixed unsolicited 503 error and added the option to insert github key G3 2024 v2 #14563

### DIFF
--- a/DuggaSys/a22kara.txt
+++ b/DuggaSys/a22kara.txt
@@ -1,0 +1,1 @@
+ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx

--- a/DuggaSys/a22kara.txt
+++ b/DuggaSys/a22kara.txt
@@ -1,1 +1,0 @@
-ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -335,6 +335,7 @@ function selectCourse(cid, coursename, coursecode, visi, vers, edvers, gitHubUrl
 	}else{
 		$("#editcoursegit-url").val("");
 	}
+	$("#githubToken").val("");
 	
 
 	//Give data attribute to course code input to check if input value is same as actual code for validation

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -427,6 +427,7 @@ function editSettings(){
 
 function updateSettings() {
 	const messageElement = document.getElementById("motd");
+	const token = document.getElementById("githubToken").value;
 	const readOnlyCheckbox = document.getElementById("readonly");
 	const popupContainer = document.getElementById("editSettings");
 
@@ -436,9 +437,35 @@ function updateSettings() {
 		readonly = 0;
 	}
 	if (window.bool9 === true) {
+		$.ajax({
+			async: false,
+			url: "../DuggaSys/gitcommitService.php",
+			type: "POST",
+			data: {'token':token, 'action':'insertTokenToMetaData'},
+			success: function() { 
+				//Returns true if the data and JSON is correct
+				dataCheck = true;
+			},
+			error: function(data){
+				//Check FetchGithubRepo for the meaning of the error code.
+				switch(data.status){
+					case 422:
+						alert(data.responseJSON.message + "\nDid not create/update token");
+						break;
+					case 503:
+						alert(data.responseJSON.message + "\nDid not create/update token");
+						break;
+					default:
+						alert("Something went wrong...");
+				}
+				 dataCheck = false;
+			}
+		});
+		
 		alert('Version updated');
 		popupContainer.style.display = "none";
 		AJAXService("SETTINGS", {motd: messageElement.value, readonly: readonly}, "COURSE");
+		return dataCheck;
 	  } else {
 		alert("You have entered incorrect information");
 	  }

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -441,7 +441,7 @@ function updateSettings() {
 			async: false,
 			url: "../DuggaSys/gitcommitService.php",
 			type: "POST",
-			data: {'token':token, 'action':'insertTokenToMetaData'},
+			data: {'token':token.value, 'action':'insertTokenToMetaData'},
 			success: function() { 
 				//Returns true if the data and JSON is correct
 				dataCheck = true;

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -441,7 +441,7 @@ function updateSettings() {
 			async: false,
 			url: "../DuggaSys/gitcommitService.php",
 			type: "POST",
-			data: {'token':token, 'action':'insertTokenToMetaData'},
+			data: {'token':token,'cid':cid, 'action':'insertTokenToMetaData'},
 			success: function() { 
 				//Returns true if the data and JSON is correct
 				dataCheck = true;

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -441,7 +441,7 @@ function updateSettings() {
 			async: false,
 			url: "../DuggaSys/gitcommitService.php",
 			type: "POST",
-			data: {'token':token.value, 'action':'insertTokenToMetaData'},
+			data: {'token':token, 'action':'insertTokenToMetaData'},
 			success: function() { 
 				//Returns true if the data and JSON is correct
 				dataCheck = true;

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -37,6 +37,62 @@ function updateCourse()
 	var courseGitURL = $("#editcoursegit-url").val();
 	var visib = $("#visib").val();
 	var courseid = "C"+cid;
+
+	var token = document.getElementById("githubToken").value;
+	
+	console.log(token);
+	if(token){
+		$.ajax({
+			async: false,
+			url: "../DuggaSys/gitcommitService.php",
+			type: "POST",
+			data: {'token':token,'cid':cid, 'action':'insertTokenToMetaData'},
+			success: function() { 
+				//Returns true if the data and JSON is correct
+				dataCheck = true;
+			},
+			error: function(data){
+				//Check FetchGithubRepo for the meaning of the error code.
+				switch(data.status){
+					case 422:
+						alert(data.responseJSON.message + "\nDid not create/update token");
+						break;
+					case 503:
+						alert(data.responseJSON.message + "\nDid not create/update token");
+						break;
+					default:
+						alert("Something went wrong...");
+				}
+				dataCheck = false;
+			}
+		});
+	}
+	$.ajax({
+		async: false,
+		url: "../DuggaSys/gitcommitService.php",
+		type: "POST",
+		data: {'githubURL':courseGitURL,'cid':cid, 'action':'directInsert'},
+		success: function() { 
+			//Returns true if the data and JSON is correct
+			dataCheck = true;
+		},
+		error: function(data){
+			//Check FetchGithubRepo for the meaning of the error code.
+			switch(data.status){
+				case 422:
+					alert(data.responseJSON.message + "\nDid not create/update token");
+					break;
+				case 503:
+					alert(data.responseJSON.message + "\nDid not create/update token");
+					break;
+				default:
+					alert("Something went wrong...");
+			}
+			dataCheck = false;
+		}
+	});
+
+	console.log(2+" "+token);
 	// Show dialog
 	$("#editCourse").css("display", "none");
 	
@@ -46,6 +102,7 @@ function updateCourse()
 	AJAXService("UPDATE", {	cid : cid, coursename : coursename, visib : visib, coursecode : coursecode, courseGitURL : courseGitURL }, "COURSE");
 	localStorage.setItem('courseid', courseid);
 	localStorage.setItem('updateCourseName', true);
+
 
 	//Check if courseGitURL has a value
 	if(courseGitURL) {
@@ -427,7 +484,6 @@ function editSettings(){
 
 function updateSettings() {
 	const messageElement = document.getElementById("motd");
-	const token = document.getElementById("githubToken").value;
 	const readOnlyCheckbox = document.getElementById("readonly");
 	const popupContainer = document.getElementById("editSettings");
 
@@ -437,31 +493,6 @@ function updateSettings() {
 		readonly = 0;
 	}
 	if (window.bool9 === true) {
-		$.ajax({
-			async: false,
-			url: "../DuggaSys/gitcommitService.php",
-			type: "POST",
-			data: {'token':token,'cid':cid, 'action':'insertTokenToMetaData'},
-			success: function() { 
-				//Returns true if the data and JSON is correct
-				dataCheck = true;
-			},
-			error: function(data){
-				//Check FetchGithubRepo for the meaning of the error code.
-				switch(data.status){
-					case 422:
-						alert(data.responseJSON.message + "\nDid not create/update token");
-						break;
-					case 503:
-						alert(data.responseJSON.message + "\nDid not create/update token");
-						break;
-					default:
-						alert("Something went wrong...");
-				}
-				 dataCheck = false;
-			}
-		});
-		
 		alert('Version updated');
 		popupContainer.style.display = "none";
 		AJAXService("SETTINGS", {motd: messageElement.value, readonly: readonly}, "COURSE");

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -159,6 +159,7 @@ if(isset($_SESSION['uid'])){
     		<div style='padding:5px;'>
 
     			<div class='inputwrapper'><span>Message of the day:</span><input class='textinput' onkeyup="validateMOTD('motd','dialog5', 'dialog52', 'submitMotd')" type='text' id='motd' placeholder='Leave blank for no MOTD' /></div>
+    			<div class='inputwrapper'><span>(optional) Insert Github Key:</span><input class='textinput' onkeyup="validateMOTD('motd','dialog5', 'dialog52', 'submitMotd')" type='text' id='githubToken' placeholder='Leave blank for no key' /></div>
     			<div class='inputwrapper'><span style='font-style:italic;'>Read Only:</span><input type="checkbox" name='readonly' id='readonly' title='Disables uploads/submits. Useful for active backup servers.'></select></div>
 				
     		</div>

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -134,6 +134,7 @@ if(isset($_SESSION['uid'])){
 					<p id="dialog6" class="validationDialog">Enter a valid github url</p>
 					<input oninput="quickValidateForm('editCourse','saveCourse')" class="textinput validate" type="text" id="editcoursegit-url" name="courseGitURL" placeholder="https://github.com/..."/>
 				</div>
+    			<div class='inputwrapper'><span>(optional) Insert Github Key:</span><input class='textinput' type='text' id='githubToken' placeholder='Leave blank for no key' /></div>
 				<div class='inputwrapper'>
 					<span>Visibility:</span>
 					<select class='selectinput' id='visib'></select>
@@ -159,7 +160,6 @@ if(isset($_SESSION['uid'])){
     		<div style='padding:5px;'>
 
     			<div class='inputwrapper'><span>Message of the day:</span><input class='textinput' onkeyup="validateMOTD('motd','dialog5', 'dialog52', 'submitMotd')" type='text' id='motd' placeholder='Leave blank for no MOTD' /></div>
-    			<div class='inputwrapper'><span>(optional) Insert Github Key:</span><input class='textinput' onkeyup="validateMOTD('motd','dialog5', 'dialog52', 'submitMotd')" type='text' id='githubToken' placeholder='Leave blank for no key' /></div>
     			<div class='inputwrapper'><span style='font-style:italic;'>Read Only:</span><input type="checkbox" name='readonly' id='readonly' title='Disables uploads/submits. Useful for active backup servers.'></select></div>
 				
     		</div>

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -33,10 +33,8 @@
 			updateGithubRepo($_POST['githubURL'], $_POST['cid']);
 		}
 		else if($_POST['action'] == 'directInsert'){
-			$myfile = fopen("a22kara.txt", "w") or die("Unable to open file!");
-            $txt = $_POST['token'];
-            fwrite($myfile, $txt);
-            fclose($myfile);
+
+			insertTokenToMetaData($_POST['token']);
 			insertIntoSQLite($_POST['githubURL'], $_POST['cid']);
 		}
 	};
@@ -93,6 +91,44 @@
 			echo $errorvar;
 		} else {
 			bfs($url, $cid, "REFRESH");
+		}
+	}
+
+	function insertTokenToMetaData($token) 
+	{
+
+		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+		
+		$query2 = $pdolite->prepare('SELECT gitToken FROM gitToken WHERE gitToken!=""');
+		$query2->execute();
+
+
+		$old_token="";
+		foreach($query2->fetchAll(PDO::FETCH_ASSOC) as $row){
+			$old_token = $row['gitToken'];
+		}
+
+
+		if(strlen($old_token)>1)
+		{
+
+			$query2 = $pdolite->prepare('UPDATE gitToken SET gitToken=:token WHERE tid=1');
+			$path='C:\Users\Användaren\Desktop\own thoughts OP\msg.txt';
+			file_put_contents($path, '');
+			$txt = "IN IF 1, NEW TOKEN: ".$token;
+
+			fwrite($myfile, $txt." ".$old_token);
+			fclose($myfile);
+			$query2->bindParam(':token', $token);
+			$query2->execute();
+
+		}
+		else
+		{
+			$query2 = $pdolite->prepare('INSERT OR REPLACE INTO gitToken (tid, gitToken) VALUES (1, :token)');
+
+			$query2->bindParam(':token', $token);
+			$query2->execute();
 		}
 	}
 

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -37,6 +37,10 @@
 			insertTokenToMetaData($_POST['token']);
 			insertIntoSQLite($_POST['githubURL'], $_POST['cid']);
 		}
+		else if($_POST['action'] == 'insertTokenToMetaData'){
+
+			insertTokenToMetaData($_POST['token']);
+		}
 	};
 
 	// -------------==============######## Creating New Course ###########==============-------------
@@ -113,12 +117,6 @@
 		{
 
 			$query2 = $pdolite->prepare('UPDATE gitToken SET gitToken=:token WHERE tid=1');
-			$path='C:\Users\Användaren\Desktop\own thoughts OP\msg.txt';
-			file_put_contents($path, '');
-			$txt = "IN IF 1, NEW TOKEN: ".$token;
-
-			fwrite($myfile, $txt." ".$old_token);
-			fclose($myfile);
 			$query2->bindParam(':token', $token);
 			$query2->execute();
 

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -2,7 +2,7 @@
 	// -------------==============######## Setup ###########==============-------------
 
 	// Variables for the refresh button, deadlines specified in seconds
-	$shortdeadline = 300; // 300 = 5 minutes
+	$shortdeadline = 10; // 300 = 5 minutes
 	$longdeadline = 600; // 600 = 10 minutes
 
 	// Used to display errors on screen since PHP doesn't do that automatically.

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -2,7 +2,7 @@
 	// -------------==============######## Setup ###########==============-------------
 
 	// Variables for the refresh button, deadlines specified in seconds
-	$shortdeadline = 10; // 300 = 5 minutes
+	$shortdeadline = 300; // 300 = 5 minutes
 	$longdeadline = 600; // 600 = 10 minutes
 
 	// Used to display errors on screen since PHP doesn't do that automatically.

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -34,12 +34,12 @@
 		}
 		else if($_POST['action'] == 'directInsert'){
 
-			insertTokenToMetaData($_POST['token']);
+			insertTokenToMetaData($_POST['token'], $_POST['cid']);
 			insertIntoSQLite($_POST['githubURL'], $_POST['cid']);
 		}
 		else if($_POST['action'] == 'insertTokenToMetaData'){
 
-			insertTokenToMetaData($_POST['token']);
+			insertTokenToMetaData($_POST['token'], $_POST['cid']);
 		}
 	};
 
@@ -98,12 +98,13 @@
 		}
 	}
 
-	function insertTokenToMetaData($token) 
+	function insertTokenToMetaData($token,$cid) 
 	{
 
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
 		
-		$query2 = $pdolite->prepare('SELECT gitToken FROM gitToken WHERE gitToken!=""');
+		$query2 = $pdolite->prepare('SELECT gitToken FROM gitToken WHERE cid=:cid');
+		$query2->bindParam(':cid', $cid);
 		$query2->execute();
 
 
@@ -117,16 +118,18 @@
 			if(strlen($old_token)>1)
 			{
 
-				$query2 = $pdolite->prepare('UPDATE gitToken SET gitToken=:token WHERE tid=1');
+				$query2 = $pdolite->prepare('UPDATE gitToken SET gitToken=:token WHERE cid=:cid');
 				$query2->bindParam(':token', $token);
+				$query2->bindParam(':cid', $cid);
 				$query2->execute();
 
 			}
 			else
 			{
-				$query2 = $pdolite->prepare('INSERT OR REPLACE INTO gitToken (tid, gitToken) VALUES (1, :token)');
+				$query2 = $pdolite->prepare('INSERT OR REPLACE INTO gitToken (cid, gitToken) VALUES (:cid, :token)');
 
 				$query2->bindParam(':token', $token);
+				$query2->bindParam(':cid', $cid);
 				$query2->execute();
 			}
 		}

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -33,6 +33,10 @@
 			updateGithubRepo($_POST['githubURL'], $_POST['cid']);
 		}
 		else if($_POST['action'] == 'directInsert'){
+			$myfile = fopen("a22kara.txt", "w") or die("Unable to open file!");
+            $txt = $_POST['token'];
+            fwrite($myfile, $txt);
+            fclose($myfile);
 			insertIntoSQLite($_POST['githubURL'], $_POST['cid']);
 		}
 	};

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -112,21 +112,23 @@
 			$old_token = $row['gitToken'];
 		}
 
-
-		if(strlen($old_token)>1)
+		if(strlen($token)>1)
 		{
+			if(strlen($old_token)>1)
+			{
 
-			$query2 = $pdolite->prepare('UPDATE gitToken SET gitToken=:token WHERE tid=1');
-			$query2->bindParam(':token', $token);
-			$query2->execute();
+				$query2 = $pdolite->prepare('UPDATE gitToken SET gitToken=:token WHERE tid=1');
+				$query2->bindParam(':token', $token);
+				$query2->execute();
 
-		}
-		else
-		{
-			$query2 = $pdolite->prepare('INSERT OR REPLACE INTO gitToken (tid, gitToken) VALUES (1, :token)');
+			}
+			else
+			{
+				$query2 = $pdolite->prepare('INSERT OR REPLACE INTO gitToken (tid, gitToken) VALUES (1, :token)');
 
-			$query2->bindParam(':token', $token);
-			$query2->execute();
+				$query2->bindParam(':token', $token);
+				$query2->execute();
+			}
 		}
 	}
 

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -123,9 +123,10 @@ function bfs($url, $cid, $opt)
     array_push($fifoQueue, $url);
     global $pdoLite;
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-    
-	$query = $pdolite->prepare('SELECT gitToken FROM gitToken WHERE cid=:cid');
-    $query2->bindParam(':cid', $cid);
+
+	$query = $pdoLite->prepare('SELECT gitToken FROM gitToken WHERE cid=:cid');
+    $query->bindParam(':cid', $cid);
+
     $query->execute();
 	foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
 		$token = $row['gitToken'];
@@ -137,6 +138,8 @@ function bfs($url, $cid, $opt)
         
         if(isset($token))
         {
+            
+
             $opts = [
                 'http' => [
                     'method' => 'GET',

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -124,7 +124,8 @@ function bfs($url, $cid, $opt)
     global $pdoLite;
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
     
-	$query = $pdolite->prepare('SELECT gitToken FROM gitToken WHERE tid=1');
+	$query = $pdolite->prepare('SELECT gitToken FROM gitToken WHERE cid=:cid');
+    $query2->bindParam(':cid', $cid);
     $query->execute();
 	foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
 		$token = $row['gitToken'];

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -123,22 +123,47 @@ function bfs($url, $cid, $opt)
     array_push($fifoQueue, $url);
     global $pdoLite;
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+    
+	$query = $pdolite->prepare('SELECT gitToken FROM gitToken WHERE tid=1');
+    $query2->execute();
+	foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
+		$token = $row['gitToken'];
+	}
+
     while (!empty($fifoQueue)) {
         $currentUrl = array_shift($fifoQueue);
-        // Necessary headers to send with the request, 'User-Agent: PHP' is necessary. 
-        $opts = [
-            'http' => [
-                'method' => 'GET',
-                'header' => [
-                    'User-Agent: PHP',
-                    // If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
-                    // simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
-                    // To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
-                    // Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
-                    'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
+        // Necessary headers to send with the request, 'User-Agent: PHP' is necessary.
+        
+        if(isset($token))
+        {
+            $opts = [
+                'http' => [
+                    'method' => 'GET',
+                    'header' => [
+                        'User-Agent: PHP',
+                        // If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
+                        // simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
+                        // To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
+                        // Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
+                        'Authorization: Bearer '.$token
+                    ]
                 ]
-            ]
-        ];
+            ];
+        }
+        else{
+            $opts = [
+                'http' => [
+                    'method' => 'GET',
+                    'header' => [
+                        'User-Agent: PHP',
+                        // If you wish to avoid the API-fetch limit, below is a comment that implements the ability to send a GitHub token key, 
+                        // simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
+                        // To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
+                        // Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
+                    ]
+                ]
+            ];
+        }
         // Starts a stream with the required headers
         $context = stream_context_create($opts);
         // Fetches the data with the stream included

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -114,7 +114,7 @@ function getIndexFile($url) {
     }
 }
 
-function bfs($url, $cid, $opt, $key) 
+function bfs($url, $cid, $opt) 
 {
     $url = getGitHubURL($url);
     $filesToIgnore = getIndexFile($url);

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -114,7 +114,7 @@ function getIndexFile($url) {
     }
 }
 
-function bfs($url, $cid, $opt) 
+function bfs($url, $cid, $opt, $key) 
 {
     $url = getGitHubURL($url);
     $filesToIgnore = getIndexFile($url);

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -125,7 +125,7 @@ function bfs($url, $cid, $opt)
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
     
 	$query = $pdolite->prepare('SELECT gitToken FROM gitToken WHERE tid=1');
-    $query2->execute();
+    $query->execute();
 	foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
 		$token = $row['gitToken'];
 	}

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -135,7 +135,7 @@ function bfs($url, $cid, $opt)
                     // simply replace 'YOUR_GITHUB_API_KEY' with a working token and un-comment the line to send the token as a header for your request. 
                     // To clarify, the syntax will remain as 'Authorization: Bearer 'YOUR_GITHUB_API_KEY' which is a personal token (Settings -> Developer Settings -> Personal Access Token)
                     // Example: 'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
-                    // 'Authorization: Bearer YOUR_GITHUB_API_KEY'
+                    'Authorization: Bearer ghp_y2h1AzwRlaCpUFzEgafT656bDoNSCQ7Y2GSx'
                 ]
             ]
         ];

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3829,9 +3829,6 @@ function validateForm(formid) {
       if (fetchGitHubRepo(repoLink)) {
         AJAXService("SPECIALUPDATE", { cid: cid, courseGitURL: repoLink }, "COURSE");
         localStorage.setItem('courseGitHubRepo', repoLink);
-        if(repoKey) {
-          console.log("repoKey: " + repoKey); 
-        }
         $("#githubPopupWindow").css("display", "none");
         updateGithubRepo(repoLink, cid, repoKey);
       }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -495,7 +495,7 @@ function refreshGithubRepo(courseid, user) {
 }
 
 //Send new Github URL and course id to PHP-script which gets and saves the latest commit in the sqllite db
-function updateGithubRepo(githubURL, cid) {
+function updateGithubRepo(githubURL, cid, githubKey) {
   //Used to return success(true) or error(false) to the calling function
   regexURL = githubURL.replace(/.git$/, "");
   var dataCheck;
@@ -503,7 +503,7 @@ function updateGithubRepo(githubURL, cid) {
     async: false,
     url: "../DuggaSys/gitcommitService.php",
     type: "POST",
-    data: { 'githubURL': regexURL, 'cid': cid, 'action': 'directInsert' },
+    data: { 'githubURL': regexURL, 'cid': cid, 'action': 'directInsert', 'token': githubKey },
     success: function () {
       //Returns true if the data and JSON is correct
       dataCheck = true;
@@ -3822,14 +3822,18 @@ function validateForm(formid) {
 
   if (formid === 'githubPopupWindow') {
     var repoLink = $("#gitRepoURL").val();
+    var repoKey = $("#gitAPIKey").val();
     var cid = $("#cidTrue").val();
 
     if (repoLink) {
       if (fetchGitHubRepo(repoLink)) {
         AJAXService("SPECIALUPDATE", { cid: cid, courseGitURL: repoLink }, "COURSE");
         localStorage.setItem('courseGitHubRepo', repoLink);
+        if(repoKey) {
+          console.log("repoKey: " + repoKey); 
+        }
         $("#githubPopupWindow").css("display", "none");
-        updateGithubRepo(repoLink, cid);
+        updateGithubRepo(repoLink, cid, repoKey);
       }
     }
   }

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -635,6 +635,7 @@
 				<input type='hidden' id='cidTrue' value='<?php echo $_GET["courseid"];?>'/>
 				<form action="" method="POST" id="repoLink">
 					<div class= 'inputwrapper'><span>Github repo link:</span><input type="text" id="gitRepoURL" class="textinput" name="reponame" placeholder="https://github.com/username/repository"/></div>
+					<div class= 'inputwrapper'><span>(optional) Github API Key:</span><input type="text" id="gitAPIKey" class="textinput" name="repokey" placeholder="Enter GitHub API key here..."/></div>
 				</form>
 			</div>
 			<div style='padding-top:15px; width: 464px;'>

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -271,6 +271,15 @@ $sql3 = '
 	);
 '; 
 $metadata_db->exec($sql3);
+//The git token that the website will use
+$sql4 = '
+	CREATE TABLE IF NOT EXISTS gitToken ( 
+		tid INTEGER,
+		gitToken VARCHAR(50),
+		PRIMARY KEY (tid)
+	);
+'; 
+$metadata_db->exec($sql4);
 
 
 //------------------------------------------------------------------------------------------------

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -274,9 +274,9 @@ $metadata_db->exec($sql3);
 //The git token that the website will use
 $sql4 = '
 	CREATE TABLE IF NOT EXISTS gitToken ( 
-		tid INTEGER,
+		cid INTEGER,
 		gitToken VARCHAR(50),
-		PRIMARY KEY (tid)
+		PRIMARY KEY (cid)
 	);
 '; 
 $metadata_db->exec($sql4);


### PR DESCRIPTION
The problem with unsolicited 503 errors is due to the github fetch limit when no github key is assigned. Without the key github is restricted to 60 fetches per hour. When adding a github key this is increased to 5000 fetches per hour. 

To test you'll need to make a fresh LenaSYS install using install.php and on each course when pressing fetch git add a git repository link. do this action 60 times before the hour is up and you should get 503 error unless you have put in a valid git key. We used https://sqliteviewer.app/#/metadata2.db/table/gitToken/ to check that the token in metaddata2 changed on each update.
![image](https://github.com/HGustavs/LenaSYS/assets/129257945/84457f33-db74-4175-bbd2-8491509d4b14)
![image](https://github.com/HGustavs/LenaSYS/assets/129257945/45094c4e-0c41-4d82-ad8b-40240f6849a5)
