### PR TITLE
fixed the pointer when dragging down

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2585,8 +2585,14 @@ function mmoving(event) {
             deltaX = startX - event.clientX;
 
             const minHeight = 50; // Declare the minimal height of an object
-            deltaY = startY - event.clientY;
-
+            // Divide deltaY by 3 for UML and by 2 for IE and SD elements so the pointer follows the mouse when resizing up and down
+            if (elementData.kind === "UMLEntity") {
+                deltaY = (startY - event.clientY) / 3;
+            } else if (elementData.kind === "IEEntity" || elementData.kind === "SDEntity") {
+                deltaY = (startY - event.clientY) / 2;
+            } else {
+                deltaY = startY - event.clientY;
+            }
             // Functionality for the four different nodes
             if (startNodeLeft && (startWidth + (deltaX / zoomfact)) > minWidth) {
                 // Fetch original width


### PR DESCRIPTION
I adjusted the deltaY (the change of vertical position) based on the kind of the element being manipulated. The kind attribute "elementData" determines the type of the element, such as 'UMLEntity', 'IEEntity', or 'SDEntity'. Since a UML entity consists of three parts and IE and SD entities consist of two parts, I divided the deltaY calculation by 3 or by 2 for the specific entity. 

This calculation adjusts the vertical movement speed for specific type of entity, allowing the pointer to move in parallel with the mouse.