### PR TITLE
G2 2024 v2 issue#14552 create updateActiveUsers_ms.php

### DIFF
--- a/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
+++ b/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
@@ -1,0 +1,10 @@
+### updateActiveUsers
+Collect active users
+Uses service __selectFromTableUserAnswar__ to _get_ information it requires from __userAnswer__.
+<br>
+
+Uses service __insertIntoTableGroupdugga__ to makes _inserts_ into the table __groupdugga__.
+Uses the services __updateTableGroupdugga__ to change the content of these columns:
+- active_users
+
+<br>

--- a/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
+++ b/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
@@ -1,10 +1,30 @@
-### updateActiveUsers
-Collect active users
-Uses service __selectFromTableUserAnswar__ to _get_ information it requires from __userAnswer__.
-<br>
+<?php
 
-Uses service __insertIntoTableGroupdugga__ to makes _inserts_ into the table __groupdugga__.
-Uses the services __updateTableGroupdugga__ to change the content of these columns:
-- active_users
+include_once "../Shared/sessions.php";
+include_once "../Shared/basic.php";
 
-<br>
+pdoConnect(); // Connect to database and start session
+session_start();
+
+
+$hash=getOP('hash');
+$AUtoken=getOP('AUtoken');
+
+$query = $pdo->prepare("SELECT active_users FROM groupdugga WHERE hash=:hash");
+	$query->bindParam(':hash', $hash);
+	$query->execute();
+	$result = $query->fetch();
+	$active = $result['active_users'];
+	if($active == null){
+		$query = $pdo->prepare("INSERT INTO groupdugga(hash,active_users) VALUES(:hash,:AUtoken);");
+		$query->bindParam(':hash', $hash);
+		$query->bindParam(':AUtoken', $AUtoken);
+		$query->execute();
+	}else{
+		$newToken = (int)$active + (int)$AUtoken;
+		$query = $pdo->prepare("UPDATE groupdugga SET active_users=:AUtoken WHERE hash=:hash;");
+		$query->bindParam(':hash', $hash);
+		$query->bindParam(':AUtoken', $newToken);
+		$query->execute();
+	}
+?>

--- a/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
+++ b/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
@@ -10,20 +10,22 @@ $hash=getOP('hash');
 $AUtoken=getOP('AUtoken');
 
 $query = $pdo->prepare("SELECT active_users FROM groupdugga WHERE hash=:hash");
-	$query->bindParam(':hash', $hash);
-	$query->execute();
-	$result = $query->fetch();
-	$active = $result['active_users'];
-	if($active == null){
-		$query = $pdo->prepare("INSERT INTO groupdugga(hash,active_users) VALUES(:hash,:AUtoken);");
-		$query->bindParam(':hash', $hash);
-		$query->bindParam(':AUtoken', $AUtoken);
-		$query->execute();
-	}else{
-		$newToken = (int)$active + (int)$AUtoken;
-		$query = $pdo->prepare("UPDATE groupdugga SET active_users=:AUtoken WHERE hash=:hash;");
-		$query->bindParam(':hash', $hash);
-		$query->bindParam(':AUtoken', $newToken);
-		$query->execute();
-	}
+$query->bindParam(':hash', $hash);
+$query->execute();
+$result = $query->fetch();
+$active = $result['active_users'];
+if($active == null){
+    $query = $pdo->prepare("INSERT INTO groupdugga(hash,active_users) VALUES(:hash,:AUtoken);");
+    $query->bindParam(':hash', $hash);
+    $query->bindParam(':AUtoken', $AUtoken);
+    $query->execute();
+}else{
+    $newToken = (int)$active + (int)$AUtoken;
+    $query = $pdo->prepare("UPDATE groupdugga SET active_users=:AUtoken WHERE hash=:hash;");
+    $query->bindParam(':hash', $hash);
+    $query->bindParam(':AUtoken', $newToken);
+    $query->execute();
+}
+
+echo json_encode($active);
 ?>

--- a/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
+++ b/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
@@ -1,11 +1,10 @@
 <?php
 
-include_once "../Shared/sessions.php";
-include_once "../Shared/basic.php";
+include_once "../../../Shared/sessions.php";
+include_once "../../../Shared/basic.php";
 
 pdoConnect(); // Connect to database and start session
 session_start();
