### PR TITLE
the "copy content from" dropdown now displays existing course versions

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -193,8 +193,8 @@
 							//Need to check if the course has a version, if it does not the button should not be created
 							if(isset($result['versname'])) {
 								// Changes format from 'HT20' to numbers to create the URL
-								$array = explode("T", $result['versname']);
-								$array_1 = explode("-", $result['startdate']);
+								$array = explode('T', $result['versname'] ?? '');
+								$array_1 = explode('-', $result['startdate'] ?? '');
         						$year = $array_1[0];
 
 								if ($array[0] === "H") {


### PR DESCRIPTION
It should be possible now to view existing course versions in the course version creator but also in choose course version dropdown. While solving the issue and trying to make it work a strange explode error occurred when you would navigate from version to version but now it's been fixed. 