### PR TITLE
Fixed move and resize jump. (#14623)

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1020,10 +1020,10 @@ function mmoving(event) {
 
             // Functionality for the four different nodes
             if (startNodeLeft && (startWidth + (deltaX / zoomfact)) > minWidth) {
-                isR = false;
-                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
-                isX = true;
-                let xChange = movementPosChange(elementData,startX,deltaX,isX);
+                let tmpW = elementData.width;
+                let tmpX = elementData.x;
+                let xChange = movementPosChange(elementData, startX, deltaX, true);
+                let widthChange = movementWidthChange(elementData, tmpW, tmpX, false);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], xChange, 0, widthChange, 0), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeRight && (startWidth - (deltaX / zoomfact)) > minWidth) {
                 isR = true;
@@ -1031,49 +1031,53 @@ function mmoving(event) {
                 stateMachine.save(StateChangeFactory.ElementResized([elementData.id], widthChange, 0), StateChange.ChangeTypes.ELEMENT_RESIZED);
             } else if (startNodeDown && (startHeight - (deltaY / zoomfact)) > minHeight) {
                 isUP = false;
-                const heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                const heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP);
                 stateMachine.save(StateChangeFactory.ElementResized([elementData.id], 0, heightChange), StateChange.ChangeTypes.ELEMENT_RESIZED);
             } else if (startNodeUp && (startHeight + (deltaY / zoomfact)) > minHeight) {
                 // Fetch original height// Deduct the new height, giving us the total change
-                isUP = true;
-                const heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
-                isX = false;
-                let yChange = movementPosChange(elementData,startY,deltaY,isX);
+                let tmpH = elementData.height;
+                let tmpY = elementData.y;
+                let yChange = movementPosChange(elementData, startY, deltaY, false);
+                const heightChange = movementHeightChange(elementData, tmpH, tmpY, true);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeUpLeft && (startHeight + (deltaY / zoomfact)) > minHeight && (startWidth + (deltaX / zoomfact)) > minWidth){
                 //set movable height
-                isUP = true;
-                let heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
-                isX = false;
-                let yChange = movementPosChange(elementData,startY,deltaY,isX);
-                isR = false;
-                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
-                isX = true;
-                let xChange = movementPosChange(elementData,startX,deltaX,isX);
+                let tmpW = elementData.width;
+                let tmpX = elementData.x;
+                let tmpH = elementData.height;
+                let tmpY = elementData.y;
+                let xChange = movementPosChange(elementData,startX,deltaX,true);
+                let widthChange = movementWidthChange(elementData,tmpW,tmpX,false);
+                let yChange = movementPosChange(elementData,startY,deltaY,false);
+                let heightChange = movementHeightChange(elementData,tmpH,tmpY,true);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], xChange, yChange, widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeUpRight && (startHeight + (deltaY / zoomfact)) > minHeight && (startWidth - (deltaX / zoomfact)) > minWidth){
                 //set movable height
-                isUP = true;
-                let heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                let tmpH = elementData.height;
+                let tmpY = elementData.y;
                 isX = false;
                 let yChange = movementPosChange(elementData,startY,deltaY,isX);
+                isUP = true;
+                let heightChange = movementHeightChange(elementData,tmpH,tmpY,isUP);
                 isR = true;
                 let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeDownLeft && (startHeight - (deltaY / zoomfact)) > minHeight && (startWidth + (deltaX / zoomfact)) > minWidth){
-                isR = false;
-                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
+                let tmpW = elementData.width;
+                let tmpX = elementData.x;
                 isX = true;
                 let xChange = movementPosChange(elementData,startX,deltaX,isX);
+                isR = false;
+                let widthChange = movementWidthChange(elementData,tmpW,tmpX,isR);
                 isUP = false;
-                let heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                let heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], xChange, 0, widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeDownRight && (startHeight - (deltaY / zoomfact)) > minHeight && (startWidth - (deltaX / zoomfact)) > minWidth){
                 isR = true;
                 let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
 
                 isUP = false;
-                const heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                const heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP);
 
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, 0, widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             }
@@ -1115,38 +1119,20 @@ function movementPosChange(element,start,delta, isX){
 }
 
 function movementWidthChange(element,start,delta,isR){
-    let tmp = element.width;
-    if (isR) {
-        element.width = (start - (delta / zoomfact));
-    } else {
-        element.width = (start + (delta / zoomfact));
-    }
+    let xChange = -(delta - element.x);
+    element.width = (isR) ? start - delta / zoomfact : start - xChange;
     // Remove the new width, giving us the total change
-    return -(tmp - element.width);
+    return element.width;
 }
 
