### PR TITLE
Deleted an condition

### DIFF
--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -54,7 +54,7 @@ function mdown(event) {
     if (event.button == 2) return;
 
     // Check if no element has been clicked or delete button has been pressed.
-    if (pointerState != pointerStates.CLICKED_ELEMENT && !hasPressedDelete && !settings.replay.active) {
+    if (!hasPressedDelete && !settings.replay.active) {
 
         // Used when clicking on a line between two elements.
         determinedLines = determineLineSelect(event.clientX, event.clientY);


### PR DESCRIPTION
The condition did so that we couldn't select the lines when it was in an object. When we did this it created a bug that makes the app to think that we do an double click when we just do one, this just hapends when the line is in an object. Maybe we can create a new issue about that so we can merge in this?