### PR TITLE
G1 2024 V4 #14878

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1754,6 +1754,10 @@ document.addEventListener('keydown', function (e) {
             displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
         }
     }
+
+    if (altPressed == true) {
+        mouseMode_onMouseUp();
+    }  
 });
 
 document.addEventListener('keyup', function (e) {
@@ -4101,9 +4105,9 @@ function boxSelect_Start(mouseX, mouseY) {
     boxSelectionInUse = true;
 }
 
-document.addEventListener("mouseleave", (event) => {  
+document.addEventListener("mouseleave", (event) => {
     if ((event.clientX >= window.innerWidth || event.clientY >= window.innerHeight) || event.clientY <= 0 || event.clientX <= 0) {  
-      mouseMode_onMouseUp();
+        mouseMode_onMouseUp();
     }  
 });
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1904,7 +1904,13 @@ document.addEventListener("mouseleave", function (event) {
 
     if ((event.clientX >= window.innerWidth || event.clientY >= window.innerHeight) || event.clientY <= 0 || event.clientX <= 0) {  
         mouseMode_onMouseUp();
-    }  
+    }
+});
+
+document.addEventListener("mouseout", function (event) {
+    if ((event.clientX >= window.innerWidth || event.clientY >= window.innerHeight) || event.clientY <= 0 || event.clientX <= 0) {  
+        mouseMode_onMouseUp();
+    }
 });
 
 // --------------------------------------- Mouse Events    --------------------------------

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -4101,6 +4101,12 @@ function boxSelect_Start(mouseX, mouseY) {
     boxSelectionInUse = true;
 }
 
+document.addEventListener("mouseleave", (event) => {  
+    if ((event.clientX >= window.innerWidth || event.clientY >= window.innerHeight) || event.clientY <= 0 || event.clientX <= 0) {  
+      mouseMode_onMouseUp();
+    }  
+});
+
 function boxSelect_Update(mouseX, mouseY) {
     if (boxSelectionInUse) {
         // Update relative position form the starting position

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1901,6 +1901,10 @@ document.addEventListener("mouseleave", function (event) {
     if (event.toElement == null && event.relatedTarget == null) {
         pointerState = pointerStates.DEFAULT;
     }
+
+    if ((event.clientX >= window.innerWidth || event.clientY >= window.innerHeight) || event.clientY <= 0 || event.clientX <= 0) {  
+        mouseMode_onMouseUp();
+    }  
 });
 
 // --------------------------------------- Mouse Events    --------------------------------
@@ -4104,12 +4108,6 @@ function boxSelect_Start(mouseX, mouseY) {
     deltaY = 0;
     boxSelectionInUse = true;
 }
-
-document.addEventListener("mouseleave", (event) => {
-    if ((event.clientX >= window.innerWidth || event.clientY >= window.innerHeight) || event.clientY <= 0 || event.clientX <= 0) {  
-        mouseMode_onMouseUp();
-    }  
-});
 
 function boxSelect_Update(mouseX, mouseY) {
     if (boxSelectionInUse) {


### PR DESCRIPTION
Added a eventlistener for when the mouse is leaving the window/website. Can test it by select the box selection tool and use the tool, but before the left mouse click is up have the mouse outside of the website/window. When your mouse is outside of the website you can have the left mouse button up, and the box selection should be gone when the mouse is returning to the website.