### PR TITLE
G1 2024 v5 #14235

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2260,6 +2260,7 @@ function resetDiagramAlert() {
     let refreshConfirm = confirm("Are you sure you want to reset to default state? All changes made to diagram will be lost");
     if (refreshConfirm) {
         resetDiagram();
+        resetZoom();
     }
 }
 
@@ -2268,5 +2269,35 @@ function resetDiagramAlert() {
  */
 function resetDiagram() {
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
+}
+
+function resetZoom(){
+    for (let i = 0; i < 2; i++) {
+        zoomfact = 1;
+
+        // Center of screen in pixels
+        var centerScreen = {
+            x: 100,
+            y: 100
+        };
+
+        // Move camera to center of diagram
+        scrollx = centerScreen.x;
+        scrolly = centerScreen.y;
+
+        var middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
+
+        console.log(zoomfact);
+
+        // Update screen
+        showdata();
+        updatepos();
+        updateGridPos();
+        updateGridSize();
+        drawRulerBars(scrollx, scrolly);
+        updateA4Pos();
+        updateA4Size();
+        //zoomCenter(centerScreen);
+    }
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2258,9 +2258,13 @@ function removeLocalDiagram(item) {
  */
 function resetDiagramAlert() {
     let refreshConfirm = confirm("Are you sure you want to reset to default state? All changes made to diagram will be lost");
+    
+    if(data.length == 0){
+        resetZoom();
+    }
+
     if (refreshConfirm) {
         resetDiagram();
-        resetZoom();
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2282,12 +2282,13 @@ function resetZoom(){
         };
 
         // Move camera to center of diagram
-        scrollx = centerScreen.x;
-        scrolly = centerScreen.y;
+        scrollx = centerScreen.x * zoomfact;
+        scrolly = centerScreen.y * zoomfact;
 
         var middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
 
-        console.log(zoomfact);
+        scrollx = middleCoordinate.x + 98;
+        scrolly = middleCoordinate.y + 100;
 
         // Update screen
         showdata();
@@ -2297,7 +2298,6 @@ function resetZoom(){
         drawRulerBars(scrollx, scrolly);
         updateA4Pos();
         updateA4Size();
-        //zoomCenter(centerScreen);
     }
 }
 //#endregion =====================================================================================


### PR DESCRIPTION
Now it is possible to center the camera when there is no element on the screen. Can test it by have element on the screen and press the reset button to see if the camera is on the default position or not (it should only remove all the element). And if there is no element on screen then you should be able to center the camera to default position.