### PR TITLE
Added new CSS

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1121,6 +1121,9 @@ border-left: 14px solid var(--color-sectioned-table-hi);
     text-decoration: none;
   }
 
+#Courselist #fabBtn {
+    color:var(--color-primary);
+}
 
   .hidden {
     margin-left: 16px;


### PR DESCRIPTION
Added CSS in blackTheme.css that uses both the "#Courselist" and "#fabBtn" to get a hihgher priority than previous "#Courselist" and "a". This made the color of the "+" in the fab-button to have the same color as the links in Courselist.