### PR TITLE
Merge issue#14650 add correct paths for logging

### DIFF
--- a/Shared/logging.php
+++ b/Shared/logging.php
@@ -1,8 +1,8 @@
 <?php
 $loggingDataJSON = file_get_contents("php://input"); // JSON string from dugga.js
 
-$latestLogFile = "logs/latestlog.json";
-$logFile = "logs/log.json";
+$latestLogFile = "../log/latestlog.json";
+$logFile = "../log/log.json";
 
 // Append log to log file
 file_put_contents($logFile, $loggingDataJSON, FILE_APPEND);


### PR DESCRIPTION
Change the paths for logging.

Before a error was shown in the response from logging.php when visiting e.g. 'show tests' as a teacher in a course