### PR TITLE
G1 2024 v6 #14235

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2307,6 +2307,11 @@ function removeLocalDiagram(item) {
  */
 function resetDiagramAlert() {
     let refreshConfirm = confirm("Are you sure you want to reset to default state? All changes made to diagram will be lost");
+    
+    if(data.length == 0){
+        resetZoom();
+    }
+    
     if (refreshConfirm) {
         resetDiagram();
     }
@@ -2319,4 +2324,33 @@ function resetDiagram() {
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
 
+function resetZoom(){
+    for (let i = 0; i < 2; i++) {
+        zoomfact = 1;
+
+        // Center of screen in pixels
+        var centerScreen = {
+            x: 100,
+            y: 100
+        };
+
+        // Move camera to center of diagram
+        scrollx = centerScreen.x * zoomfact;
+        scrolly = centerScreen.y * zoomfact;
+
+        var middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
+
+        scrollx = middleCoordinate.x + 98;
+        scrolly = middleCoordinate.y + 100;
+
+        // Update screen
+        showdata();
+        updatepos();
+        updateGridPos();
+        updateGridSize();
+        drawRulerBars(scrollx, scrolly);
+        updateA4Pos();
+        updateA4Size();
+    }
+}
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2307,11 +2307,6 @@ function removeLocalDiagram(item) {
  */
 function resetDiagramAlert() {
     let refreshConfirm = confirm("Are you sure you want to reset to default state? All changes made to diagram will be lost");
-    
-    if(data.length == 0){
-        resetZoom();
-    }
-    
     if (refreshConfirm) {
         resetDiagram();
     }
@@ -2322,35 +2317,5 @@ function resetDiagramAlert() {
  */
 function resetDiagram() {
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
-}
-
-function resetZoom(){
-    for (let i = 0; i < 2; i++) {
-        zoomfact = 1;
-
-        // Center of screen in pixels
-        var centerScreen = {
-            x: 100,
-            y: 100
-        };
-
-        // Move camera to center of diagram
-        scrollx = centerScreen.x * zoomfact;
-        scrolly = centerScreen.y * zoomfact;
-
-        var middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
-
-        scrollx = middleCoordinate.x + 98;
-        scrolly = middleCoordinate.y + 100;
-
-        // Update screen
-        showdata();
-        updatepos();
-        updateGridPos();
-        updateGridSize();
-        drawRulerBars(scrollx, scrolly);
-        updateA4Pos();
-        updateA4Size();
-    }
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram/camera.js
+++ b/DuggaSys/diagram/camera.js
@@ -4,7 +4,7 @@
 function centerCamera() {
     // Stops execution if there are no elements to center the camera around.
     if (data.length == 0) {
-        displayMessage(messageTypes.ERROR, "Error: There are no elements to center to!");
+        centerToOrigo();
         return;
     }
     // Centering needs to happen twice for it to work, temp solution
@@ -50,4 +50,34 @@ function centerCamera() {
         zoomCenter(centerDiagram);
     }
     displayMessage(messageTypes.SUCCESS, `Centered the camera.`);
+}
+
+function centerToOrigo(){
+    for (let i = 0; i < 2; i++) {
+        zoomfact = 1;
+
+        // Center of screen in pixels
+        var centerScreen = {
+            x: 100,
+            y: 100
+        };
+
+        // Move camera to center of diagram
+        scrollx = centerScreen.x * zoomfact;
+        scrolly = centerScreen.y * zoomfact;
+
+        var middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
+
+        scrollx = middleCoordinate.x + 98;
+        scrolly = middleCoordinate.y + 100;
+
+        // Update screen
+        showdata();
+        updatepos();
+        updateGridPos();
+        updateGridSize();
+        drawRulerBars(scrollx, scrolly);
+        updateA4Pos();
+        updateA4Size();
+    }
 }

--- a/DuggaSys/diagram/camera.js
+++ b/DuggaSys/diagram/camera.js
@@ -1,15 +1,17 @@
 /**
- * @description Centers the camera between the highest and lowest x and y values of all elements
+ * @description Centers the camera between the highest and lowest x and y values of all elements or if no element the camera moves to start position
  */
 function centerCamera() {
     let centerToOrigo = false;
     let offsetX = 0;
     let offsetY = 0;
 
-    // Stops execution if there are no elements to center the camera around.
+    // If there is no element then the camera moves to start position (X = 100 and Y = 100).
     if (data.length == 0) {
         centerToOrigo = true;
+        // offsetX is 98 because if not, X is going to be at 2 and it have to be at 100.
         offsetX = 98;
+        // offsetY is 100 because if not, Y is going to be at 0 and it have to be at 100.
         offsetY = 100;
     }
     // Centering needs to happen twice for it to work, temp solution

--- a/DuggaSys/diagram/camera.js
+++ b/DuggaSys/diagram/camera.js
@@ -2,20 +2,19 @@
  * @description Centers the camera between the highest and lowest x and y values of all elements
  */
 function centerCamera() {
+    let centerToOrigo = false;
+    let offsetX = 0;
+    let offsetY = 0;
+
     // Stops execution if there are no elements to center the camera around.
     if (data.length == 0) {
-        centerToOrigo();
-        return;
+        centerToOrigo = true;
+        offsetX = 98;
+        offsetY = 100;
     }
     // Centering needs to happen twice for it to work, temp solution
     for (let i = 0; i < 2; i++) {
         zoomfact = 1;
-
-        const minX = Math.min.apply(null, data.map(i => i.x));
-        const maxX = Math.max.apply(null, data.map(i => i.x + i.width));
-        const minY = Math.min.apply(null, data.map(i => i.y));
-        const maxY = Math.max.apply(null, data.map(i => i.y + i.height));
-        determineZoomfact(maxX, maxY, minX, minY);
 
         // Center of screen in pixels
         const centerScreen = {
@@ -23,21 +22,33 @@ function centerCamera() {
             y: window.innerHeight / 2
         };
 
-        // Center of diagram in coordinates
-        const centerDiagram = {
-            x: minX + ((maxX - minX) / 2),
-            y: minY + ((maxY - minY) / 2)
-        };
+        if(centerToOrigo == false){
+            const minX = Math.min.apply(null, data.map(i => i.x));
+            const maxX = Math.max.apply(null, data.map(i => i.x + i.width));
+            const minY = Math.min.apply(null, data.map(i => i.y));
+            const maxY = Math.max.apply(null, data.map(i => i.y + i.height));
+            determineZoomfact(maxX, maxY, minX, minY);
 
-        // Move camera to center of diagram
-        scrollx = centerDiagram.x * zoomfact;
-        scrolly = centerDiagram.y * zoomfact;
+            // Center of diagram in coordinates
+            var centerDiagram = {
+                x: minX + ((maxX - minX) / 2),
+                y: minY + ((maxY - minY) / 2)
+            };
+
+            // Move camera to center of diagram
+            scrollx = centerDiagram.x * zoomfact;
+            scrolly = centerDiagram.y * zoomfact;
+        } else {
+            // Move camera to start position
+            scrollx = centerScreen.x * zoomfact;
+            scrolly = centerScreen.y * zoomfact;
+        }
 
         const middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
         document.getElementById("zoom-message").innerHTML = zoomfact + "x";
 
-        scrollx = middleCoordinate.x;
-        scrolly = middleCoordinate.y;
+        scrollx = middleCoordinate.x + offsetX;
+        scrolly = middleCoordinate.y + offsetY;
 
         // Update screen
         showdata();
@@ -47,37 +58,9 @@ function centerCamera() {
         drawRulerBars(scrollx, scrolly);
         updateA4Pos();
         updateA4Size();
-        zoomCenter(centerDiagram);
+        if(centerToOrigo == false){
+            zoomCenter(centerDiagram);
+        }
     }
     displayMessage(messageTypes.SUCCESS, `Centered the camera.`);
-}
-
-function centerToOrigo(){
-    for (let i = 0; i < 2; i++) {
-        zoomfact = 1;
-
-        // Center of screen in pixels
-        var centerScreen = {
-            x: 100,
-            y: 100
-        };
-
-        // Move camera to center of diagram
-        scrollx = centerScreen.x * zoomfact;
-        scrolly = centerScreen.y * zoomfact;
-
-        var middleCoordinate = screenToDiagramCoordinates(centerScreen.x, centerScreen.y);
-
-        scrollx = middleCoordinate.x + 98;
-        scrolly = middleCoordinate.y + 100;
-
-        // Update screen
-        showdata();
-        updatepos();
-        updateGridPos();
-        updateGridSize();
-        drawRulerBars(scrollx, scrolly);
-        updateA4Pos();
-        updateA4Size();
-    }
 }

--- a/DuggaSys/diagram/camera.js
+++ b/DuggaSys/diagram/camera.js
@@ -2,13 +2,13 @@
  * @description Centers the camera between the highest and lowest x and y values of all elements or if no element the camera moves to start position
  */
 function centerCamera() {
-    let noDiagram = true;
+    let emptyDiagram = true;
     let offsetX = 0;
     let offsetY = 0;
 
     // If there is no element then the camera moves to start position (X = 100 and Y = 100).
     if (data.length == 0) {
-        noDiagram = false;
+        emptyDiagram = false;
         // offsetX is 98 because if not, X is going to be at 2 and it have to be at 100.
         offsetX = 98;
         // offsetY is 100 because if not, Y is going to be at 0 and it have to be at 100.
@@ -24,7 +24,7 @@ function centerCamera() {
             y: window.innerHeight / 2
         };
 
-        if(noDiagram == true){
+        if(emptyDiagram == true){
             const minX = Math.min.apply(null, data.map(i => i.x));
             const maxX = Math.max.apply(null, data.map(i => i.x + i.width));
             const minY = Math.min.apply(null, data.map(i => i.y));
@@ -60,7 +60,7 @@ function centerCamera() {
         drawRulerBars(scrollx, scrolly);
         updateA4Pos();
         updateA4Size();
-        if(noDiagram == true){
+        if(emptyDiagram == true){
             zoomCenter(centerDiagram);
         }
     }

--- a/DuggaSys/diagram/camera.js
+++ b/DuggaSys/diagram/camera.js
@@ -2,13 +2,13 @@
  * @description Centers the camera between the highest and lowest x and y values of all elements or if no element the camera moves to start position
  */
 function centerCamera() {
-    let centerToOrigo = false;
+    let noDiagram = true;
     let offsetX = 0;
     let offsetY = 0;
 
     // If there is no element then the camera moves to start position (X = 100 and Y = 100).
     if (data.length == 0) {
-        centerToOrigo = true;
+        noDiagram = false;
         // offsetX is 98 because if not, X is going to be at 2 and it have to be at 100.
         offsetX = 98;
         // offsetY is 100 because if not, Y is going to be at 0 and it have to be at 100.
@@ -24,7 +24,7 @@ function centerCamera() {
             y: window.innerHeight / 2
         };
 
-        if(centerToOrigo == false){
+        if(noDiagram == true){
             const minX = Math.min.apply(null, data.map(i => i.x));
             const maxX = Math.max.apply(null, data.map(i => i.x + i.width));
             const minY = Math.min.apply(null, data.map(i => i.y));
@@ -60,7 +60,7 @@ function centerCamera() {
         drawRulerBars(scrollx, scrolly);
         updateA4Pos();
         updateA4Size();
-        if(centerToOrigo == false){
+        if(noDiagram == true){
             zoomCenter(centerDiagram);
         }
     }


### PR DESCRIPTION
Now it is possible to center the camera when there is no element on the screen. Can test it by have element on the screen and press the reset button to see if the camera is on the default position or not (it should only remove all the element). And if there is no element on screen then you should be able to center the camera to default position.