### PR TITLE
G3 2024 v3 #14666 - Fixed "Show tests"

### DIFF
--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -3,7 +3,7 @@
 session_start();
 include_once "../Shared/sessions.php";
 include_once "../Shared/basic.php";
-//pdoConnect();
+pdoConnect();
 $cid=getOPG('courseid');
 $vers=getOPG('coursevers');
 ?>

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -31,8 +31,6 @@ $vers=getOPG('coursevers');
 	<script src="../Shared/dugga.js"></script>
 	<script src="duggaed.js"></script>
   <script src="../Shared/SortableTableLibrary/sortableTable.js"></script>
-  <script src="timer.js"></script>
-  <script src="clickcounter.js"></script>
   <script src="../Shared/markdown.js"></script>
 	<script src="backToTop.js"></script>
 

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -1,4 +1,3 @@
-
 <?php
 session_start();
 include_once "../Shared/sessions.php";

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -26,8 +26,6 @@
 	<script src="../Shared/dugga.js"></script>
 	<script src="../DuggaSys/templates/svg-dugga.js"></script>
 	<script src="../Shared/markdown.js"></script>
-	<script src="timer.js"></script>
-	<script src="clickcounter.js"></script>
 	<script>var querystring=parseGet();</script>
 
 <?php

--- a/DuggaSys/testDugga.php
+++ b/DuggaSys/testDugga.php
@@ -13,8 +13,6 @@
 	<script src="../Shared/js/jquery-1.11.0.min.js"></script>
 	<script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
 	<script src="../Shared/dugga.js"></script>
-	<script src="timer.js"></script>
-	<script src="clickcounter.js"></script>
 	<script>var querystring=parseGet();</script>
 
 <?php

--- a/DuggaSys/validateHash.php
+++ b/DuggaSys/validateHash.php
@@ -58,8 +58,6 @@
 	<script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
 	<script src="../Shared/dugga.js"></script>
 	<script src="../Shared/markdown.js"></script>
-	<script src="timer.js"></script>
-	<script src="clickcounter.js"></script>
 	<script>var querystring=parseGet();</script>
 </head>
 <body>	

--- a/backend-models/OlderDuggaSYSLogs#13199.txt
+++ b/backend-models/OlderDuggaSYSLogs#13199.txt
@@ -2,7 +2,6 @@ DuggaSys folder commits thats been checked:
 
 ace.js -No Testing, one commit? The rest of commits must be else where (21972 rows code)
 backToTop.js -No Testing
-clickcounter.js -No Testing
 
 codeviewer.js -No testing
 codeviewer.php -No testing


### PR DESCRIPTION
# The solution
We removed all references to timer.js and clickcounter.js since these have been removed since a previous merge. These files only consisted of commented out code and were deemed excessive (and were thus deleted). 

This issue was fixed by uncommenting the pdoConnect() in duggaed.php. 

# Potential new issue found
Pressing “Give students access to the selected version” will result in a crash in all courses. This needs to be fixed.

The “Give students access to the selected version” button can be found in the header of a course:
![image](https://github.com/HGustavs/LenaSYS/assets/129295853/7c2875b5-4775-4d13-9e19-1b8c1f23f9a3)
The result: 
![image](https://github.com/HGustavs/LenaSYS/assets/129295853/b9c59b62-81f3-427c-b78b-64bf546cf963)
This new potential issue does not have the same problem as ours and requires a different solution (since pdoConnect() is not commented out in this page). 