### PR TITLE
Made courseed.php backwards compatible with the old database G3 2024 v5 #14849

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -46,8 +46,8 @@
 			catch(Exception $e){
 				$query = $pdo->prepare('SELECT updated FROM course WHERE cid = :cid;');
 				$query->bindParam(':cid', $_SESSION['courseid']);
+				$query->execute();
 			}
-
 			
 			// Add error handling for the execute function
 			if (!$query->execute()) {
@@ -60,16 +60,11 @@
 			
 			if ($row !== false) {
 				// Now we know $row is an array and we can safely access its elements
+				//$checkIfGithubURL = $row['courseGitURL'];
 				if(isset($row['courseGitURL'])){
 					$checkIfGithubURL = $row['courseGitURL'];
-				}
-				else{
-					$checkIfGithubURL = null;
-				}
-				if ($checkIfGithubURL) {
-					$updateTime = $row['updated'];
 				} else {
-					$updateTime = "No Github URL set";
+					$checkIfGithubURL = null;
 				}
 			} else {
 				// $row is false, which means no data was fetched
@@ -699,46 +694,45 @@ function hamburgerToggle() {
 }
 
 //count down the fetch cooldown
-let gitFetchCooldownMin, gitFetchCooldownSec, cooldownHolder;
+const gitFetchCooldownMin = document.getElementById("gitFetchMin");
+const gitFetchCooldownSec = document.getElementById("gitFetchSec");
+const cooldownHolder = document.getElementById("cooldownHolder");
 
-document.addEventListener("DOMContentLoaded", function() {
-    gitFetchCooldownMin = document.getElementById("gitFetchMin");
-    gitFetchCooldownSec = document.getElementById("gitFetchSec");
-    cooldownHolder = document.getElementById("cooldownHolder");
-
-    if (gitFetchCooldownMin && gitFetchCooldownSec) { // Check if elements exist
-        setInterval(function() 
+setInterval(
+	function() 
+	{
+		if(gitFetchCooldownSec.innerHTML>0 || gitFetchCooldownMin.innerHTML>0)
 		{
-            if (gitFetchCooldownSec.innerHTML > 0 || gitFetchCooldownMin.innerHTML > 0) {
-                gitFetchCooldownSec.innerHTML -= 1;
-                if (gitFetchCooldownSec.innerHTML < 0) 
-				{
-                    gitFetchCooldownMin.innerHTML -= 1;
-                    gitFetchCooldownSec.innerHTML = 59;
-                }
-            } 
-			else 
+			gitFetchCooldownSec.innerHTML-=1;
+			if(gitFetchCooldownSec.innerHTML<0)
 			{
-                cooldownHolder.style.display = "none";
-            }
-        }, 1000);
-    }
-});
+				gitFetchCooldownMin.innerHTML-=1;
+				gitFetchCooldownSec.innerHTML=59;
+			}
+			
+		}
+		else
+		{
+			cooldownHolder.style.display="none";
+		}
+	}, 1000
+);
 
-function resetGitFetchTimer(superuser) {
-    if (cooldownHolder && cooldownHolder.style.display == "none") {
-        cooldownHolder.style.display = "block";
-        if (superuser == 1) 
+function resetGitFetchTimer(superuser)
+{
+	if(cooldownHolder.style.display=="none"){
+		cooldownHolder.style.display="block";
+		if(superuser==1)
 		{
-            gitFetchCooldownMin.innerHTML = 4;
-            gitFetchCooldownSec.innerHTML = 59;
-        } 
-		else 
+			gitFetchCooldownMin.innerHTML=4;
+			gitFetchCooldownSec.innerHTML=59;
+		}
+		else
 		{
-            gitFetchCooldownMin.innerHTML = 9;
-        	gitFetchCooldownSec.innerHTML = 59;
-        }
-    }
+			gitFetchCooldownMin.innerHTML=9;
+			gitFetchCooldownSec.innerHTML=59;
+		}
+	}
 }
 
 </script>


### PR DESCRIPTION
When using the old database that the live version of LenaSYS is using, it wasn't possible to load into courseed.php. This was due to missing attributes and tables when comparing the database to the newer one. The main problem was that the database tried to execute queries made for the new database on the old database, so we implemented try/catches that execute an alternate query that works for it.

!IMPORTANT!
To test this you will need to use the old database.