-
 
 $hash=getOP('hash');
 $AUtoken=getOP('AUtoken');

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1242,12 +1242,21 @@ function AJAXService(opt,apara,kind)
 		
 	}
 	else if(kind=="GROUPTOKEN") {
-		$.ajax({
-			url: "showDuggaservice.php",
-			type:"POST",
-			data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
-			dataType: "json"
-		});
+		if(opt=="UPDATEAU"){
+			$.ajax({
+				url: "../DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php",
+				type:"POST",
+				data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
+				dataType: "json"
+			});
+		}else{
+			$.ajax({
+				url: "showDuggaservice.php",
+				type:"POST",
+				data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
+				dataType: "json"
+			});
+		}
 	} else if(kind=="ACCESSEDDUGGA") {
 		$.ajax({
 			url: "showDuggaservice.php",

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1240,8 +1240,7 @@ function AJAXService(opt,apara,kind)
 			success: returnedUserFeedback
 		});
 		
-	}
-	else if(kind=="GROUPTOKEN") {
+	} else if(kind=="GROUPTOKEN") {
 		$.ajax({
 			url: "showDuggaservice.php",
 			type:"POST",
@@ -1255,8 +1254,7 @@ function AJAXService(opt,apara,kind)
 			data: "hash="+hash+"&opt="+opt+para,
 			dataType: "json"
 		});
-	}
-	else if(kind=="CONT_LOGINBOX_SERVICE") {
+	} else if(kind=="CONT_LOGINBOX_SERVICE") {
 		$.ajax({
 			url: "contribution_loginbox_service.php",
 			type:"POST",
@@ -1264,8 +1262,7 @@ function AJAXService(opt,apara,kind)
 			dataType: "json",
 			success: CONT_LOGINBOX_SERVICE_RETURN
 		});
-	}
-	else if(kind=="CONT_ACCOUNT_STATUS"){
+	} else if(kind=="CONT_ACCOUNT_STATUS"){
 		$.ajax({
 			url: "contributionservice.php",
 			type:"POST",

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1242,14 +1242,12 @@ function AJAXService(opt,apara,kind)
 		
 	}
 	else if(kind=="GROUPTOKEN") {
-
-			$.ajax({
-				url: "showDuggaservice.php",
-				type:"POST",
-				data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
-				dataType: "json"
-			});		
-			
+		$.ajax({
+			url: "showDuggaservice.php",
+			type:"POST",
+			data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
+			dataType: "json"
+		});		
 	} else if(kind=="ACCESSEDDUGGA") {
 		$.ajax({
 			url: "showDuggaservice.php",

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1242,21 +1242,14 @@ function AJAXService(opt,apara,kind)
 		
 	}
 	else if(kind=="GROUPTOKEN") {
-		if(opt=="UPDATEAU"){
-			$.ajax({
-				url: "../DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php",
-				type:"POST",
-				data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
-				dataType: "json"
-			});
-		}else{
+
 			$.ajax({
 				url: "showDuggaservice.php",
 				type:"POST",
 				data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
 				dataType: "json"
-			});
-		}
+			});		
+			
 	} else if(kind=="ACCESSEDDUGGA") {
 		$.ajax({
 			url: "showDuggaservice.php",


### PR DESCRIPTION
The new microservice is in: updateActiveUsers_ms.php.

I have tested it by running this in the terminal: 
curl -X POST -d "hash=AcIj-Ld6&AUtoken=9999" http://localhost/LenaSYS/DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php
and compare the output from the instance in the groupdugga table in the database. I have not been able to test the service in the application.

This service is taken from groupDuggaservice.php monorepo.

To make the microservice run instead of the monorepo version change row 1244 in dugga.js to:
	else if(kind=="GROUPTOKEN") {
		if(opt=="UPDATEAU"){
			$.ajax({
				url: "../DuggaSys/microservices/showDuggaservice/updateActiveUsers_ms.php",
				type:"POST",
				data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
				dataType: "json"
			});
		}else{
			$.ajax({
				url: "showDuggaservice.php",
				type:"POST",
				data:"AUtoken="+groupTokenValue+"&hash="+hash+"&opt="+opt+para,
				dataType: "json"
			});
		}
	}