### PR TITLE
deleted some math to fix centering and fixed EIrelation

### DIFF
--- a/DuggaSys/diagram/defaults.js
+++ b/DuggaSys/diagram/defaults.js
@@ -99,11 +99,11 @@ const defaults = {
         fill: color.WHITE,
         stroke: color.BLACK,
         width: 50,
-        height: 50,
+        height: 25,
         type: "IE",
         canChangeTo: Object.values(relationType),
         minWidth: 50,
-        minHeight: 50,
+        minHeight: 25,
     },
     SDEntity: {
         name: "State",

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -58,7 +58,7 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.IERelation:
             divContent = drawElementIERelation(element, boxw, boxh, linew);
             cssClass = 'ie-element';
-            style = `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:1;`;
+            style = `left:0; top:0; width:auto; height:${boxh}px; z-index:1;`;
             break;
         case elementTypesNames.UMLInitialState:
             let initVec = `
@@ -446,7 +446,7 @@ function drawElementIERelation(element, boxw, boxh, linew) {
         content += `<line x1="${boxw / 1.6}" y1="${boxw / 2.9}" x2="${boxw / 2.6}" y2="${boxw / 12.7}" stroke='black' />
                     <line x1="${boxw / 2.6}" y1="${boxw / 2.87}" x2="${boxw / 1.6}" y2="${boxw / 12.7}" stroke='black' />`;
     }
-    return drawSvg(boxw, boxh / 2, content, `style='transform:rotate(180deg); stroke-width:${linew};'`);
+    return drawSvg(boxw, boxh, content, `style='transform:rotate(180deg); stroke-width:${linew};'`);
 }
 
 function drawElementState(element, vectorGraphic) {

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -4,7 +4,7 @@
 function updateCSSForAllElements() {
     function updateElementDivCSS(elementData, divObject, useDelta = false) {
         let left = Math.round(((elementData.x - zoomOrigo.x) * zoomfact) + (scrollx * (1.0 / zoomfact)));
-        let top = Math.round((((elementData.y - zoomOrigo.y) - (settings.grid.gridSize / 2)) * zoomfact) + (scrolly * (1.0 / zoomfact)));
+        let top = Math.round((((elementData.y - zoomOrigo.y)) * zoomfact) + (scrolly * (1.0 / zoomfact)));
 
         if (useDelta) {
             left -= deltaX;


### PR DESCRIPTION
We deleted "- (settings.grid.gridSize / 2)" from updateElementDivCSS() so now the elements are centered except IEEntity, SDstate, UML class and note. It is because those elements are multiple objects in one and their real heights are stored in arrays. This causes the program to use the height of zero for calculating the mouse position.

The arrays:
var UMLHeight = [];
var IEHeight = []; 
var SDHeight = [];
var NOTEHeight = [];