### PR TITLE
G3 2024 v4 #14851 Tooltips appearing on the wrong row

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -463,15 +463,33 @@
 				<div class="cursorPointer" onclick='closeWindows();' title="Close window">x</div>
 			</div>
 			<div style='padding:5px;'>
-				<div class='inputwrapper'><span>Version ID:</span><input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd');" class='textinput' type='text' id='cversid' placeholder='Version ID' maxlength='8'/></div>
-				<div class="formDialog" style="display: block; left:50px; top:-5px;"><span id="dialog2" style="display: none; left:0px;" class="formDialogText">Only numbers(between 3-8 numbers)</span></div>
+				<div class='inputwrapper'>
+					<span>Version ID:</span>
+					<div class="formDialog" style="display: block; left:-122px;">
+						<span id="dialog2" style="display: none; left:0px;" class="formDialogText formDialog">Only numbers(between 3-8 numbers)</span>
+					</div>
+					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd');" class='textinput' type='text' id='cversid' placeholder='Version ID' maxlength='8'/>
+				</div>
 				<!--<p id="dialog2" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Only numbers(between 3-8 numbers)</p>-->
-				<div class='inputwrapper'><span>Version Name:</span><input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='versname' placeholder='Version Name' /></div>
-				<div class="formDialog" style="display: block; left:50px; top:-5px;"><span id="dialog" style="display: none; left:0px;" class="formDialogText">Must be in of the form HTNN, VTNN or STNN</span></div>
+				<div class='inputwrapper'>
+					<span>Version Name:</span>
+					<div class="formDialog" style="display: block; left:-135px; top:-5px;">
+						<span id="dialog" style="display: none; left:0px;" class="formDialogText formDialog">Must be in of the form HTNN, VTNN or STNN</span>
+					</div>
+					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='versname' placeholder='Version Name' />
+				</div>
 				<!--<p id="dialog" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Must be A-Z 0-9.</p>-->
-				<div class='inputwrapper'><span>Start Date:</span><input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='date' id='startdate' value='' /></div>
-				<div class='inputwrapper'><span>End Date:</span><input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='date' id='enddate' value='' /></div>
-				<div class="formDialog" style="display: block; left:50px; top:-25px;"><span id="dialog3" style="display: none; left:0px;" class="formDialogText">Start date has to be before end date</span></div>
+				<div class='inputwrapper'>
+					<span>Start Date:</span>
+					<div class="formDialog" style="display: block; left:-120px; top:-5px;">
+						<span id="dialog3" style="display: none; left:0px;" class="formDialogText formDialog">Start date has to be before end date</span>
+					</div>
+					<input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='date' id='startdate' value='' />
+				</div>
+				<div class='inputwrapper'>
+					<span>End Date:</span>
+					<input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='date' id='enddate' value='' />
+				</div>
 				<!--<p id="dialog3" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Start date has to be before end date</p>-->
 				<div class='inputwrapper'><span>MOTD:</span><input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='vmotd' placeholder='MOTD' value='' /></div>
 				<div class="formDialog" style="display: block; left:50px; top:-12px;"><span id="dialog4" style="display: none; left:0px;" class="formDialogText">Prohibited symbols.</span></div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -470,7 +470,6 @@
 					</div>
 					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd');" class='textinput' type='text' id='cversid' placeholder='Version ID' maxlength='8'/>
 				</div>
-				<!--<p id="dialog2" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Only numbers(between 3-8 numbers)</p>-->
 				<div class='inputwrapper'>
 					<span>Version Name:</span>
 					<div class="formDialog versionDialog" id='dialogContainer'>
@@ -478,7 +477,6 @@
 					</div>
 					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='versname' placeholder='Version Name' />
 				</div>
-				<!--<p id="dialog" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Must be A-Z 0-9.</p>-->
 				<div class='inputwrapper'>
 					<span>Start Date:</span>
 					<div class="formDialog versionDialog" id='dialogContainer3'>
@@ -490,7 +488,6 @@
 					<span>End Date:</span>
 					<input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='date' id='enddate' value='' />
 				</div>
-				<!--<p id="dialog3" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Start date has to be before end date</p>-->
 				<div class='inputwrapper'><span>MOTD:</span><input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='vmotd' placeholder='MOTD' value='' /></div>
 				<div class="formDialog" style="display: block; left:50px; top:-12px;"><span id="dialog4" style="display: none; left:0px;" class="formDialogText">Prohibited symbols.</span></div>
 				<div class="formDialog" style="display: block; left:50px; top:4px;"><span id="dialog42" style="display: none; left:0px;" class="formDialogText">Message can only contain a maximum of 50 symbols.</span></div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -465,7 +465,7 @@
 			<div style='padding:5px;'>
 				<div class='inputwrapper'>
 					<span>Version ID:</span>
