### PR TITLE
Placing a element now de-selects everything.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2078,6 +2078,8 @@ function mouseMode_onMouseUp(event) {
     if (!hasPressedDelete) {
         switch (mouseMode) {
             case mouseModes.PLACING_ELEMENT:       
+                clearContext();
+                clearContextLine();
                 if (ghostElement && event.button == 0) {
                     addObjectToData(ghostElement, false);
 


### PR DESCRIPTION
Calling clearContext() and clearContextLine() in the PLACING_ELEMENT mousemode so everything becomes de-selected when you place a new element.