### PR TITLE
g2-2024-v3 issue #14803

### DIFF
--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -93,20 +93,19 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid) || has
 			$debug.="Error updating dugga ".$error[2];
 		}
 	}else if(strcmp($opt,"DELDU")===0){
-		$query = $pdo->prepare("DELETE FROM quiz WHERE id=:qid");
+		$query = $pdo->prepare("DELETE FROM useranswer WHERE quiz=:qid;");
 		$query->bindParam(':qid', $qid);
-		try{
-			if(!$query->execute()) {
-				if($query->errorInfo()[0] == 23000) {
-					$debug = "The item could not be deleted because of a foreign key constraint.";
-				} else {
-					$debug = "The item could not be deleted.";
-				}
-			}
-		}catch(Exception $e){
-			$debug = "The item could not be deleted.";
+
+		if(!$query->execute()) {
+			$debug = "Useranswer could not be deleted.";
 		}
 
+		$query = $pdo->prepare("DELETE FROM quiz WHERE id=:qid;");
+		$query->bindParam(':qid', $qid);
+
+		if(!$query->execute()) {
+			$debug = "Quiz could not be deleted.";
+		}
     }else if(strcmp($opt,"ADDVARI")===0){
 		$querystring="INSERT INTO variant(quizID,creator,disabled,param,variantanswer) VALUES (:qid,:uid,:disabled,:param,:variantanswer)";
 		$stmt = $pdo->prepare($querystring);


### PR DESCRIPTION
The error was occurring because the ```useranswer``` table has a foreign key constraint to ```quiz```. The solution I ended up with was to delete all instances of ```useranswer``` with a reference to the quiz to be deleted.

  This is only a good idea if useranswers are SOLELY answers in quizes, which I assume. However, I am not 100% sure this is the case. A tester should ideally come to the same conclusion as me. What the tables are supposed to do can be found in ```dbTables.md```. 

The two rows look like:
```
### quiz
The quiz table contains everything related to a dugga, and connects the dugga to a specific .js template file. It does not save answers, it only loads the dugga how it is supposed to look like.
```

```
### userAnswer
Stores all the duggas that has been saved in the system. That is, the answers that a student has entered is stored here.
```