### PR TITLE
remove unused method call hideDeleted() g3-2024-v5-#15055

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1591,12 +1591,12 @@ function returnedSection(data) {
           if (retdata['writeaccess']) {
             if (itemKind === 3) {
               if (isLoggedIn) {
-                str += "<td onmouseup='hideDeleted()' class='LightBox" + hideState + "'>";
+                str += "<td class='LightBox" + hideState + "'>";
                 str += "<div class='dragbleArea'><img style='width: 53%; padding-left: 6px;padding-top: 5px;' alt='pen icon dugga' src='../Shared/icons/select.png'></div>";
               }
             } else if (itemKind === 4) {
               if (isLoggedIn) {
-                str += "<td onmouseup='hideDeleted()' style='background-color: #614875;' class='LightBox" + hideState + "'  >";
+                str += "<td style='background-color: #614875;' class='LightBox" + hideState + "'  >";
                 str += "<div id='selectionDragI" + item['lid'] + "' class='dragbleArea'><img style='width: 53%; padding-left: 6px;padding-top: 5px;' alt='pen icon dugga' src='../Shared/icons/select.png'></div>";
               }
             }
@@ -1606,7 +1606,7 @@ function returnedSection(data) {
 
         if (retdata['writeaccess']) {
           if (itemKind === 2 || itemKind === 5 || itemKind === 6 || itemKind === 7) { // Draggable area with white background
-            str += "<td onmouseup='hideDeleted()' style'text-align: left;' class='LightBox" + hideState + "'>";
+            str += "<td style'text-align: left;' class='LightBox" + hideState + "'>";
             str += "<div class='dragbleArea'><img style='width: 53%; padding-left: 6px;padding-top: 5px;' alt='pen icon dugga' src='../Shared/icons/select.png'></div>";
 
           }
@@ -1647,7 +1647,7 @@ function returnedSection(data) {
         } else if (itemKind === 1) {
           if (isLoggedIn) {
             // Styling for Section row
-            str += "<td onmouseup='hideDeleted()' style='background-color: #614875;' class='LightBox" + hideState + "'>";
+            str += "<td style='background-color: #614875;' class='LightBox" + hideState + "'>";
             str += "<div id='selectionDragI" + item['lid'] + "' class='dragbleArea'><img alt='pen icon dugga' style='width: 53%;padding-left: 6px;padding-top: 5px;' src='../Shared/icons/select.png'></div>";
           }
           str += `<td class='section item${hideState}' placeholder='${momentexists}'id='I${item['lid']}' style='cursor:pointer;' `;


### PR DESCRIPTION
I assume that hideDeleted() was needed at some point to make the drag and arrange feature work properly, but have now been deprecated. There was a possibility of hideDeleted() being renamed but did not find any method matching the "hide deleted" name. The `.deleted` class used to mark the sections that are being deleted within 60 seconds, is not used for any extra hiding functionality.