### PR TITLE
G1 2024 v5 #14992

### DIFF
--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -217,6 +217,7 @@ function ddown(event) {
                     pointerState = pointerStates.CLICKED_ELEMENT;
                     targetElement = event.currentTarget;
                     targetElementDiv = document.getElementById(targetElement.id);
+                    canPressDeleteBtn = true;
                 }
             case mouseModes.EDGE_CREATION:
                 if (event.button == 2) return;
@@ -368,10 +369,11 @@ function mouseLeave() {
  */
 function checkDeleteBtn() {
     if (lastMousePos.x > deleteBtnX && lastMousePos.x < (deleteBtnX + deleteBtnSize) && lastMousePos.y > deleteBtnY && lastMousePos.y < (deleteBtnY + deleteBtnSize)) {
-        if (deleteBtnX != 0 && !mouseOverElement) {
+        if (canPressDeleteBtn == true) {
             if (context.length > 0) removeElements(context);
             if (contextLine.length > 0) removeLines(contextLine);
             updateSelection(null);
+            canPressDeleteBtn = false;
             return true;
         }
     }

--- a/DuggaSys/diagram/globals.js
+++ b/DuggaSys/diagram/globals.js
@@ -9,6 +9,7 @@ var sscrollx, sscrolly;
 var cwidth, cheight;
 var deleteBtnX = 0, deleteBtnY = 0;
 var deleteBtnSize = 0;
+var canPressDeleteBtn = false;
 var startWidth;
 var startHeight;
 var startNodeLeft = false;


### PR DESCRIPTION
Now should it be able to click on the cross/X on the element when it is in a super state or Sequence condition. Can test it by first place out a super state or sequence condition, then have a element on top of it. After that try to delete the element by clicking on the cross/X when the element is selected. And now you should not be able to press the cross/X button if not the element is selected.