### PR TITLE
14986 align lifelines and expansion boxes

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -302,14 +302,14 @@
 }
 .node.md {
     right: calc(50% - 4px);
+    left: calc(50% + 4px);
     bottom: 0; 
-    margin-left: 2%;
     cursor: row-resize;
 }
 
 .node.mu {
     right: calc(50% - 4px);
-    margin-left: 2%;
+    left: calc(50% + 4px);
     cursor: row-resize;
 }
 

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -303,11 +303,13 @@
 .node.md {
     right: calc(50% - 4px);
     bottom: 0; 
+    margin-left: 2%;
     cursor: row-resize;
 }
 
 .node.mu {
     right: calc(50% - 4px);
+    margin-left: 2%;
     cursor: row-resize;
 }
 

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -302,14 +302,12 @@
 }
 .node.md {
     right: calc(50% - 4px);
-    left: calc(50% + 4px);
     bottom: 0; 
     cursor: row-resize;
 }
 
 .node.mu {
     right: calc(50% - 4px);
-    left: calc(50% + 4px);
     cursor: row-resize;
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8969,73 +8969,76 @@ function drawElement(element, ghosted = false) {
     //sequence actor and its life line and also the object since they can be switched via options pane.
     else if (element.kind == elementTypesNames.sequenceActor) {
         //div to encapsulate sequence actor/object and its lifeline.
-        str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'
-        style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;z-index:1;`;
+        str += '<div>';
 
-        if (context.includes(element)) {
-            str += `z-index: 1;`;
-        }
-        if (ghosted) {
-            str += `pointer-events: none; opacity: ${ghostPreview};`;
-        }
-        str += `'>`;
-        str += `<svg width='${boxw}' height='${boxh}'>`;
-        //svg for the life line
-        str += `<path class="text" 
-        d="M${(boxw / 2) + linew},${(boxw / 4) + linew}
-        V${boxh}
-        "
-        stroke-width='${linew}'
-        stroke='${element.stroke}'
-        stroke-dasharray='${linew * 3},${linew * 3}'
-        fill='transparent'
-        />`;
-        str += `<g>`
-        str += `<circle cx="${(boxw / 2) + linew}" cy="${(boxw / 8) + linew}" r="${boxw / 8}px" fill='${element.fill}' stroke='${element.stroke}' stroke-width='${linew}'/>`;
-        str += `<path class="text"
-                d="M${(boxw / 2) + linew},${(boxw / 4) + linew}
-                    v${boxw / 6}
-                    m-${(boxw / 4)},0
-                    h${boxw / 2}
-                    m-${(boxw / 4)},0
-                    v${boxw / 3}
-                    l${boxw / 4},${boxw / 4}
-                    m${(boxw / 4) * -1},${(boxw / 4) * -1}
-                    l${(boxw / 4) * -1},${boxw / 4}
-                "
-                stroke-width='${linew}'
-                stroke='${element.stroke}'
-                fill='transparent'
+            str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'
+            style='left:0px; top:0px; width:${boxw}px; height:${boxh}px; font-size:${texth}px; z-index:1;`;
+
+            if (context.includes(element)) {
+                str += `z-index: 1;`;
+            }
+            if (ghosted) {
+                str += `pointer-events: none; opacity: ${ghostPreview};`;
+            }
+            str += `'>`;
+            str += `<svg width='${boxw}' height='${boxh}'>`;
+            //svg for the life line
+            str += `<path class="text" 
+            d="M${(boxw / 2) + linew},${(boxw / 4) + linew}
+            V${boxh}
+            "
+            stroke-width='${linew}'
+            stroke='${element.stroke}'
+            stroke-dasharray='${linew * 3},${linew * 3}'
+            fill='transparent'
             />`;
-        //svg for the actor name text, it has a background rect for ease of readability.
-        //make the rect fit the text if the text isn't too big
-        if (!tooBig) {
-            //rect for sitting behind the actor text
-            str += `<rect class='text'
-                    x='${xAnchor - (textWidth / 2)}'
-                    y='${boxw + (linew * 2)}'
-                    width='${textWidth}'
-                    height='${texth - linew}'
-                    stroke='none'
-                    fill='${element.fill}'
+            str += `<g>`
+            str += `<circle cx="${(boxw / 2) + linew}" cy="${(boxw / 8) + linew}" r="${boxw / 8}px" fill='${element.fill}' stroke='${element.stroke}' stroke-width='${linew}'/>`;
+            str += `<path class="text"
+                    d="M${(boxw / 2) + linew},${(boxw / 4) + linew}
+                        v${boxw / 6}
+                        m-${(boxw / 4)},0
+                        h${boxw / 2}
+                        m-${(boxw / 4)},0
+                        v${boxw / 3}
+                        l${boxw / 4},${boxw / 4}
+                        m${(boxw / 4) * -1},${(boxw / 4) * -1}
+                        l${(boxw / 4) * -1},${boxw / 4}
+                    "
+                    stroke-width='${linew}'
+                    stroke='${element.stroke}'
+                    fill='transparent'
                 />`;
-            str += `<text class='text' x='${xAnchor}' y='${boxw + (texth / 2) + (linew * 2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
-        }
-        //else just make a boxw width rect and adjust the text to fit this new rect better
-        else {
-            //rect for sitting behind the actor text
-            str += `<rect class='text'
-                    x='${linew}'
-                    y='${boxw + (linew * 2)}'
-                    width='${boxw - linew}'
-                    height='${texth - linew}'
-                    stroke='none'
-                    fill='${element.fill}'
-                />`;
-            str += `<text class='text' x='${linew}' y='${boxw + texth}'>${element.name}</text>`;
-        }
-        str += `</g>`;
-        str += `</svg>`;
+            //svg for the actor name text, it has a background rect for ease of readability.
+            //make the rect fit the text if the text isn't too big
+            if (!tooBig) {
+                //rect for sitting behind the actor text
+                str += `<rect class='text'
+                        x='${xAnchor - (textWidth / 2)}'
+                        y='${boxw + (linew * 2)}'
+                        width='${textWidth}'
+                        height='${texth - linew}'
+                        stroke='none'
+                        fill='${element.fill}'
+                    />`;
+                str += `<text class='text' x='${xAnchor}' y='${boxw + (texth / 2) + (linew * 2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+            }
+            //else just make a boxw width rect and adjust the text to fit this new rect better
+            else {
+                //rect for sitting behind the actor text
+                str += `<rect class='text'
+                        x='${linew}'
+                        y='${boxw + (linew * 2)}'
+                        width='${boxw - linew}'
+                        height='${texth - linew}'
+                        stroke='none'
+                        fill='${element.fill}'
+                    />`;
+                str += `<text class='text' x='${linew}' y='${boxw + texth}'>${element.name}</text>`;
+            }
+            str += `</g>`;
+            str += `</svg>`;
+        str += '<div>';
     }
     //actor or object is determined via the buttons in the context menu. the default is actor.
     else if (element.kind == "sequenceObject") {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8970,7 +8970,7 @@ function drawElement(element, ghosted = false) {
     else if (element.kind == elementTypesNames.sequenceActor) {
         //div to encapsulate sequence actor/object and its lifeline.
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'
-        style='left:0px; top:0px; width:${boxw + 4}px; height:${boxh}px; font-size:${texth}px; z-index:1;`;
+        style='left:0px; top:0px; width:${boxw + 4 * zoomfact}px; height:${boxh}px; font-size:${texth}px; z-index:1;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;
@@ -9041,7 +9041,7 @@ function drawElement(element, ghosted = false) {
     else if (element.kind == "sequenceObject") {
         //svg for object.
         str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'
-        style='left:0px; top:0px;width:${boxw}px;height:${boxh}px;font-size:${texth}px;z-index:1;`;
+        style='left:0px; top:0px;width:${boxw + 4 * zoomfact}px; height:${boxh}px; font-size:${texth}px;z-index:1;`;
 
         if (context.includes(element)) {
             str += `z-index: 1;`;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -8969,76 +8969,73 @@ function drawElement(element, ghosted = false) {
     //sequence actor and its life line and also the object since they can be switched via options pane.
     else if (element.kind == elementTypesNames.sequenceActor) {
         //div to encapsulate sequence actor/object and its lifeline.
-        str += '<div>';
+        str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'
+        style='left:0px; top:0px; width:${boxw + 4}px; height:${boxh}px; font-size:${texth}px; z-index:1;`;
 
-            str += `<div id='${element.id}'	class='element' onmousedown='ddown(event);' onmouseenter='mouseEnter();' onmouseleave='mouseLeave()';'
-            style='left:0px; top:0px; width:${boxw}px; height:${boxh}px; font-size:${texth}px; z-index:1;`;
-
-            if (context.includes(element)) {
-                str += `z-index: 1;`;
-            }
-            if (ghosted) {
-                str += `pointer-events: none; opacity: ${ghostPreview};`;
-            }
-            str += `'>`;
-            str += `<svg width='${boxw}' height='${boxh}'>`;
-            //svg for the life line
-            str += `<path class="text" 
-            d="M${(boxw / 2) + linew},${(boxw / 4) + linew}
-            V${boxh}
-            "
-            stroke-width='${linew}'
-            stroke='${element.stroke}'
-            stroke-dasharray='${linew * 3},${linew * 3}'
-            fill='transparent'
+        if (context.includes(element)) {
+            str += `z-index: 1;`;
+        }
+        if (ghosted) {
+            str += `pointer-events: none; opacity: ${ghostPreview};`;
+        }
+        str += `'>`;
+        str += `<svg width='${boxw}' height='${boxh}'>`;
+        //svg for the life line
+        str += `<path class="text" 
+        d="M${(boxw / 2) + linew},${(boxw / 4) + linew}
+        V${boxh}
+        "
+        stroke-width='${linew}'
+        stroke='${element.stroke}'
+        stroke-dasharray='${linew * 3},${linew * 3}'
+        fill='transparent'
+        />`;
+        str += `<g>`
+        str += `<circle cx="${(boxw / 2) + linew}" cy="${(boxw / 8) + linew}" r="${boxw / 8}px" fill='${element.fill}' stroke='${element.stroke}' stroke-width='${linew}'/>`;
+        str += `<path class="text"
+                d="M${(boxw / 2) + linew},${(boxw / 4) + linew}
+                    v${boxw / 6}
+                    m-${(boxw / 4)},0
+                    h${boxw / 2}
+                    m-${(boxw / 4)},0
+                    v${boxw / 3}
+                    l${boxw / 4},${boxw / 4}
+                    m${(boxw / 4) * -1},${(boxw / 4) * -1}
+                    l${(boxw / 4) * -1},${boxw / 4}
+                "
+                stroke-width='${linew}'
+                stroke='${element.stroke}'
+                fill='transparent'
             />`;
-            str += `<g>`
-            str += `<circle cx="${(boxw / 2) + linew}" cy="${(boxw / 8) + linew}" r="${boxw / 8}px" fill='${element.fill}' stroke='${element.stroke}' stroke-width='${linew}'/>`;
-            str += `<path class="text"
-                    d="M${(boxw / 2) + linew},${(boxw / 4) + linew}
-                        v${boxw / 6}
-                        m-${(boxw / 4)},0
-                        h${boxw / 2}
-                        m-${(boxw / 4)},0
-                        v${boxw / 3}
-                        l${boxw / 4},${boxw / 4}
-                        m${(boxw / 4) * -1},${(boxw / 4) * -1}
-                        l${(boxw / 4) * -1},${boxw / 4}
-                    "
-                    stroke-width='${linew}'
-                    stroke='${element.stroke}'
-                    fill='transparent'
+        //svg for the actor name text, it has a background rect for ease of readability.
+        //make the rect fit the text if the text isn't too big
+        if (!tooBig) {
+            //rect for sitting behind the actor text
+            str += `<rect class='text'
+                    x='${xAnchor - (textWidth / 2)}'
+                    y='${boxw + (linew * 2)}'
+                    width='${textWidth}'
+                    height='${texth - linew}'
+                    stroke='none'
+                    fill='${element.fill}'
                 />`;
-            //svg for the actor name text, it has a background rect for ease of readability.
-            //make the rect fit the text if the text isn't too big
-            if (!tooBig) {
-                //rect for sitting behind the actor text
-                str += `<rect class='text'
-                        x='${xAnchor - (textWidth / 2)}'
-                        y='${boxw + (linew * 2)}'
-                        width='${textWidth}'
-                        height='${texth - linew}'
-                        stroke='none'
-                        fill='${element.fill}'
-                    />`;
-                str += `<text class='text' x='${xAnchor}' y='${boxw + (texth / 2) + (linew * 2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
-            }
-            //else just make a boxw width rect and adjust the text to fit this new rect better
-            else {
-                //rect for sitting behind the actor text
-                str += `<rect class='text'
-                        x='${linew}'
-                        y='${boxw + (linew * 2)}'
-                        width='${boxw - linew}'
-                        height='${texth - linew}'
-                        stroke='none'
-                        fill='${element.fill}'
-                    />`;
-                str += `<text class='text' x='${linew}' y='${boxw + texth}'>${element.name}</text>`;
-            }
-            str += `</g>`;
-            str += `</svg>`;
-        str += '<div>';
+            str += `<text class='text' x='${xAnchor}' y='${boxw + (texth / 2) + (linew * 2)}' dominant-baseline='middle' text-anchor='${vAlignment}'>${element.name}</text>`;
+        }
+        //else just make a boxw width rect and adjust the text to fit this new rect better
+        else {
+            //rect for sitting behind the actor text
+            str += `<rect class='text'
+                    x='${linew}'
+                    y='${boxw + (linew * 2)}'
+                    width='${boxw - linew}'
+                    height='${texth - linew}'
+                    stroke='none'
+                    fill='${element.fill}'
+                />`;
+            str += `<text class='text' x='${linew}' y='${boxw + texth}'>${element.name}</text>`;
+        }
+        str += `</g>`;
+        str += `</svg>`;
     }
     //actor or object is determined via the buttons in the context menu. the default is actor.
     else if (element.kind == "sequenceObject") {


### PR DESCRIPTION
I added 4px to the width of the sequence actor and object that scale with the zoom factor on the page, in order to center the resize squares to the lifelines.
This solution is the best one I have found that seems to scale correctly with the zoom without changing the entire SVG
![image](https://github.com/HGustavs/LenaSYS/assets/129264882/bdcd2a33-aaa5-4260-a00e-77543a845e6a)
![image](https://github.com/HGustavs/LenaSYS/assets/129264882/203b06f9-3bef-40de-8a18-d4537244428e)
