### PR TITLE
Changed important alerts to toasts. G3 2024 v6 #15388

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -77,7 +77,7 @@ function setup() {
 			cvers: cvers
 		}, "CODEVIEW");
 	} catch (e) {
-		alert("Error while setting up: " + e.message)
+		toast("error","Error while setting up: " + e.message, 10);
 	}
 }
 
@@ -268,7 +268,7 @@ function returned(data)
 
 	// Create boxes
 	if (retData['numbox'] > retData['box'].length) {
-		alert("Number of boxes is inconsistent\n" + retData['numbox'] + "\n" + retData['box'].length);
+		toast("error", "Number of boxes is inconsistent\n" + retData['numbox'] + "\n" + retData['box'].length, 10);
 	}
 
 	for (var i = 0; i < retData['numbox']; i++) {
@@ -484,7 +484,7 @@ function handleFiles(files, boxnumber) {
 		// This command is important to activate reader
 		console.log(reader.readAsText(file));
 	} else {
-		alert("FILETYPE [" + filetype + "] NOT SUPPORTED")
+		toast("error", "FILETYPE [" + filetype + "] NOT SUPPORTED", 10);
 	}
 
     reader.onload = event => {
@@ -950,7 +950,7 @@ function editImpRows(editType)
 
 	} else if (enterPress === false){
 		//alert("editType == +: " + (editType=="+") + " (rowFrom <= rowTo): " + (rowFrom <= rowTo) + " (rowFrom > 0): " + (rowFrom > 0) + " (rowTo > 0): " + (rowTo > 0) + " rowFrom: " + rowFrom + " rowTo: " + rowTo);
-		alert("Incorrect value(s) (from: " + rowFrom + " to: " + rowTo + ")  for important rows!");
+		toast("error", "Incorrect value(s) (from: " + rowFrom + " to: " + rowTo + ")  for important rows!", 10);
 	}
 }
 
@@ -1010,7 +1010,7 @@ function updateContent(file, content, boxnumber)
 				addedRows = [];
 				removedRows = [];
 			} catch (e) {
-				alert("Error when updating content: " + e.message);
+				toast("error","Error when updating content: " + e.message, 10);
 			}
 			console.log("Timeout");
 			setTimeout("location.reload()", 500); //SETBACK TO 500
@@ -1021,7 +1021,7 @@ function updateContent(file, content, boxnumber)
 				AJAXService("EDITTITLE", {exampleid: querystring['exampleid'], courseid: querystring['courseid'], boxid: box[0], boxtitle: document.querySelector("#boxtitle").textContent}, "BOXTITLE");
 				console.log("Ajaxservice, Qstring:Exampleid, Qstring:courseid; ", querystring[exampleid], querystring['courseid']);
 			} catch (e) {
-				alert("Error when updating content: " + e.message);
+				toast("error","Error when updating content: " + e.message, 10);
 			}
 		}
 	}
@@ -1484,7 +1484,7 @@ function maketoken(kind, val, from, to, rowno) {
 
 function error(str, val, row) {
 	var debug = "Tokenizer error: " + str + val + " at row " + row;
-	alert("Tokenizer Error: " + str + val + " at row " + row);
+	toast("error","Tokenizer Error: " + str + val + " at row " + row, 10);
 }
 
 //----------------------------------------------------------------------------------
@@ -2529,7 +2529,7 @@ function updateTemplate() {
 			content: content
 		}, "CODEVIEW");
 	} catch (e) {
-		alert("Error when updating template: " + e.message)
+		toast("error","Error when updating template: " + e.message, 10);
 	}
 }
 

