### PR TITLE
G3 2024 v3 #14526

### DIFF
--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -89,12 +89,12 @@
 		$urlParting = explode('/', $url);
 		// The 4th part contains the name of the repo, which is accessed by [4]
 		$repoName = $urlParting[4];
-		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid,repoName, repoURL,gitToken, lastCommit) VALUES (:cid, :repoName, :repoURL, :gitToken, :lastCommit)"); 
+		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid,repoName, repoURL, lastCommit, gitToken) VALUES (:cid, :repoName, :repoURL, :lastCommit, :gitToken )"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoName', $repoName);
 		$query->bindParam(':repoURL', $url);
-		$query->bindParam(':gitToken', $token);
 		$query->bindParam(':lastCommit', $lastCommit);
+		$query->bindParam(':gitToken', $token);
 		
 		if (!$query->execute()) {
 			$error = $query->errorInfo();

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -82,13 +82,11 @@
 		$urlParting = explode('/', $url);
 		// The 4th part contains the name of the repo, which is accessed by [4]
 		$repoName = $urlParting[4];
-
 		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid,repoName, repoURL) VALUES (:cid, :repoName, :repoURL)"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoName', $repoName);
 		$query->bindParam(':repoURL', $url);
 		
-
 		if (!$query->execute()) {
 			$error = $query->errorInfo();
 			echo "Error updating file entries" . $error[2];

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -78,14 +78,17 @@
 
 	function insertIntoSQLite($url, $cid) { 
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+		$lastCommit = bfs($url, $cid, "GETCOMMIT");
+		print_r($lastCommit);
 		// Splits the url into different parts for every "/" there is
 		$urlParting = explode('/', $url);
 		// The 4th part contains the name of the repo, which is accessed by [4]
 		$repoName = $urlParting[4];
-		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid,repoName, repoURL) VALUES (:cid, :repoName, :repoURL)"); 
+		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid,repoName, repoURL, lastCommit) VALUES (:cid, :repoName, :repoURL, :lastCommit)"); 
 		$query->bindParam(':cid', $cid);
 		$query->bindParam(':repoName', $repoName);
 		$query->bindParam(':repoURL', $url);
+		$query->bindParam(':lastCommit', $lastCommit);
 		
 		if (!$query->execute()) {
 			$error = $query->errorInfo();

--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -78,9 +78,17 @@
 
 	function insertIntoSQLite($url, $cid) { 
 		$pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid, repoURL) VALUES (:cid, :repoURL)"); 
+		// Splits the url into different parts for every "/" there is
+		$urlParting = explode('/', $url);
+		// The 4th part contains the name of the repo, which is accessed by [4]
+		$repoName = $urlParting[4];
+
+		$query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid,repoName, repoURL) VALUES (:cid, :repoName, :repoURL)"); 
 		$query->bindParam(':cid', $cid);
+		$query->bindParam(':repoName', $repoName);
 		$query->bindParam(':repoURL', $url);
+		
+
 		if (!$query->execute()) {
 			$error = $query->errorInfo();
 			echo "Error updating file entries" . $error[2];


### PR DESCRIPTION
Made it so that the github repos files are saved to the githubmetadata2.db.

To be able to test this you must reinstall lenaSYS so the database is up to date. 

Add a github repo in editcourse 
<img width="995" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129262677/3db4ad73-2a4b-4903-8a41-e60b34e3b456"> 

And also test it by adding it in fetch github.
<img width="653" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129262677/92093265-2118-41f0-b491-c730af9a3fa0">

we used DB Browser to look in the githubmetadata2.DB

@a22natth and @a22oscja assinged aswell.