### PR TITLE
Updated thrashcan and deletion functionality

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -646,7 +646,11 @@ function showSaveButton() {
 
 // Displaying and hidding the dynamic comfirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
+
+  // console.log("Clicked id" + active_lid)
+  // console.log("Selected IDs:" + selectedItemList)
   if (operation == "openConfirmBox") {
+    // console.log(collectedLid);
     active_lid = item ? $(item).parents('table').attr('value') : null;
     $("#sectionConfirmBox").css("display", "flex");
   } else if (operation == "openHideConfirmBox") {
@@ -661,6 +665,11 @@ function confirmBox(operation, item = null) {
     $("#sectionShowConfirmBox").css("display", "flex");
     $('#close-item-button').focus();
   } else if (operation == "deleteItem") {
+    if(!selectedItemList.includes(active_lid)){
+      selectedItemList.push(active_lid); // Push clicked item to selectedItemList before it's items are deleted
+    }
+    // console.log("Clicked id" + active_lid)
+    // console.log("Selected IDs:" + selectedItemList)
     deleteItem(selectedItemList);
     $("#sectionConfirmBox").css("display", "none");
   } else if (operation == "hideItem" && !selectedItemList.length == 0) {


### PR DESCRIPTION
When the user clicks the trashcan item, the "confirmationBox" opens up. I've implemented so the clicked dugga get pushed to the "selectedItemList" when the user clicks "Yes" in the confirmation window. For safety reasons have I included an if-statement that don't push the dugga-id if it's already inside the "selectedItemList" array.

When yes is clicked, the function "deleteItem" deletes all the items in the array "selectedItemList".

I have left some commented code that could be helpful for testers. If everything work properly the commented code should be removed.

Commented code is on line: 650, 651, 653, 671 and 672