### PR TITLE
Errors when entering new courses

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -66,14 +66,14 @@
 				} else {
 					$checkIfGithubURL = null;
 				}
-				if (isset($row['updated'])){
+				if (isset($row['updated'])) {
 					$updateTime = $row['updated'];
 				}
-				else{
+				else {
 					$updateTime = "No data found for the given course ID";
 				}
 			}
-			else{
+			else {
 				$checkIfGithubURL = null;
 				$updateTime = "No data found for the given course ID";
 			}

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -65,9 +65,17 @@
 					$checkIfGithubURL = $row['courseGitURL'];
 				} else {
 					$checkIfGithubURL = null;
-					// $row is false, which means no data was fetched
+				}
+				if (isset($row['updated'])){
+					$updateTime = $row['updated'];
+				}
+				else{
 					$updateTime = "No data found for the given course ID";
 				}
+			}
+			else{
+				$checkIfGithubURL = null;
+				$updateTime = "No data found for the given course ID";
 			}
 
 


### PR DESCRIPTION
It was never declared if there was data in the database, specifically it would only declare if there was no github repo set.

Now it sets depending on if its column has a value and also gets set if there is no data at all.

**Testing:**

- open basically any page on the website(sectioned, courseed, etc), check for an alert that complains about updateTime when the page loads. 