### PR TITLE
14916 fix setasactivecourse msphp

### DIFF
--- a/DuggaSys/microservices/sharedMicroservices/setAsActiveCourse_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/setAsActiveCourse_ms.php
@@ -3,23 +3,21 @@ date_default_timezone_set("Europe/Stockholm");
 
 // Include basic application services!
 include_once "../../../Shared/basic.php";
-include_once "getUid_ms.php";
 
 function setAsActiveCourse($pdo) {
 
-$cid = getOP('cid');
-$versid = getOP('versid');
-$makeactive = getOP('makeactive');
+	$cid = getOP('cid');
+	$versid = getOP('versid');
+	$makeactive = getOP('makeactive');
 
-getUid();
-
-if ($makeactive == 3) {
-	$query = $pdo->prepare("UPDATE course SET activeversion=:vers WHERE cid=:cid");
-	$query->bindParam(':cid', $cid);
-	$query->bindParam(':vers', $versid);
-	if (!$query->execute()) {
-		$error = $query->errorInfo();
-		$debug = "Error updating entries\n" . $error[2];
+	if ($makeactive == 3) {
+		$query = $pdo->prepare("UPDATE course SET activeversion=:vers WHERE cid=:cid");
+		$query->bindParam(':cid', $cid);
+		$query->bindParam(':vers', $versid);
+		if (!$query->execute()) {
+			$error = $query->errorInfo();
+			$debug = "Error updating entries\n" . $error[2];
+			echo json_encode($debug);
+		}
 	}
-}
 }

--- a/DuggaSys/microservices/sharedMicroservices/setAsActiveCourse_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/setAsActiveCourse_ms.php
@@ -3,14 +3,10 @@ date_default_timezone_set("Europe/Stockholm");
 
 // Include basic application services!
 include_once "../../../Shared/basic.php";
-include_once "../../../Shared/sessions.php";
 include_once "getUid_ms.php";
 
-// Connect to database and start session
-pdoConnect();
-session_start();
+function setAsActiveCourse($pdo) {
 
-// Global variables
 $cid = getOP('cid');
 $versid = getOP('versid');
 $makeactive = getOP('makeactive');
@@ -25,4 +21,5 @@ if ($makeactive == 3) {
 		$error = $query->errorInfo();
 		$debug = "Error updating entries\n" . $error[2];
 	}
+}
 }


### PR DESCRIPTION
fixed issue according to description:

### Fix setAsActiveCourse_ms.php #14916

Add pdo as parameter, dont create a new one with pdoconnect
Remove as many includes as possible
Remove session_start()
The reason for this: This things are already done by the calling microservice

IF IT DOESNT NEED PDO ( DOES NOT EXECUTE QUERIES) , JUST MARK ISSUE AS COMPLETE)