### PR TITLE
Synced height and width expansion for issue#14828

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9658,17 +9658,18 @@ function drawElementState(element, ghosted, vectorGraphic) {
     } else if (element.fill == color.WHITE && theme.href.includes('style')) {
         element.fill = color.BLACK;
     }
-    return `<div id="${element.id}" 
+    return `<div id="${element.id}"
                 class="element uml-state"
-                style="margin-top:${((boxh / 2.5))}px;width:${boxw}px;height:${boxh}px;z-index:1;${ghostAttr}" 
-                onmousedown='ddown(event);' 
-                onmouseenter='mouseEnter();' 
+                style="margin-top:${((boxh / 2))}px;width:${boxw}px;height:${boxh}px;z-index:1;${ghostAttr}"
+                onmousedown='ddown(event);'
+                onmouseenter='mouseEnter();'
                 onmouseleave='mouseLeave();'>
-                <svg width="100%" height="100%" 
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg" 
+                <svg width="100%" height="100%"
+                    viewBox="0 0 ${boxw} ${boxh}" <!-- dynamically set viewBox -->
+                    xmlns="http://www.w3.org/2000/svg"
                     xml:space="preserve"
                     style="fill:${element.fill};fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+                    <circle cx="50%" cy="50%" r="50%" />
                     ${vectorGraphic}
                 </svg>
             </div>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9669,7 +9669,7 @@ function drawElementState(element, ghosted, vectorGraphic) {
                     xmlns="http://www.w3.org/2000/svg"
                     xml:space="preserve"
                     style="fill:${element.fill};fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-                    <circle cx="50%" cy="50%" r="50%" />
+                  // <circle cx="50%" cy="50%" r="50%" />
                     ${vectorGraphic}
                 </svg>
             </div>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9650,30 +9650,44 @@ function drawElementIEEntity(element, ghosted) {
 function drawElementState(element, ghosted, vectorGraphic) {
     let ghostPreview = ghostLine ? 0 : 0.4;
     const ghostAttr = (ghosted) ? `pointer-events: none; opacity: ${ghostPreview};` : "";
-    var boxw = Math.round(element.width * zoomfact);
-    var boxh = Math.round(element.height * zoomfact);
+    const maxSize = Math.max(Math.round(element.width * zoomfact), Math.round(element.height * zoomfact));
+
     const theme = document.getElementById("themeBlack");
     if (element.fill == color.BLACK && theme.href.includes('blackTheme')) {
         element.fill = color.WHITE;
     } else if (element.fill == color.WHITE && theme.href.includes('style')) {
         element.fill = color.BLACK;
     }
+
+    const circleRadius = maxSize / 2;
+    const animationDuration = 1000;
+    const circleAnimation = `
+        <animate attributeName="r"
+                 attributeType="XML"
+                 from="0"
+                 to="${circleRadius}"
+                 dur="${animationDuration}ms"
+                 fill="freeze" />`;
+
     return `<div id="${element.id}"
                 class="element uml-state"
-                style="margin-top:${((boxh / 2))}px;width:${boxw}px;height:${boxh}px;z-index:1;${ghostAttr}"
+                style="margin-top:${((maxSize / 2.5))}px;width:${maxSize}px;height:${maxSize}px;z-index:1;${ghostAttr}"
                 onmousedown='ddown(event);'
                 onmouseenter='mouseEnter();'
                 onmouseleave='mouseLeave();'>
                 <svg width="100%" height="100%"
-                    viewBox="0 0 ${boxw} ${boxh}" <!-- dynamically set viewBox -->
+                    viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
                     xml:space="preserve"
                     style="fill:${element.fill};fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-                  // <circle cx="50%" cy="50%" r="50%" />
-                    ${vectorGraphic}
+                    <g>
+                        ${vectorGraphic}
+                        ${circleAnimation}
+                    </g>
                 </svg>
             </div>`;
 }
+
 
 function drawElementSuperState(element, ghosted, textWidth) {
     let ghostPreview = ghostLine ? 0 : 0.4;


### PR DESCRIPTION
Fixed an half-done solution for the height and width expansion so they expand together "kinda", to get a perfect circle one must fix the expansion to fit but its possible. The room that the box takes up are also decreased by the size of the circle as requested.

However, some weird problems showed up. The changes creates a small circle like a blob on top of the init state circle which doesnt expand and stays idle. Also the uncommented code at line 9672 seem to affect the circle if its removed, even if its "outcommented" which is very odd. Also the final state circle appears exactly like the init state circle for some reason. I havent been able to locate where these anomalies come from, and the diagram.css and style.css seem to have nothing affecting this. 

Link to issue: 
https://github.com/HGustavs/LenaSYS/issues/14828