### PR TITLE
changed the conditions in EntityIsOverlapping

### DIFF
--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -88,14 +88,22 @@ function entityIsOverlapping(id, x, y) {
     })
 
     for (let i = 0; i < data.length; i++) {
-        if (data[i].id === id) continue; 
-        if (context.includes(data[i])) break; 
-       
-        //Checks if the objects are of the same type or allowed types for overlapping.
-        if ((data[i].kind !== element.kind && (( data[i].type === "SE") && (element.type === "SE"))) ||
-           ((data[i].kind !== element.kind && (((( data[i].kind === elementTypesNames.UMLSuperState) && (element.type === "SD"))) ||
-           (data[i].type === "SD" ) && (element.kind === elementTypesNames.UMLSuperState))))) {
-                continue; 
+        if (data[i].id === id) continue;
+        if (context.includes(data[i])) break;
+
+        // No element can be placed over another of the same kind
+        if (data[i].kind !== element.kind) {
+            
+            // Sequence life-lines can be placed on activations
+            if ((data[i].kind === "sequenceActor" || data[i].kind === "sequenceObject") && element.kind === "sequenceActivation") continue;
+             
+            // All sequence elements can be placed over loops, alternatives and activations and vice versa
+            else if (data[i].type === "SE" && (element.kind === "sequenceLoopOrAlt" || element.kind === "sequenceActivation")) continue;
+            else if (element.type === "SE" && (data[i].kind === "sequenceLoopOrAlt" || data[i].kind === "sequenceActivation")) continue;
+
+            // Superstates can be placed on state-diagram elements and vice versa
+            else if (data[i].kind === elementTypesNames.UMLSuperState && element.type === "SD") continue;
+            else if (data[i].type === "SD" && element.kind === elementTypesNames.UMLSuperState) continue;          
         }
 
         const x2 = data[i].x + data[i].width;

--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -88,25 +88,25 @@ function entityIsOverlapping(id, x, y) {
     })
 
     for (let i = 0; i < data.length; i++) {
-        if (data[i].id === id) continue;
-        if (context.includes(data[i])) break;
-        if (data[i].kind == elementTypesNames.UMLSuperState || element.kind == elementTypesNames.UMLSuperState ||
-            data[i].kind == elementTypesNames.sequenceActor || element.kind == elementTypesNames.sequenceActor ||
-            data[i].kind == elementTypesNames.sequenceObject || element.kind == elementTypesNames.sequenceObject ||
-            data[i].kind == elementTypesNames.sequenceLoopOrAlt || element.kind == elementTypesNames.sequenceLoopOrAlt
-        ) {
-            break;
+        if (data[i].id === id) continue; 
+        if (context.includes(data[i])) break; 
+       
+        //Checks if the objects are of the same type or allowed types for overlapping.
+        if ((data[i].kind !== element.kind && (( data[i].type === "SE") && (element.type === "SE"))) ||
+           ((data[i].kind !== element.kind && (((( data[i].kind === elementTypesNames.UMLSuperState) && (element.type === "SD"))) ||
+           (data[i].type === "SD" ) && (element.kind === elementTypesNames.UMLSuperState))))) {
+                continue; 
         }
 
         const x2 = data[i].x + data[i].width;
         let y2 = data[i].y + data[i].height;
-
+    
         arr.forEach(entityHeights => {
             entityHeights.forEach(entity => {
                 if (data[i].id == entity.id) y2 = data[i].y + entity.height;
             });
         });
-
+    
         if (x < x2 &&
             x + element.width > data[i].x &&
             y < y2 &&


### PR DESCRIPTION
The if-statement that we changed didn't work good att all. If there was a sequence object on the diagram you could place objects on eachother freely. Now you can place sequence objects on eachother as long as it's not the same kind as the overlapping object. Same with UML state objects.

While solving the issue we also fixed so that you only can insert UML-state properties into UML superstate and that you only can insert sequense-diagram properties into loop/condition. 