-function movementHeightChange(element,start,delta,isUp,preResizeHeight){
+function movementHeightChange(element,start,delta,isUp){
     // Adds a deep clone of the element to preResizeHeight if it isn't in it
     let tmp = element.height;
+    yChange = -(delta - element.y);
     if (isUp) {
-        element.height = (start + (delta / zoomfact));
+        element.height = (start - yChange);
     } else {
         element.height = (start - (delta / zoomfact));
-    }
-    let foundID = false;
-    if (preResizeHeight == undefined) {
-        let resizedElement = structuredClone(element);
-        preResizeHeight.push(resizedElement);
-    } else {
-        for (let i = 0; i < preResizeHeight.length; i++) {
-            if (element.id == preResizeHeight[i].id) {
-                foundID = true;
-            }
-        }
-        if (!foundID) {
-            let resizedElement = structuredClone(element);
-            preResizeHeight.push(resizedElement);
-        }
     }
     return -(tmp - element.height);
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1128,13 +1128,9 @@ function movementWidthChange(element,start,delta,isR){
 function movementHeightChange(element,start,delta,isUp){
     // Adds a deep clone of the element to preResizeHeight if it isn't in it
     let tmp = element.height;
-    yChange = -(delta - element.y);
-    if (isUp) {
-        element.height = (start - yChange);
-    } else {
-        element.height = (start - (delta / zoomfact));
-    }
-    return -(tmp - element.height);
+    let yChange = -(delta - element.y);
+    element.height = (isUp) ? start - yChange : start - delta / zoomfact;
+    return element.height;
 
 }
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1090,9 +1090,11 @@ function mmoving(event) {
 }
 
 function movementPosChange(element,start,delta, isX){
+    // mouse position is used causing the line to "jump" to the mous pos.
+    // The magic numebers are used to center the node middle with the mouse pointer
     let property = (isX) ? 'x' : 'y';
-    let x = (isX) ? start - delta : 0;
-    let y = (isX) ? 0 : start - delta;
+    let x = (isX) ? start - delta - 6 * zoomfact : 0;
+    let y = (isX) ? 0 : start - delta + 17 * zoomfact;
     let tmp = element[property];
     element[property] = screenToDiagramCoordinates(x, y)[property];
     // Deduct the new position, giving us the total change
@@ -1100,7 +1102,7 @@ function movementPosChange(element,start,delta, isX){
 }
 
 function movementWidthChange(element, start, delta, isR){
-    element.width = (isR) ? start - delta / zoomfact : start + (delta - element.x);
+    element.width = (isR) ? start - delta / zoomfact : start + delta - element.x;
     return element.width;
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1021,59 +1021,59 @@ function mmoving(event) {
             // Functionality for the four different nodes
             if (startNodeLeft && (startWidth + (deltaX / zoomfact)) > minWidth) {
                 isR = false;
-                let widthChange = movementXChange(elementData,startWidth,deltaX,isR);
+                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
                 isX = true;
                 let xChange = movementPosChange(elementData,startX,deltaX,isX);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], xChange, 0, widthChange, 0), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeRight && (startWidth - (deltaX / zoomfact)) > minWidth) {
                 isR = true;
-                let widthChange = movementXChange(elementData,startWidth,deltaX,isR);
+                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
                 stateMachine.save(StateChangeFactory.ElementResized([elementData.id], widthChange, 0), StateChange.ChangeTypes.ELEMENT_RESIZED);
             } else if (startNodeDown && (startHeight - (deltaY / zoomfact)) > minHeight) {
                 isUP = false;
-                const heightChange = movementYChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                const heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
                 stateMachine.save(StateChangeFactory.ElementResized([elementData.id], 0, heightChange), StateChange.ChangeTypes.ELEMENT_RESIZED);
             } else if (startNodeUp && (startHeight + (deltaY / zoomfact)) > minHeight) {
                 // Fetch original height// Deduct the new height, giving us the total change
                 isUP = true;
-                const heightChange = movementYChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                const heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
                 isX = false;
                 let yChange = movementPosChange(elementData,startY,deltaY,isX);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, 0, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeUpLeft && (startHeight + (deltaY / zoomfact)) > minHeight && (startWidth + (deltaX / zoomfact)) > minWidth){
                 //set movable height
                 isUP = true;
-                let heightChange = movementYChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                let heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
                 isX = false;
                 let yChange = movementPosChange(elementData,startY,deltaY,isX);
                 isR = false;
-                let widthChange = movementXChange(elementData,startWidth,deltaX,isR);
+                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
                 isX = true;
                 let xChange = movementPosChange(elementData,startX,deltaX,isX);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], xChange, yChange, widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeUpRight && (startHeight + (deltaY / zoomfact)) > minHeight && (startWidth - (deltaX / zoomfact)) > minWidth){
                 //set movable height
                 isUP = true;
-                let heightChange = movementYChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                let heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
                 isX = false;
                 let yChange = movementPosChange(elementData,startY,deltaY,isX);
                 isR = true;
-                let widthChange = movementXChange(elementData,startWidth,deltaX,isR);
+                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, yChange, widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeDownLeft && (startHeight - (deltaY / zoomfact)) > minHeight && (startWidth + (deltaX / zoomfact)) > minWidth){
                 isR = false;
-                let widthChange = movementXChange(elementData,startWidth,deltaX,isR);
+                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
                 isX = true;
                 let xChange = movementPosChange(elementData,startX,deltaX,isX);
                 isUP = false;
-                let heightChange = movementYChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                let heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], xChange, 0, widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             } else if (startNodeDownRight && (startHeight - (deltaY / zoomfact)) > minHeight && (startWidth - (deltaX / zoomfact)) > minWidth){
                 isR = true;
-                let widthChange = movementXChange(elementData,startWidth,deltaX,isR);
+                let widthChange = movementWidthChange(elementData,startWidth,deltaX,isR);
 
                 isUP = false;
-                const heightChange = movementYChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
+                const heightChange = movementHeightChange(elementData,startHeight,deltaY,isUP,preResizeHeight);
 
                 stateMachine.save(StateChangeFactory.ElementMovedAndResized([elementData.id], 0, 0, widthChange, heightChange), StateChange.ChangeTypes.ELEMENT_MOVED_AND_RESIZED);
             }
@@ -1114,7 +1114,7 @@ function movementPosChange(element,start,delta, isX){
     return -(tmp - elem);
 }
 
-function movementXChange(element,start,delta,isR){
+function movementWidthChange(element,start,delta,isR){
     let tmp = element.width;
     if (isR) {
         element.width = (start - (delta / zoomfact));
@@ -1125,7 +1125,7 @@ function movementXChange(element,start,delta,isR){
     return -(tmp - element.width);
 }
 
-function movementYChange(element,start,delta,isUp,preResizeHeight){
+function movementHeightChange(element,start,delta,isUp,preResizeHeight){
     // Adds a deep clone of the element to preResizeHeight if it isn't in it
     let tmp = element.height;
     if (isUp) {


### PR DESCRIPTION
Fixed issue where an element would make a big jump when moving or resizing it. 

There is still a very small jump when resizing using the left node and the upper node (also affects the upper left and lower left nodes), but this seems related to the 'startX' and 'startY' values.

Also removed the 'preResizeHeight' code from the upper node (This code is not used anymore from what I can see).