### PR TITLE
Added async false

### DIFF
--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1024,6 +1024,7 @@ function AJAXService(opt,apara,kind)
 				type: "POST",
 				data: "opt="+opt+para,
 				dataType: "json",
+				async: false,
 				success: returnedCourse
             });
 		} else if (opt === "NEWVRS") {
@@ -1032,6 +1033,7 @@ function AJAXService(opt,apara,kind)
 				type: "POST",
 				data: "opt="+opt+para,
 				dataType: "json",
+				async: false,
 				success: returnedCourse
             });
         } else if (opt === "CPYVRS") {
@@ -1040,6 +1042,7 @@ function AJAXService(opt,apara,kind)
 				type: "POST",
 				data: "opt="+opt+para,
 				dataType: "json",
+				async: false,
 				success: returnedCourse
             });
         } else {


### PR DESCRIPTION
Added async false to avoid xhr error in courseedervice

In previous version when copying new course version or editing version there is an xhr error in the network traffic caused by asynchronous calls being made.

![image](https://github.com/HGustavs/LenaSYS/assets/129263393/be5d757d-fc6b-4f5e-9de1-2f376d2fef63)

With these changes a response can be retrieved