### PR TITLE
Fixed visual bug when copying a new course version 

### DIFF
--- a/DuggaSys/courseedservice.php
+++ b/DuggaSys/courseedservice.php
@@ -222,9 +222,11 @@ if (checklogin()) {
 					$debug = "Error reading quiz\n" . $error[2];
 				} else {
 					foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
-						$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,qrelease,relativedeadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
+						$ruery = $pdo->prepare("INSERT INTO quiz (cid,autograde,gradesystem,qname,quizFile,qrelease,deadline,relativedeadline,modified,creator,vers) SELECT cid,autograde,gradesystem,qname,quizFile,:qrel as qrelease,:deadl as deadline,relativedeadline,modified,creator,:newvers as vers from quiz WHERE id = :oldid;");
 						$ruery->bindParam(':oldid', $row['id']);
 						$ruery->bindParam(':newvers', $versid);
+						$ruery->bindParam(':qrel', $startdate);
+						$ruery->bindParam(':deadl', $enddate);
 						if (!$ruery->execute()) {
 							$error = $ruery->errorInfo();
 							$allOperationsSucceeded = false;


### PR DESCRIPTION
It appeared that a red line would appear when one would create a new course version, and for some reason, I hope that it is local otherwise, it might be some weird bug with the code. But hopefully, it should work.

To tester:
Valid input format

Version ID: 2001
Version Name: HT01
Start Date: 01/05/2024
End Date: 30/06/2024
MOTD: MOTD
Copy content from: ST20 - 52432