### PR TITLE
remove echo from validateHash.php

### DIFF
--- a/DuggaSys/validateHash.php
+++ b/DuggaSys/validateHash.php
@@ -37,7 +37,6 @@
             header("Location: $link");
             exit();	
         }else{
-            echo "{$_SESSION['checkhash']} / $hashpwd is not valid!";
             header("Location: ../errorpages/404.php");
 		    exit();	
         }


### PR DESCRIPTION
opened the validateHash.php file and removed the echo statement that happens before a redirect (header())