### PR TITLE
Fixed aligments on input and select elements

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -299,7 +299,7 @@
 					<div id='inputwrapper-deadline' class='inputwrapper'>
 							<legend><h3>Deadline</h3></legend>
 							<span>Absolute</span>
-							<span style='float:right;margin-right:10px;'>
+							<span style='float:right'>
 								<input onchange="quickValidateForm('editSection', 'saveBtn');" class='textinput' type='date' id='setDeadlineValue' value='' />
 								<select style='width:55px;' id='deadlineminutes'></select>
 								<select style='width:55px;' id='deadlinehours'></select>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2256,13 +2256,12 @@ input.inactive-button {
 .inputwrapper select{
   border-radius: 0px;
 }
-#inputwrapper-name{
-  width: 440px;
-}
+
 #copyvers{
   margin-right: 0px;
 }
-#editCourse #visib{
+
+#editCourse {
   margin-right: 0px;
 }
 
@@ -2705,6 +2704,7 @@ label.login-label {
   text-align: start;
   border-radius: 0px;
   box-sizing: border-box;
+  margin-right: 10px;
 }
 
 .greyedout-textinput {
@@ -7719,11 +7719,6 @@ textarea#mrkdwntxt {
   z-index: 2000;
   background-color: rgba(255, 255, 255, 255);
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);
-}
-
-#visib{
-  margin-right: 0px;
-  border-radius: 0px;
 }
 
 #saveCourse{


### PR DESCRIPTION
There were specific styles being prioritized on certain elements. Which has probably been quick fixes. When these were solved, new issues with alignment appeared in other places. Most likely due to other quick fixes. There was a span element covering two elements which had a margin covering them both. Causing them to visually have double margin values when these elements themselves inherited the correct margins.

Hopefully, whenever a new element is added in the future, they should now inherit the correct styles. However, there might potentially be some places on the website where new issues arise. I can't find any for now, but they might pop up in the future unless a thorough search is conducted.

For testing, just check the alignments on all input elements you can find. For the specific elements in the issue, it's been solved.

![image](https://github.com/HGustavs/LenaSYS/assets/128893264/05b12f7f-373c-4e07-9afa-1589879b2e48)