-					<div class="formDialog" style="display: block; left:-122px;">
+					<div class="formDialog versionDialog" id='dialogContainer2'>
 						<span id="dialog2" style="display: none; left:0px;" class="formDialogText formDialog">Only numbers(between 3-8 numbers)</span>
 					</div>
 					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd');" class='textinput' type='text' id='cversid' placeholder='Version ID' maxlength='8'/>
@@ -473,7 +473,7 @@
 				<!--<p id="dialog2" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Only numbers(between 3-8 numbers)</p>-->
 				<div class='inputwrapper'>
 					<span>Version Name:</span>
-					<div class="formDialog" style="display: block; left:-135px; top:-5px;">
+					<div class="formDialog versionDialog" id='dialogContainer'>
 						<span id="dialog" style="display: none; left:0px;" class="formDialogText formDialog">Must be in of the form HTNN, VTNN or STNN</span>
 					</div>
 					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='versname' placeholder='Version Name' />
@@ -481,7 +481,7 @@
 				<!--<p id="dialog" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Must be A-Z 0-9.</p>-->
 				<div class='inputwrapper'>
 					<span>Start Date:</span>
-					<div class="formDialog" style="display: block; left:-120px; top:-5px;">
+					<div class="formDialog versionDialog" id='dialogContainer3'>
 						<span id="dialog3" style="display: none; left:0px;" class="formDialogText formDialog">Start date has to be before end date</span>
 					</div>
 					<input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='date' id='startdate' value='' />

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -466,21 +466,21 @@
 				<div class='inputwrapper'>
 					<span>Version ID:</span>
 					<div class="formDialog versionDialog" id='dialogContainer2'>
-						<span id="dialog2" style="display: none; left:0px;" class="formDialogText formDialog">Only numbers(between 3-8 numbers)</span>
+						<span id="dialog2" class="formDialogText formDialog">Only numbers(between 3-8 numbers)</span>
 					</div>
 					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd');" class='textinput' type='text' id='cversid' placeholder='Version ID' maxlength='8'/>
 				</div>
 				<div class='inputwrapper'>
 					<span>Version Name:</span>
 					<div class="formDialog versionDialog" id='dialogContainer'>
-						<span id="dialog" style="display: none; left:0px;" class="formDialogText formDialog">Must be in of the form HTNN, VTNN or STNN</span>
+						<span id="dialog" class="formDialogText formDialog">Must be in of the form HTNN, VTNN or STNN</span>
 					</div>
 					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='versname' placeholder='Version Name' />
 				</div>
 				<div class='inputwrapper'>
 					<span>Start Date:</span>
 					<div class="formDialog versionDialog" id='dialogContainer3'>
-						<span id="dialog3" style="display: none; left:0px;" class="formDialogText formDialog">Start date has to be before end date</span>
+						<span id="dialog3" class="formDialogText formDialog">Start date has to be before end date</span>
 					</div>
 					<input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='date' id='startdate' value='' />
 				</div>
@@ -491,7 +491,7 @@
 				<div class='inputwrapper'>
 					<span>MOTD:</span>
 					<div class="formDialog versionDialog" id='dialogContainer4'>
-						<span id="dialog4" style="display: none; left:0px;" class="formDialogText">Prohibited symbols.</span>
+						<span id="dialog4" class="formDialogText">Prohibited symbols.</span>
 					</div>
 					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='vmotd' placeholder='MOTD' value='' />
 				</div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -488,8 +488,13 @@
 					<span>End Date:</span>
 					<input onchange="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='date' id='enddate' value='' />
 				</div>
-				<div class='inputwrapper'><span>MOTD:</span><input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='vmotd' placeholder='MOTD' value='' /></div>
-				<div class="formDialog" style="display: block; left:50px; top:-12px;"><span id="dialog4" style="display: none; left:0px;" class="formDialogText">Prohibited symbols.</span></div>
+				<div class='inputwrapper'>
+					<span>MOTD:</span>
+					<div class="formDialog versionDialog" id='dialogContainer4'>
+						<span id="dialog4" style="display: none; left:0px;" class="formDialogText">Prohibited symbols.</span>
+					</div>
+					<input onkeyup="quickValidateForm('newCourseVersion', 'submitCourseMotd'); " class='textinput' type='text' id='vmotd' placeholder='MOTD' value='' />
+				</div>
 				<div class="formDialog" style="display: block; left:50px; top:4px;"><span id="dialog42" style="display: none; left:0px;" class="formDialogText">Message can only contain a maximum of 50 symbols.</span></div>
 				<!--<p id="dialog4" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Prohibited symbols</p>-->
 				<!--<p id="dialog42" style="font-size:11px; border:0px; margin-left: 10px; display:none;">Message can only contain a maximum of 50 symbols</p>-->

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -488,6 +488,10 @@ body {
     color: var(--color-text-list) !important;
 }
 
