### PR TITLE
When editing a course it will require you to input a github key

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -61,7 +61,8 @@ function updateCourse() {
 			//Check FetchGithubRepo for the meaning of the error code.
 			switch (data.status) {
 				case 403:
-					toast("error", data.status + " Error \nplease insert valid git key", 7);
+					toast("error", "Error " + data.status +  ": \nData limit reached, did not download files", 7);
+					closeWindows();
 					break;
 				case 422:
 					toast("error", data.responseJSON.message + "\nDid not create/update token", 7);


### PR DESCRIPTION
It was not actually requiring you to insert a github key, it stemmed from the bfs function reaching the data limit. 

Since there reasonably is not much I can do about the data limit as well as the bfs function being worked on in another issue I just changed the error message to a more descriptive and made it close the window upon it being sent.

Dont think this really needs testing, but simply reach the data limit and insert only a link for a course that you do not already have files downloaded for.