### PR TITLE
Added media querys and made the icons scalable

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -238,21 +238,33 @@
 .diagramIcons{
     position: relative;
     margin: auto;
-    width: 34px;
-    height: 34px;
+    width: 3.7vh;
+    height: 3.7vh;
     cursor:pointer;
     border: solid 1px var(--color-primary);
     margin-top: 3px;
-    
-   
 }
+
+@media (max-height: 650px) {
+    .diagramIcons {
+        width: 3.3vh;
+        height: 3.3vh; 
+    }
+}
+
+@media (max-height: 540px) {
+    .diagramIcons {
+        width: 3vh;
+        height: 3vh; 
+    }
+}
+
 .diagramIcons:hover, .active{
     background: var(--color-primary-light);
     border: solid 1px var(--color-border-2);
 }
 .diagramIcons img{
-    width:34px;
-    height:34px;
+    height:100%;
 }
 .node {
     position: absolute;


### PR DESCRIPTION
The icons in the toolbar is now scalable and with the added media querys you can now use the program with a much smaller screen. There's still a minimum limit to where the tooltip wont fit but we find it hard to see that a user would ever use such a small screen when using the diagram editor.