### PR TITLE
g2-2024-v6 issue #15514

### DIFF
--- a/DuggaSys/tests/microservices/duggaedService/createDugga_ms_test.php
+++ b/DuggaSys/tests/microservices/duggaedService/createDugga_ms_test.php
@@ -4,7 +4,7 @@ include_once "../../../../Shared/test.php";
 
 $testsData = array(
     'createDugga_ms' => array(
-        'expected-output' => '{"entries":[{"qname":"createDuggaTest","autograde":0,"gradesystem":1,"qstart":"2024-03-03","deadline":"2024-01-01 01:01:01","qrelease":"2024-02-02 02:02:02","jsondeadline":"{\"TestJSON\":\"2024-04-04 04:04:04\"}"}]}',
+        'expected-output' => '{"entries":[{"qname":"createDuggaTest","autograde":0,"gradesystem":1,"quizFile":"group-assignment","qstart":"2024-03-03","deadline":"2024-01-01 01:01:01","qrelease":"2024-02-02 02:02:02","jsondeadline":"{\"TestJSON\":\"2024-04-04 04:04:04\"}","group":1}]}',
         
         'query-after-test-1' => "DELETE FROM quiz WHERE qname = 'createDuggaTest' AND cid = 1885",
         'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/duggaedService/createDugga_ms.php',
@@ -31,7 +31,7 @@ $testsData = array(
                     'qname',
                     'autograde',
                     'gradesystem',
-                    'quizfile',
+                    'quizFile',
                     'qstart',
                     'deadline',
                     'qrelease',


### PR DESCRIPTION
The file should now be fixed.

I tested it by doing:
```
INSERT INTO quiz (cid, autograde, gradesystem, qname, quizFile, qrelease, deadline, relativedeadline, creator, vers, qstart, jsondeadline, `group`)
VALUES (1885, 0, 1, 'Test321', 'group-assignment', '2024-02-02 02:02:02', '2024-01-01 01:01:01', 'Snart', 101, '1337', '2024-03-03', '{"TestJSON":"2024-04-04 04:04:04"}', 1);
```

And then executing ```createDugga_ms_test.php``` and looking at the response (no filter).

Now all relevant values should be retrieved.

Since ```createDugga_ms_test.php``` is the only test for duggaedService implemented at this time, the expected output only needed to be updated there.