### PR TITLE
G2 2024 v3 issue#14587 - Fix bugs in showDuggaService

### DIFF
--- a/DuggaSys/filereceive_dugga.php
+++ b/DuggaSys/filereceive_dugga.php
@@ -516,7 +516,9 @@ if(!$error){
 //echo "{$hash}|";
 //echo "{$hashpwd}|";
 //echo "{$variant}|<br>";
-header("Location: /sh/?s=$hash");
+
+//redirects back to the dugga
+header("Location: showDugga.php?did=$duggaid&courseid=$cid&coursevers=$vers&moment=$moment&cid=$cid");
 exit();	
 
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -269,7 +269,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 			$receiptLink = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/sh/?s=$hash";
 			?>
     		<div id='emailPopup' style="display:block">
-				<p>Your dugga has been saved. Besure to store the hash and hash password in a safe place before submitting the dugga in canvas! <em>There is <strong>no way</strong> to restore a submission without the hash and hash password.</p>
+				<p>Your dugga has been saved. Besure to store the hash and hash password in a safe place before submitting the dugga in canvas! <em>There is <strong>no way</strong> to restore a submission without the hash and hash password.</em></p>
 				<div id="submission-receipt" rows="15" cols="50" style="height: 180px;resize: none; border-style: solid; border-width: 1px; font-size: 13px; font-weight: bold;">
 					<?php echo $duggatitle; ?></br></br>
 					Direct link (to be submitted in canvas):</br>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -270,7 +270,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 			$receiptLink = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/$parentDir/sh/?s=$hash";
 			?>
     		<div id='emailPopup' style="display:block">
-				<p>Your dugga has been saved. Besure to store the hash and hash password in a safe place before submitting the dugga in canvas! <em>There is <strong>no way</strong> to restore a submission without the hash and hash password.</em></p>
+				<p>Your dugga has been saved. Be sure to store the hash and hash password in a safe place before submitting the dugga in canvas! <em>There is <strong>no way</strong> to restore a submission without the hash and hash password.</em></p>
 				<div id="submission-receipt" rows="15" cols="50" style="height: 180px;resize: none; border-style: solid; border-width: 1px; font-size: 13px; font-weight: bold;">
 					<?php echo $duggatitle; ?></br></br>
 					Direct link (to be submitted in canvas):</br>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -265,8 +265,9 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 			<div id='receiptInfo'></div>
 
 			<?php 
+			$parentDir = basename(dirname(__DIR__));
 			#determine if it's https or http, add $_SERVER[HTTP_HOST] (url) and add hash. Might need to change s to either a or c, depending on type of submit.
-			$receiptLink = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/sh/?s=$hash";
+			$receiptLink = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/$parentDir/sh/?s=$hash";
 			?>
     		<div id='emailPopup' style="display:block">
 				<p>Your dugga has been saved. Besure to store the hash and hash password in a safe place before submitting the dugga in canvas! <em>There is <strong>no way</strong> to restore a submission without the hash and hash password.</em></p>

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -283,6 +283,7 @@ if(isSuperUser($userid)){
 				$hashpwd=$_SESSION["submission-password-$courseid-$coursevers-$duggaid-$moment"];
 				$variant=$_SESSION["submission-variant-$courseid-$coursevers-$duggaid-$moment"];	
 				$link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "https") . "://$_SERVER[HTTP_HOST]/sh/?s=$hash";
+				echo $link;
 				unset($grade);
 
 				$query = $pdo->prepare("SELECT password,timesSubmitted,timesAccessed,grade from userAnswer WHERE hash=:hash;");

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -283,7 +283,6 @@ if(isSuperUser($userid)){
 				$hashpwd=$_SESSION["submission-password-$courseid-$coursevers-$duggaid-$moment"];
 				$variant=$_SESSION["submission-variant-$courseid-$coursevers-$duggaid-$moment"];	
 				$link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "https") . "://$_SERVER[HTTP_HOST]/sh/?s=$hash";
-				echo $link;
 				unset($grade);
 
 				$query = $pdo->prepare("SELECT password,timesSubmitted,timesAccessed,grade from userAnswer WHERE hash=:hash;");

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -327,7 +327,7 @@ if(isSuperUser($userid)){
 					}
 				}
 			}else{
-				$debug="Unable to save dugga!";
+				$debug="Teachers cannot save dugga!";
 			}
         } 
 

