### PR TITLE
G2 2024 v5 issue#15387

### DIFF
--- a/DuggaSys/microservices/codeviewerService/deleteCodeExample_ms.php
+++ b/DuggaSys/microservices/codeviewerService/deleteCodeExample_ms.php
@@ -2,7 +2,8 @@
 date_default_timezone_set("Europe/Stockholm");
 
 // Include basic application services
-include ('../sharedMicroservices/getUid_ms.php');
+include_once "../sharedMicroservices/getUid_ms.php";
+include_once "./retrieveCodeviewerService_ms.php";
 include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
 
@@ -14,8 +15,8 @@ session_start();
 $exampleId=getOP('exampleid');
 $boxId=getOP('boxid');
 $opt=getOP('opt');
-
-getUid();
+$debug="NONE!";
+$userid=getUid();
 
 
 $query1 = $pdo->prepare("DELETE FROM improw WHERE exampleid=:exampleid;");
@@ -59,6 +60,6 @@ if(!$query5->execute()) {
     echo (json_encode(array('writeaccess' => 'w', 'debug' => $error[2])));
     return;
 }
-echo (json_encode(array('deleted' => true, 'debug' => $debug)));
+$array=retrieveCodeviewerService($opt,$pdo,$userid,$debug);
+echo json_encode($array);
 return;
-?>

--- a/DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php
+++ b/DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php
@@ -3,6 +3,7 @@ date_default_timezone_set("Europe/Stockholm");
 
 // Include basic application services
 include_once "../sharedMicroservices/getUid_ms.php";
+include_once "./retrieveCodeviewerService_ms.php";
 include_once "../../../Shared/basic.php";
 include_once "../../../Shared/sessions.php";
 
@@ -14,8 +15,8 @@ session_start();
 $exampleId = getOP('exampleid');
 $boxId = getOP('boxid');
 $opt = getOP('opt');
-
-getUid();
+$debug="NONE!";
+$userid=getUid();
 
 $exampleCount = 0;
 
@@ -46,3 +47,6 @@ if ($exampleCount > 0) {
 		}
 	}
 }
+$array=retrieveCodeviewerService($opt,$pdo,$userid,$debug);
+echo json_encode($array);
+return;

--- a/DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php
+++ b/DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php
@@ -15,6 +15,7 @@ session_start();
 $exampleId = getOP('exampleid');
 $boxId = getOP('boxid');
 $opt = getOP('opt');
+$boxTitle = getOP('boxtitle');
 $debug="NONE!";
 $userid=getUid();
 
