### PR TITLE
Made courseed.php backwards compatible with the old database G3 2024 v4 #14849

### DIFF
--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -86,12 +86,21 @@ if (checklogin()) {
 		// The code for modification using sessions
 		if (strcmp($opt, "DEL") === 0) {
 		} else if (strcmp($opt, "NEW") === 0) {
-			$query = $pdo->prepare("INSERT INTO course (coursecode,coursename,visibility,creator, hp) VALUES(:coursecode,:coursename,0,:usrid, 7.5)");
-
+			$query = $pdo->prepare("INSERT INTO course (coursecode,coursename,visibility,creator,hp,courseGitURL) VALUES(:coursecode,:coursename,0,:usrid,7.5,:courseGitURL)");
 			$query->bindParam(':usrid', $userid);
 			$query->bindParam(':coursecode', $coursecode);
 			$query->bindParam(':coursename', $coursename);
 			$query->bindParam(':courseGitURL', $courseGitURL); // for github url
+			try{
+				$query->execute();
+			}
+			catch(Exception $e){
+				$query = $pdo->prepare("INSERT INTO course (coursecode,coursename,visibility,creator, hp) VALUES(:coursecode,:coursename,0,:usrid, 7.5)");
+				$query->bindParam(':usrid', $userid);
+				$query->bindParam(':coursecode', $coursecode);
+				$query->bindParam(':coursename', $coursename);
+				$query->execute();
+			}
 
 			if (!$query->execute()) {
 				$error = $query->errorInfo();
@@ -460,14 +469,23 @@ if (checklogin()) {
 				$debug = "Error duplicate course name\n" . $error[2];
 			}
 		} else if (strcmp($opt, "UPDATE") === 0) {
-			$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode WHERE cid=:cid;");
-
+			$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode,courseGitURL=:courseGitURL WHERE cid=:cid;");
 			$query->bindParam(':cid', $cid);
 			$query->bindParam(':coursename', $coursename);
 			$query->bindParam(':visibility', $visibility);
 			$query->bindParam(':coursecode', $coursecode);
 			$query->bindParam(':courseGitURL', $courseGitURL);
-
+			try{
+				$query->execute();
+			}
+			catch(Exception $e){
+				$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode WHERE cid=:cid;");
+				$query->bindParam(':cid', $cid);
+				$query->bindParam(':coursename', $coursename);
+				$query->bindParam(':visibility', $visibility);
+				$query->bindParam(':coursecode', $coursecode);
+				$query->execute();
+			}
 			if (!$query->execute()) {
 				$error = $query->errorInfo();
 				$debug = "Error updating entries\n" . $error[2];
@@ -510,7 +528,7 @@ if (checklogin()) {
 			} else {
 				$momentlist = array();
 				foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
-					$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode WHERE cid=:cid;");
+					$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode, courseGitURL=:courseGitURL WHERE cid=:cid;");
 
 					print_r($row['coursename'] . $row['visibility'] . $row['coursecode']);
 					$query->bindParam(':cid', $cid);
@@ -518,6 +536,17 @@ if (checklogin()) {
 					$query->bindParam(':visibility', $row['visibility']);
 					$query->bindParam(':coursecode', $row['coursecode']);
 					$query->bindParam(':courseGitURL', $courseGitURL);
+					try{
+						$query->execute();
+					}
+					catch(Exception $e){
+						$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode WHERE cid=:cid;");
+						$query->bindParam(':cid', $cid);
+						$query->bindParam(':coursename', $row['coursename']);
+						$query->bindParam(':visibility', $row['visibility']);
+						$query->bindParam(':coursecode', $row['coursecode']);
+						$query->execute();
+					}
 
 					if (!$query->execute()) {
 						$error = $query->errorInfo();
@@ -698,10 +727,6 @@ if (!$query->execute()) {
 
 	$debug = "Error reading courses\n" . $error[2];
 } else {
-
-	/*$myfile = fopen("a22natth.txt", "w") or die("unable to open file");
-	fwrite($myfile, "hejg!!!j" );
-	fclose($myfile);*/
 
 	foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
 		$writeAccess = false;

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -562,7 +562,7 @@ foreach ($queryz->fetchAll(PDO::FETCH_ASSOC) as $row) {
 }
 
 //Delete course matterial from courses that have been marked as deleted.
-/* $deleted = 3;
+/*$deleted = 3;
 $query = $pdo->prepare("DELETE codeexample FROM course,codeexample WHERE course.visibility=:deleted AND codeexample.cid = course.cid;");
 $query->bindParam(':deleted', $deleted);
 
@@ -571,13 +571,16 @@ if (!$query->execute()) {
 	$error = $query->errorInfo();
 	$debug = "Error reading courses\n" . $error[2];
 
-}
+}*/
 
 
 //user_participant
 $query = $pdo->prepare("DELETE user_participant FROM user_participant,course,listentries WHERE course.visibility=:deleted AND listentries.cid = course.cid AND listentries.lid = user_participant.lid;");
 $query->bindParam(':deleted', $deleted);
- if(!$query->execute()) {
+try{
+	$query->execute();
+}
+catch(Exception $e){
 	$error=$query->errorInfo();
 	$debug="Error reading courses\n".$error[2];
 }
@@ -668,7 +671,7 @@ $query->bindParam(':deleted', $deleted);
 if (!$query->execute()) {
 	$error = $query->errorInfo();
 	$debug = "Error reading courses\n" . $error[2];
-} */
+}
 
 
 try{
@@ -696,9 +699,9 @@ if (!$query->execute()) {
 	$debug = "Error reading courses\n" . $error[2];
 } else {
 
-	$myfile = fopen("a22natth.txt", "w") or die("unable to open file");
+	/*$myfile = fopen("a22natth.txt", "w") or die("unable to open file");
 	fwrite($myfile, "hejg!!!j" );
-	fclose($myfile);
+	fclose($myfile);*/
 
 	foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
 		$writeAccess = false;

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -588,7 +588,7 @@ foreach ($queryz->fetchAll(PDO::FETCH_ASSOC) as $row) {
 }
 
 //Delete course matterial from courses that have been marked as deleted.
-/*$deleted = 3;
+$deleted = 3;
 $query = $pdo->prepare("DELETE codeexample FROM course,codeexample WHERE course.visibility=:deleted AND codeexample.cid = course.cid;");
 $query->bindParam(':deleted', $deleted);
 
@@ -597,7 +597,7 @@ if (!$query->execute()) {
 	$error = $query->errorInfo();
 	$debug = "Error reading courses\n" . $error[2];
 
-}*/
+}
 
 
 //user_participant
@@ -610,7 +610,8 @@ catch(Exception $e){
 	$error=$query->errorInfo();
 	$debug="Error reading courses\n".$error[2];
 }
-
+	
+	
 //useranswer
 $query = $pdo->prepare("DELETE userAnswer FROM course,userAnswer WHERE course.visibility=:deleted AND userAnswer.cid = course.cid;");
 $query->bindParam(':deleted', $deleted);
@@ -700,14 +701,12 @@ if (!$query->execute()) {
 }
 
 
+$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion,courseGitURL FROM course ORDER BY coursename");
 try{
-	$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion,courseGitURL FROM course ORDER BY coursename");
-	//$query->bindParam(':cid', $cid);
 	$query->execute();
 }
 catch(Exception $e){
 	$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion FROM course ORDER BY coursename");
-	$error = $query->errorInfo();
 }
 
 /*

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -99,7 +99,6 @@ if (checklogin()) {
 				$query->bindParam(':usrid', $userid);
 				$query->bindParam(':coursecode', $coursecode);
 				$query->bindParam(':coursename', $coursename);
-				$query->execute();
 			}
 
 			if (!$query->execute()) {
@@ -484,7 +483,6 @@ if (checklogin()) {
 				$query->bindParam(':coursename', $coursename);
 				$query->bindParam(':visibility', $visibility);
 				$query->bindParam(':coursecode', $coursecode);
-				$query->execute();
 			}
 			if (!$query->execute()) {
 				$error = $query->errorInfo();
@@ -545,7 +543,6 @@ if (checklogin()) {
 						$query->bindParam(':coursename', $row['coursename']);
 						$query->bindParam(':visibility', $row['visibility']);
 						$query->bindParam(':coursecode', $row['coursecode']);
-						$query->execute();
 					}
 
 					if (!$query->execute()) {
@@ -704,11 +701,12 @@ if (!$query->execute()) {
 
 
 try{
-	$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion FROM course ORDER BY coursename");
+	$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion,courseGitURL FROM course ORDER BY coursename");
 	//$query->bindParam(':cid', $cid);
 	$query->execute();
 }
 catch(Exception $e){
+	$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion FROM course ORDER BY coursename");
 	$error = $query->errorInfo();
 }
 
@@ -721,11 +719,10 @@ catch(Exception $e){
 
 */
 
-
 if (!$query->execute()) {
 	$error = $query->errorInfo();
-
 	$debug = "Error reading courses\n" . $error[2];
+
 } else {
 
 	foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
@@ -756,7 +753,7 @@ if (!$query->execute()) {
 					'activeversion' => $row['activeversion'],
 					'activeedversion' => $row['activeedversion'],
 					'registered' => $isRegisteredToCourse,
-					//'courseGitURL' => $row['courseGitURL']
+					'courseGitURL' => $row['courseGitURL']
 				)
 			);
 		}

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -18,7 +18,7 @@ include_once "../Shared/sessions.php";
 // Connect to database and start session
 pdoConnect();
 session_start();
-
+ 
 $opt = getOP('opt');
 $cid = getOP('cid');
 $coursename = getOP('coursename');
@@ -35,7 +35,7 @@ $enddate = getOP('enddate');
 $makeactive = getOP('makeactive');
 $motd = getOP('motd');
 $readonly = getOP('readonly');
-$courseGitURL = getOP('courseGitURL'); // for github url
+$courseGitURL = getOP('courseGitURL'); // for github url 
 $LastCourseCreated = array();
 
 if (isset($_SESSION['uid'])) {
@@ -46,10 +46,15 @@ if (isset($_SESSION['uid'])) {
 $ha = null;
 $debug = "NONE!";
 
+
+
 // Gets username based on uid, USED FOR LOGGING
 $query = $pdo->prepare("SELECT username FROM user WHERE uid = :uid");
 $query->bindParam(':uid', $userid);
 $query->execute();
+
+
+
 
 // This while is only performed if userid was set through _SESSION['uid'] check above, a guest will not have it's username set, USED FOR LOGGING
 while ($row = $query->fetch(PDO::FETCH_ASSOC)) {
@@ -81,7 +86,7 @@ if (checklogin()) {
 		// The code for modification using sessions
 		if (strcmp($opt, "DEL") === 0) {
 		} else if (strcmp($opt, "NEW") === 0) {
-			$query = $pdo->prepare("INSERT INTO course (coursecode,coursename,visibility,creator, hp, courseGitURL) VALUES(:coursecode,:coursename,0,:usrid, 7.5, :courseGitURL)");
+			$query = $pdo->prepare("INSERT INTO course (coursecode,coursename,visibility,creator, hp) VALUES(:coursecode,:coursename,0,:usrid, 7.5)");
 
 			$query->bindParam(':usrid', $userid);
 			$query->bindParam(':coursecode', $coursecode);
@@ -455,7 +460,7 @@ if (checklogin()) {
 				$debug = "Error duplicate course name\n" . $error[2];
 			}
 		} else if (strcmp($opt, "UPDATE") === 0) {
-			$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode, courseGitURL=:courseGitURL WHERE cid=:cid;");
+			$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode WHERE cid=:cid;");
 
 			$query->bindParam(':cid', $cid);
 			$query->bindParam(':coursename', $coursename);
@@ -505,7 +510,7 @@ if (checklogin()) {
 			} else {
 				$momentlist = array();
 				foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
-					$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode, courseGitURL=:courseGitURL WHERE cid=:cid;");
+					$query = $pdo->prepare("UPDATE course SET coursename=:coursename, visibility=:visibility, coursecode=:coursecode WHERE cid=:cid;");
 
 					print_r($row['coursename'] . $row['visibility'] . $row['coursecode']);
 					$query->bindParam(':cid', $cid);
@@ -523,6 +528,7 @@ if (checklogin()) {
 		}
 	}
 }
+
 //------------------------------------------------------------------------------------------------
 // Retrieve Information
 //------------------------------------------------------------------------------------------------
@@ -556,12 +562,15 @@ foreach ($queryz->fetchAll(PDO::FETCH_ASSOC) as $row) {
 }
 
 //Delete course matterial from courses that have been marked as deleted.
-$deleted = 3;
+/* $deleted = 3;
 $query = $pdo->prepare("DELETE codeexample FROM course,codeexample WHERE course.visibility=:deleted AND codeexample.cid = course.cid;");
 $query->bindParam(':deleted', $deleted);
+
 if (!$query->execute()) {
+
 	$error = $query->errorInfo();
 	$debug = "Error reading courses\n" . $error[2];
+
 }
 
 
@@ -571,7 +580,7 @@ $query->bindParam(':deleted', $deleted);
  if(!$query->execute()) {
 	$error=$query->errorInfo();
 	$debug="Error reading courses\n".$error[2];
-} 
+}
 
 //useranswer
 $query = $pdo->prepare("DELETE userAnswer FROM course,userAnswer WHERE course.visibility=:deleted AND userAnswer.cid = course.cid;");
@@ -659,10 +668,17 @@ $query->bindParam(':deleted', $deleted);
 if (!$query->execute()) {
 	$error = $query->errorInfo();
 	$debug = "Error reading courses\n" . $error[2];
+} */
+
+
+try{
+	$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion FROM course ORDER BY coursename");
+	//$query->bindParam(':cid', $cid);
+	$query->execute();
 }
-
-
-$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion,courseGitURL FROM course ORDER BY coursename");
+catch(Exception $e){
+	$error = $query->errorInfo();
+}
 
 /*
 
@@ -673,11 +689,16 @@ $query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversio
 
 */
 
+
 if (!$query->execute()) {
 	$error = $query->errorInfo();
+
 	$debug = "Error reading courses\n" . $error[2];
 } else {
 
+	$myfile = fopen("a22natth.txt", "w") or die("unable to open file");
+	fwrite($myfile, "hejg!!!j" );
+	fclose($myfile);
 
 	foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
 		$writeAccess = false;
@@ -707,7 +728,7 @@ if (!$query->execute()) {
 					'activeversion' => $row['activeversion'],
 					'activeedversion' => $row['activeedversion'],
 					'registered' => $isRegisteredToCourse,
-					'courseGitURL' => $row['courseGitURL']
+					//'courseGitURL' => $row['courseGitURL']
 				)
 			);
 		}

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -91,6 +91,7 @@ if (checklogin()) {
 			$query->bindParam(':coursecode', $coursecode);
 			$query->bindParam(':coursename', $coursename);
 			$query->bindParam(':courseGitURL', $courseGitURL); // for github url
+			$query->execute();
 			try{
 				$query->execute();
 			}
@@ -483,6 +484,7 @@ if (checklogin()) {
 				$query->bindParam(':coursename', $coursename);
 				$query->bindParam(':visibility', $visibility);
 				$query->bindParam(':coursecode', $coursecode);
+				//$query->execute();
 			}
 			if (!$query->execute()) {
 				$error = $query->errorInfo();
@@ -543,6 +545,7 @@ if (checklogin()) {
 						$query->bindParam(':coursename', $row['coursename']);
 						$query->bindParam(':visibility', $row['visibility']);
 						$query->bindParam(':coursecode', $row['coursecode']);
+						$query->execute();
 					}
 
 					if (!$query->execute()) {
@@ -588,7 +591,7 @@ foreach ($queryz->fetchAll(PDO::FETCH_ASSOC) as $row) {
 }
 
 //Delete course matterial from courses that have been marked as deleted.
-$deleted = 3;
+/*$deleted = 3;
 $query = $pdo->prepare("DELETE codeexample FROM course,codeexample WHERE course.visibility=:deleted AND codeexample.cid = course.cid;");
 $query->bindParam(':deleted', $deleted);
 
@@ -597,7 +600,7 @@ if (!$query->execute()) {
 	$error = $query->errorInfo();
 	$debug = "Error reading courses\n" . $error[2];
 
-}
+}*/
 
 
 //user_participant
@@ -610,8 +613,7 @@ catch(Exception $e){
 	$error=$query->errorInfo();
 	$debug="Error reading courses\n".$error[2];
 }
-	
-	
+
 //useranswer
 $query = $pdo->prepare("DELETE userAnswer FROM course,userAnswer WHERE course.visibility=:deleted AND userAnswer.cid = course.cid;");
 $query->bindParam(':deleted', $deleted);
@@ -701,12 +703,14 @@ if (!$query->execute()) {
 }
 
 
-$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion,courseGitURL FROM course ORDER BY coursename");
 try{
+	$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion,courseGitURL FROM course ORDER BY coursename");
+	//$query->bindParam(':cid', $cid);
 	$query->execute();
 }
 catch(Exception $e){
 	$query = $pdo->prepare("SELECT coursename,coursecode,cid,visibility,activeversion,activeedversion FROM course ORDER BY coursename");
+	$error = $query->errorInfo();
 }
 
 /*
@@ -717,6 +721,7 @@ catch(Exception $e){
 3 == deleted
 
 */
+
 
 if (!$query->execute()) {
 	$error = $query->errorInfo();

--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -610,8 +610,9 @@ try{
 	$query->execute();
 }
 catch(Exception $e){
-	$error=$query->errorInfo();
-	$debug="Error reading courses\n".$error[2];
+	//as the column doesnt exist on any of the tables with old data this is left blank, uncomment for debugging
+	//$error = $query->errorInfo();
+	//$debug = "Error reading courses\n" . $error[2];
 }
 
 //useranswer

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -40,6 +40,14 @@
 			global $pdo;
 			$query = $pdo->prepare('SELECT updated, courseGitURL FROM course WHERE cid = :cid;');
 			$query->bindParam(':cid', $_SESSION['courseid']);
+			try{
+				$query->execute();
+			}
+			catch(Exception $e){
+				$query = $pdo->prepare('SELECT updated FROM course WHERE cid = :cid;');
+				$query->bindParam(':cid', $_SESSION['courseid']);
+				$query->execute();
+			}
 			
 			// Add error handling for the execute function
 			if (!$query->execute()) {
@@ -52,11 +60,11 @@
 			
 			if ($row !== false) {
 				// Now we know $row is an array and we can safely access its elements
-				$checkIfGithubURL = $row['courseGitURL'];
-				if ($checkIfGithubURL) {
-					$updateTime = $row['updated'];
+				//$checkIfGithubURL = $row['courseGitURL'];
+				if(isset($row['courseGitURL'])){
+					$checkIfGithubURL = $row['courseGitURL'];
 				} else {
-					$updateTime = "No Github URL set";
+					$checkIfGithubURL = null;
 				}
 			} else {
 				// $row is false, which means no data was fetched


### PR DESCRIPTION
When using the old database that the live version of LenaSYS is using, it wasn't possible to load into courseed.php. This was due to missing attributes and tables when comparing the database to the newer one. The main problem was that the database tried to execute queries made for the new database on the old database, so we implemented try/catches that execute an alternate query that works for it. 

**!IMPORTANT!**
To test this you will need to use the old database.