### PR TITLE
Remove gradesystem input on the kind type 3

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -442,7 +442,7 @@ function changedType(kind) {
     $("#link").html(makeoptionsItem(xelink, retdata['codeexamples'], 'sectionname', 'exampleid'));
   } else if (kind == 3) {
     document.querySelector("#inputwrapper-group").style.display = "none";
-    document.querySelector("#inputwrapper-gradesystem").style.display = "block";
+    document.querySelector("#inputwrapper-gradesystem").style.display = "none";
     $("#link").html(makeoptionsItem(xelink, retdata['duggor'], 'qname', 'id'));
   } else if (kind == 4) {
     document.querySelector("#inputwrapper-group").style.display = "block";


### PR DESCRIPTION
Issue: Its not possible to update the "gradesystem", "visibility" or "moment" of a listed entry in a course. 

I have not been able to recreate the problem with "visibility" or "moment", it works fine for me. however "gradesystem" was not working on listentries with kind 3(type: tests)

After doing some research it seems that only kind 4 should be able to have gradesystem changed.

I remove the gradesysteminput field from listentries with kind 3. When you go into settings for a listentrie that has type: test the inputfield for gradesystem will no longer be shown.