### PR TITLE
Add filesize value in fileLink table db when fetching code examples #15230

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -4122,7 +4122,7 @@ function fetchGitCodeExamples(courseid){
 //Function to store Code Examples in directory and in database (metadata2.db)
 function storeCodeExamples(cid, codeExamplesContent, githubURL){
     var templateNo = updateTemplate();
-    var decodedContent=[], shaKeys=[], fileNames=[], fileURL=[], downloadURL=[], filePath=[], fileType=[];
+    var decodedContent=[], shaKeys=[], fileNames=[], fileURL=[], downloadURL=[], filePath=[], fileType=[], fileSize=[];
     //Push all file data into separate arrays and add them into one single array.
     codeExamplesContent.map(function(item) {
        decodedContent.push(atob(item.content.content));
@@ -4132,6 +4132,7 @@ function storeCodeExamples(cid, codeExamplesContent, githubURL){
        downloadURL.push(item.content.download_url);
        filePath.push(item.content.path);
        fileType.push(item.content.type);
+       fileSize.push(item.content.size);
     });
 
     var AllJsonData = {
@@ -4143,7 +4144,8 @@ function storeCodeExamples(cid, codeExamplesContent, githubURL){
       downloadURLS: downloadURL,
       fileTypes: fileType,
       codeExamplesLinkParam: CeHiddenParameters,
-      templateid: templateNo
+      templateid: templateNo,
+      fileSizes: fileSize
     }
     //Send data to sectioned.php as JSON through POST and GET
     fetch('sectioned.php?cid=' + cid + '&githubURL=' + githubURL, {
@@ -4156,7 +4158,7 @@ function storeCodeExamples(cid, codeExamplesContent, githubURL){
       .then(response => response.text())
       .then(data => {
         //For testing/finding bugs/errors
-        console.log(data);
+        //console.log(data);
         confirmBox('closeConfirmBox');
       })
       .catch(error => {

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -772,7 +772,7 @@ function writeFilesInDir($path, $fileNames, $content){
     }
 }
 
-function insertIntoFileLinkDB($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $CeHiddenParam) {
+function insertIntoFileLinkDB($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $CeHiddenParam, $fileSizes) {
 	global $pdo;
 	$count = count($fileNames);
 	for($i = 0; $i < $count; $i ++) {
@@ -781,13 +781,13 @@ function insertIntoFileLinkDB($cid, $fileNames, $filePaths, $fileURLS, $download
 		$query->bindParam(':cid', $cid);
 		$query->execute();
 		$norows = $query->fetchColumn();
-		echo $norows;
 		if($norows == 0) {
 			//TODO: Kind value should be fixed to dynamic
 			//TODO: add filesize with insert. Can be fetched from codeExamplesContent in sectioned.js 
-			$query = $pdo->prepare("INSERT INTO fileLink(filename,kind,cid) VALUES(:fileName,'3',:cid);");
+			$query = $pdo->prepare("INSERT INTO fileLink(filename,kind,cid,filesize) VALUES(:fileName,'3',:cid,:filesize);");
 			$query->bindParam(':cid', $cid);
 			$query->bindParam(':fileName', $fileNames[$i]);
+			$query->bindParam(':filesize', $fileSizes[$i]);
 			if (!$query->execute()) {
 				$error = $query->errorInfo();
 				echo "Error updating entries" . $error[2];
@@ -856,6 +856,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 	$fileTypes = isset($requestDataContent['fileTypes']) ? $requestDataContent['fileTypes'] : null;
 	$CeHiddenParam = isset($requestDataContent['codeExamplesLinkParam']) ? $requestDataContent['codeExamplesLinkParam'] : null;
 	$templateid = isset($requestDataContent['templateid']) ? $requestDataContent['templateid'] : null;
+	$fileSizes = isset($requestDataContent['fileSizes']) ? $requestDataContent['fileSizes'] : null;
 	$path = '../../LenaSYS/courses/' . $cid;
 	$pathCoursesRoot = '../../LenaSYS/courses';
 
@@ -863,7 +864,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 	writeFilesInDir($path, $fileNames, $codeExamplesContent);
 	insertIntoSqLiteGitRepo($cid, $githubURL);
 	insertIntoSqLiteGitFiles($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $SHA); 
-	insertIntoFileLinkDB($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $CeHiddenParam);
+	insertIntoFileLinkDB($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $CeHiddenParam, $fileSizes);
 	updateCodeExampleDB($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $CeHiddenParam, $templateid);
 	insertIntoBoxDB($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $CeHiddenParam, $templateid);
 }


### PR DESCRIPTION
To test:
After a codeexample has been fetched.
Check that the column filesize in table fileLink for the fetched files has recieved an insert containing their filesize.