### PR TITLE
Primary Keys in IE Entities are now underlined #14734

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -6789,6 +6789,10 @@ function generateContextProperties() {
                                 str += `<div style='color:white'>Name</div>`;
                                 str += `<input id='elementProperty_${property}' type='text' value='${element[property]}' onfocus='propFieldSelected(true)' onblur='propFieldSelected(false)'>`;
                                 break;
+                            case 'primarykey':
+                                str += `<div style='color:white'>Primary Key</div>`;
+                                str += `<textarea id='elementProperty_${property}' rows='2' style='width:98%;resize:none;text-decoration:underline;'>${textboxFormatString(element[property])}</textarea>`;
+                                break;
                             case 'attributes':
                                 str += `<div style='color:white'>Attributes</div>`;
                                 str += `<textarea id='elementProperty_${property}' rows='4' style='width:98%;resize:none;'>${textboxFormatString(element[property])}</textarea>`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1322,6 +1322,7 @@ var defaults = {
         width: 200,
         height: 0,
         type: "IE",
+        primaryKey: ['*PrimaryKey'],
         attributes: ['-Attribute'],
         functions: ['+function'],
         canChangeTo: ["UML", "ER", "IE", "SD"]

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9684,7 +9684,7 @@ function drawElementIEEntity(element, ghosted) {
 
     if(element.primaryKey && element.primaryKey.length > 0) {
         primaryKeyArray = element.primaryKey;
-        text.unshift(...primaryKeyArray); // adding primary keys to the beginning of the array
+        text.unshift(...primaryKeyArray);
     }
 
     let tHeight = texth * (text.length + 1) * lineHeight;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9671,6 +9671,7 @@ const drawText = (x, y, a, t, extra='') => {
 
 function drawElementIEEntity(element, ghosted) {
     let str = "";
+    let primaryKeyArray;
     let ghostPreview = ghostLine ? 0 : 0.4;
     let linew = Math.round(strokewidth * zoomfact);
     let boxw = Math.round(element.width * zoomfact);
@@ -9681,10 +9682,9 @@ function drawElementIEEntity(element, ghosted) {
 
     const text = splitFull(element.attributes, maxCharactersPerLine);
 
-    let primaryKeyText = "";
     if(element.primaryKey && element.primaryKey.length > 0) {
-        primaryKeyText = `${element.primaryKey.join(", ")}`; // makes so that value in primary key text area is one (1) line always.
-        text.unshift(primaryKeyText); // adding primary key to the beginning of text
+        primaryKeyArray = element.primaryKey;
+        text.unshift(...primaryKeyArray); // adding primary keys to the beginning of the array
     }
 
     let tHeight = texth * (text.length + 1) * lineHeight;
@@ -9715,7 +9715,7 @@ function drawElementIEEntity(element, ghosted) {
         let text = "";
         for (let i = 0; i < s.length; i++)
         {
-            if (s[i] === primaryKeyText) // Checks if the current line is the primary key
+            if (i < primaryKeyArray.length)
             {
                 text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i], 'style="text-decoration-line:underline;"');
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3142,6 +3142,9 @@ function saveProperties() {
                 var formatPK = [];
                 for (var i = 0; i < arrayElementPK.length; i++) {
                     if (!(arrayElementPK[i] == '\n' || arrayElementPK[i] == '' || arrayElementPK[i] == ' ')) {
+                        if (Array.from(arrayElementPK[i])[0] != '*') { // Checks if line starts with a star ('*')
+                            arrayElementPK[i] = "*" + arrayElementPK[i];
+                        }
                         formatPK.push(arrayElementPK[i]);
                     }
                 }
@@ -3158,7 +3161,7 @@ function saveProperties() {
                 var formatArr = [];
                 for (var i = 0; i < arrElementAttr.length; i++) {
                     if (!(arrElementAttr[i] == '\n' || arrElementAttr[i] == '' || arrElementAttr[i] == ' ')) {
-                        if (Array.from(arrElementAttr[i])[0] != '-') {
+                        if (Array.from(arrElementAttr[i])[0] != '-') { // Checks if line starts with a hyphen ('-')
                             arrElementAttr[i] = "-" + arrElementAttr[i];
                         }
                         formatArr.push(arrElementAttr[i]);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3138,7 +3138,7 @@ function saveProperties() {
                 //Get string from textarea
                 var elementPK = child.value;
                 //Create an array from string where newline seperates elements
-                var arrayElementPK = elementAttr.split('\n');
+                var arrayElementPK = elementPK.split('\n');
                 var formatPK = [];
                 for (var i = 0; i < arrayElementPK.length; i++) {
                     if (!(arrayElementPK[i] == '\n' || arrayElementPK[i] == '' || arrayElementPK[i] == ' ')) {
@@ -3158,6 +3158,9 @@ function saveProperties() {
                 var formatArr = [];
                 for (var i = 0; i < arrElementAttr.length; i++) {
                     if (!(arrElementAttr[i] == '\n' || arrElementAttr[i] == '' || arrElementAttr[i] == ' ')) {
+                        if (Array.from(arrElementAttr[i])[0] != '-') {
+                            arrElementAttr[i] = "-" + arrElementAttr[i];
+                        }
                         formatArr.push(arrElementAttr[i]);
                     }
                 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3134,6 +3134,22 @@ function saveProperties() {
                     propsChanged.name = value;
                 }
                 break;
+            case 'primaryKey':
+                //Get string from textarea
+                var elementPK = child.value;
+                //Create an array from string where newline seperates elements
+                var arrayElementPK = elementAttr.split('\n');
+                var formatPK = [];
+                for (var i = 0; i < arrayElementPK.length; i++) {
+                    if (!(arrayElementPK[i] == '\n' || arrayElementPK[i] == '' || arrayElementPK[i] == ' ')) {
+                        formatPK.push(arrayElementPK[i]);
+                    }
+                }
+                //Update the attribute array
+                arrayElementPK = formatPK;
+                element[propName] = arrayElementPK;
+                propsChanged.attributes = arrayElementPK;
+                break;
             case 'attributes':
                 //Get string from textarea
                 var elementAttr = child.value;
@@ -9661,6 +9677,12 @@ function drawElementIEEntity(element, ghosted) {
 
     const text = splitFull(element.attributes, maxCharactersPerLine);
 
+    let primaryKeyText = "";
+    if(element.primaryKey && element.primaryKey.length > 0) {
+        primaryKeyText = `${element.primaryKey.join(", ")}`;
+        text.unshift(primaryKeyText); // adding primary key to the beginning of text
+    }
+
     let tHeight = texth * (text.length + 1) * lineHeight;
     let totalHeight =  tHeight - linew * 2 + texth * 2;
     updateElementHeight(IEHeight, element, totalHeight + boxh)
@@ -9683,11 +9705,24 @@ function drawElementIEEntity(element, ghosted) {
     str += drawDiv( 'uml-header', `width: ${boxw}; height: ${height - linew * 2}px`, headSvg);
 
     // Content, Attributes
-    const textBox = (s, css) => {
+    const textBox = (s, css) =>
+    {
         let height = texth * (s.length + 1) * lineHeight + boxh;
         let text = "";
-        for (let i = 0; i < s.length; i++) {
-            text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i]);
+        for (let i = 0; i < s.length; i++)
+        {
+            //     text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i]);
+            // }
+
+            // Check if the current line is the primary key
+            if (s[i] === primaryKeyText)
+            {
+                text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i], true);  // Pass true for primary key
+            }
+            else
+            {
+                text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i]);
+            }
         }
         let rect = drawRect(boxw, height, linew, element);
         let contentSvg = drawSvg(boxw, height, rect + text);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -3135,23 +3135,21 @@ function saveProperties() {
                 }
                 break;
             case 'primaryKey':
-                //Get string from textarea
-                var elementPK = child.value;
-                //Create an array from string where newline seperates elements
-                var arrayElementPK = elementPK.split('\n');
-                var formatPK = [];
-                for (var i = 0; i < arrayElementPK.length; i++) {
-                    if (!(arrayElementPK[i] == '\n' || arrayElementPK[i] == '' || arrayElementPK[i] == ' ')) {
-                        if (Array.from(arrayElementPK[i])[0] != '*') { // Checks if line starts with a star ('*')
-                            arrayElementPK[i] = "*" + arrayElementPK[i];
+                var textAreaPK = child.value;
+                var lines = textAreaPK.split('\n');
+                var cleanedLines = [];
+                for (var i = 0; i < lines.length; i++) {
+                    if (!(lines[i] == '\n' || lines[i] == '' || lines[i] == ' ')) {
+                        if (Array.from(lines[i])[0] != '*') { // Checks if line starts with a star ('*')
+                            lines[i] = "*" + lines[i];
                         }
-                        formatPK.push(arrayElementPK[i]);
+                        cleanedLines.push(lines[i]);
                     }
                 }
-                //Update the attribute array
-                arrayElementPK = formatPK;
-                element[propName] = arrayElementPK;
-                propsChanged.attributes = arrayElementPK;
+                //Updates property
+                lines = cleanedLines;
+                element[propName] = lines;
+                propsChanged.propName = lines;
                 break;
             case 'attributes':
                 //Get string from textarea

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9717,11 +9717,7 @@ function drawElementIEEntity(element, ghosted) {
         let text = "";
         for (let i = 0; i < s.length; i++)
         {
-            //     text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i]);
-            // }
-
-            // Check if the current line is the primary key
-            if (s[i] === primaryKeyText)
+            if (s[i] === primaryKeyText) // Checks if the current line is the primary key
             {
                 text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i], 'style="text-decoration-line:underline;"');
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9708,7 +9708,7 @@ function drawElementIEEntity(element, ghosted) {
     let headSvg = drawSvg(boxw, height, headRect + headText);
     str += drawDiv( 'uml-header', `width: ${boxw}; height: ${height - linew * 2}px`, headSvg);
 
-    // Content, Attributes
+    // Content, Attributes box area
     const textBox = (s, css) =>
     {
         let height = texth * (s.length + 1) * lineHeight + boxh;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9685,7 +9685,7 @@ function drawElementIEEntity(element, ghosted) {
 
     let primaryKeyText = "";
     if(element.primaryKey && element.primaryKey.length > 0) {
-        primaryKeyText = `${element.primaryKey.join(", ")}`;
+        primaryKeyText = `${element.primaryKey.join(", ")}`; // makes so that value in primary key text area is one (1) line always.
         text.unshift(primaryKeyText); // adding primary key to the beginning of text
     }
 
@@ -9723,7 +9723,7 @@ function drawElementIEEntity(element, ghosted) {
             // Check if the current line is the primary key
             if (s[i] === primaryKeyText)
             {
-                text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i], true);  // Pass true for primary key
+                text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i], 'style="text-decoration-line:underline;"');
             }
             else
             {


### PR DESCRIPTION
![image](https://github.com/HGustavs/LenaSYS/assets/129370135/d02437a1-d96f-4f27-baa1-868710aa4417)

Solution includes:
+ add text area for primary key in PropertyFieldset in Option pane
+ adding a property to the IEEntity object called "primaryKey"
+ adding a switch case for "primaryKey" during the looping through properties of IEEntity when saved (in saveProperties() function).
+ adding an if condition to underline text in the textbox part inside drawElementIEEntity() function that draws the object/element on the diagram.
+ adding signs (stars * or hyphens -) based on if primary key or attribute (adds automatically if user doesnt manually type them in
+ also possible to have multiple primary keys (can easily be changed later to only have one and any additional text will be added to the first line.