### PR TITLE
Changed .toastText overflow-y from scroll to auto.

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9658,7 +9658,7 @@ margin:2px;
 .toastText {
   font-family: Arial; 
   grid-area: "text";
-  overflow-y: scroll;
+  overflow-y: auto;
   width: 100%;
   min-height: 2rem;
   height: 3rem;


### PR DESCRIPTION
Having overflow-y set to auto enables it to switch to a scroll-wheel whenever the text overflows in the y-direction. If the text does not overflow the toast, it will no longer show a scroll-wheel. Whenever the text overflows the toast, that's when the scroll-wheel appears.

The easiest way to test this is to go into toast.php and extend the timers for the toasts and then edit the content inside.