### PR TITLE
fixed padlock expanding elements #15267

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -182,7 +182,6 @@
     display: block;
     position: absolute;
     background: inherit;
-    /* background-color: #fff; */
 }
 
 .element:has(#pad_lock) {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -176,12 +176,13 @@
     position: absolute;
 }
 
-#pad_lock{
+#pad_lock {
     bottom: -5px;
-    left: -8px;
+    left: 3px;
     display: block;
     position: absolute;
-    background-color: #fff;
+    background: inherit;
+    /* background-color: #fff; */
 }
 
 .element:has(#pad_lock) {

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -177,9 +177,15 @@
 }
 
 #pad_lock{
-    top: -45%;
+    bottom: -5px;
+    left: -8px;
     display: block;
-    position: relative;
+    position: absolute;
+    background-color: #fff;
+}
+
+.element:has(#pad_lock) {
+    overflow: visible;
 }
 
 #canvasOverlay{

--- a/DuggaSys/diagram/zoom.js
+++ b/DuggaSys/diagram/zoom.js
@@ -96,7 +96,7 @@ function zoomin(scrollEvent = undefined) {
     // the 5 and 8 are the default positions for 1x zoom, can be seen in diagram.css
     document.querySelectorAll('#pad_lock').forEach(padLock => {
         padLock.style.bottom = `${-5 * zoomfact}px`;
-        padLock.style.left = `${-8 * zoomfact}px`;
+        padLock.style.left = `${3 * zoomfact}px`;
     });
 }
 
@@ -199,7 +199,7 @@ function zoomout(scrollEvent = undefined) {
     // the 5 and 8 are the default positions for 1x zoom, can be seen in diagram.css
     document.querySelectorAll('#pad_lock').forEach(padLock => {
         padLock.style.bottom = `${-5 * zoomfact}px`;
-        padLock.style.left = `${-8 * zoomfact}px`;
+        padLock.style.left = `${3 * zoomfact}px`;
     });
 }
 

--- a/DuggaSys/diagram/zoom.js
+++ b/DuggaSys/diagram/zoom.js
@@ -91,6 +91,13 @@ function zoomin(scrollEvent = undefined) {
 
     // Draw new rules to match the new zoomfact
     drawRulerBars(scrollx, scrolly);
+
+    // moves the padlocks with the zoom
+    // the 5 and 8 are the default positions for 1x zoom, can be seen in diagram.css
+    document.querySelectorAll('#pad_lock').forEach(padLock => {
+        padLock.style.bottom = `${-5 * zoomfact}px`;
+        padLock.style.left = `${-8 * zoomfact}px`;
+    });
 }
 
 /**
@@ -187,6 +194,13 @@ function zoomout(scrollEvent = undefined) {
 
     // Draw new rules to match the new zoomfact
     drawRulerBars(scrollx, scrolly);
+    
+    // moves the padlocks with the zoom
+    // the 5 and 8 are the default positions for 1x zoom, can be seen in diagram.css
+    document.querySelectorAll('#pad_lock').forEach(padLock => {
+        padLock.style.bottom = `${-5 * zoomfact}px`;
+        padLock.style.left = `${-8 * zoomfact}px`;
+    });
 }
 
 /**

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1278,7 +1278,6 @@ border-left: 14px solid var(--color-sectioned-table-hi);
     position: absolute;
     background: inherit;
     filter: invert(65%);
-    /* background-color: var(--color-background); */
 }
 
 .material-box {

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1271,6 +1271,16 @@ border-left: 14px solid var(--color-sectioned-table-hi);
     color:white;
 }
 
+#pad_lock {
+    bottom: -5px;
+    left: 3px;
+    display: block;
+    position: absolute;
+    background: inherit;
+    filter: invert(65%);
+    /* background-color: var(--color-background); */
+}
+
 .material-box {
   border-radius: 2px;
   margin: 10px; 

--- a/Shared/icons/pad_lock.svg
+++ b/Shared/icons/pad_lock.svg
@@ -3,7 +3,7 @@
  <g>
   <title>Layer 1</title>
   <rect stroke="#000" fill-opacity="0" rx="40" id="svg_10" height="90.00004" width="140" y="12" x="30.6456" stroke-width="23" fill="#000000"/>
-  <rect stroke="#000" rx="40" id="svg_9" height="130" width="180" y="105.12882" x="10.6456" stroke-width="23" fill="none"/>
+  <rect stroke="#000" rx="40" id="svg_9" height="130" width="180" y="105.12882" x="10.6456" stroke-width="23" fill="#fff"/>
   <rect stroke="#000" rx="100" id="svg_12" height="10" width="10" y="152" x="95.64561" stroke-width="29" fill="#fff"/>
   <rect stroke="#000" id="svg_13" height="16.77417" width="1.93548" y="168" x="99.67785" stroke-width="25" fill="#fff"/>
   <rect stroke="#000" id="svg_18" height="29.62952" width="3.70368" y="70.77797" x="171.92568" fill-opacity="0" stroke-width="12" fill="#000000"/>


### PR DESCRIPTION
Moved the padlock with `position: absolute`, removed `overflow: hidden` if a padlock is present, moved the padlock with zoom