### PR TITLE
Fixed the dark theme of boxes in "Rapport inlämning" - G3 2024 v5 #15405

### DIFF
--- a/DuggaSys/templates/generic_dugga_file_receive.html
+++ b/DuggaSys/templates/generic_dugga_file_receive.html
@@ -1,14 +1,14 @@
 <div id="container">
 	<div class='instructions-container'>
 	<div class='instructions-button' onclick='toggleInstructions(this)'><h3>Instructions</h3></div>	
-		<div class="instructions-content" style=" -webkit-columns: 1; -moz-columns: 1; columns: 1; " id="snus">
+		<div class="instructions-content" id="snus">
 			<p>This is a template dugga that allows uploading of material. PDF, ZIP and RAR is allowed. PDF-files will be previewed.</p>
 		</div>
 	</div>
 
 	<div class='instructions-container'>
 		<div class='instructions-button' onclick='toggleInstructions(this)'><h3>Submission</h3></div>	
-		<div class="instructions-content" style=" -webkit-columns: 1; -moz-columns: 1; columns: 1; " id="tomten"></div>	
+		<div class="instructions-content" id="tomten"></div>	
 	</div>
 </div>
 <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -364,17 +364,17 @@ function createFileUploadArea(fileuploadfileds){
 		str += "<div class='instructionBox'>";
 		str += "<div class='submissionInstructions'>";
 		if (type === "pdf"){
-			str += "<h4>Pdf Submission and Preview</h4>";
+			str += "<h4 class='submissionBoxTitles'>Pdf Submission and Preview</h4>";
 		} else if (type === "link"){
 			str += "<h4>Link Submission and Preview</h4>";
 		} else if (type === "zip") {
-			str += "<h4>Zip / Rar file Upload</h4>";
+			str += "<h4 class='submissionBoxTitles'>Zip / Rar file Upload</h4>";
 		} else if (type === "multi"){
 			str += "<h4>Multiple file Upload</h4>";
 		} else if (type === "text"){
 			str += "<h4>Text Submission</h4>";
 			str += "</div>";
-      str +="<div id='"+fieldname+"Prev' style='min-height:100px;background:#f8f8ff;padding:10px;border-top:2px 2px solid #d3d3d3;border-bottom:2px 2px solid #d3d3d3;'><span style='font-style:italic;M'>Submission History</span></div>";
+      str +="<div id='"+fieldname+"Prev'<span style='font-style:italic;M'>Submission History</span></div>";
 			str += "<div style='padding:10px;'>";
 			str +="<table style='width:100%;'>";
 			str +="<tr>";
@@ -389,7 +389,7 @@ function createFileUploadArea(fileuploadfileds){
 		str += "</div>";
 		str += "<div>";
 		if (type !== "text"){
-            str +="<div id='"+fieldname+"Prev' style='min-height:100px;padding:10px;border-top:2px 2px solid #d3d3d3;border-bottom:2px 2px solid #d3d3d3;'><span style='font-stile:italic;'>Submission History</span></div>";
+            str +="<div id='"+fieldname+"Prev'><span style='font-stile:italic;'>Submission History</span></div>";
             str +="<div style='padding:10px;'>";
             str +="<h4>Instructions</h4>";
             str +="<div id='"+fieldname+"Instruction' style='font-style: italic;padding:0px;'></div>"

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -361,8 +361,8 @@ function createFileUploadArea(fileuploadfileds){
 		error +="<span>Bummer!</span>";
 		error +=" The extension "+inParams["extension"]+" is not allowed!</div>";
 
-		str += "<div style='border:1px solid #614875; margin: 5px auto; margin-bottom:10px;'>";
-		str += "<div style='height:20px;background-color:#614875;padding:9px;color:#FFF;'>";
+		str += "<div class='instructionBox'>";
+		str += "<div class='submissionInstructions'>";
 		if (type === "pdf"){
 			str += "<h4>Pdf Submission and Preview</h4>";
 		} else if (type === "link"){

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -389,7 +389,7 @@ function createFileUploadArea(fileuploadfileds){
 		str += "</div>";
 		str += "<div>";
 		if (type !== "text"){
-            str +="<div id='"+fieldname+"Prev' style='min-height:100px;background:#f8f8ff;padding:10px;border-top:2px 2px solid #d3d3d3;border-bottom:2px 2px solid #d3d3d3;'><span style='font-stile:italic;'>Submission History</span></div>";
+            str +="<div id='"+fieldname+"Prev' style='min-height:100px;padding:10px;border-top:2px 2px solid #d3d3d3;border-bottom:2px 2px solid #d3d3d3;'><span style='font-stile:italic;'>Submission History</span></div>";
             str +="<div style='padding:10px;'>";
             str +="<h4>Instructions</h4>";
             str +="<div id='"+fieldname+"Instruction' style='font-style: italic;padding:0px;'></div>"

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -374,7 +374,7 @@ function createFileUploadArea(fileuploadfileds){
 		} else if (type === "text"){
 			str += "<h4>Text Submission</h4>";
 			str += "</div>";
-      str +="<div id='"+fieldname+"Prev'<span style='font-style:italic;M'>Submission History</span></div>";
+      		str +="<div id='"+fieldname+"Prev'<span class='submissionHistory'>Submission History</span></div>";
 			str += "<div style='padding:10px;'>";
 			str +="<table style='width:100%;'>";
 			str +="<tr>";
@@ -389,7 +389,7 @@ function createFileUploadArea(fileuploadfileds){
 		str += "</div>";
 		str += "<div>";
 		if (type !== "text"){
-            str +="<div id='"+fieldname+"Prev'><span style='font-stile:italic;'>Submission History</span></div>";
+            str +="<div id='"+fieldname+"Prev'><span class='submissionHistory''>Submission History</span></div>";
             str +="<div style='padding:10px;'>";
             str +="<h4>Instructions</h4>";
             str +="<div id='"+fieldname+"Instruction' style='font-style: italic;padding:0px;'></div>"

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -479,13 +479,20 @@ body {
     color:white;
 }
 
+.previewTable th{
+    background-color: var(--color-background);
+}
+
+#InlPHPDocumentPrev{
+    background-color: var(--color-background);
+}
+
 .previewTable tr:nth-child(odd){
     background-color: var(--color-sectioned-table-lo);
 }
 .previewTable tr:nth-child(even){
     background-color: var(--color-sectioned-table-hi);
 }
-
 
 /*A global styling for darkmode, a class for white text on darkbackgrounds*/
 .DarkModeText{

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -391,6 +391,12 @@
 	color: var(--color-text-light);
 }
 
+.instructionBox{
+    border:1px solid #614875; 
+    margin: 5px auto; 
+    margin-bottom:10px;
+}
+
 /* BOXMENU STYLING START */
 .buttomenu2Style{
 	background-color: var(--color-background-codeviewer-nav);

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -623,7 +623,7 @@ body {
 }
 
 .instructions-content{
-    border: 2px solid  var(--color-sectioned-table-lo);
+    border: 1px solid  var(--color-sectioned-table-lo);
 } 
 
 .feedback-button:hover:after, .instructions-button:hover:after {

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -470,10 +470,22 @@ body {
   background-color: var(--color-background);
   color: var(--color-text-light);
 }
-    /*A global styling for darkmode, added the class where there needed darkbackgrounds*/
+/*A global styling for darkmode, added the class where there needed darkbackgrounds*/
 .DarkModeBackgrounds{
-        background-color: var(--color-background);
-    } 
+    background-color: var(--color-background);
+} 
+
+.previewTable a{
+    color:white;
+}
+
+.previewTable tr:nth-child(odd){
+    background-color: var(--color-sectioned-table-lo);
+}
+.previewTable tr:nth-child(even){
+    background-color: var(--color-sectioned-table-hi);
+}
+
 
 /*A global styling for darkmode, a class for white text on darkbackgrounds*/
 .DarkModeText{

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -350,8 +350,8 @@ svg text {
 	white-space: nowrap;
 }
 .previewTable tr {
-		display: table-row;
-		vertical-align: inherit;
+	display: table-row;
+	vertical-align: inherit;
 }
 .previewTable th {
 	font-weight: bold;
@@ -361,7 +361,6 @@ svg text {
 	padding-left: 10px;
 }
 .previewTable td {
-	padding-right: 30px;
 	padding-left: 10px;
 	width: 1px;
 }

--- a/Shared/css/markdown.css
+++ b/Shared/css/markdown.css
@@ -10,7 +10,6 @@
 	word-wrap: break-word;
 	overflow-y: scroll;
 	background-color: #fff;
-	/*padding:10px;*/
     overflow-x: scroll;
 }
 

--- a/Shared/css/markdown.css
+++ b/Shared/css/markdown.css
@@ -10,7 +10,7 @@
 	word-wrap: break-word;
 	overflow-y: scroll;
 	background-color: #fff;
-	padding:10px;
+	/*padding:10px;*/
     overflow-x: scroll;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9805,4 +9805,8 @@ margin:2px;
   columns: 1; 
 }
 
+.submissionHistory{
+  font-style:italic;
+}
+
 /* END */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9764,4 +9764,19 @@ margin:2px;
   100% { transform: rotate(360deg); }
 }
 
+/*Styling for Submission Instructions*/
+
+.submissionInstructions{
+  height:20px;
+  background-color:#614875;
+  padding:9px;
+  color:#FFF;
+}
+
+.instructionBox{
+  border:1px solid #614875; 
+  margin: 5px auto; 
+  margin-bottom:10px;
+}
+
 /* END */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9779,4 +9779,30 @@ margin:2px;
   margin-bottom:10px;
 }
 
+.instructions-content{
+  -webkit-columns: 1;
+  -moz-columns: 1; 
+  columns: 1; 
+}
+
+#InlPHPDocumentPrev{
+  min-height:100px;
+  background:#f8f8ff;
+  padding:10px;
+  border-top:2px 2px solid #d3d3d3;
+}
+
+#InlPHPZipPrev{
+  min-height:100px;
+  padding:10px;
+  border-top:2px 2px solid #d3d3d3;
+  border-bottom:2px 2px solid #d3d3d3;
+}
+
+#tomten{
+  -webkit-columns: 1; 
+  -moz-columns: 1; 
+  columns: 1; 
+}
+
 /* END */


### PR DESCRIPTION
Previously, when entering “Datorgrafik” and clicking on “Rapport inlämning”, the boxes below were not adjusted to the dark theme.
<img width="588" alt="Pasted Graphic 6" src="https://github.com/HGustavs/LenaSYS/assets/129295853/358754be-18c6-4dd5-a1fa-3cf67ff2275b">

With the solution to this issue, changes were made to mirror the alternating background color of the table columns and the text-color. This can be seen in the example below:
<img width="613" alt="Pasted Graphic 7" src="https://github.com/HGustavs/LenaSYS/assets/129295853/0c670702-46a7-43c5-9c19-a09130d32c8c">
