### PR TITLE
fixed Scale sequence actor on the height aswell #14857

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2694,30 +2694,34 @@ function mmoving(event) {
             // Functionality for the four different nodes
             if (startNodeLeft && (startWidth + (deltaX / zoomfact)) > minWidth) {
                 // Fetch original width
-                var tmp = elementData.width;
-                elementData.width = (startWidth + (deltaX / zoomfact));
+                var originalWidth = elementData.width;
+                elementData.width = startWidth + (deltaX / zoomfact);
 
                 // Deduct the new width, giving us the total change
-                const widthChange = -(tmp - elementData.width);
+                var widthChange = elementData.width - originalWidth;
 
                 // Fetch original x-position
-                tmp = elementData.x;
-                elementData.x = screenToDiagramCoordinates((startX - deltaX), 0).x;
-
+                var originalHeight = elementData.height;
+                elementData.height = startHeight * (elementData.width / startWidth);
                 // Deduct the new position, giving us the total change
-                const xChange = -(tmp - elementData.x);
+                var heightChange = elementData.height - originalHeight;
 
-                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], xChange, 0, widthChange, 0), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
+                stateMachine.save(StateChangeFactory.ElementResized([elementData.id], widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_RESIZED);
             } else if (startNodeRight && (startWidth - (deltaX / zoomfact)) > minWidth) {
                 // Fetch original width
-                var tmp = elementData.width;
-                elementData.width = (startWidth - (deltaX / zoomfact));
+                var originalWidth = elementData.width;
+                elementData.width = startWidth - (deltaX / zoomfact);
 
                 // Remove the new width, giving us the total change
-                const widthChange = -(tmp - elementData.width);
+                var widthChange = elementData.width - originalWidth;
 
                 // Right node will never change the position of the element. We pass 0 as x and y movement.
-                stateMachine.save(StateChangeFactory.ElementResized([elementData.id], widthChange, 0), StateChange.ChangeTypes.ELEMENT_RESIZED);
+                var originalHeight = elementData.height;
+                elementData.height = startHeight * (elementData.width / startWidth);
+
+                var heightChange = elementData.height - originalHeight;
+
+                stateMachine.save(StateChangeFactory.ElementResized([elementData.id], widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_RESIZED);
             } else if (startNodeDown && (startHeight - (deltaY / zoomfact)) > minHeight) {
                 // Fetch original height
                 var tmp = elementData.height;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2694,26 +2694,26 @@ function mmoving(event) {
             // Functionality for the four different nodes
             if (startNodeLeft && (startWidth + (deltaX / zoomfact)) > minWidth) {
                 // Fetch original width
-                var originalWidth = elementData.width;
-                elementData.width = startWidth + (deltaX / zoomfact);
+                var tmp = elementData.width;
+                elementData.width = (startWidth + (deltaX / zoomfact));
 
                 // Deduct the new width, giving us the total change
-                var widthChange = elementData.width - originalWidth;
+                const widthChange = -(tmp - elementData.width);
 
                 // Fetch original x-position
                 var originalHeight = elementData.height;
                 elementData.height = startHeight * (elementData.width / startWidth);
                 // Deduct the new position, giving us the total change
-                var heightChange = elementData.height - originalHeight;
+                const xChange = -(tmp - elementData.x);
 
-                stateMachine.save(StateChangeFactory.ElementResized([elementData.id], widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_RESIZED);
+                stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], xChange, 0, widthChange, 0), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeRight && (startWidth - (deltaX / zoomfact)) > minWidth) {
                 // Fetch original width
-                var originalWidth = elementData.width;
-                elementData.width = startWidth - (deltaX / zoomfact);
+                var tmp = elementData.width;
+                elementData.width = (startWidth - (deltaX / zoomfact));
 
                 // Remove the new width, giving us the total change
-                var widthChange = elementData.width - originalWidth;
+                const widthChange = -(tmp - elementData.width);
 
                 // Right node will never change the position of the element. We pass 0 as x and y movement.
                 var originalHeight = elementData.height;


### PR DESCRIPTION
b22samer and a22robko have fixed the issue where adjusting the width (X-axis scaling). We are now using widthChange to manage how much the width appears to change without actually modifying it when scaled vertically. We've added heightChange to correctly adjust the height based on any width changes during horizontal scaling.
<img width="484" alt="Screenshot 2024-04-26 at 15 43 53" src="https://github.com/HGustavs/LenaSYS/assets/129367092/29744c19-0525-4743-85b4-835553fd9743">