### PR TITLE
Added ESC to go back in accessed.php

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -930,20 +930,26 @@ document.addEventListener('click', function(e){
 //----------------------------------------------------------------------------------
 // Keyboard shortcuts - Edit functionality in the accessed table
 //----------------------------------------------------------------------------------
-document.addEventListener("keyup", function(event)
+document.addEventListener('keydown', function(event)
 {
-  if (event.keyCode === 13)
-  {
-    // If user presses key: Enter (13)
-    // if group dropdown is open, update and close it
-    if (typeof(activeElement) !== "undefined")
-    	updateAndCloseGroupDropdown(activeElement.parentElement.lastChild);
-    // update current cell
-    updateCellInternal();
-  } else if (event.keyCode === 27) {
-    // If user presses key: Escape (27)
-    clearUpdateCellInternal();
-  }
+	if (event.key === 'Enter') {
+		// if group dropdown is open, update and close it
+		if (typeof(activeElement) !== "undefined") {
+		updateAndCloseGroupDropdown(activeElement.parentElement.lastChild);
+		}
+		// update current cell
+		updateCellInternal();
+	} 
+	if (event.key === 'Escape') {
+		let link = document.getElementById("upIcon").href;
+		clearUpdateCellInternal();
+		let popupIsOpen = checkIfPopupIsOpen();
+		if (!popupIsOpen) {
+			window.location.assign(link);
+		} else {
+			return;
+		}
+	}
 });
 
 //----------------------------------------------------------------------------------
@@ -1071,4 +1077,17 @@ function closeArrow(arrowElement){
 		"-moz-transform": "rotate(0deg)",
 		"transform": "rotate(0deg)"
 	});
+}
+//Insert all new Popups/Modules in allPopups. Else ESC button will override
+function checkIfPopupIsOpen() {
+	let allPopups = [
+		"#addUser",
+		"#createUser"
+	];
+	for (let popup of allPopups) {
+		if ($(popup).css("display") !== "none") {
+			return true;
+		}
+	}
+	return false;
 }

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -930,12 +930,12 @@ document.addEventListener('click', function(e){
 //----------------------------------------------------------------------------------
 // Keyboard shortcuts - Edit functionality in the accessed table
 //----------------------------------------------------------------------------------
-document.addEventListener('keydown', function(event)
+document.addEventListener('keyup', function(event)
 {
 	if (event.key === 'Enter') {
 		// if group dropdown is open, update and close it
 		if (typeof(activeElement) !== "undefined") {
-		updateAndCloseGroupDropdown(activeElement.parentElement.lastChild);
+			updateAndCloseGroupDropdown(activeElement.parentElement.lastChild);
 		}
 		// update current cell
 		updateCellInternal();


### PR DESCRIPTION
Fixed current iteration of keyup for enter and esc. 
Integrated a check if popups are open in this eventlistener.
As the popups already has a close function attached to them we only go back if none are open.
Only current popups/modules in accessed are "createUser" and "addUser".
"removeUser" and "createClass" will be added later. These should be inserted into allPopups array when implemented.

For testing:
Try opening a popup and press the ESC key.
Try pressing the ESC key without a popup open.

If a popup is open it should only close.
If a popup is not open it should redirect to sectioned.php.