--- a/DuggaSys/contribution.js
+++ b/DuggaSys/contribution.js
@@ -670,7 +670,7 @@ function toRadians(angle) {
 function changeDay() {
   if(firstSelWeek != null && secondSelWeek != null){  
     if (firstSelWeek > secondSelWeek){
-      alert("Second week can't be earlier than first week");
+      toast("error","Second week can't be earlier than first week", 10);
     } else {
       AJAXService("updateday", {
         userid: localStorage.getItem('GitHubUser'),

--- a/DuggaSys/contribution.php
+++ b/DuggaSys/contribution.php
@@ -3,6 +3,7 @@ session_start();
 include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 include_once "../Shared/basic.php";
+include_once "../Shared/toast.php";
 pdoConnect();
 $cid=getOPG('cid');
 $vers=getOPG('coursevers');

--- a/DuggaSys/contribution_loginbox.js
+++ b/DuggaSys/contribution_loginbox.js
@@ -173,7 +173,7 @@ function git_logout()
   
     if(username == null || username == "" || !(typeof(username) === 'string'))
     {
-      alert("invalid input of username");
+      toast("error", "invalid input of username", 10);
     }
     else
     {
@@ -324,7 +324,7 @@ function git_logout()
         }
       }
       else
-        alert("invalid data returned from git-data");
+        toast("error","invalid data returned from git-data", 10);
   
     }
   
@@ -338,7 +338,7 @@ function git_logout()
         userExists_Git = data;
       }
       else
-        alert("invalid data returned from git-data");
+        toast("error","invalid data returned from git-data", 10);
   
       return userExists_Git;
   

--- a/DuggaSys/contribution_loginbox.php
+++ b/DuggaSys/contribution_loginbox.php
@@ -1,3 +1,7 @@
+<?php 
+    include_once "../Shared/toast.php";
+?>
+
 <style>	
 	.loginFail {
 		animation: loginFail 2s;

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -983,7 +983,7 @@ function returnedDugga(data) {
 		}
 		else {
 				$("#quiz").html("");
-				alert("You don't have access to this page. You are now being redirected!")
+				toast("warning","You don't have access to this page. You are now being redirected!", 10);
 				changeURL(`sectioned.php?courseid=${querystring['courseid']}&coursename=${data.coursename}&coursevers=${querystring['coursevers']}`);
 		}
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3858,7 +3858,7 @@ function validateForm(formid) {
     }
     // If all information is correct
     if (window.bool5 === true && window.bool3 === true && window.bool === true) {
-      alert('New version created');
+      toast('success','New version created', 5);
       createVersion();
       $('#newCourseVersion input').val("");
 
@@ -3879,9 +3879,9 @@ function validateForm(formid) {
 
     // If all information is correct
     if (window.bool4 === true && window.bool6 === true && window.bool9 === true) {
-      alert('Version updated');
       updateVersion();
       resetMOTDCookieForCurrentCourse();
+      toast('success','Version updated', 7);
     } else {
       toast("error","You have entered incorrect information",7);
     }

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -3,8 +3,7 @@
         WARNING: "warning", 
         ERROR: "error", 
         SUCCESS: "success",
-        UNDO: "undo",
-        CONFIRM: "confirm"
+        UNDO: "undo"
     }); 
     // Close the toast by clicking the X icon
     function closeToast(toastDiv) {
@@ -52,18 +51,6 @@
         let toastText = document.createElement('p');
         toastText.classList.add('toastText');
 
-        // The toast confirm options are created
-        // toastYes / toastNo = the toast confirm buttons (used for CONFIRM type)
-        let toastYes = document.createElement('span');
-        let toastNo = document.createElement('span');
-        toastYes.classList.add('toastYes');
-        toastNo.classList.add('toastNo');
-
-        // The toast buttonbox is created
-        // toastButtonBox = the toast confirm button
-        let toastButtonBox = document.createElement('div');
-        toastButtonBox.classList.add('toastButtonBox');
-
         // Adds the smaller toast divs to the bigger toast div
         toastDiv.appendChild(toastLeft);
         toastDiv.appendChild(toastCenter);
@@ -104,16 +91,6 @@
                 toastLeft.setAttribute( "onClick", "javascript: "+arguments);
                 typeText.innerHTML = "Notice";
                 toastDiv.classList.add(types.UNDO);
-                break;
-            case types.CONFIRM:
-                typeIcon.innerHTML = "Help";
-                typeText.innerHTML = "Error";
-                toastCenter.appendChild(toastButtonBox);
-                toastButtonBox.appendChild(toastYes);
-                toastButtonBox.appendChild(toastNo);
-                toastYes.innerHTML = "Yes"
-                toastNo.innerHTML = "No"
-                toastDiv.classList.add(types.CONFIRM);
                 break;
             // We create a default situation in case no type is given.
             // The default toast will not have an icon nor heading.

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -3,7 +3,8 @@
         WARNING: "warning", 
         ERROR: "error", 
         SUCCESS: "success",
-        UNDO: "undo"
+        UNDO: "undo",
+        CONFIRM: "confirm"
     }); 
     // Close the toast by clicking the X icon
     function closeToast(toastDiv) {
@@ -51,6 +52,18 @@
         let toastText = document.createElement('p');
         toastText.classList.add('toastText');
 
+        // The toast confirm options are created
+        // toastYes / toastNo = the toast confirm buttons (used for CONFIRM type)
+        let toastYes = document.createElement('span');
+        let toastNo = document.createElement('span');
+        toastYes.classList.add('toastYes');
+        toastNo.classList.add('toastNo');
+
+        // The toast buttonbox is created
+        // toastButtonBox = the toast confirm button
+        let toastButtonBox = document.createElement('div');
+        toastButtonBox.classList.add('toastButtonBox');
+
         // Adds the smaller toast divs to the bigger toast div
         toastDiv.appendChild(toastLeft);
         toastDiv.appendChild(toastCenter);
@@ -91,6 +104,16 @@
                 toastLeft.setAttribute( "onClick", "javascript: "+arguments);
                 typeText.innerHTML = "Notice";
                 toastDiv.classList.add(types.UNDO);
+                break;
+            case types.CONFIRM:
+                typeIcon.innerHTML = "Help";
+                typeText.innerHTML = "Error";
+                toastCenter.appendChild(toastButtonBox);
+                toastButtonBox.appendChild(toastYes);
+                toastButtonBox.appendChild(toastNo);
+                toastYes.innerHTML = "Yes"
+                toastNo.innerHTML = "No"
+                toastDiv.classList.add(types.CONFIRM);
                 break;
             // We create a default situation in case no type is given.
             // The default toast will not have an icon nor heading.


### PR DESCRIPTION
I changed the most prominent alerts to toasts when browsing LenaSYS. Some alerts are left untouched due to them being needed for debugging or having important functions on the backend. By doing changes in courseed or codeviewer etc the alerts should now be replaced by toasts. 

One issue that this has generated is that toast does not pause the execution of code like alerts did. This means that some alerts, for example in codeviewer, shows for a short moment before the site is refreshed.