### PR TITLE
remove unecessary console logs

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3364,15 +3364,11 @@ function createExamples(momentID, isManual) {
 // When the user is watching the course page, set isActivelyFocused to true
 $(window).on('focus', function () {
   isActivelyFocused = true;
-  console.log('User is focusing on course page, isActivelyFocused is now', isActivelyFocused);
-
 });
 
 // When the user stops watching the course page, set isActivelyFocused to false
 $(window).on('blur', function () {
-  isActivelyFocused = false;
-  console.log('User lost focus on course page, isActivelyFocused is now', isActivelyFocused);
-  
+  isActivelyFocused = false;  
 });
 
 // Create an interval that checks if the window is focused and the updateInterval has passed, 


### PR DESCRIPTION
It appears to have been the same lines that were removed in the old issue, likely someone accidentally put them back in.

**testing:**
check if the "User is focusing on course page, isActivelyFocused is now true" and "User lost focus on course page, isActivelyFocused is now false" console logs persist anywhere (although they were only present in sectioned.php)