### PR TITLE
G1 2024 v3 #14651

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -704,6 +704,7 @@
     display: flex;
     justify-content: space-around;
     padding: 1px;
+    z-index: 900;
 }
 .diagramZoomIcons img {
     height: 27px;


### PR DESCRIPTION
Added a z-index for the class "zoom-container" in css. Can test it by placing for example sequence lifeline on top of the zoom function on the bottom left and see if the element is on top of the zoom button and if you can still use the button.