### PR TITLE
Fixed timer for github repo fetch

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3946,6 +3946,8 @@ function validateForm(formid) {
         localStorage.setItem('courseGitHubRepo', repoLink);
         $("#githubPopupWindow").css("display", "none");
         updateGithubRepo(repoLink, cid, repoKey);
+        //resets and display the cooldown for the github url button
+        resetGitFetchTimer(isSuperUser);
         // Refresh page after github link
         location.reload();
       }

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -39,6 +39,11 @@
 	}
 ?>
 
+<!-- decoding and storing the php session uid as variable for js. Necessary for github url cooldown function call -->
+<script>
+	var isSuperUser = <?php echo json_encode(isSuperUser($_SESSION['uid'])); ?>;
+</script>
+
 <!DOCTYPE html>
 <html lang="en">
 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -231,7 +231,7 @@
 							echo "<td class='refresh' style='display: inline-block;'>";
 							echo "<div class='refresh menuButton tooltip'>";
 								echo "<span id='refreshBTN' value='Refresh' href='#'>";
-									echo "<img alt='refresh icon' id='refreshIMG' class='navButt' onclick='refreshGithubRepo(".$_SESSION['courseid'].",".isSuperUser($_SESSION['uid']).");resetGitFetchTimer(".isSuperUser($_SESSION['uid']).")' src='../Shared/icons/gitrefresh.svg'>";
+									echo "<img alt='refresh icon' id='refreshIMG' class='navButt' onclick='refreshGithubRepo(".$_SESSION['courseid'].",".isSuperUser($_SESSION['uid']).")' src='../Shared/icons/gitrefresh.svg'>";
 								echo "</span>";
 
 								//Check if user is super user


### PR DESCRIPTION
The cooldown was displayed after simply clicking the github repo button in the navbar. This has been changed to only trigger after the save button in the popup is clicked. If the input field is left empty, the cooldown will not trigger. There doesn't seem to be any actual validation for the input field though. As long as you enter something, the functions will trigger. Having an actual validation that not only checks the format, but also that it contains an actual working repo link would probably be outside the scope here.

Solution:
The function that that starts and displays the timer is "resetGitFetchTimer()". This function call was moved from navheader.php to sectioned.js. To be able to use the php-variable it needs to be initiated as a js-variable before sectioned.js is loaded. Until another course is visited the variable will remain static, which is fine. Since changing uid would mean relogging and then loading a new course, which means navheader.php would be loaded again and the value would therefore be initiated with the new value.

For testing:
Go to a course, click the repo button. Click save without entering anything in the field. Nothing happening? Success! Now enter something in the field, click save. Now hover over the repo-button. The cooldown should now be displayed.