### PR TITLE
G1 2024 v5 #15136

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -815,6 +815,7 @@ document.addEventListener('keyup', function (e) {
     if (isKeybindValid(e, keybinds.TOGGLE_ER_TABLE)) toggleErTable();
     if (isKeybindValid(e, keybinds.SAVE_DIAGRAM)) showSavePopout();
     if (isKeybindValid(e, keybinds.RESET_DIAGRAM)) resetDiagramAlert(); //new keybind for reseting diagram
+    if (isKeybindValid(e, keybinds.TOGGLE_TEST_CASE)) toggleTestCase(); //new keybind for Toggleing test case
 
     //if(isKeybindValid(e, keybinds.TOGGLE_ERROR_CHECK)) toggleErrorCheck(); Note that this functionality has been moved to hideErrorCheck(); because special conditions apply.
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -814,6 +814,8 @@ document.addEventListener('keyup', function (e) {
     if (isKeybindValid(e, keybinds.TOGGLE_REPLAY_MODE)) toggleReplay();
     if (isKeybindValid(e, keybinds.TOGGLE_ER_TABLE)) toggleErTable();
     if (isKeybindValid(e, keybinds.SAVE_DIAGRAM)) showSavePopout();
+    if (isKeybindValid(e, keybinds.RESET_DIAGRAM)) resetDiagramAlert(); //new keybind for reseting diagram
+
     //if(isKeybindValid(e, keybinds.TOGGLE_ERROR_CHECK)) toggleErrorCheck(); Note that this functionality has been moved to hideErrorCheck(); because special conditions apply.
 
     if (isKeybindValid(e, keybinds.COPY)) {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -934,6 +934,7 @@
                 <img src="../Shared/icons/diagram_Refresh_Button.svg" alt="Reset diagram"/>
                 <span class="toolTipText"><b>Reset diagram</b><br>
                     <p>Reset diagram to default state</p><br>
+                    <p id="tooltip-RESET_DIAGRAM" class="key_tooltip">Keybinding:</p>
                 </span>
             </div>
             <div id="stepForwardToggle" class="diagramIcons" onclick="toggleStepForward()">

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -998,7 +998,7 @@
                 <span class="toolTipText"><b>Save current diagram</b><br>
                     <p>Click to save current diagram</p>
                     <br>
-                    <p id="tooltip-Save_diagram" class="key_tooltip">Keybinding:</p> <!--its currently binded to ctrl "s"-->
+                    <p id="tooltip-SAVE_DIAGRAM" class="key_tooltip">Keybinding:</p> <!--its currently binded to ctrl "s"-->
                 </span>
             </div>
         </fieldset>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -689,7 +689,7 @@
                             <p>Represents the passage of time.</p>
                             <p>Shows events that occur to an object during the process.</p>
                             <br>
-                            <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                            <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                         </span>
                         <div id="togglePlacementTypeButton12" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
@@ -704,7 +704,7 @@
                                 <p>Represents the passage of time.</p>
                                 <p>Shows events that occur to an object during the process.</p>
                                 <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> <!-- LIFELINE OBJECT !-->
@@ -714,7 +714,7 @@
                                 <p>Represents the passage of time.</p>
                                 <p>Shows events that occur to an object during the process.</p>
                                 <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
@@ -723,14 +723,14 @@
                                 <p>Creates an activation box.</p>
                                 <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
                                 <br>
-                                <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                           </div>     
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > <!-- LOOP !-->
                             <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="placementTypeToolTipText"><b>Sequence Object</b><br>
                                 <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>                         
                         </div>
@@ -747,7 +747,7 @@
                             <p>Creates an activation box.</p>
                             <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
                             <br>
-                            <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
+                            <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                         </span>
                         <div id="togglePlacementTypeButton16" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
@@ -762,7 +762,7 @@
                                 <p>Represents the passage of time.</p>
                                 <p>Shows events that occur to an object during the process.</p>
                                 <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> <!-- LIFELINE OBJECT !-->
@@ -772,7 +772,7 @@
                                 <p>Represents the passage of time.</p>
                                 <p>Shows events that occur to an object during the process.</p>
                                 <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
                             <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
@@ -781,14 +781,14 @@
                                 <p>Creates an activation box.</p>
                                 <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
                                 <br>
-                                <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>     
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > <!-- LOOP !-->
                             <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                 <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>                         
                         </div>
@@ -805,7 +805,7 @@
                             <p>Creates an activation box.</p>
                             <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
                             <br>
-                            <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
+                            <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                         </span>
                         <div id="togglePlacementTypeButton13" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
@@ -820,7 +820,7 @@
                                 <p>Represents the passage of time.</p>
                                 <p>Shows events that occur to an object during the process.</p>
                                 <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> <!-- LIFELINE OBJECT !-->
@@ -830,7 +830,7 @@
                                 <p>Represents the passage of time.</p>
                                 <p>Shows events that occur to an object during the process.</p>
                                 <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
                             <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
@@ -839,14 +839,14 @@
                                 <p>Creates an activation box.</p>
                                 <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
                                 <br>
-                                <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>     
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > <!-- LOOP !-->
                             <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                 <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>                         
                         </div>
@@ -861,7 +861,7 @@
                          <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="toolTipText"><b>Sequence Condition</b><br>
                                 <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                         <div id="togglePlacementTypeButton14" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
@@ -876,7 +876,7 @@
                                 <p>Represents the passage of time.</p>
                                 <p>Shows events that occur to an object during the process.</p>
                                 <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> <!-- LIFELINE OBJECT !-->
@@ -886,7 +886,7 @@
                                 <p>Represents the passage of time.</p>
                                 <p>Shows events that occur to an object during the process.</p>
                                 <br>
-                                <p id="tooltip-SQ-LIFELINE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
@@ -895,14 +895,14 @@
                                 <p>Creates an activation box.</p>
                                 <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
                                 <br>
-                                <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>      
                             <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > <!-- LOOP !-->
                             <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                 <p>Creates a option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
+                                <p id="tooltip-SEQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>                         
                         </div>

--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -44,6 +44,7 @@ const keybinds = {
     TOGGLE_ERROR_CHECK:  {key: "h", ctrl: false},
     SAVE_DIAGRAM: { key: "s", ctrl: true },
     LOAD_DIAGRAM: { key: "l", ctrl: true },
+    RESET_DIAGRAM: { key: "i", ctrl: false},
 };
 
 /**

--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -44,7 +44,8 @@ const keybinds = {
     TOGGLE_ERROR_CHECK:  {key: "h", ctrl: false},
     SAVE_DIAGRAM: { key: "s", ctrl: true },
     LOAD_DIAGRAM: { key: "l", ctrl: true },
-    RESET_DIAGRAM: { key: "i", ctrl: false},
+    RESET_DIAGRAM: { key: "i", ctrl: false}, //new keybind for reseting diagram
+    TOGGLE_TEST_CASE: { key: "u", ctrl: false}, //new keybind for Toggleing test case
 };
 
 /**


### PR DESCRIPTION
I fixed new keybindings for the Toggle test case and reset diagram functions since they didnt have a keybind earlier but I didnt use the specific keybinds in the issue description since the R keybind was already used and using CTRL + R is the same key combination used to reload a webpage. And E was also already used by toggle er table. So the keybinds used was "i" for the reset diagram and "u" for toggle test case. And then sequence lifeline already had 7 as the keybind I just went into the php file to change the tooltip ids for these elements to be able to display the 7 as the keybind since that wouldnt pop up before and it would just say "keybinds" on these elements. And save current diagram had the same problem which was solved in the same way.

To test this you can hover these different elements to see that the right keybind pops up next to the "keybinding:" text and then try the different following keybinds:

Reset diagram: i 
Toggle test case: u
Sequence lifeline: 7 
Save current diagram: CTRL + S