### PR TITLE
Changed the background color for confirm toasts #15591

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1365,6 +1365,6 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 }
 
 .confirm { 
-    background-color: #ecf7ff;
+    background-color: #e9e9e9;
 }
 /*/ END /*/

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9658,7 +9658,7 @@ margin:2px;
 }
 
 .confirm {
-  background-color: #ecf7ff;
+  background-color: #fecc56;
 }
 
 .toast.show {


### PR DESCRIPTION
Changed the background color for confirm toasts for both dark and light themes to the default toast color scheme.

To test, add the following code to courseed.js:

```javascript
toast("confirm", "test", 0);
```