### PR TITLE
Fixed if-statement calling for copy incorrectly when creating new course

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1241,6 +1241,11 @@ function createVersion() {
   param.startdate = getDateFormat(new Date($("#startdate").val()));
   param.enddate = getDateFormat(new Date($("#enddate").val()));
 
+  //If no previous versions exist. "None" can't be selected which makes it empty. Set to "None" for if-statement a few lines down.
+  if (param.copycourse == "") {
+    param.copycourse = "None";
+  }
+
   newversid = param.versid;
 
   if (param.versid == "" || param.versname == "") {


### PR DESCRIPTION
…rse version

The if-statement checks if "param.copycourse" is "None" and then calls either "CPYVRS" or "NEWVRS" via AJAXService.

The problem when creating a new version on a course that has no existing versions was that the dropdown that controls the variable "param.copycourse" had no "None"-option. So the value was simply empty. Which meant that the if-statement was calling "CPYVRS" since the value did no equal "None".

Sidenote:
There we're previous problems with a variable that caused activeversion (aka default version) to not work. Which in turn made creating new versions not work since even though the existed in the database due to the correct if-statement, they weren't displayed on the site still because a course doesn't seem to fetch versions if the course itself has no default version. The fix for this variable was in place but since the weekly merge, group 2 made changes to which files we're called and move the function into another file, which correctly initiated the variable. Therefore, since wednesday, this part of the prolem became a non-issue.

Testing:
1. Create a brand new course (to make sure it has no previous versions).
2. Go into the course and create a new version in the popup, select checkbox to make it default.
3. Go back to the landing page and enter the course again. Is the new version automatically selected in the dropdown in the header? Success!
4. verify in the database that the course has the version as active.