### PR TITLE
Automatic scroll function for new items

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1221,10 +1221,13 @@ async function newItem(itemtitle) {
     if (element.tagName == 'DIV') {
       element = element.firstChild;
       element.classList.add("highlightChange");
+      element.scrollIntoView({behavior: 'smooth', block: 'center'});
     } else if (element.tagName == 'A') {
       document.getElementById('I' + collectedLid[0]).classList.add("highlightChange");
+      document.getElementById('I' + collectedLid[0]).scrollIntoView({behavior: 'smooth', block: 'center'});
     } else if (element.tagName == 'SPAN') {
       document.getElementById('I' + collectedLid[0]).firstChild.classList.add("highlightChange");
+      document.getElementById('I' + collectedLid[0]).firstChild.scrollIntoView({behavior: 'smooth', block: 'center'});
     }
   }, 100);
   // Duration time for the alert before remove

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9253,7 +9253,7 @@ border: none !important;
 /* END */
 
 /* This is used to highlight updated and new items (ex coursees, duggas)*/
-.highlightChange > a{
+.highlightChange > a {
   animation: glowAnimation 8s ease-out;
 }
 @keyframes glowAnimation {
@@ -9267,11 +9267,11 @@ border: none !important;
     text-shadow: 0px 0px 0px #FF0000;
   }
 }
-.highlightChange{
+.highlightChange {
   animation: glowAnimation 8s ease-out;
 }
 
-.lineDiagramDark{
+.lineDiagramDark { 
   border: 2px solid var(--color-border-list);
   background-color: var(--color-sectioned-table-lo);
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9254,7 +9254,7 @@ border: none !important;
 
 /* This is used to highlight updated and new items (ex coursees, duggas)*/
 .highlightChange > a{
-  animation: glowAnimation 4s ease-out;
+  animation: glowAnimation 8s ease-out;
 }
 @keyframes glowAnimation {
   0%{
@@ -9268,7 +9268,7 @@ border: none !important;
   }
 }
 .highlightChange{
-  animation: glowAnimation 4s ease-out;
+  animation: glowAnimation 8s ease-out;
 }
 
 .lineDiagramDark{


### PR DESCRIPTION
Smooth scrolling has been added for when an item is created. It does appear to be decently fast(atleast on firefox), but it is the standard used in all browsers, so it should be reasonable.

As for the highlighting of items, could not figure out how to make highlight only go back upon hover. Because of this I simply doubled the time it takes to fade out, which makes it a little more clear.