### PR TITLE
G1 2024 v3 #14769

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1737,6 +1737,7 @@ document.addEventListener('keydown', function (e) {
 document.addEventListener('keyup', function (e) {
     var pressedKey = e.key.toLowerCase();
 
+    hidePlacementType();
     // Toggle modifiers when released
     if (pressedKey == keybinds.LEFT_CONTROL.key) ctrlPressed = false;
     if (pressedKey == keybinds.ALT.key) altPressed = false;


### PR DESCRIPTION
Can now press a keybinding and the sub-menu is closing when open. Can test it by have a sub-menu open and press for example "1" and the sub-menu should be closing.