### PR TITLE
background overlap fix #15555

### DIFF
--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -428,3 +428,8 @@ const lineAlwaysFrom = [
 const lineAlwaysTo = [
     elementTypesNames.UMLFinalState,
 ];
+
+const backgroundElement = [
+    elementTypesNames.UMLSuperState,
+    elementTypesNames.sequenceLoopOrAlt,
+];

--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -93,7 +93,6 @@ function entityIsOverlapping(id, x, y) {
 
         // No element can be placed over another of the same kind
         if (data[i].kind !== element.kind) {
-
             // Sequence life-lines can be placed on activations
             if ((data[i].kind === "sequenceActor" || data[i].kind === "sequenceObject") && element.kind === "sequenceActivation") continue;
 
@@ -102,8 +101,8 @@ function entityIsOverlapping(id, x, y) {
             else if (element.type === "SE" && (data[i].kind === "sequenceLoopOrAlt" || data[i].kind === "sequenceActivation")) continue;
 
             // Superstates can be placed on state-diagram elements and vice versa
-            else if (data[i].kind === elementTypesNames.UMLSuperState && element.type === "SD") continue;
-            else if (data[i].type === "SD" && element.kind === elementTypesNames.UMLSuperState) continue;
+            else if (data[i].kind === elementTypesNames.UMLSuperState && !backgroundElement.includes(element.kind)) continue;
+            else if (!backgroundElement.includes(data[i].kind) && element.kind === elementTypesNames.UMLSuperState) continue;
         }
 
         const x2 = data[i].x + data[i].width;

--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -88,6 +88,7 @@ function entityIsOverlapping(id, x, y) {
     });
 
     for (let i = 0; i < data.length; i++) {
+        console.log(data[i].kind, element.kind, )
         if (data[i].id === id) continue;
         if (context.includes(data[i])) break;
 
@@ -101,8 +102,14 @@ function entityIsOverlapping(id, x, y) {
             else if (element.type === "SE" && (data[i].kind === "sequenceLoopOrAlt" || data[i].kind === "sequenceActivation")) continue;
 
             // Superstates can be placed on state-diagram elements and vice versa
-            else if (data[i].kind === elementTypesNames.UMLSuperState && !backgroundElement.includes(element.kind)) continue;
-            else if (!backgroundElement.includes(data[i].kind) && element.kind === elementTypesNames.UMLSuperState) continue;
+            else if (!backgroundElement.includes(element.kind) &&
+                (data[i].kind === elementTypesNames.UMLSuperState ||
+                data[i].kind === elementTypesNames.sequenceLoopOrAlt)
+            ) continue;
+            else if (!backgroundElement.includes(data[i].kind) &&
+                (element.kind === elementTypesNames.UMLSuperState ||
+                element.kind === elementTypesNames.sequenceLoopOrAlt)
+            ) continue;
         }
 
         const x2 = data[i].x + data[i].width;


### PR DESCRIPTION
UML super state and loopOrAlt can no longer overlap. They can overlap with all other elements.