### PR TITLE
Changed the hamburger menu and login color - G3 2024 v5 #15318

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1555,6 +1555,7 @@ div .navButt:hover {
 .loggedout {
   /* Original --  background-color: var(--color-red);*/
   background-color: var(--color-border-primary2);
+  color: var(--color-text-logo);
 }
 
 .loggedout:hover {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1431,6 +1431,7 @@ header td {
 #hamburgerIcon{
   transform: scale(1.8);
   margin-left: 10px;
+  color: white;
 }
 #courseVersionDropDown{
   vertical-align: top;
@@ -5660,7 +5661,7 @@ only screen and (max-device-width: 568px) {
 
   #navBurgerIcon { 
     display: block;
-    
+    color:white;
   }
  
   #navBurgerBox{


### PR DESCRIPTION
Minor additions were made to the style.css file where the login text and the hamburger menu always remains white, regardless of theme. This can be seen in the examples below. 

<img width="390" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129295853/5a6c5c70-6700-48b8-a6e1-c00bbc6aada4">

In dark mode:

<img width="388" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129295853/b545fc31-c365-46ae-ab74-30d4d9ce29e9">


Within sectioned.js (logged out):
<img width="461" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129295853/6dd25790-b52f-4e01-99c7-b365c774a0e5">

On homepage(courseed.php, logged out):
<img width="459" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129295853/bf20f28f-ef04-4f0e-a169-955876fe4feb">

On homepage in darkmode (logged out):
<img width="459" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129295853/8ef7b3db-97de-45ef-b553-86d508722fee">
