### PR TITLE
legacy support for showDugga.php

### DIFF
--- a/DuggaSys/showdoc.php
+++ b/DuggaSys/showdoc.php
@@ -1,5 +1,5 @@
 <?php
-	ini_set("auto_detect_line_endings", true);
+	//ini_set("auto_detect_line_endings", true);
 	include_once "../Shared/basic.php";
 	include_once "../Shared/sessions.php";
 		
@@ -96,11 +96,27 @@
 			$query->bindParam(':cid', $cid);
 			$query->bindParam(':fname', $fname);
 			$query->bindParam(':vers', $coursevers);
-			$result = $query->execute();
+			try{
+				$result = $query->execute();
+			}
+			catch(Exception $e){
+				$query = $pdo->prepare("SELECT filename,kind from fileLink WHERE (cid=:cid or isGlobal='1') and (vers is null OR vers=:vers) and UPPER(filename)=UPPER(:fname) ORDER BY kind DESC LIMIT 1;");
+				$query->bindParam(':cid', $cid);
+				$query->bindParam(':fname', $fname);
+				$query->bindParam(':vers', $coursevers);
+				$result = $query->execute();
+			}
+			
 			if($row = $query->fetch(PDO::FETCH_ASSOC)){
 				$filekind=$row['kind'];
 				$filename = $row['filename'];
-				$path = $row['path'];
+				if(isset($row['path'])){
+					$path = $row['path'];
+				}
+				else{
+					$path = null;
+				}
+				
 		
 				if($filekind==1){
 					// Link


### PR DESCRIPTION
showdugga seemed to work correctly for the most part, I have tested by inputting data needed into the database. As I noticed that all showdugga pages use showdoc.php instead if you do not have access to editing the page. This did not work but had support implemented already, so it was an easy fix.

From what I could tell from looking around everything should work now. However, it is not possible to actually get the current system to display anything (as the files/data needed is not included in the data we were given). Because of this, the testing becomes quite rudimentary. All in all i'd say out of all the pages, this one is the most likely to break with proper files/data, but I believe there is no way to get around this from our side.

**Testing:**

- get access to old database from me/leaders/anyone who has it.
- go to a course page, then to any dugga.
- mess around all you'd like, there really is not much to see.

**Switching between access and no access:**

- go to sessions.php
- on line 426 lies the function isSuperUser(), make this return true upon being called (add return true; to the top of it)