### PR TITLE
Create microservice addClass issue #14756

### DIFF
--- a/DuggaSys/microservices/accessedService/addClass_ms.php
+++ b/DuggaSys/microservices/accessedService/addClass_ms.php
@@ -1,0 +1,58 @@
+<?
+include_once "../../../Shared/sessions.php";
+include_once "../../../Shared/basic.php";
+include_once "../shared_microservices/getUid_ms.php";
+
+date_default_timezone_set("Europe/Stockholm");
+
+// Connect to database and start session
+pdoConnect();
+session_start();
+
+// Global variables
+$opt = getOP('opt');
+$cid = getOP('courseid');
+$newclass = getOP('newclass');
+$userid = getUid();
+
+// Permission checks
+if (hasAccess($userid, $cid, 'w') || isSuperUser($userid)) {
+    $hasAccess = true;
+} else {
+    $hasAccess = false;
+}
+
+if (not(checklogin() && $hasAccess))
+    return;
+
+if (strcmp($opt, "ADDCLASS") == 0) {
+    $newClassData = json_decode(htmlspecialchars_decode($newclass));
+
+    foreach ($newClassData as $newClass) {
+        $class = $newClass[0];
+        $responsible = $newClass[1];
+        $classname = $newClass[2];
+        $regcode = $newClass[3];
+        $classcode = $newClass[4];
+        $hp = $newClass[5];
+        $tempo = $newClass[6];
+        $hpProgress = $newClass[7];
+    }
+
+    $querystring = "INSERT INTO class (class, responsible, classname, regcode, classcode, hp, tempo, hpProgress) VALUES(:class, :responsible, :classname, :regcode, :classcode, :hp, :tempo, :hpProgress);";
+    $stmt = $pdo->prepare($querystring);
+    $stmt->bindParam(':class', $class);
+    $stmt->bindParam(':responsible', $responsible);
+    $stmt->bindParam(':classname', $classname);
+    $stmt->bindParam(':regcode', $regcode);
+    $stmt->bindParam(':classcode', $classcode);
+    $stmt->bindParam(':hp', $hp);
+    $stmt->bindParam(':tempo', $tempo);
+    $stmt->bindParam(':hpProgress', $hpProgress);
+
+    if (!$stmt->execute()) {
+        $debug = "Not able to create the specified class.";
+    }
+
+    echo json_encode($debug);
+}

--- a/DuggaSys/microservices/accessedService/addClass_ms.php
+++ b/DuggaSys/microservices/accessedService/addClass_ms.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
 include_once "../shared_microservices/getUid_ms.php";


### PR DESCRIPTION
The microservice is supposed to be used when adding a new course, as can be seen from the ```accessedservice.txt``` text:
```* Add new course (opt = ADDCLASS)```. However, when creating a new course I was not able to see the ```accessedservice.php``` file being called at all. I couldn't find ```ADDCLASS``` used anywhere else either. Because of this I have not actually been able to  test the implementation.

If any tester finds where it's used you can test the implementation by changing the ```kind=="ACCESS"``` part in the ```AJAXService()``` function inside ```dugga.js``` to:

```
else if(kind=="ACCESS"){
	let serviceURL = "accessedservice.php";
	if (opt=="ADDCLASS"){
		serviceURL="../DuggaSys/microservices/accessedService/addClass_ms.php";
	}
	$.ajax({
		url: serviceURL,
		type: "POST",
		data: "opt="+opt+para,
		dataType: "json",
		success: returnedFile
	})
```