### PR TITLE
Fixed the top dropdown not showing on smaller screens #15111.

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6959,7 +6959,7 @@ only screen and (max-device-width: 568px) {
 /* Fix mobile-view for top FAB-button and Sectionlist heading */
 @media screen and (max-width: 680px) {
   .fixed-action-button2{
-    display:none !important;
+    display:none;
   }
 
   #showElements {


### PR DESCRIPTION
The issue was due to an !important set on the element that was displaying the element. By removing this it seems to work.