### PR TITLE
B22samer and a22robko adjusted the calculation for determining the mi…

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -9408,7 +9408,7 @@ function drawElementNote(element, ghosted) {
     const lineHeight = 1.5;
 
     const text = splitFull(element.attributes, maxCharactersPerLine);
-    let length = (text.length > 4) ? text.length : 4;
+    let length = (text.length > 2) ? text.length : 2;
     let totalHeight = boxh * (1 + length) / 2;
     updateElementHeight(NOTEHeight, element, totalHeight);
     element.stroke = (element.fill == color.BLACK) ? color.WHITE : color.BLACK;


### PR DESCRIPTION
…nimum height of the note element to accommodate 2 lines of text by default instead of 4 as earlier.