### PR TITLE
Grid works properly on all webbrowsers regardless of window size and resize. #14549

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -762,8 +762,8 @@
 }
 
 #grid_rect {
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100vh;
     overflow: visible;
     fill: url(#grid);
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1695,10 +1695,10 @@ document.addEventListener('keyup', function (e) {
     }
 })
 
-window.addEventListener("resize", () => {
-    updateContainerBounds();
-    drawRulerBars(scrollx, scrolly);
-});
+// window.addEventListener("resize", () => {
+//     updateContainerBounds();
+//     drawRulerBars(scrollx, scrolly);
+// });  // original resize solution
 
 window.onfocus = function () {
     altPressed = false;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1703,12 +1703,29 @@ document.addEventListener('keyup', function (e) {
 window.addEventListener("resize", test);
 var testCount = 0;
 function test() { // function to test which methods affect the grid
-    updateContainerBounds(); // used to set the numbers on the rulers (? unclear)
-    updateGridSize(); // should update size of grid but doesn't properly...
-    drawRulerBars(scrollx, scrolly); // updates the rulers to match window size.
-
     console.log(testCount); // count to see if the methods run and to differentiate between events.
     testCount++;
+    redrawGrid(); // Attempt at creating a function that will redraw the grid properly after resize.
+}
+
+function redrawGrid() {
+    const svgElement = document.getElementById('svgbacklayer');
+    if (!svgElement) { // Safety check to prevent errors.
+        console.log("svgElement is null, cannot redraw the Grid.") // TODO: update to a better error msg.
+        return;
+    }
+
+    const pattern = document.getElementById('grid');
+    if (pattern) {
+        pattern.setAttribute('patternTransform', 'scale(1)'); // Updates the pattern, same scale no change
+    } else {
+        console.log("wrong w/ pattern"); // TODO: update error msg if redraw works.
+    }
+
+    svgElement.style.overflow = 'hidden';  // Force reflow
+    setTimeout(() => {
+        svgElement.style.overflow = 'visible';
+    }, 0); // Runs immediately
 }
 
 window.onfocus = function () {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1714,19 +1714,21 @@ function redrawGrid() {
         console.log("svgElement is null, cannot redraw the Grid.") // TODO: update to a better error msg.
         return;
     }
-    const svgW = svgElement.clientWidth;
-    const svgH = svgElement.clientHeight;
 
     const pattern = document.getElementById('grid');
     if (pattern) {
-        pattern.setAttribute('patternTransform', 'scale(1)'); // Updates the pattern, same scale no change
+        pattern.setAttribute('patternTransform', 'scale(1)'); // Updates the pattern, same scale no change.
     } else {
-        console.log("wrong w/ pattern"); // TODO: update error msg if redraw works.
+        console.log("smth wrong w/ pattern"); // TODO: update error msg if redraw works.
     }
 
-    svgElement.style.overflow = 'hidden';  // Force reflow
+    const grid_rect = document.getElementById('grid_rect');
+    grid_rect.setAttribute('fill', 'url(#grid)')
+
+
+    grid_rect.style.overflow = 'hidden';  // Force reflow
     setTimeout(() => {
-        svgElement.style.overflow = 'visible';
+        grid_rect.style.overflow = 'visible';
     }, 0); // Runs immediately
 
     updateContainerBounds(); // Updates rulers but only after mouse button 1 press on the diagram canvas.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1714,13 +1714,6 @@ function handleResize() { // function to test which methods affect the grid
  */
 function redrawGrid()
 {
-    const svgElement = document.getElementById('svgbacklayer');
-    if (!svgElement)
-    { // Safety check to prevent errors.
-        console.log("svgElement is null, cannot redraw the Grid.") // TODO: update to a better error msg.
-        return;
-    }
-
     const pattern = document.getElementById('grid');
     if (pattern)
     {
@@ -1729,12 +1722,16 @@ function redrawGrid()
     else
     {
         console.log("smth wrong w/ pattern"); // TODO: update error msg if redraw works.
+        return;
     }
 
     const grid_rect = document.getElementById('grid_rect');
+    if (!grid_rect)
+    { // Safety check to prevent errors.
+        console.log("grid_rect is null, cannot redraw the Grid."); // TODO: update to a better error msg.
+        return;
+    }
     grid_rect.setAttribute('fill', 'url(#grid)')
-
-
     grid_rect.style.overflow = 'hidden';  // Force reflow
     setTimeout(() =>
     {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1704,23 +1704,6 @@ window.addEventListener("resize", handleResize);
 var testCount = 0;
 function handleResize() {
     updateRulers();
-    // redrawGrid();
-}
-
-/**
- * @description Used to update diagram grid on window resize.
- */
-function redrawGrid()
-{
-    const grid_rect = document.getElementById('grid_rect');
-    if (!grid_rect)
-    {
-        console.log("grid_rect is null");
-        return;
-    }
-    grid_rect.setAttribute('fill', 'url(#grid)')
-    grid_rect.style.overflow = 'hidden';
-    grid_rect.style.overflow = 'visible';
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1702,11 +1702,9 @@ document.addEventListener('keyup', function (e) {
 
 window.addEventListener("resize", handleResize);
 var testCount = 0;
-function handleResize() { // function to test which methods affect the grid
-    console.log(testCount); // count to see if the methods run and to differentiate between events.
-    testCount++;
+function handleResize() {
     updateRulers();
-    redrawGrid(); // Attempt at creating a function that will redraw the grid properly after resize.
+    redrawGrid();
 }
 
 /**
@@ -1714,29 +1712,15 @@ function handleResize() { // function to test which methods affect the grid
  */
 function redrawGrid()
 {
-    const pattern = document.getElementById('grid');
-    if (pattern)
-    {
-        pattern.setAttribute('patternTransform', 'scale(1)'); // Updates the pattern, same scale no change.
-    }
-    else
-    {
-        console.log("smth wrong w/ pattern"); // TODO: update error msg if redraw works.
-        return;
-    }
-
     const grid_rect = document.getElementById('grid_rect');
     if (!grid_rect)
-    { // Safety check to prevent errors.
-        console.log("grid_rect is null, cannot redraw the Grid."); // TODO: update to a better error msg.
+    {
+        console.log("grid_rect is null");
         return;
     }
     grid_rect.setAttribute('fill', 'url(#grid)')
-    grid_rect.style.overflow = 'hidden';  // Force reflow
-    setTimeout(() =>
-    {
-        grid_rect.style.overflow = 'visible';
-    }, 0); // Runs immediately
+    grid_rect.style.overflow = 'hidden';
+    grid_rect.style.overflow = 'visible';
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1714,6 +1714,8 @@ function redrawGrid() {
         console.log("svgElement is null, cannot redraw the Grid.") // TODO: update to a better error msg.
         return;
     }
+    const svgW = svgElement.clientWidth;
+    const svgH = svgElement.clientHeight;
 
     const pattern = document.getElementById('grid');
     if (pattern) {
@@ -1726,6 +1728,8 @@ function redrawGrid() {
     setTimeout(() => {
         svgElement.style.overflow = 'visible';
     }, 0); // Runs immediately
+
+    updateContainerBounds(); // Updates rulers but only after mouse button 1 press on the diagram canvas.
 }
 
 window.onfocus = function () {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1695,11 +1695,6 @@ document.addEventListener('keyup', function (e) {
     }
 })
 
-// window.addEventListener("resize", () => {
-//     updateContainerBounds();
-//     drawRulerBars(scrollx, scrolly);
-// });  // original resize solution
-
 window.addEventListener("resize", handleResize);
 var testCount = 0;
 function handleResize() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1700,6 +1700,17 @@ document.addEventListener('keyup', function (e) {
 //     drawRulerBars(scrollx, scrolly);
 // });  // original resize solution
 
+window.addEventListener("resize", test);
+var testCount = 0;
+function test() { // function to test which methods affect the grid
+    updateContainerBounds();
+    updateGridSize(); // should update size of grid but doesn't properly...
+    drawRulerBars(scrollx, scrolly); // updates the rulers on the side to match window size.
+
+    console.log(testCount); // count to see if the methods run and to differentiate between events.
+    testCount++;
+}
+
 window.onfocus = function () {
     altPressed = false;
     ctrlPressed = false;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1700,9 +1700,9 @@ document.addEventListener('keyup', function (e) {
 //     drawRulerBars(scrollx, scrolly);
 // });  // original resize solution
 
-window.addEventListener("resize", test);
+window.addEventListener("resize", handleResize);
 var testCount = 0;
-function test() { // function to test which methods affect the grid
+function handleResize() { // function to test which methods affect the grid
     console.log(testCount); // count to see if the methods run and to differentiate between events.
     testCount++;
     redrawGrid(); // Attempt at creating a function that will redraw the grid properly after resize.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1705,20 +1705,26 @@ var testCount = 0;
 function handleResize() { // function to test which methods affect the grid
     console.log(testCount); // count to see if the methods run and to differentiate between events.
     testCount++;
+    updateRulers();
     redrawGrid(); // Attempt at creating a function that will redraw the grid properly after resize.
 }
 
-function redrawGrid() {
+function redrawGrid()
+{
     const svgElement = document.getElementById('svgbacklayer');
-    if (!svgElement) { // Safety check to prevent errors.
+    if (!svgElement)
+    { // Safety check to prevent errors.
         console.log("svgElement is null, cannot redraw the Grid.") // TODO: update to a better error msg.
         return;
     }
 
     const pattern = document.getElementById('grid');
-    if (pattern) {
+    if (pattern)
+    {
         pattern.setAttribute('patternTransform', 'scale(1)'); // Updates the pattern, same scale no change.
-    } else {
+    }
+    else
+    {
         console.log("smth wrong w/ pattern"); // TODO: update error msg if redraw works.
     }
 
@@ -1727,11 +1733,16 @@ function redrawGrid() {
 
 
     grid_rect.style.overflow = 'hidden';  // Force reflow
-    setTimeout(() => {
+    setTimeout(() =>
+    {
         grid_rect.style.overflow = 'visible';
     }, 0); // Runs immediately
+}
 
-    // Updates rulers based on window size.
+/**
+ * @description Used to update ruler bars on window resize.
+ */
+function updateRulers() {
     updateContainerBounds();
     drawRulerBars(scrollx, scrolly);
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1709,6 +1709,9 @@ function handleResize() { // function to test which methods affect the grid
     redrawGrid(); // Attempt at creating a function that will redraw the grid properly after resize.
 }
 
+/**
+ * @description Used to update diagram grid on window resize.
+ */
 function redrawGrid()
 {
     const svgElement = document.getElementById('svgbacklayer');

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1703,9 +1703,9 @@ document.addEventListener('keyup', function (e) {
 window.addEventListener("resize", test);
 var testCount = 0;
 function test() { // function to test which methods affect the grid
-    updateContainerBounds();
+    updateContainerBounds(); // used to set the numbers on the rulers (? unclear)
     updateGridSize(); // should update size of grid but doesn't properly...
-    drawRulerBars(scrollx, scrolly); // updates the rulers on the side to match window size.
+    drawRulerBars(scrollx, scrolly); // updates the rulers to match window size.
 
     console.log(testCount); // count to see if the methods run and to differentiate between events.
     testCount++;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1704,7 +1704,7 @@ window.addEventListener("resize", handleResize);
 var testCount = 0;
 function handleResize() {
     updateRulers();
-    redrawGrid();
+    // redrawGrid();
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1731,7 +1731,9 @@ function redrawGrid() {
         grid_rect.style.overflow = 'visible';
     }, 0); // Runs immediately
 
-    updateContainerBounds(); // Updates rulers but only after mouse button 1 press on the diagram canvas.
+    // Updates rulers based on window size.
+    updateContainerBounds();
+    drawRulerBars(scrollx, scrolly);
 }
 
 window.onfocus = function () {


### PR DESCRIPTION
Change grid_rect to 100vw/vh as grid_rect is the element filled with the grid pattern and what the user actually sees. Now that it is 100vw/100vh, it covers the whole window, regardless of its parent. It will always be the size of the user's window and the rest of the diagram components are "on top" of the grid. This should work for all browsers.

Slightly changed the Event Listener for resize of window to make it more managable and easy to read. The methods for the rulers on the side are moved and grouped together in one function as it is always 2 specific methods that are needed when updating the rulers.