### PR TITLE
G3 2024 v3 #14664 error message for wrong login is fixed

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -214,6 +214,7 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 	</div>
 	
 	<!-- LoginBox (receipt&Feedback-box ) Start! -->
+	<!-- issue 14664 can be tracked here -->
 	<div id='receiptBox' class="loginBoxContainer" style="display:none">
 	  <div class="receiptBox loginBox" style="max-width:400px; overflow-y:visible;">
 			<div class='loginBoxheader'><h3>Dugga Submission Receipt</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -214,7 +214,6 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 	</div>
 	
 	<!-- LoginBox (receipt&Feedback-box ) Start! -->
-	<!-- issue 14664 can be tracked here -->
 	<div id='receiptBox' class="loginBoxContainer" style="display:none">
 	  <div class="receiptBox loginBox" style="max-width:400px; overflow-y:visible;">
 			<div class='loginBoxheader'><h3>Dugga Submission Receipt</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -691,6 +691,8 @@ const cooldownHolder = document.getElementById("cooldownHolder");
 setInterval(
 	function() 
 	{
+		//issue 14664, should be a typeerror down below: The TypeError is because of a innerHTML returns a string, not a number. We need to convert the innerHTML values to numbers, parseInt() function can be used which will convert a string innerHTML to an integer. 
+		
 		if(gitFetchCooldownSec.innerHTML>0 || gitFetchCooldownMin.innerHTML>0)
 		{
 			gitFetchCooldownSec.innerHTML-=1;

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -691,7 +691,7 @@ const cooldownHolder = document.getElementById("cooldownHolder");
 setInterval(
 	function() 
 	{
-		//issue 14664, should be a typeerror down below: The TypeError is because of a innerHTML returns a string, not a number. We need to convert the innerHTML values to numbers, parseInt() function can be used which will convert a string innerHTML to an integer. 
+		//issue 14664, should be a typeerror down below: The TypeError is because of a innerHTML returns a string, not a number. We need to convert the innerHTML values to numbers, parseInt() function can be used which will convert a string innerHTML to an integer. 3
 		
 		if(gitFetchCooldownSec.innerHTML>0 || gitFetchCooldownMin.innerHTML>0)
 		{

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -691,7 +691,6 @@ const cooldownHolder = document.getElementById("cooldownHolder");
 setInterval(
 	function() 
 	{
-		
 		if(gitFetchCooldownSec.innerHTML>0 || gitFetchCooldownMin.innerHTML>0)
 		{
 			gitFetchCooldownSec.innerHTML-=1;

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -691,7 +691,6 @@ const cooldownHolder = document.getElementById("cooldownHolder");
 setInterval(
 	function() 
 	{
-		//issue 14664, should be a typeerror down below: The TypeError is because of a innerHTML returns a string, not a number. We need to convert the innerHTML values to numbers, parseInt() function can be used which will convert a string innerHTML to an integer. 3
 		
 		if(gitFetchCooldownSec.innerHTML>0 || gitFetchCooldownMin.innerHTML>0)
 		{


### PR DESCRIPTION
Before it wasn't possible to display an error message for wrong login because of Uncaught PDOException that caused a php error for uncaught SyntaxError for invalid JSON. But now when a user enters wrong credentials the error is displayed.