### PR TITLE
Add functionality to "Add User" && "Remove User" button #15562

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -134,7 +134,58 @@ function hideRemoveUserPopup() {
 //----------------------------------------------------------------------------
 //-------------==========########## Commands ##########==========-------------
 //----------------------------------------------------------------------------
-
+function addUserToCourse() {
+	let input = document.getElementById('addUsername').value;
+	let term = $("#addTermUsr").val();
+	$.ajax({
+		type: 'POST',
+		url: 'accessedservice.php',
+		data: {
+			opt: 'RETRIEVE',
+			action: 'USER',
+			username: input
+		},
+		success: function(response) {
+			userJson = response.substring(0, response.indexOf('{"entries":'));
+			let responseData = JSON.parse(userJson);
+			let uid = responseData.user[0].uid;
+			AJAXService("USERTOTABLE", {
+				courseid: querystring['courseid'],
+				uid: uid,
+				term: term,
+				coursevers: querystring['coursevers'],
+				action: 'COURSE'
+			}, "ACCESS");
+		},
+		error: function(xhr, status, error) {
+			console.error("Error", error);
+		}
+	});
+	/*$.ajax({
+		type: 'POST',
+		url: 'accessedservice.php',
+		data: {
+			opt: 'ADDUSR',
+			action: 'COURSE',
+			courseid: querystring['courseid'],
+			uid: uid,
+			username: input,
+			coursevers: querystring['coursevers']
+		},
+		success: function(response) {
+			//console.log(response);
+		},
+		error: function(xhr, status, error) {
+			console.error("Error", error);
+		}
+	});
+	/*AJAXService("ADDUSR", {
+		courseid: querystring['courseid'],
+		uid: uid,
+		coursevers: querystring['coursevers']
+	}, "ACCESS");*/
+	hideAddUserPopup();
+}
 function addSingleUser() {
 
 	var newUser = new Array();

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -122,6 +122,14 @@ function hideCreateClassPopup() {
 	$("#createClass").css("display", "none");
 }
 
+function hideAddUserPopup() {
+	$("#addUser").css("display", "none");
+}
+
+function hideRemoveUserPopup() {
+	$("#removeUser").css("display", "none");
+}
+
 //----------------------------------------------------------------------------
 //-------------==========########## Commands ##########==========-------------
 //----------------------------------------------------------------------------
@@ -1094,4 +1102,31 @@ function checkIfPopupIsOpen() {
 		}
 	}
 	return false;
+}
+function loadUsersToDropdown() {
+	$.ajax({
+		url: 'accessedservice.php',
+		type: 'POST',
+		data: { opt: 'RETRIEVE', action: 'USERS'},
+		success: function(response) {
+			usersJson = response.substring(0, response.indexOf('{"entries":'));
+			let responseData = JSON.parse(usersJson);
+			let filteredUsers = [];
+			let length = responseData.users.length;
+			for (let i = 0; i < length; i++) {
+				let user = responseData.users[i];
+				filteredUsers.push(user);
+			}
+			let dropdownList = document.getElementById("users_dropdown2");
+			filteredUsers.forEach(user => {
+				let option = document.createElement("option");
+				option.text = user.username;
+				dropdownList.appendChild(option);
+			});
+		},
+		error: function(xhr, status, error) {
+			console.error(error);
+		}
+	});
+	
 }

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -650,7 +650,7 @@ function updateCellCallback(rowno, colno, column, tableid) {
 function rowFilter(row) {
 	var obj = JSON.parse(row["access"]);
 	var searchtermArray;
-	if (accessFilter.indexOf(obj.access) > -1) {
+	if (accessFilter.indexOf(obj.access) > -2) {
 		if (searchterm == "") {
 			return true;
 		} else {

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -1150,7 +1150,8 @@ function closeArrow(arrowElement){
 function checkIfPopupIsOpen() {
 	let allPopups = [
 		"#addUser",
-		"#createUser"
+		"#createUser",
+		"#removeUser"
 	];
 	for (let popup of allPopups) {
 		if ($(popup).css("display") !== "none") {

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -162,29 +162,6 @@ function addUserToCourse() {
 			console.error("Error", error);
 		}
 	});
-	/*$.ajax({
-		type: 'POST',
-		url: 'accessedservice.php',
-		data: {
-			opt: 'ADDUSR',
-			action: 'COURSE',
-			courseid: querystring['courseid'],
-			uid: uid,
-			username: input,
-			coursevers: querystring['coursevers']
-		},
-		success: function(response) {
-			//console.log(response);
-		},
-		error: function(xhr, status, error) {
-			console.error("Error", error);
-		}
-	});
-	/*AJAXService("ADDUSR", {
-		courseid: querystring['courseid'],
-		uid: uid,
-		coursevers: querystring['coursevers']
-	}, "ACCESS");*/
 	hideAddUserPopup();
 }
 function addSingleUser() {

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -94,13 +94,14 @@ function showCreateUserPopup() {
 	$("#createUser").css("display", "flex");
 }
 
-function showAddUserPopup() {
+function showAddUserPopup(id) {
 	$("#addUser").css("display", "flex");
+	loadUsersToDropdown(id);
 }
 
-function showRemoveUserPopup() {
+function showRemoveUserPopup(id) {
 	$("#removeUser").css("display", "flex");
-	loadUsersToDropdown();
+	loadUsersToDropdown(id);
 }
 
 function showCreateClassPopup() {
@@ -1155,7 +1156,7 @@ function checkIfPopupIsOpen() {
 	}
 	return false;
 }
-function loadUsersToDropdown() {
+function loadUsersToDropdown(id) {
 	$.ajax({
 		url: 'accessedservice.php',
 		type: 'POST',
@@ -1169,7 +1170,7 @@ function loadUsersToDropdown() {
 				let user = responseData.users[i];
 				filteredUsers.push(user);
 			}
-			let dropdownList = document.getElementById("users_dropdown_remove");
+			let dropdownList = document.getElementById(id);
 			filteredUsers.forEach(user => {
 				let option = document.createElement("option");
 				option.value = user.username;

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -136,7 +136,7 @@ function hideRemoveUserPopup() {
 //-------------==========########## Commands ##########==========-------------
 //----------------------------------------------------------------------------
 function addUserToCourse() {
-	let input = document.getElementById('addUsername').value;
+	let input = document.getElementById('addUsernameAdd').value;
 	let term = $("#addTermAdd").val();
 	$.ajax({
 		type: 'POST',
@@ -163,6 +163,32 @@ function addUserToCourse() {
 		}
 	});
 	hideAddUserPopup();
+}
+function removeUserFromCourse() {
+	let input = document.getElementById('addUsernameRemove').value;
+	$.ajax({
+		type: 'POST',
+		url: 'accessedservice.php',
+		data: {
+			opt: 'RETRIEVE',
+			action: 'USER',
+			username: input
+		},
+		success: function(response) {
+			userJson = response.substring(0, response.indexOf('{"entries":'));
+			let responseData = JSON.parse(userJson);
+			let uid = responseData.user[0].uid;
+			AJAXService("DELETE", {
+				courseid: querystring['courseid'],
+				uid: uid,
+				action: 'COURSE'
+			}, "ACCESS");
+		},
+		error: function(xhr, status, error) {
+			console.error("Error", error);
+		}
+	});
+	hideRemoveUserPopup();
 }
 function addSingleUser() {
 

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -100,6 +100,7 @@ function showAddUserPopup() {
 
 function showRemoveUserPopup() {
 	$("#removeUser").css("display", "flex");
+	loadUsersToDropdown();
 }
 
 function showCreateClassPopup() {
@@ -1120,7 +1121,7 @@ function loadUsersToDropdown() {
 			let dropdownList = document.getElementById("users_dropdown2");
 			filteredUsers.forEach(user => {
 				let option = document.createElement("option");
-				option.text = user.username;
+				option.value = user.username;
 				dropdownList.appendChild(option);
 			});
 		},

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -137,7 +137,7 @@ function hideRemoveUserPopup() {
 //----------------------------------------------------------------------------
 function addUserToCourse() {
 	let input = document.getElementById('addUsername').value;
-	let term = $("#addTermUsr").val();
+	let term = $("#addTermAdd").val();
 	$.ajax({
 		type: 'POST',
 		url: 'accessedservice.php',

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -287,10 +287,10 @@ function validateTerm(term) {
 	return null; //the provided term is correct
 }
 
-function tooltipTerm() {
-	let error = validateTerm(document.getElementById('addTerm').value);
-	let termInputBox = document.getElementById('addTerm');
-	let term = document.getElementById('addTerm').value;
+function tooltipTerm(element) {
+	let error = validateTerm(element.value);
+	let termInputBox = element;
+	let term = element.value;
 
 	if(error && term.length > 0) {	// Error, fade in tooltip
 		document.getElementById('tooltipTerm').innerHTML = error;

--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -1169,7 +1169,7 @@ function loadUsersToDropdown() {
 				let user = responseData.users[i];
 				filteredUsers.push(user);
 			}
-			let dropdownList = document.getElementById("users_dropdown2");
+			let dropdownList = document.getElementById("users_dropdown_remove");
 			filteredUsers.forEach(user => {
 				let option = document.createElement("option");
 				option.value = user.username;

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -136,7 +136,7 @@
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
 						<input type="text" name="product" list="users_dropdown" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
-						<datalist id="users_dropdown">
+						<datalist id="users_dropdown1">
 							<option value="User 1"></option>
 							<option value="User 2"></option>
 							<option value="User 3"></option>
@@ -163,7 +163,7 @@
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
 						<input type="text" name="product" list="users_dropdown" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
-						<datalist id="users_dropdown">
+						<datalist id="users_dropdown2">
 							<option value="User 1"></option>
 							<option value="User 2"></option>
 							<option value="User 3"></option>

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -185,12 +185,12 @@
 	<div class="fixed-action-button extra-margin" id="fabButtonAcc">
 		<a class="btn-floating fab-btn-lg noselect" id="fabBtn">+</a>
 		<ol class="fab-btn-list" style="margin: 0; padding: 0; display: none;" reversed>
-			<li onclick="showRemoveUserPopup();">
+			<li onclick="showRemoveUserPopup('users_dropdown_remove');">
 				<a id="cFabBtn" class="btn-floating fab-btn-sm scale-transition scale-out" data-tooltip='Remove user'>
 					<img class="fab-icon" src="../Shared/icons/remove_user_icon.svg">
 				</a>
 			</li>
-			<li onclick="showAddUserPopup();">
+			<li onclick="showAddUserPopup('users_dropdown_add');">
 				<a id="cFabBtn" class="btn-floating fab-btn-sm scale-transition scale-out" data-tooltip='Add user'>
 					<img class="fab-icon" src="../Shared/icons/createUser.svg">
 				</a>

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -84,7 +84,7 @@
 					<div class='flexwrapper'>
 						<span>Term:</span>
 						<div class="tooltipDugga"><span id="tooltipTerm" style="display: none;" class="tooltipDuggatext">  </span></div>
-						<input placeholder="HT-11" class='textinput' id='addTerm' onchange="tooltipTerm()" onkeyup="tooltipTerm()">
+						<input placeholder="HT-11" class='textinput' id='addTerm' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
 					</div>
 					<div class='flexwrapper'>
 						<span>Email:</span>
@@ -135,12 +135,14 @@
 					<div class='flexwrapper'>
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
-						<input type="text" name="product" list="users_dropdown" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<input type="text" name="product" list="users_dropdown2" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
 						<datalist id="users_dropdown1">
-							<option value="User 1"></option>
-							<option value="User 2"></option>
-							<option value="User 3"></option>
 						</datalist>
+					</div>
+					<div class='flexwrapper'>
+						<span>Term:</span>
+						<div class="tooltipDugga"><span id="tooltipTerm" style="display: none;" class="tooltipDuggatext">  </span></div>
+						<input placeholder="HT-11" class='textinput' id='addTerm' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
 					</div>
 					<div class="flex-end">
 						<input class='submit-button' type='button' value='Save' onclick='addSingleUser();' />
@@ -162,12 +164,13 @@
 					<div class='flexwrapper'>
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
-						<input type="text" name="product" list="users_dropdown" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
-						<datalist id="users_dropdown2">
-							<option value="User 1"></option>
-							<option value="User 2"></option>
-							<option value="User 3"></option>
-						</datalist>
+						<input type="text" name="product" list="users_dropdown2" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<datalist id="users_dropdown2"></datalist>
+					</div>
+					<div class='flexwrapper'>
+						<span>Term:</span>
+						<div class="tooltipDugga"><span id="tooltipTerm" style="display: none;" class="tooltipDuggatext">  </span></div>
+						<input placeholder="HT-11" class='textinput' id='addTerm' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
 					</div>
 					<div class="flex-end">
 						<input class='submit-button' type='button' value='Save' onclick='addSingleUser();' />

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -135,7 +135,7 @@
 					<div class='flexwrapper'>
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
-						<input type="text" name="product" list="users_dropdown_add" class='textinput' type='text' id='addUsername' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<input type="text" name="product" list="users_dropdown_add" class='textinput' type='text' id='addUsernameAdd' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
 						<datalist id="users_dropdown_add">
 						</datalist>
 					</div>
@@ -164,7 +164,7 @@
 					<div class='flexwrapper'>
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
-						<input type="text" name="product" list="users_dropdown_remove" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<input type="text" name="product" list="users_dropdown_remove" class='textinput' type='text' id='addUsernameRemove' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
 						<datalist id="users_dropdown_remove"></datalist>
 					</div>
 					<div class='flexwrapper'>
@@ -173,7 +173,7 @@
 						<input placeholder="HT-11" class='textinput' id='addTermRemove' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
 					</div>
 					<div class="flex-end">
-						<input class='submit-button' type='button' value='Save' onclick='addSingleUser();' />
+						<input class='submit-button' type='button' value='Save' onclick='removeUserFromCourse();' />
 					</div>
 				</div>
       		</div>

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -135,7 +135,7 @@
 					<div class='flexwrapper'>
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
-						<input type="text" name="product" list="users_dropdown_add" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<input type="text" name="product" list="users_dropdown_add" class='textinput' type='text' id='addUsername' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
 						<datalist id="users_dropdown_add">
 						</datalist>
 					</div>
@@ -145,7 +145,7 @@
 						<input placeholder="HT-11" class='textinput' id='addTermAdd' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
 					</div>
 					<div class="flex-end">
-						<input class='submit-button' type='button' value='Save' onclick='addSingleUser();' />
+						<input class='submit-button' type='button' value='Save' onclick='addUserToCourse();' />
 					</div>
 				</div>
       		</div>

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -142,7 +142,7 @@
 					<div class='flexwrapper'>
 						<span>Term:</span>
 						<div class="tooltipDugga"><span id="tooltipTerm" style="display: none;" class="tooltipDuggatext">  </span></div>
-						<input placeholder="HT-11" class='textinput' id='addTerm' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
+						<input placeholder="HT-11" class='textinput' id='addTermAdd' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
 					</div>
 					<div class="flex-end">
 						<input class='submit-button' type='button' value='Save' onclick='addSingleUser();' />
@@ -170,7 +170,7 @@
 					<div class='flexwrapper'>
 						<span>Term:</span>
 						<div class="tooltipDugga"><span id="tooltipTerm" style="display: none;" class="tooltipDuggatext">  </span></div>
-						<input placeholder="HT-11" class='textinput' id='addTerm' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
+						<input placeholder="HT-11" class='textinput' id='addTermRemove' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
 					</div>
 					<div class="flex-end">
 						<input class='submit-button' type='button' value='Save' onclick='addSingleUser();' />

--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -135,8 +135,8 @@
 					<div class='flexwrapper'>
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
-						<input type="text" name="product" list="users_dropdown2" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
-						<datalist id="users_dropdown1">
+						<input type="text" name="product" list="users_dropdown_add" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<datalist id="users_dropdown_add">
 						</datalist>
 					</div>
 					<div class='flexwrapper'>
@@ -164,8 +164,8 @@
 					<div class='flexwrapper'>
 						<span>Choose user:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
-						<input type="text" name="product" list="users_dropdown2" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
-						<datalist id="users_dropdown2"></datalist>
+						<input type="text" name="product" list="users_dropdown_remove" class='textinput' type='text' id='addFirstname' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<datalist id="users_dropdown_remove"></datalist>
 					</div>
 					<div class='flexwrapper'>
 						<span>Term:</span>

--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -338,7 +338,7 @@ if(checklogin() && $hasAccess) {
 			$query->bindParam(':uid', $uid);
 			$query->bindParam(':cid', $cid);
 			try {
-				if(!$stmt->execute()) {
+				if(!$query->execute()) {
 					$error=$stmt->errorInfo();
 					$debug.="Error deleting user from course: ".$error[2];
 				}

--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -332,6 +332,21 @@ if(checklogin() && $hasAccess) {
 
 			}
 		}
+	} else if (strcmp($opt, "DELETE") == 0) {
+		if ($action === "COURSE") {
+			$query = $pdo->prepare("DELETE FROM user_course WHERE uid=:uid AND cid=:cid;");
+			$query->bindParam(':uid', $uid);
+			$query->bindParam(':cid', $cid);
+			try {
+				if(!$stmt->execute()) {
+					$error=$stmt->errorInfo();
+					$debug.="Error deleting user from course: ".$error[2];
+				}
+			}catch(Exception $e) {
+				$debug.="Error deleting user from course: ".$e->getMessage();
+
+			}
+		}
 	}
 }
 

--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -312,6 +312,26 @@ if(checklogin() && $hasAccess) {
 				echo json_encode($response);
 			}
 		}
+	} else if (strcmp($opt, "USERTOTABLE") == 0) {
+		if ($action === "COURSE") {
+			$stmt = $pdo->prepare("INSERT INTO user_course (uid, cid, access,term,creator,vers,vershistory) VALUES(:uid, :cid,'R',:term,:creator,:vers,'') ON DUPLICATE KEY UPDATE vers=:avers, vershistory=CONCAT(vershistory, CONCAT(:bvers,','))");
+			$stmt->bindParam(':uid', $uid);
+			$stmt->bindParam(':cid', $cid);
+			$stmt->bindParam(':term', $term);
+			$stmt->bindParam(':creator', $userid);
+			$stmt->bindParam(':vers', $coursevers);
+			$stmt->bindParam(':avers', $coursevers);
+			$stmt->bindParam(':bvers', $coursevers);
+			try {
+				if(!$stmt->execute()) {
+					$error=$stmt->errorInfo();
+					$debug.="Error connecting user to course: ".$error[2];
+				}
+			}catch(Exception $e) {
+				$debug.="Error connecting user to course: ".$e->getMessage();
+
+			}
+		}
 	}
 }
 

--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -28,6 +28,8 @@ $className = getOP('className');
 $username = getOP('username');
 $addedtime = getOP('addedtime');
 $val = getOP('val');
+$action = getOP('action');
+$term = getOP('term');
 $newusers = getOP('newusers');
 $newclass = getOP('newclass');
 $coursevers = getOP('coursevers');
@@ -285,9 +287,33 @@ if(checklogin() && $hasAccess) {
 				}
         	}
 		} // End of foreach user
-	} // End ADD_USER
+		//End of ADDUSR
+	} else if (strcmp($opt,"RETRIEVE")==0) {
+		if ($action === "USERS") {
+			$query = $pdo->prepare("SELECT uid, username FROM user");
+			if ($query->execute()) {
+				$users = $query->fetchAll(PDO::FETCH_ASSOC);
+				$response = array("success" => true, "users" => $users);
+				echo json_encode($response);
+			} else {
+				$response = array("success" => false, "message" => "Failed to fetch users.");
+				echo json_encode($response);
+			}
+		}
+		if ($action === "USER") {
+			$query = $pdo->prepare("SELECT * FROM user WHERE username=:username;");
+			$query->bindParam(':username', $username);
+			if ($query->execute()) {
+				$user = $query->fetchAll(PDO::FETCH_ASSOC);
+				$response = array("success" => true, "user" => $user);
+				echo json_encode($response);
+			} else {
+				$response = array("success" => false, "message" => "Failed to fetch user.");
+				echo json_encode($response);
+			}
+		}
+	}
 }
-
 
 //------------------------------------------------------------------------------------------------
 // Retrieve Information


### PR DESCRIPTION
Whats done:
- Dropdown list in both Remove user and add user is filled with all users.
- Add User now adds a user to the course without having to create one again. 
- Remove User now removes selected user from that course.
- Changed so readaccess users is seen is the list and not just teachers.
- Dynamic tooltipTerm for input validation.

For some reason the Term element has to be in Remove User popup. I dont know why but when its removed the dropdown options are not shown. Will look into this

Todo in future issues:

- Add Classes?
- Add Groups?
- Maybe update Term value if user already exists in course while trying to Add User.

Testing:
All users should show in both dropdown lists (Add User and Remove User)

Try adding any user into any course. Then reload the page and it should show up as a list entry.

Try removing a user from a course. It should disappear from the list entries