+.formDialog .formDialogText::after {
+    border-color: transparent transparent transparent var(--color-text-header);
+}
+
 #announcementBoxOverlay{
     display: none;
     background-color: var(--color-background);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3093,18 +3093,15 @@ div.submit-button:disabled {
 
 .versionDialog{
   display: block;
+  top:-5px;
 }
 
 #dialogContainer{
-  left:-135px; top:-5px;
+  left:-135px; 
 }
 
-#dialogContainer2{
-  left:-120px; top:-5px;
-}
-
-#dialogContainer3{
-  left:-120px; top:-5px;
+#dialogContainer2, #dialogContainer3{
+  left:-120px; 
 }
 
 /* Tooltip */
@@ -5718,6 +5715,14 @@ only screen and (max-device-width: 568px) {
   .loginBox {
     /*top: 8%;
     left: 10%;*/
+  }
+
+  #dialogContainer2, #dialogContainer3{
+    left: -150px;
+  }
+
+  #dialogContainer{
+    left: -165px;
   }
   
   #searchNavButt{

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3098,6 +3098,11 @@ div.submit-button:disabled {
   top: -5px;
 }
 
+#dialog2, #dialog, #dialog3, #dialog4{
+  display: none;
+  left:0px;
+}
+
 #dialogContainer {
   left: -135px; 
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3098,7 +3098,7 @@ div.submit-button:disabled {
   top: -5px;
 }
 
-#dialog2, #dialog, #dialog3, #dialog4{
+#dialog2, #dialog, #dialog3, #dialog4 {
   display: none;
   left:0px;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3091,20 +3091,20 @@ div.submit-button:disabled {
   border-color: transparent transparent transparent var(--color-border-6);
 }
 
-.versionDialog{
+/* Tooltip */
+
+.versionDialog {
   display: block;
   top:-5px;
 }
 
-#dialogContainer{
+#dialogContainer {
   left:-135px; 
 }
 
-#dialogContainer2, #dialogContainer3{
+#dialogContainer2, #dialogContainer3 {
   left:-120px; 
 }
-
-/* Tooltip */
 
 .tooltipDugga {
   position: relative;
@@ -5717,11 +5717,11 @@ only screen and (max-device-width: 568px) {
     left: 10%;*/
   }
 
-  #dialogContainer2, #dialogContainer3{
+  #dialogContainer2, #dialogContainer3 {
     left: -150px;
   }
 
-  #dialogContainer{
+  #dialogContainer {
     left: -165px;
   }
   

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3095,15 +3095,20 @@ div.submit-button:disabled {
 
 .versionDialog {
   display: block;
-  top:-5px;
+  top: -5px;
 }
 
 #dialogContainer {
-  left:-135px; 
+  left: -135px; 
 }
 
 #dialogContainer2, #dialogContainer3 {
-  left:-120px; 
+  left: -120px; 
+}
+
+#dialogContainer4 {
+  left: -110px; 
+  top: 5px;
 }
 
 .tooltipDugga {
@@ -5717,13 +5722,18 @@ only screen and (max-device-width: 568px) {
     left: 10%;*/
   }
 
+  #dialogContainer {
+    left: -165px;
+  }
+
   #dialogContainer2, #dialogContainer3 {
     left: -150px;
   }
 
-  #dialogContainer {
-    left: -165px;
+  #dialogContainer4{
+    left: -139px;
   }
+
   
   #searchNavButt{
     display: none;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3091,6 +3091,22 @@ div.submit-button:disabled {
   border-color: transparent transparent transparent var(--color-border-6);
 }
 
+.versionDialog{
+  display: block;
+}
+
+#dialogContainer{
+  left:-135px; top:-5px;
+}
+
+#dialogContainer2{
+  left:-120px; top:-5px;
+}
+
+#dialogContainer3{
+  left:-120px; top:-5px;
+}
+
 /* Tooltip */
 
 .tooltipDugga {


### PR DESCRIPTION
Fixed it so that tooltips appeared on the correct row **when trying to create a new course version**. These tooltips can be seen when pressing the "+"-icon from the navbar and entering an invalid input in the form. 

The "+"-icon:
![Skärmavbild 2024-04-23 kl  14 01 13](https://github.com/HGustavs/LenaSYS/assets/129263915/acf634a2-2590-4d84-ab86-68f7653a9323)

Now the tooltips should look like this:
![Skärmavbild 2024-04-24 kl  11 16 06](https://github.com/HGustavs/LenaSYS/assets/129263915/a7905702-3c58-4675-8b85-c4ba3ee17af2)


Also updated it so that the little triangle shape at the right side of the tooltip also appeared in darkmode.

**To test this pull request: test that the tooltips for every input appear on the right row for you. Also make sure no new errors are created and that everything looks fine.** 
