### PR TITLE
Sequence Lifeline object is black instead of white

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -702,6 +702,7 @@
 .placementTypeBoxIcons img{
     width:34px;
     height:34px;
+    filter: brightness(0) invert(1);
 }
 .placementTypeToolTipText{
     top:0%;


### PR DESCRIPTION
I added a CSS code to make the image inside the class "placementTypeBoxIcons" white. 