### PR TITLE
IE Inheritance ghost element appears under the object

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -58,7 +58,9 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.IERelation:
             divContent = drawElementIERelation(element, boxw, boxh, linew);
             cssClass = 'ie-element';
-            style = `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:1;`;
+            style = element.name == "Inheritance" ?
+             `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:2;` :
+             `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:1;`;
             break;
         case elementTypesNames.UMLInitialState:
             let initVec = `


### PR DESCRIPTION
Implemented a CSS styling to fix the issue where the Inheritance ghost element was appearing underneath other objects. By adding a z-index of 2 to the "Inheritance" element, it now correctly appears above other elements.