### PR TITLE
Ghosts now follow mouse centered.

### DIFF
--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -498,11 +498,11 @@ var defaults = {
         fill: color.WHITE,
         stroke: color.BLACK,
         width: 50,
-        height: 50,
+        height: 25,
         type: "IE",
         canChangeTo: Object.values(relationType),
         minWidth: 50,
-        minHeight: 50,
+        minHeight: 25,
     },
     SDEntity: {
         name: "State",

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -58,7 +58,7 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.IERelation:
             divContent = drawElementIERelation(element, boxw, boxh, linew);
             cssClass = 'ie-element';
-            style = `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:1;`;
+            style = `left:0; top:0; width:auto; height:${boxh}px; z-index:1;`;
             break;
         case elementTypesNames.UMLInitialState:
             let initVec = `
@@ -441,7 +441,7 @@ function drawElementIERelation(element, boxw, boxh, linew) {
         content += `<line x1="${boxw / 1.6}" y1="${boxw / 2.9}" x2="${boxw / 2.6}" y2="${boxw / 12.7}" stroke='black' />
                     <line x1="${boxw / 2.6}" y1="${boxw / 2.87}" x2="${boxw / 1.6}" y2="${boxw / 12.7}" stroke='black' />`
     }
-    return drawSvg(boxw, boxh / 2, content, `style='transform:rotate(180deg); stroke-width:${linew};'`);
+    return drawSvg(boxw, boxh, content, `style='transform:rotate(180deg); stroke-width:${linew};'`);
 }
 
 function drawElementState(element, vectorGraphic) {

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -3,9 +3,22 @@
  */
 function updateCSSForAllElements() {
     function updateElementDivCSS(elementData, divObject, useDelta = false) {
+        let boxh = divObject.offsetHeight;
+    
         let left = Math.round(((elementData.x - zoomOrigo.x) * zoomfact) + (scrollx * (1.0 / zoomfact)));
-        let top = Math.round((((elementData.y - zoomOrigo.y) - (settings.grid.gridSize / 2)) * zoomfact) + (scrolly * (1.0 / zoomfact)));
-
+        let top;
+        if (elementData.kind === "UMLEntity" || elementData.kind === "SDEntity" || elementData.kind === "IEEntity") {
+            top = Math.round(((elementData.y - zoomOrigo.y) * zoomfact) + (scrolly * (1.0 / (zoomfact))) - (boxh / 2));
+        } else if (elementData.kind === "note") {
+            top = Math.round(((elementData.y - zoomOrigo.y) * zoomfact) + (scrolly * (1.0 / (zoomfact))) - (boxh / 3.5));
+        }else if (elementData.kind === "sequenceLoopOrAlt") {
+            top = Math.round(((elementData.y - zoomOrigo.y) * zoomfact) + (scrolly * (1.0 / (zoomfact))) - (boxh / 6.8));
+        } else {
+            top = Math.round(((elementData.y - zoomOrigo.y) * zoomfact) + (scrolly * (1.0 / zoomfact)));
+        }
+    
+        divObject.style.left = left + 'px';
+        divObject.style.top = top + 'px';
         if (useDelta) {
             left -= deltaX;
             top -= deltaY;


### PR DESCRIPTION
Due to the fact that some elements (like UML-entity, IE-entity e) is created in a different way than the "normal" way we needed to make different calculations for those cases. The IE-relation didn't center because the program treated it like a square. We changed that, solving the issue with it not being in the center of the mouse while also improving the element with better properties resulting in no more false errors where the program before thought it were overlapping when it wasn't. 