### PR TITLE
If a user is logged out in profile.php, they should be taken to the home page and no errors should appear

### DIFF
--- a/DuggaSys/profile.php
+++ b/DuggaSys/profile.php
@@ -23,8 +23,13 @@ pdoConnect();
 	<script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
 	<script src="../Shared/dugga.js"></script>
 	<script src="profile.js"></script>
-
-	<script src="pushnotifications.js"></script>
+	<?php
+	if (defined('PUSH_NOTIFICATIONS_VAPID_PUBLIC_KEY')) {
+	?>
+		<script src="pushnotifications.js"></script>
+	<?php
+	}
+	?>
 </head>
 <body>
 

--- a/DuggaSys/pushnotifications.js
+++ b/DuggaSys/pushnotifications.js
@@ -2,7 +2,7 @@
 
 $(function() {
 
-	var sendPushRegistrationToServer = function(subscription, deregister) {
+	let sendPushRegistrationToServer = function(subscription, deregister) {
 		$.ajax({
 			url: "pushnotifications.php",
 			type: "POST",
@@ -17,7 +17,7 @@ $(function() {
 	};
 
 
-	var subscribe = function() {
+	let subscribe = function() {
 		$("#notificationsToggle")[0].disabled = true;
 
 		navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
@@ -44,7 +44,7 @@ $(function() {
 		});
 	};
 
-	var unsubscribe = function() {
+	let unsubscribe = function() {
 		$("#notificationsToggle")[0].disabled = true;
 
 		navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
@@ -62,7 +62,7 @@ $(function() {
 		});
 	};
 
-	var updateTextAndButton = function(subscribed) {
+	let updateTextAndButton = function(subscribed) {
 		if (subscribed) {
 			$("#notificationsText").html("Push notifications are activated on this device.");
 			$("#notificationsToggle").off("click").on("click", unsubscribe).html("Deactivate push notifications");
@@ -74,7 +74,7 @@ $(function() {
 		}
 	};
 
-	var initialiseState = function() {
+	let initialiseState = function() {
 		if (!('showNotification' in ServiceWorkerRegistration.prototype) || !('PushManager' in window)) {
 			$("#notificationsText").html("Push notifications not supported in this browser").css('color', '#a00'); // Notification or PushManager support not found
 			return;
@@ -84,11 +84,12 @@ $(function() {
 			return;
 		}
 		navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
-			serviceWorkerRegistration.pushManager.getSubscription()
-				.then(function(subscription) {
-					updateTextAndButton(subscription !== null);
+			serviceWorkerRegistration.pushManager
+				.getSubscription()
+				.then((subscription) => {
+					updateTextAndButton(subscription);
 				})
-				.catch(function(err) {
+				.catch((err) => {
 					console.log('Error during getSubscription()', err);
 				});
 		});

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1680,7 +1680,12 @@ function processLogout() {
 		success:function(data) {
 			localStorage.removeItem("ls-security-question");
 			localStorage.removeItem("securitynotification");
-			reloadPage();
+			if(window.location.pathname == "/LenaSYS/DuggaSys/profile.php"){
+				window.location.href = "courseed.php";
+			}
+			else{
+				reloadPage();
+			}
 		},
 		error:function() {
 			console.log("error");


### PR DESCRIPTION
If you log out while in profile.php you will now be directed to courseed.php.

Also the error regarding push notifications will no longer appear if not working in a setup that supports it. Essentially it was trying to interact with an element that would only be created if support for push notifications was installed, hence it was never created.

I also included some improvements to pushnotifications.js (changing var to let, and making parts of it use the standard for pushnotifications). I did not touch the other parts as I was unable to test it, so did not want to touch.

**Testing instructions:**

- To reach profile.php, be logged in and click your name in the top right from any page.
     - if at this point it tells you that you need a secure https connection (which it will, unless you use one), go into profile.js
     - comment out lines 212-214 (they do nothing except this)
- at this point, check for errors and such
- if you wish to try to load the page with the push notification support and you do not already have support for it installed
     - add ! to the if-statements at lines 27 and 95 in profile.php
     - note that errors will appear if you click the button that now exists since the support is not installed
- at this point, log out from within profile.php and any other page to verify that it does not always move you.