### PR TITLE
G1 2024 v3 #14548

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3109,7 +3109,8 @@ function changeLineProperties() {
 
     if (line.label != label.value) {
         label.value = label.value.trim();
-        line.label = label.value
+        var label_value = label.value.replaceAll('<', "&#60").replaceAll('>', "&#62");
+        line.label = label_value;
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, {label: label.value}), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     }
     // UML or IE line
@@ -7059,7 +7060,7 @@ function generateContextProperties() {
  * @description function for include button to the options panel,writes out << Include >>
  */
 function setLineLabel() {
-    document.getElementById("lineLabel").value = "&#60&#60include&#62&#62";
+    document.getElementById("lineLabel").value = "<<include>>";
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3109,8 +3109,7 @@ function changeLineProperties() {
 
     if (line.label != label.value) {
         label.value = label.value.trim();
-        var label_value = label.value.replaceAll('<', "&#60").replaceAll('>', "&#62");
-        line.label = label_value;
+        line.label = label.value
         stateMachine.save(StateChangeFactory.ElementAttributesChanged(contextLine[0].id, {label: label.value}), StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     }
     // UML or IE line
@@ -7961,6 +7960,7 @@ function drawLine(line, targetGhost = false) {
         var canvas = document.getElementById('canvasOverlay');
         var canvasContext = canvas.getContext('2d');
         canvasContext.font = `${height}px ${canvasContext.font.split('px')[1]}`;
+        var labelValue = line.label.replaceAll('<', "&#60").replaceAll('>', "&#62");
         var textWidth = canvasContext.measureText(line.label).width;
 
         var label = {
@@ -8035,7 +8035,7 @@ function drawLine(line, targetGhost = false) {
                 x='${(fx + length + (30 * zoomfact))}'
                 y='${(labelPositionY - 70 * zoomfact) + ((textheight / 4) * zoomfact)}'
                 style='fill:${lineColor}; font-size:${Math.round(zoomfact * textheight)}px;'>
-                ${line.label}
+                ${labelValue}
                 </text>`;
         } else {
             str += `<rect
@@ -8052,7 +8052,7 @@ function drawLine(line, targetGhost = false) {
                 style='font-size:${Math.round(zoomfact * textheight)}px;'
                 x='${label.centerX - (2 * zoomfact) + label.labelMovedX + label.displacementX}'
                 y='${label.centerY - (2 * zoomfact) + label.labelMovedY + label.displacementY}'>
-                ${line.label}
+                ${labelValue}
                 </text>`;
         }
     }


### PR DESCRIPTION
We have now managed to make it work so that when you press the button, "\<\<include\>\>" appears instead of "&#60&#60include&#62&#62". Additionally, the white background has been adjusted to fit the text better than before when it was much longer.
So for the textfield, converted character encodings into angle brackets; Then for the label, convert angle brackets into character encodings.
Here is an image of what the diagram looks like now:
<img width="980" alt="Screenshot 2024-04-17 at 14 12 00" src="https://github.com/HGustavs/LenaSYS/assets/129367092/e4ffc0f3-52a2-4509-96c5-1c368d20ba42">
