### PR TITLE
Fetching github repo now works correctly - #15129

### DIFF
--- a/DuggaSys/gitcommitService.php
+++ b/DuggaSys/gitcommitService.php
@@ -44,6 +44,11 @@
 	// getCourseID: Fetch the course ID from MySQL with Github URL, then fetch the latest commit from the repo
 	//--------------------------------------------------------------------------------------------------
 
+	function putInLog($message){
+		$file = '../../LenaSYS/log/gitErrorLog.txt';
+		error_log($message, 3, $file);
+	}
+
 	function getCourseID($githubURL) {
 		// Connect to database and start session
 		pdoConnect();
@@ -103,7 +108,7 @@
 			print_r($error);
 			echo $errorvar;
 		} else {
-			bfs($url, $cid, "REFRESH");
+			bfs($url, $cid, "DOWNLOAD");
 		}
 	}
 

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -206,24 +206,25 @@ function bfs($url, $cid, $opt)
         // If unable to get file contents then it is logged into the specified textfile with
         // the specific http error code
         if($data === false || !$data) {
+            $curl = curl_init($url);
+            curl_setopt($curl, CURLOPT_USERAGENT, 'curl/7.48.0');
+            curl_setopt($curl, CURLOPT_HEADER, 0);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+            $response = json_decode(curl_exec($curl));
+            $http_response_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+            $file = '../../LenaSYS/log/gitErrorLog.txt';
             if(strlen($token)<1)
             {
                 setcookie("missingToken", 1, time() + (5), "/");
+                $message = "\n" . date("Y-m-d H:i:s",time()) . " - Error: connection failed - Error code: ".$http_response_code." Consider setting a token\n";
             }
             else
             {
-                $curl = curl_init($url);
-                curl_setopt($curl, CURLOPT_USERAGENT, 'curl/7.48.0');
-                curl_setopt($curl, CURLOPT_HEADER, 0);
-                curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-                $response = json_decode(curl_exec($curl));
-                $http_response_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
                 $message = "\n" . date("Y-m-d H:i:s",time()) . " - Error: connection failed - Error code: ".$http_response_code."\n";
-                $file = '../../LenaSYS/log/gitErrorLog.txt';
-                
-                http_response_code($http_response_code);
-                error_log($message, 3, $file);
             }
+            
+            http_response_code($http_response_code);
+            error_log($message, 3, $file);
         }
         if ($data) {
             // Decodes the fetched data into JSON

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3881,7 +3881,7 @@ function validateForm(formid) {
         $("#githubPopupWindow").css("display", "none");
         updateGithubRepo(repoLink, cid, repoKey);
         // Refresh page after github link
-        location.reload();
+        //location.reload();
       }
     }
   }


### PR DESCRIPTION
The issues I could find seemed to be related to the page reloading upon the save button having been clicked (in course) as well as the program simply not being set to "DOWNLOAD" when using one of the windows.

Tested both in course and through edit course, with both working to actually download files now, on top of inserting to metadata.

As I also noticed that the error logging was turned off if no token was present, I also took the time to fix this as i'd imagine it was causing confusion.
I also added a small function to gitcommitservice which simply lets you write into the log (as using echo/print_r no longer gives alerts, likely from toasts now existing).

The main issue currently would be that the downloading of files can be quite slow (took me 8 minutes for lenaSYS), but I could not see any good places to make it more effective with a quick look over.