@@ -29,21 +30,14 @@ while ($row = $query->fetch(PDO::FETCH_ASSOC)) {
 }
 
 if ($exampleCount > 0) {
-	if (checklogin() && ($writeAccess == "w" || isSuperUser($_SESSION['uid']))) {
+	if (checklogin() && ($writeAccess == "w" || isSuperUser($userid))) {
 
 		if (strcmp('EDITTITLE', $opt) === 0) {
-			$exampleid = $_POST['exampleid'];
-			$boxId = $_POST['boxid'];
-			$boxTitle = $_POST['boxtitle'];
-
 			$query = $pdo->prepare("UPDATE box SET boxtitle=:boxtitle WHERE boxid=:boxid AND exampleid=:exampleid;");
 			$query->bindParam(':boxtitle', $boxTitle);
 			$query->bindValue(':exampleid', $exampleId);
 			$query->bindParam(':boxid', $boxId);
 			$query->execute();
-
-			echo json_encode(array('title' => $boxTitle, 'id' => $boxId));
-			return;
 		}
 	}
 }

--- a/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
+++ b/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
@@ -2,6 +2,7 @@
 
 include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
+include_once "../sharedMicroservices/getUid_ms.php";
 include_once "./retrieveCodeviewerService_ms.php";
 
 pdoConnect();
@@ -18,14 +19,7 @@ $sectionName=getOP('sectionname');
 $exampleName=getOP('examplename');
 $playlink=getOP('playlink');
 $debug="NONE!";
-$userid="";
-
-// Checks user id, if user has none a guest id is set
-if(isset($_SESSION['uid'])){
-	$userid=$_SESSION['uid'];
-}else{
-	$userid="1";
-}
+$userid=getUid();
 
 if(strcmp('EDITEXAMPLE',$opt)===0){
 	if(isset($_POST['playlink'])) {$playlink = $_POST['playlink'];}

--- a/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
+++ b/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
@@ -22,11 +22,23 @@ $debug="NONE!";
 $userid=getUid();
 
 if(strcmp('EDITEXAMPLE',$opt)===0){
-	if(isset($_POST['playlink'])) {$playlink = $_POST['playlink'];}
-	if(isset($_POST['examplename'])) {$exampleName = $_POST['examplename'];}
-	if(isset($_POST['sectionname'])) {$sectionName = $_POST['sectionname'];}
-	if(isset($_POST['beforeid'])) {$beforeId = $_POST['beforeid'];}
-	if(isset($_POST['afterid'])) {$afterId = $_POST['afterid'];}
+
+	$query = $pdo->prepare( "SELECT exampleid,sectionname,examplename,runlink,cid,cversion,beforeid,afterid,public FROM codeexample WHERE exampleid = :exampleid;");
+	$query->bindParam(':exampleid', $exampleId);
+	  $query->execute();
+  
+	  while ($row = $query->fetch(PDO::FETCH_ASSOC)){
+		  $exampleCount++;
+		  $exampleId=$row['exampleid'];
+		  $exampleName=$row['examplename'];
+		  $courseID=$row['cid'];
+		  $cversion=$row['cversion'];
+		  $beforeId=$row['beforeid'];
+		  $afterId=$row['afterid'];
+		  $public=$row['public'];
+		  $sectionName=$row['sectionname'];
+		  $playlink=$row['runlink'];
+	  }
 
 	// Change content of example
 	$query = $pdo->prepare( "UPDATE codeexample SET runlink = :playlink , examplename = :examplename, sectionname = :sectionname WHERE exampleid = :exampleid AND cid = :cid AND cversion = :cvers;");

--- a/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
+++ b/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
@@ -12,6 +12,11 @@ $opt=getOP('opt');
 $exampleId=getOP('exampleid');
 $courseId=getOP('courseid');
 $courseVersion=getOP('cvers');
+$playlink=getOP('playlink');
+$exampleName=getOP('examplename');
+$sectionName=getOP('sectionname');
+$beforeId=getOP('beforeid');
+$afterId=getOP('afterid');
 $debug="NONE!";
 $userid=getUid();
 
@@ -32,11 +37,11 @@ while ($row = $query->fetch(PDO::FETCH_ASSOC)){
 }
 
 if(strcmp('EDITEXAMPLE',$opt)===0){
-	$playlink=getOP('playlink');
-	$exampleName=getOP('examplename');
-	$sectionName=getOP('sectionname');
-	$beforeId=getOP('beforeid');
-	$afterId=getOP('afterid');
+	if(isset($_POST['playlink'])) {$playlink = $_POST['playlink'];}
+	if(isset($_POST['examplename'])) {$exampleName = $_POST['examplename'];}
+	if(isset($_POST['sectionname'])) {$sectionName = $_POST['sectionname'];}
+	if(isset($_POST['beforeid'])) {$beforeId = $_POST['beforeid'];}
+	if(isset($_POST['afterid'])) {$afterId = $_POST['afterid'];}
 
 	// Change content of example
 	$query = $pdo->prepare( "UPDATE codeexample SET runlink = :playlink , examplename = :examplename, sectionname = :sectionname WHERE exampleid = :exampleid AND cid = :cid AND cversion = :cvers;");

--- a/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
+++ b/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
@@ -10,35 +10,33 @@ session_start();
 
 $opt=getOP('opt');
 $exampleId=getOP('exampleid');
-$boxId=getOP('boxid');
 $courseId=getOP('courseid');
 $courseVersion=getOP('cvers');
-$beforeId=getOP('beforeid');
-$afterId=getOP('afterid');
-$sectionName=getOP('sectionname');
-$exampleName=getOP('examplename');
-$playlink=getOP('playlink');
 $debug="NONE!";
 $userid=getUid();
 
-if(strcmp('EDITEXAMPLE',$opt)===0){
+$query = $pdo->prepare( "SELECT exampleid,sectionname,examplename,runlink,cid,cversion,beforeid,afterid,public FROM codeexample WHERE exampleid = :exampleid;");
+$query->bindParam(':exampleid', $exampleId);
+$query->execute();
 
-	$query = $pdo->prepare( "SELECT exampleid,sectionname,examplename,runlink,cid,cversion,beforeid,afterid,public FROM codeexample WHERE exampleid = :exampleid;");
-	$query->bindParam(':exampleid', $exampleId);
-	  $query->execute();
-  
-	  while ($row = $query->fetch(PDO::FETCH_ASSOC)){
-		  $exampleCount++;
-		  $exampleId=$row['exampleid'];
-		  $exampleName=$row['examplename'];
-		  $courseID=$row['cid'];
-		  $cversion=$row['cversion'];
-		  $beforeId=$row['beforeid'];
-		  $afterId=$row['afterid'];
-		  $public=$row['public'];
-		  $sectionName=$row['sectionname'];
-		  $playlink=$row['runlink'];
-	  }
+while ($row = $query->fetch(PDO::FETCH_ASSOC)){
+  	$exampleId=$row['exampleid'];
+  	$exampleName=$row['examplename'];
+	$courseID=$row['cid'];
+	$cversion=$row['cversion'];
+	$beforeId=$row['beforeid'];
+	$afterId=$row['afterid'];
+	$public=$row['public'];
+	$sectionName=$row['sectionname'];
+	$playlink=$row['runlink'];
+}
+
+if(strcmp('EDITEXAMPLE',$opt)===0){
+	$playlink=getOP('playlink');
+	$exampleName=getOP('examplename');
+	$sectionName=getOP('sectionname');
+	$beforeId=getOP('beforeid');
+	$afterId=getOP('afterid');
 
 	// Change content of example
 	$query = $pdo->prepare( "UPDATE codeexample SET runlink = :playlink , examplename = :examplename, sectionname = :sectionname WHERE exampleid = :exampleid AND cid = :cid AND cversion = :cvers;");

--- a/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
+++ b/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
@@ -2,6 +2,7 @@
 
 include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
+include_once "./retrieveCodeviewerService_ms.php";
 
 pdoConnect();
 session_start();
@@ -101,4 +102,6 @@ if(strcmp('EDITEXAMPLE',$opt)===0){
 		}
 	}
 }
-?>
+$array=retrieveCodeviewerService($opt,$pdo,$userid,$debug);
+echo json_encode($array);
+return;

--- a/DuggaSys/microservices/codeviewerService/editContentOfExample_ms.php
+++ b/DuggaSys/microservices/codeviewerService/editContentOfExample_ms.php
@@ -2,6 +2,8 @@
 
 include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
+include_once "../sharedMicroservices/getUid_ms.php";
+include_once "./retrieveCodeviewerService_ms.php";
 
 pdoConnect();
 session_start();
@@ -18,6 +20,7 @@ $fontsize = getOP('fontsize');
 $addedRows = getOP('addedRows');
 $removedRows = getOP('removedRows');
 $debug="NONE!";
+$userid=getUid();
 
 if(strcmp('EDITCONTENT',$opt)===0) {
     $query = $pdo->prepare("UPDATE box SET boxtitle=:boxtitle, boxcontent=:boxcontent, filename=:filename, fontsize=:fontsize, wordlistid=:wordlist WHERE boxid=:boxid AND exampleid=:exampleid;");
@@ -56,5 +59,6 @@ if(strcmp('EDITCONTENT',$opt)===0) {
         }
     }
 }
-
-?>
+$array=retrieveCodeviewerService($opt,$pdo,$userid,$debug);
+echo json_encode($array);
+return;

--- a/DuggaSys/microservices/codeviewerService/retrieveCodeviewerService_ms.php
+++ b/DuggaSys/microservices/codeviewerService/retrieveCodeviewerService_ms.php
@@ -43,7 +43,7 @@ function retrieveCodeviewerService($opt, $pdo, $userid, $debug){
     $info = "opt: " . $opt . " courseId: " . $courseId . " courseVersion: " . $courseVersion . " exampleName: " . $exampleName . " sectionName: " . $sectionName . " exampleId: " . $exampleId;
 
     // Checks and sets user rights
-    if (checklogin() && (hasAccess($userid, $courseId, 'w') || hasAccess($userid, $courseId, 'st'))) {
+    if (checklogin() && (hasAccess($userid, $courseId, 'w') || hasAccess($userid, $courseId, 'st') || isSuperUser($userid))) {
         $writeAccess = "w";
     } else {
         $writeAccess = "s";

--- a/DuggaSys/microservices/codeviewerService/retrieveCodeviewerService_ms.php
+++ b/DuggaSys/microservices/codeviewerService/retrieveCodeviewerService_ms.php
@@ -8,8 +8,7 @@ include_once ("../../../Shared/basic.php");
 //------------------------------------------------------------------------------------------------
 // Retrieve Information
 //------------------------------------------------------------------------------------------------
-function retrieveCodeviewerService($opt, $pdo, $userid, $debug)
-{
+function retrieveCodeviewerService($opt, $pdo, $userid, $debug){
     include_once "../../../Shared/sessions.php";
 
     // Connect to database and start session
@@ -145,17 +144,17 @@ function retrieveCodeviewerService($opt, $pdo, $userid, $debug)
 
                 if ($filekind == 2) {
                     // Global
-                    $file = "../courses/global/" . $filename;
+                    $file = "../../../courses/global/" . $filename;
                 } else if ($filekind == 3) {
                     // Course Local
                     if ($path == null)
-                        $file = "../courses/" . $courseId . "/" . $filename;
+                        $file = "../../../courses/" . $courseId . "/" . $filename;
                     else
-                        $file = "../courses/" . $courseId . "/Github/" . $path;
+                        $file = "../../../courses/" . $courseId . "/Github/" . $path;
 
                 } else if ($filekind == 4) {
                     // Local
-                    $file = "../courses/" . $courseId . "/" . $courseVersion . "/" . $path;
+                    $file = "../../../courses/" . $courseId . "/" . $courseVersion . "/" . $path;
                 } else {
                     $file = "UNK";
                 }

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1175,32 +1175,82 @@ function AJAXService(opt,apara,kind)
 				success: returnedGroup
 			});
 	}else if(kind=="CODEVIEW"){
-			$.ajax({
-				url: "codeviewerService.php",
-				type: "POST",
-				data: "opt="+opt+para,
-				dataType: "json",
-				success: returned,
-				error: returnedError
-			});
+		switch (opt){
+			case "EDITEXAMPLE":
+				$.ajax({
+					url: "codeviewerService.php",
+					//url: "../DuggaSys/microservices/codeviewerService/editCodeExample_ms.php",
+					type: "POST",
+					data: "opt="+opt+para,
+					dataType: "json",
+					success: returned,
+					error: returnedError
+				});
+				break;
+			case "DELEXAMPLE":
+				$.ajax({
+					url: "codeviewerService.php",
+					//url : "../DuggaSys/microservices/codeviewerService/deleteCodeExample_ms.php",
+					type: "POST",
+					data: "opt="+opt+para,
+					dataType: "json",
+					success: returned,
+					error: returnedError
+				});
+				break;
+			default:
+				$.ajax({
+					url: "codeviewerService.php",
+					type: "POST",
+					data: "opt="+opt+para,
+					dataType: "json",
+					success: returned,
+					error: returnedError
+				});
+		}
 	}else if(kind=="BOXCONTENT"){
-		$.ajax({
-			url: "codeviewerService.php",
-			//url : "../DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php",
-			type: "POST",
-			data: "opt="+opt+para,
-			dataType: "json",
-			success: returned
-		});
+		switch (opt){
+			case "EDITCONTENT":
+				$.ajax({
+					url: "codeviewerService.php",
+					//url : "../DuggaSys/microservices/codeviewerService/editContentOfExample_ms.php",
+					type: "POST",
+					data: "opt="+opt+para,
+					dataType: "json",
+					success: returned
+				});
+				break;
+			default:
+				$.ajax({
+					url: "codeviewerService.php",
+					type: "POST",
+					data: "opt="+opt+para,
+					dataType: "json",
+					success: returned
+				});
+			}
 	}else if(kind=="BOXTITLE"){
-		$.ajax({
-			url: "codeviewerService.php",
-			//url: "../DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php",
-			type: "POST",
-			data: "opt="+opt+para,
-			dataType: "json",
-			success: returnedTitle
-		});
+		switch (opt){
+			case "EDITTITLE":
+				$.ajax({
+					url: "codeviewerService.php",
+					//url: "../DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php",
+					type: "POST",
+					data: "opt="+opt+para,
+					dataType: "json",
+					success: returnedTitle
+				});
+				break;
+			default:
+				$.ajax({
+					url: "codeviewerService.php",
+					type: "POST",
+					data: "opt="+opt+para,
+					dataType: "json",
+					success: returnedTitle
+				});
+		}
+	
 	// }else if(kind=="STATS") {
 	// 	$.ajax({
 	// 		url: "stats.php",


### PR DESCRIPTION
retrieveCodeviewerService_ms.php has now been implemented with its microservices.

I used curl commands to test because the website would refresh when calling a service, making the output not show in the network tab.

editCodeExample
```
curl -X POST -d "opt=EDITEXAMPLE&courseid=1885&cvers=1337&exampleid=7000&examplename=UNK&sectionname=UNK&addedWords=foo,bar&log_uuid=TmX2JZ8vpNIWHYh
" http://localhost/LenaSYS/DuggaSys/microservices/codeviewerService/editCodeExample_ms.php
```

editContentOfExample
```
curl -X POST -d "opt=EDITCONTENT&courseid=1885&cvers=1337&exampleid=7000&boxtitle=Testingbox&boxcontent=Code&wordlist=3&filename=JS-TEST1.js&fontsize=10&boxid=1
&log_uuid=TmX2JZ8vpNIWHYh
" http://localhost/LenaSYS/DuggaSys/microservices/codeviewerService/editContentOfExample_ms.php
```

editBoxTitle
This wouldn't work with the curl commands  at first since authentication fails, to test I just commented out the if statement with the “checklogin” on line 33
```
curl -X POST -d "opt=EDITTITLE&courseid=1885&cvers=1337&exampleid=7000&boxtitle=testbox1&boxid=1
&log_uuid=TmX2JZ8vpNIWHYh
" http://localhost/LenaSYS/DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php
```
deleteCodeExample
```
curl -X POST -d "opt=DELEXAMPLE&exampleid=7000&boxid=1
" http://localhost/LenaSYS/DuggaSys/microservices/codeviewerService/deleteCodeExample_ms.php
```