### PR TITLE
Added a confirm toast to the toast roster G3 2024 v6 #14813

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -23,7 +23,6 @@ $(document).ready(function () {
 	});
 });
 
-toast("confirm", "Test", 0);
 AJAXService("GET", {}, "COURSE");
 
 //----------------------------------------

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -23,6 +23,7 @@ $(document).ready(function () {
 	});
 });
 
+toast("confirm", "Test", 0);
 AJAXService("GET", {}, "COURSE");
 
 //----------------------------------------

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1365,6 +1365,6 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 }
 
 .confirm { 
-    background-color: #d8eeff;
+    background-color: #ecf7ff;
 }
 /*/ END /*/

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1363,4 +1363,8 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 .error {
   background-color: rgb(243, 129, 129);
 }
+
+.confirm { 
+    background-color: #d8eeff;
+}
 /*/ END /*/

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9655,7 +9655,7 @@ margin:2px;
 }
 
 .confirm {
-  background-color: #d8eeff;
+  background-color: #ecf7ff;
 }
 
 .toast.show {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9617,8 +9617,29 @@ margin:2px;
   grid-area: "closeDiv";
 }
 
-.toast div:first-child, .toast div:nth-child(3) {
-  width: fit-content;
+.toastNo, .toastYes {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 5px 10px;
+  color: white;
+}
+
+.toastNo {
+ background-color: var(--color-red);
+}
+
+.toastNo:hover {
+  background-color: var(--color-red-hover);
+}
+.toastYes {
+  background-color: var(--color-green);
+}
+
+.toastYes:hover {
+  background-color: #008000;
 }
 
 .warning {
@@ -9659,7 +9680,8 @@ margin:2px;
 
 
 .toastButtonBox {
-  float: left;
+  display: flex;
+  justify-content: space-around;
   margin: 0 auto;
   width: 100%;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9658,6 +9658,13 @@ margin:2px;
 }
 
 
+.toastButtonBox {
+  float: left;
+  margin: 0 auto;
+  width: 100%;
+}
+
+
 .toast.expanded {
   height: auto;
   cursor: default;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9654,6 +9654,10 @@ margin:2px;
   background-color: rgb(243, 129, 129);
 }
 
+.confirm {
+  background-color: #d8eeff;
+}
+
 .toast.show {
   display: grid; 
   -webkit-animation: fadein 0.5s;

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -57,21 +57,26 @@
         let toastYes = document.createElement('span');
         let toastNo = document.createElement('span');
 
+        // Creates the icon-element for each option.
         let yesIcon = document.createElement('span');
         let noIcon = document.createElement('span');
 
+        // Creates the text-element for each option (yes / no)
         let yesText = document.createElement('span');
         let noText = document.createElement('span');
 
+        // Inserts the text into each option
         yesText.innerHTML = "Yes";
         noText.innerHTML = "No";
 
+        // Creates an icon for each option
         yesIcon.innerHTML = "done";
         noIcon.innerHTML = "close";
 
         yesIcon.classList.add('material-symbols-outlined');
         noIcon.classList.add('material-symbols-outlined');
 
+        // Adds the styling to each button
         toastYes.classList.add('toastYes');
         toastNo.classList.add('toastNo');
 
@@ -91,6 +96,7 @@
         toastCenter.appendChild(toastText);
         toastRight.appendChild(closeIcon);
          
+        // Add the icon and text to the button elements
         toastYes.appendChild(yesIcon);
         toastYes.appendChild(yesText);
 

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -15,7 +15,7 @@
         }
     }
     // Create a toast notification
-    function toast(type, text, duration, arguments = null) {
+    function toast(type, text, duration, arguments = null, arguments2 = null) {
         // We locate the container for all toasts
         const toastContainer = document.getElementById('toastContainer');
         // The toast div is created
@@ -139,6 +139,8 @@
                 toastCenter.appendChild(toastButtonBox);
                 toastButtonBox.appendChild(toastYes);
                 toastButtonBox.appendChild(toastNo);
+                toastYes.setAttribute( "onClick", "javascript: "+arguments);
+                toastNo.setAttribute( "onClick", "javascript: "+arguments2);
                 toastDiv.classList.add(types.CONFIRM);
                 break;
             // We create a default situation in case no type is given.

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -135,7 +135,7 @@
                 break;
             case types.CONFIRM:
                 typeIcon.innerHTML = "Help";
-                typeText.innerHTML = "Error";
+                typeText.innerHTML = "Confirm";
                 toastCenter.appendChild(toastButtonBox);
                 toastButtonBox.appendChild(toastYes);
                 toastButtonBox.appendChild(toastNo);

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -3,7 +3,8 @@
         WARNING: "warning", 
         ERROR: "error", 
         SUCCESS: "success",
-        UNDO: "undo"
+        UNDO: "undo",
+        CONFIRM: "confirm"
     }); 
     // Close the toast by clicking the X icon
     function closeToast(toastDiv) {
@@ -51,6 +52,18 @@
         let toastText = document.createElement('p');
         toastText.classList.add('toastText');
 
+        // The toast confirm options are created
+        // toastYes / toastNo = the toast confirm buttons (used for CONFIRM type)
+        let toastYes = document.createElement('span');
+        let toastNo = document.createElement('span');
+        toastYes.classList.add('toastYes');
+        toastNo.classList.add('toastNo');
+
+        // The toast buttonbox is created
+        // toastButtonBox = the toast confirm button
+        let toastButtonBox = document.createElement('div');
+        toastButtonBox.classList.add('toastButtonBox');
+
         // Adds the smaller toast divs to the bigger toast div
         toastDiv.appendChild(toastLeft);
         toastDiv.appendChild(toastCenter);
@@ -91,6 +104,16 @@
                 toastLeft.setAttribute( "onClick", "javascript: "+arguments);
                 typeText.innerHTML = "Notice";
                 toastDiv.classList.add(types.UNDO);
+                break;
+            case types.CONFIRM:
+                typeIcon.innerHTML = "Help";
+                typeText.innerHTML = "Error";
+                toastCenter.appendChild(toastButtonBox);
+                toastButtonBox.appendChild(toastYes);
+                toastButtonBox.appendChild(toastNo);
+                toastYes.innerHTML = "Yes"
+                toastNo.innerHTML = "No"
+                toastDiv.classList.add(types.CONFIRM);
                 break;
             // We create a default situation in case no type is given.
             // The default toast will not have an icon nor heading.

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -56,6 +56,22 @@
         // toastYes / toastNo = the toast confirm buttons (used for CONFIRM type)
         let toastYes = document.createElement('span');
         let toastNo = document.createElement('span');
+
+        let yesIcon = document.createElement('span');
+        let noIcon = document.createElement('span');
+
+        let yesText = document.createElement('span');
+        let noText = document.createElement('span');
+
+        yesText.innerHTML = "Yes";
+        noText.innerHTML = "No";
+
+        yesIcon.innerHTML = "done";
+        noIcon.innerHTML = "close";
+
+        yesIcon.classList.add('material-symbols-outlined');
+        noIcon.classList.add('material-symbols-outlined');
+
         toastYes.classList.add('toastYes');
         toastNo.classList.add('toastNo');
 
@@ -75,6 +91,12 @@
         toastCenter.appendChild(toastText);
         toastRight.appendChild(closeIcon);
          
+        toastYes.appendChild(yesIcon);
+        toastYes.appendChild(yesText);
+
+        toastNo.appendChild(noIcon);
+        toastNo.appendChild(noText);
+
         // Add the toast div to the toast container (containing all toasts)
         toastContainer.appendChild(toastDiv);
        
@@ -111,8 +133,6 @@
                 toastCenter.appendChild(toastButtonBox);
                 toastButtonBox.appendChild(toastYes);
                 toastButtonBox.appendChild(toastNo);
-                toastYes.innerHTML = "Yes"
-                toastNo.innerHTML = "No"
                 toastDiv.classList.add(types.CONFIRM);
                 break;
             // We create a default situation in case no type is given.


### PR DESCRIPTION
Now there is a confirm toast available to be used among the rest of the toasts. I did this through adding additional elements to toastContainer that shows the two buttons (thanks Moa). To pass the arguments for the buttons, the last two arguments in the toast functioned are used for this (arguments and arguments2). 

![image](https://github.com/HGustavs/LenaSYS/assets/129257945/6be947c8-93f3-4006-b6f7-8e971af787d2)

To call this function, you just add the following code to a php-file that implements toast.php (for example courseed.php):

``` javascript
toast("confirm", "Are you sure you want to do that?", 0, "", "");
```
