### PR TITLE
legacy support for resulted.php

### DIFF
--- a/DuggaSys/resultedservice.php
+++ b/DuggaSys/resultedservice.php
@@ -35,11 +35,19 @@ if(checklogin())
 
 if(isSuperUser($userid) || hasAccess($userid, $cid, 'w')){
 	// Get data to display in table rows
-	$query = $pdo->prepare("SELECT hash, password, submitted, timesSubmitted, timesAccessed, moment,last_Time_techer_visited FROM userAnswer WHERE cid=:cid AND vers=:vers");
 
-	$query->bindParam(':cid', $cid);
-	$query->bindParam(':vers', $coursevers);
+	try{
+		$query = $pdo->prepare("SELECT hash, password, submitted, timesSubmitted, timesAccessed, moment,last_Time_techer_visited FROM userAnswer WHERE cid=:cid AND vers=:vers");
+		$query->bindParam(':cid', $cid);
+		$query->bindParam(':vers', $coursevers);
+		$query->execute();
+	}
+	catch(Exception $e){
+		$query = $pdo->prepare("SELECT hash, password, submitted, timesSubmitted, timesAccessed, moment FROM userAnswer WHERE cid=:cid AND vers=:vers");
 
+		$query->bindParam(':cid', $cid);
+		$query->bindParam(':vers', $coursevers);
+	}
 	if(!$query->execute()) {
     	$error=$query->errorInfo();
 	}
@@ -65,11 +73,18 @@ if(isSuperUser($userid) || hasAccess($userid, $cid, 'w')){
 			}
 		}
 
+		if(isset($row['last_Time_techer_visited'])){
+			$teacherVisited = $row['last_Time_techer_visited'];
+		}
+		else{
+			$teacherVisited = null;
+		}
+
     	$tableSubmissionInfo = array(
         	'duggaName' => $duggaName,
         	'hash' => $row['hash'],
         	'password' => $row['password'],
-        	'teacher_visited' => $row['last_Time_techer_visited'],
+        	'teacher_visited' => $teacherVisited,
         	'submitted' => $row['submitted'],
 			'timesSubmitted' => $row['timesSubmitted'],
 			'timesAccessed' => $row['timesAccessed'],

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -40,6 +40,14 @@
 			global $pdo;
 			$query = $pdo->prepare('SELECT updated, courseGitURL FROM course WHERE cid = :cid;');
 			$query->bindParam(':cid', $_SESSION['courseid']);
+			try{
+				$query->execute();
+			}
+			catch(Exception $e){
+				$query = $pdo->prepare('SELECT updated FROM course WHERE cid = :cid;');
+				$query->bindParam(':cid', $_SESSION['courseid']);
+			}
+
 			
 			// Add error handling for the execute function
 			if (!$query->execute()) {
@@ -52,7 +60,12 @@
 			
 			if ($row !== false) {
 				// Now we know $row is an array and we can safely access its elements
-				$checkIfGithubURL = $row['courseGitURL'];
+				if(isset($row['courseGitURL'])){
+					$checkIfGithubURL = $row['courseGitURL'];
+				}
+				else{
+					$checkIfGithubURL = null;
+				}
 				if ($checkIfGithubURL) {
 					$updateTime = $row['updated'];
 				} else {


### PR DESCRIPTION
*due to the previous one not being merged, these changes are copied over from #14850 

old text:

This changes a few things regarding queries to the database to support the old version of the lenaSYS database. mostly adding a few try/catch and isset statements.

**testing instructions:**

- Get the old database version (ask William or Marcus for this) and then run that sql file towards the database.
- Go into resultedservice.php and add "true ||" to the beginning of the if-statement at row 36 (this has to be done due to the user we are logged in to no longer existing, hence this is done to make sure we have rights to see the content of the page)
- At this point, load the page to see if the purple bar at the bottom (this is the table) appears, i also suggest checking the content sent by resultedservice.php is being sent (use the network section of the inspect tools in the browser for this).
- Make sure to check that both the old and new database versions work. To get your old database back, simply run the installer.

**If you wish to further test to the point of actually seeing content in the table:**

- add a row to user, fill out the required fields.
- add a row to listentries, it must have all required fields filled out, as well as "kind" being 3 and "vers" corresponding to a course.
- lastly make a row in useranswer, link the "cid" and "moment" that was created earlier and also make sure that "vers" matches

Note that these things must use an existing course as a basis, so do not just make up vers, cid and such.

Now if that all those extra steps of making table rows sound a little too annoying (because they are), here is a picture of it working on my pc:
![Screenshot 2024-04-24 170744](https://github.com/HGustavs/LenaSYS/assets/129263158/68a2ee91-b761-4788-9cc9-e47040e1f916)

