### PR TITLE
Added ESC to go back in codeviewer.php #15438

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -5099,10 +5099,10 @@ function toggleTitleDescription(toCheck){
 	}
 }
 
-document.addEventListener('keydown', function(event){
+document.addEventListener('keyup', function(event){
 	if (event.key === 'Escape') {
 		let link = document.getElementById("upIcon").href;
-	    let isOpenPopup = closeCurrOpenPopupForm();
+	    let isOpenPopup = checkIfPopupIsOpen();
 		if (!isOpenPopup) {
 			window.location.assign(link);
 		} else {
@@ -5111,16 +5111,17 @@ document.addEventListener('keydown', function(event){
 	}
 })
 
-function closeCurrOpenPopupForm(){
+function checkIfPopupIsOpen() {
 	let allPopups = [
-		"#editExample",
-		"#editContent",
-		"#chooseTemplate",
+		"#editExampleContainer",
+		"#editContentContainer",
+		"#chooseTemplateContainer",
+		"#burgerMenu",
+		".previewWindowContainer loginBoxContainer"
 	];
-
 	for (let popup of allPopups){
 		if ($(popup).css("display") !== "none"){
-			$(popup).css("display","none");
+			console.log(popup);
 			return true;
 		}
 	}

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -5098,19 +5098,18 @@ function toggleTitleDescription(toCheck){
       	box.classList.remove('visuallyhidden');
 	}
 }
-
+//-------------------------------------------------
+// EventListener for Escape keyup
+//-------------------------------------------------
 document.addEventListener('keyup', function(event){
 	if (event.key === 'Escape') {
 		let link = document.getElementById("upIcon").href;
-	    let isOpenPopup = checkIfPopupIsOpen();
+		let isOpenPopup = checkIfPopupIsOpen();
 		if (!isOpenPopup) {
 			window.location.assign(link);
-		} else {
-			return
 		}
 	}
-})
-
+});
 function checkIfPopupIsOpen() {
 	let allPopups = [
 		"#editExampleContainer",
@@ -5119,7 +5118,7 @@ function checkIfPopupIsOpen() {
 		"#burgerMenu",
 		".previewWindowContainer.loginBoxContainer"
 	];
-	for (let popup of allPopups){
+	for (let popup of allPopups) {
 		if ($(popup).css("display") !== "none"){
 			return true;
 		}

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -5098,3 +5098,31 @@ function toggleTitleDescription(toCheck){
       	box.classList.remove('visuallyhidden');
 	}
 }
+
+document.addEventListener('keydown', function(event){
+	if (event.key === 'Escape') {
+		let link = document.getElementById("upIcon").href;
+	    let isOpenPopup = closeCurrOpenPopupForm();
+		if (!isOpenPopup) {
+			window.location.assign(link);
+		} else {
+			return
+		}
+	}
+})
+
+function closeCurrOpenPopupForm(){
+	let allPopups = [
+		"#editExample",
+		"#editContent",
+		"#chooseTemplate",
+	];
+
+	for (let popup of allPopups){
+		if ($(popup).css("display") !== "none"){
+			$(popup).css("display","none");
+			return true;
+		}
+	}
+	return false;
+}

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -5121,7 +5121,6 @@ function checkIfPopupIsOpen() {
 	];
 	for (let popup of allPopups){
 		if ($(popup).css("display") !== "none"){
-			console.log(popup);
 			return true;
 		}
 	}

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -5117,7 +5117,7 @@ function checkIfPopupIsOpen() {
 		"#editContentContainer",
 		"#chooseTemplateContainer",
 		"#burgerMenu",
-		".previewWindowContainer loginBoxContainer"
+		".previewWindowContainer.loginBoxContainer"
 	];
 	for (let popup of allPopups){
 		if ($(popup).css("display") !== "none"){


### PR DESCRIPTION
Implemented keyup event for esc.
Integrated a check if popups are open in codeviewer.
Should work on all popups.

For testing:
Try opening a popup and press the ESC key.
Try pressing the ESC key without a popup open.

If a popup is open it should only close.
If a popup is not open it should redirect to sectioned.php.


--------------------------------------------------------------------------
Problem when pressing esc while previewWindow loginBox is open. 
Its container "previewWindowContainer loginBoxContainer" is set to none while "previewWindow loginBox" is still not changed from block to none. Circumvented this in this pullrequest but this will be looked into in another issue.