### PR TITLE
Added ESC to go back in fileed#15439

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -1038,15 +1038,15 @@ document.addEventListener('DOMContentLoaded', function (){
 //---------------------------------------------
 //Add all current and newly created popups/modules in allPopups for ESC button not to override
 function checkIfPopupIsOpen() {
-	let allPopups = [
-		"#addFile",
+    let allPopups = [
+        "#addFile",
         ".fileViewWindow",
         ".previewWindow"
-	];
-	for (let popup of allPopups) {
-		if ($(popup).css("display") !== "none") {
-			return true;
-		}
-	}
-	return false;
+    ];
+    for (let popup of allPopups) {
+        if ($(popup).css("display") !== "none") {
+            return true;
+        }
+    }
+    return false;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -445,7 +445,7 @@ function fileDownload(name, path, extension){
 
 // Close the file preview window by 'x' button or ESC key ----
 function filePreviewClose(){
-    var fileview = document.querySelector(".fileView");
+    let fileview = document.querySelector(".fileView");
     $(".fileViewContainer").hide();
     $(".fileViewWindow").hide();
     while(fileview.firstChild){
@@ -454,21 +454,14 @@ function filePreviewClose(){
 }
 document.addEventListener('keyup', function(event){
     if (event.key === 'Escape') {
-        var fileview = document.querySelector(".fileView");
-        $(".fileViewContainer").hide();
-        $(".fileViewWindow").hide();
-        while (fileview.firstChild) {
-            fileview.removeChild(fileview.firstChild);
-        }
+        filePreviewClose();
     }
 });
 document.addEventListener('keydown', function (event) {
     if (event.key === 'Escape') {
         let link = document.getElementById("upIcon").href;
         let isPopupOpen = checkIfPopupIsOpen();
-        //let isBlockedPopupOpen = checkIfBlockedPopupIsOpen();
         if (!isPopupOpen) {
-            console.log("window location is reached");
             window.location.assign(link);
         }
     }
@@ -1053,7 +1046,6 @@ function checkIfPopupIsOpen() {
 	];
 	for (let popup of allPopups) {
 		if ($(popup).css("display") !== "none") {
-            console.log(popup, "is open");
 			return true;
 		}
 	}

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -452,18 +452,17 @@ function filePreviewClose(){
         fileview.removeChild(fileview.firstChild);
     }
 }
-document.addEventListener('keyup', function(event){
-    if (event.key === 'Escape') {
-        filePreviewClose();
-    }
-});
-document.addEventListener('keydown', function (event) {
+document.addEventListener('keyup', function (event) {
     if (event.key === 'Escape') {
         let link = document.getElementById("upIcon").href;
         let isPopupOpen = checkIfPopupIsOpen();
         if (!isPopupOpen) {
             window.location.assign(link);
         }
+        filePreviewClose();
+    }
+    if (event.key === 'x') {
+        filePreviewClose();
     }
     // ---------------------------------------------------
     // Toggle to hide fab-button to click through it with CTRL

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -452,23 +452,24 @@ function filePreviewClose(){
         fileview.removeChild(fileview.firstChild);
     }
 }
-
-document.addEventListener('keydown', function (event) {
+document.addEventListener('keyup', function(event){
     if (event.key === 'Escape') {
-        let link = document.getElementById("upIcon").href;
         var fileview = document.querySelector(".fileView");
         $(".fileViewContainer").hide();
         $(".fileViewWindow").hide();
         while (fileview.firstChild) {
             fileview.removeChild(fileview.firstChild);
         }
-        console.log(link);
-        let isPopupOpen = checkIfPopupIsOpen()
+    }
+});
+document.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape') {
+        let link = document.getElementById("upIcon").href;
+        let isPopupOpen = checkIfPopupIsOpen();
+        //let isBlockedPopupOpen = checkIfBlockedPopupIsOpen();
         if (!isPopupOpen) {
             console.log("window location is reached");
             window.location.assign(link);
-        } else {
-            return
         }
     }
     // ---------------------------------------------------
@@ -1045,28 +1046,16 @@ document.addEventListener('DOMContentLoaded', function (){
 //---------------------------------------------
 //Add all current and newly created popups/modules in allPopups for ESC button not to override
 function checkIfPopupIsOpen() {
-    let hiddenCheck = true;
 	let allPopups = [
 		"#addFile",
+        ".fileViewWindow",
+        ".previewWindow"
 	];
-    let allHiddenPopups = [
-        "#fileViewWindow",
-        "#previewWindow"
-    ];
 	for (let popup of allPopups) {
 		if ($(popup).css("display") !== "none") {
+            console.log(popup, "is open");
 			return true;
 		}
 	}
-    for (let hiddenPopup of allHiddenPopups) {
-        let element = document.getElementById(hiddenPopup);
-        if (window.getComputedStyle(element).visibility !== "hidden") {
-            console.log(hiddenPopup, "inside checkvisibility")
-            hiddenCheck = false;
-        }
-    }
-    if (!hiddenCheck) {
-        return true;
-    } 
 	return false;
 }

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -467,16 +467,16 @@ document.addEventListener('keyup', function (event) {
     // ---------------------------------------------------
     // Toggle to hide fab-button to click through it with CTRL
     //----------------------------------------------------
-	if(event.key === 'Control'){
-        var element = document.getElementById('fabButton');
-		if(window.getComputedStyle(element, null).getPropertyValue("opacity") != "1"){
-			element.style.opacity = "1";
-			element.style.pointerEvents = "auto";
-		}else{
+    if (event.key === 'Control') {
+        let element = document.getElementById('fabButton');
+        if (window.getComputedStyle(element, null).getPropertyValue("opacity") != "1") {
+            element.style.opacity = "1";
+            element.style.pointerEvents = "auto";
+        } else {
             element.style.opacity = "0.3";
-			element.style.pointerEvents = "none";
-		}	
-	}
+            element.style.pointerEvents = "none";
+        }	
+    }
 });
 
 //---------------------------------------------------------------------------------------------

--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -454,14 +454,36 @@ function filePreviewClose(){
 }
 
 document.addEventListener('keydown', function (event) {
-    var fileview = document.querySelector(".fileView");
     if (event.key === 'Escape') {
+        let link = document.getElementById("upIcon").href;
+        var fileview = document.querySelector(".fileView");
         $(".fileViewContainer").hide();
         $(".fileViewWindow").hide();
         while (fileview.firstChild) {
             fileview.removeChild(fileview.firstChild);
         }
+        console.log(link);
+        let isPopupOpen = checkIfPopupIsOpen()
+        if (!isPopupOpen) {
+            console.log("window location is reached");
+            window.location.assign(link);
+        } else {
+            return
+        }
     }
+    // ---------------------------------------------------
+    // Toggle to hide fab-button to click through it with CTRL
+    //----------------------------------------------------
+	if(event.key === 'Control'){
+        var element = document.getElementById('fabButton');
+		if(window.getComputedStyle(element, null).getPropertyValue("opacity") != "1"){
+			element.style.opacity = "1";
+			element.style.pointerEvents = "auto";
+		}else{
+            element.style.opacity = "0.3";
+			element.style.pointerEvents = "none";
+		}	
+	}
 });
 
 //---------------------------------------------------------------------------------------------
@@ -1020,22 +1042,31 @@ document.addEventListener('DOMContentLoaded', function (){
  function updateAce(data){
     editor.getSession().setValue(data);
 }
-
-// ---------------------------------------------------
-// Toggle to hide fab-button to click through it with CTRL
-//----------------------------------------------------
-
-document.addEventListener('keydown', function(e) {
-	var element = document.getElementById('fabButton');
-	if(e.keyCode === 17){
-		if(window.getComputedStyle(element, null).getPropertyValue("opacity") != "1"){
-			element.style.opacity = "1";
-			element.style.pointerEvents = "auto";
-		}else{
-            element.style.opacity = "0.3";
-			element.style.pointerEvents = "none";
-		}	
+//---------------------------------------------
+//Add all current and newly created popups/modules in allPopups for ESC button not to override
+function checkIfPopupIsOpen() {
+    let hiddenCheck = true;
+	let allPopups = [
+		"#addFile",
+	];
+    let allHiddenPopups = [
+        "#fileViewWindow",
+        "#previewWindow"
+    ];
+	for (let popup of allPopups) {
+		if ($(popup).css("display") !== "none") {
+			return true;
+		}
 	}
-});
-
-
+    for (let hiddenPopup of allHiddenPopups) {
+        let element = document.getElementById(hiddenPopup);
+        if (window.getComputedStyle(element).visibility !== "hidden") {
+            console.log(hiddenPopup, "inside checkvisibility")
+            hiddenCheck = false;
+        }
+    }
+    if (!hiddenCheck) {
+        return true;
+    } 
+	return false;
+}


### PR DESCRIPTION
Fixed current iteration of keyup for esc and control.
Integrated current filePreviewClose() call when pressing esc and popup is open.
Integrated a check if popups are open in this eventlistener.
Current popups are when adding a file, previewWindow (Edit file icon) and fileViewPreview (clicking on the file name).
Added intended integration with "x" key. this was not implemented but previous devs had intended for it.
Also fixed previous indentation.

For testing:
Try opening a popup and press the ESC key.
Try pressing the ESC key without a popup open.

If a popup is open it should only close.
If a popup is not open it should redirect to sectioned.php.

Also try closing fileView with x key. It should not produce duplicates in view if opened again.