### PR TITLE
ctrl + a sets mouse to pointer

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1628,8 +1628,10 @@ document.addEventListener('keydown', function (e) {
 
     if (isKeybindValid(e, keybinds.SELECT_ALL)){
         e.preventDefault();
-        if (mouseMode != mouseModes.EDGE_CREATION) selectAll();
+        document.getElementById("mouseMode0").click();
+        selectAll();
     }
+
     if (isKeybindValid(e, keybinds.CENTER_CAMERA)){
         e.preventDefault();
     }


### PR DESCRIPTION
Simulate a click at mouseMode0 when ctrl + a is pressed before the select all so the user always comes to the select mode.