--- a/DuggaSys/templates/3d-dugga.js
+++ b/DuggaSys/templates/3d-dugga.js
@@ -79,7 +79,7 @@ function returnedDugga(data)
 	if (data['debug'] != "NONE!") {alert(data['debug']);}
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/bit-dugga.js
+++ b/DuggaSys/templates/bit-dugga.js
@@ -129,7 +129,7 @@ function returnedDugga(data)
 
 function saveClick()
 {
-	$('#submission-receipt').html(`${response['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${response['link']}\n\nHash\n${response['hash']}\n\nHash password\n${response['hashpwd']}`);
+	//$('#submission-receipt').html(`${response['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${response['link']}\n\nHash\n${response['hash']}\n\nHash password\n${response['hashpwd']}`);
 		showReceiptPopup();
 	Timer.stopTimer();
 

--- a/DuggaSys/templates/boxmodell.js
+++ b/DuggaSys/templates/boxmodell.js
@@ -84,7 +84,7 @@ function returnedDugga(data)
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/clipping_masking_dugga.js
+++ b/DuggaSys/templates/clipping_masking_dugga.js
@@ -142,7 +142,7 @@ function returnedDugga(data)
 		}
 
     if(data['opt']=="SAVDU"){
-        $('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+        //$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
         showReceiptPopup();
     }
     if(data["feedback"] !== null && data["feedback"] !== "" && data["feedback"] !== "UNK") {

--- a/DuggaSys/templates/color-dugga.js
+++ b/DuggaSys/templates/color-dugga.js
@@ -62,7 +62,7 @@ function returnedDugga(data)
 	if(data['debug']!="NONE!") alert(data['debug']);
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/curve-dugga.js
+++ b/DuggaSys/templates/curve-dugga.js
@@ -99,7 +99,7 @@ function returnedDugga(data) {
 
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 	

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -47,7 +47,7 @@ function returnedDugga(data)
 	if(data['debug']!="NONE!") alert(data['debug']);
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/dugga2.js
+++ b/DuggaSys/templates/dugga2.js
@@ -61,7 +61,7 @@ function returnedDugga(data)
 	if(data['debug']!="NONE!") alert(data['debug']);
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`Direct link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`Direct link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 	

--- a/DuggaSys/templates/dugga3.js
+++ b/DuggaSys/templates/dugga3.js
@@ -97,7 +97,7 @@ function returnedDugga(data) {
 		alert(data['debug']);
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`Direct link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`Direct link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 	

--- a/DuggaSys/templates/dugga4.js
+++ b/DuggaSys/templates/dugga4.js
@@ -65,7 +65,7 @@ function returnedDugga(data)
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/dugga5.js
+++ b/DuggaSys/templates/dugga5.js
@@ -86,7 +86,7 @@ function returnedDugga(data)
 	if (data['debug'] != "NONE!") {alert(data['debug']);}
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -39,7 +39,7 @@ function returnedDugga(data)
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/shapes-dugga.js
+++ b/DuggaSys/templates/shapes-dugga.js
@@ -66,7 +66,7 @@ function returnedDugga(data)
 	if(data['debug']!="NONE!") alert(data['debug']);
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/svg-dugga.js
+++ b/DuggaSys/templates/svg-dugga.js
@@ -42,7 +42,7 @@ function returnedDugga(data)
 	if(data['debug'] != "NONE!") { alert(data['debug']); }
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/templates/transforms-dugga.js
+++ b/DuggaSys/templates/transforms-dugga.js
@@ -69,7 +69,7 @@ function returnedDugga(data)
 	if (data['debug'] != "NONE!") { alert(data['debug']); }
 
 	if(data['opt']=="SAVDU"){
-		$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
+		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
 

--- a/DuggaSys/validateHash.php
+++ b/DuggaSys/validateHash.php
@@ -33,7 +33,8 @@
             $_SESSION["submission-$newcourseid-$newcoursevers-$newduggaid-$newmoment"]=$hash;
             $_SESSION["submission-password-$newcourseid-$newcoursevers-$newduggaid-$newmoment"]=$hashpwd;
             $_SESSION["submission-variant-$newcourseid-$newcoursevers-$newduggaid-$newmoment"]=$variant;
-            $link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/sh/?s=$hash";
+            $parentDir = basename(dirname(__DIR__));
+            $link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/$parentDir/sh/?s=$hash";
             header("Location: $link");
             exit();	
         }else{


### PR DESCRIPTION
Original issue: #14587 

I could not replicate the original error message received in the issue. My guess is that the cause of that error was that the user reporting it was using linux and/or had not configured ZIP-ARCHIVE as is explained in the [install guide](https://github.com/HGustavs/LenaSYS/blob/60fa0a4f5d03b176fc48452ed0b53346defc3cbc/README.md#to-get-zip-archive-to-workused-in-download-zip-function).
I did not have any issues with ZIP-ARCHIVE since I am using windows where it is built in.

I did however find a bunch of different bugs that kept the user from being able to save a dugga.
- When a dugga is saved the generated link linked to the wrong /sh folder instead of /LenaSYS/sh.
- Loading a saved dugga in ValidateHash.php also linked to /sh instead of LenaSYS/sh.
- Uploading a pdf/zip sent the user to /sh instead of back to the dugga.
- Javascript in the dugga template files were overwriting the contents of the submission receipt, breaking the markup and undoing the fixes made to the showDugga.php file.

I have fixed these and saving/loading is working as it should on my system now.

To test:
Login to a student account, since teachers are not allowed to submit (I used the acc mestr - password) .
Enter the course: Webbutveckling - datorgrafik, this one has all types of dugga.
Try submitting and loading the different types of dugga.