### PR TITLE
preventDefault() added to MOVING_OBJECT

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -665,6 +665,7 @@ document.addEventListener('keydown', function (e) {
 
     // Moving object with arrows
     if (isKeybindValid(e, keybinds.MOVING_OBJECT_UP) && !settings.grid.snapToGrid) {
+        e.preventDefault();
         let overlapDetected = false;
         context.forEach(obj => {
             if (entityIsOverlapping(obj.id, obj.x, obj.y - 1)) {
@@ -679,6 +680,7 @@ document.addEventListener('keydown', function (e) {
         }
     }
     if (isKeybindValid(e, keybinds.MOVING_OBJECT_DOWN) && !settings.grid.snapToGrid) {
+        e.preventDefault();
         let overlapDetected = false;
         context.forEach(obj => {
             if (entityIsOverlapping(obj.id, obj.x, obj.y + 1)) {
@@ -693,6 +695,7 @@ document.addEventListener('keydown', function (e) {
         }
     }
     if (isKeybindValid(e, keybinds.MOVING_OBJECT_LEFT) && !settings.grid.snapToGrid) {
+        e.preventDefault();
         let overlapDetected = false;
         context.forEach(obj => {
             if (entityIsOverlapping(obj.id, obj.x - 1, obj.y)) {
@@ -707,6 +710,7 @@ document.addEventListener('keydown', function (e) {
         }
     }
     if (isKeybindValid(e, keybinds.MOVING_OBJECT_RIGHT) && !settings.grid.snapToGrid) {
+        e.preventDefault();
         let overlapDetected = false;
         context.forEach(obj => {
             if (entityIsOverlapping(obj.id, obj.x + 1, obj.y)) {


### PR DESCRIPTION
Adding e.preventDefault() to the arrows keybindings prevents the user from scrolling with the arrows while in a diagramdugga.

Regarding the change-request we (me and a22cazlu) couldn't reconstruct the problem trying different browsers and we dont see how adding the e.preventDefaults that almost all other keybindings also have would be the reason for the problem that the reviewer described. Is it possible that the reviewer didn't test the issue in the correct landscape or that any other factor might be the reason for the problem?