### PR TITLE
G1 2024 v6 #15553

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -794,6 +794,21 @@ document.addEventListener('keydown', function (e) {
         }
     }
 
+    if (isKeybindValid(e, keybinds.SAVE_DIAGRAM)) {
+        e.preventDefault();
+        showSavePopout();
+    }
+
+    if (isKeybindValid(e, keybinds.LOAD_DIAGRAM)) {
+        e.preventDefault();
+        showModal();
+    }
+
+    if (isKeybindValid(e, keybinds.TEST_CASE)) {
+        e.preventDefault();
+        toggleTestCase();
+    }
+
     if (altPressed) {
         mouseMode_onMouseUp();
     }
@@ -893,7 +908,6 @@ document.addEventListener('keyup', function (e) {
     if (isKeybindValid(e, keybinds.CENTER_CAMERA)) centerCamera();
     if (isKeybindValid(e, keybinds.TOGGLE_REPLAY_MODE)) toggleReplay();
     if (isKeybindValid(e, keybinds.TOGGLE_ER_TABLE)) toggleErTable();
-    if (isKeybindValid(e, keybinds.SAVE_DIAGRAM)) showSavePopout();
     //if(isKeybindValid(e, keybinds.TOGGLE_ERROR_CHECK)) toggleErrorCheck(); Note that this functionality has been moved to hideErrorCheck(); because special conditions apply.
 
     if (isKeybindValid(e, keybinds.COPY)) {

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -975,7 +975,7 @@
                 <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle test-cases"/>
                 <span class="toolTipText"><b>Toggle test-cases</b><br>
                     <p>Click to toggle test-cases in options</p><br>
-                    <p id="tooltip-TOGGLE_TEST_CASE" class="key_tooltip">Keybinding:</p>
+                    <p id="tooltip-TOGGLE_TEST_CASE" class="key_tooltip">Keybinding: CTRL + ALT + "T"</p>
                 </span>
             </div>
         </fieldset> 
@@ -998,7 +998,7 @@
                 <span class="toolTipText"><b>Save current diagram</b><br>
                     <p>Click to save current diagram</p>
                     <br>
-                    <p id="tooltip-Save_diagram" class="key_tooltip">Keybinding:</p> <!--its currently binded to ctrl "s"-->
+                    <p id="tooltip-Save_diagram" class="key_tooltip">Keybinding: CTRL + "S"</p> <!--its currently binded to ctrl "s"-->
                 </span>
             </div>
         </fieldset>
@@ -1009,7 +1009,7 @@
                 <span class="toolTipText"><b>Load diagram</b><br>
                     <p>Click to load a diagram</p>
                     <br>
-                    <p id="tooltip-Load_diagram" class="key_tooltip">Keybinding:</p> <!--its currently binded to ctrl "L"-->
+                    <p id="tooltip-Load_diagram" class="key_tooltip">Keybinding: CTRL + "L"</p> <!--its currently binded to ctrl "L"-->
                 </span>
             </div>
         </fieldset>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -975,7 +975,7 @@
                 <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle test-cases"/>
                 <span class="toolTipText"><b>Toggle test-cases</b><br>
                     <p>Click to toggle test-cases in options</p><br>
-                    <p id="tooltip-TOGGLE_TEST_CASE" class="key_tooltip">Keybinding: CTRL + ALT + "T"</p>
+                    <p id="tooltip-TOGGLE_TEST_CASE" class="key_tooltip">Keybinding: "CTRL + ALT + T"</p>
                 </span>
             </div>
         </fieldset> 
@@ -998,7 +998,7 @@
                 <span class="toolTipText"><b>Save current diagram</b><br>
                     <p>Click to save current diagram</p>
                     <br>
-                    <p id="tooltip-Save_diagram" class="key_tooltip">Keybinding: CTRL + "S"</p> <!--its currently binded to ctrl "s"-->
+                    <p id="tooltip-Save_diagram" class="key_tooltip">Keybinding: "CTRL + S"</p> <!--its currently binded to ctrl "s"-->
                 </span>
             </div>
         </fieldset>
@@ -1009,7 +1009,7 @@
                 <span class="toolTipText"><b>Load diagram</b><br>
                     <p>Click to load a diagram</p>
                     <br>
-                    <p id="tooltip-Load_diagram" class="key_tooltip">Keybinding: CTRL + "L"</p> <!--its currently binded to ctrl "L"-->
+                    <p id="tooltip-Load_diagram" class="key_tooltip">Keybinding: "CTRL + L"</p> <!--its currently binded to ctrl "L"-->
                 </span>
             </div>
         </fieldset>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -998,7 +998,7 @@
                 <span class="toolTipText"><b>Save current diagram</b><br>
                     <p>Click to save current diagram</p>
                     <br>
-                    <p id="tooltip-Save_diagram" class="key_tooltip">Keybinding: "CTRL + S"</p> <!--its currently binded to ctrl "s"-->
+                    <p id="tooltip-Save_diagram" class="key_tooltip">Keybinding: "CTRL + S"</p>
                 </span>
             </div>
         </fieldset>
@@ -1009,7 +1009,7 @@
                 <span class="toolTipText"><b>Load diagram</b><br>
                     <p>Click to load a diagram</p>
                     <br>
-                    <p id="tooltip-Load_diagram" class="key_tooltip">Keybinding: "CTRL + L"</p> <!--its currently binded to ctrl "L"-->
+                    <p id="tooltip-Load_diagram" class="key_tooltip">Keybinding: "CTRL + L"</p>
                 </span>
             </div>
         </fieldset>

--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -42,6 +42,7 @@ const keybinds = {
     TOGGLE_ERROR_CHECK: {key: "h", ctrl: false},
     SAVE_DIAGRAM: {key: "s", ctrl: true},
     LOAD_DIAGRAM: {key: "l", ctrl: true},
+    TEST_CASE: {key: "t", ctrl: true, alt: true},
 };
 
 /**


### PR DESCRIPTION
Added the new keybinding for save diagram, load diagram and test case. The keybinding is CTRL + S for save diagram, CTRL + L and CTRL + ALT + T for test case. Needed to have CTRL + ALT for test case because if I use CTRL + T a new tab pop out. 