### PR TITLE
Elements now correctly fade in and out.

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -756,6 +756,7 @@ function elementIsValid(element) {
 			$(messageElement).fadeOut();
 			element.classList.add("color-change-neutral");
     		element.classList.remove("color-change-invalid");
+			element.classList.remove("color-change-valid");
 			return true; // Optional fields
 		}
 	}

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -746,23 +746,25 @@ function elementIsValid(element) {
 	// Stop any ongoing animations
 	$(messageElement).stop(true, true);
 
-	// Reset initial validation styling and messages
-	element.classList.remove("bg-color-change-invalid");
-	$(messageElement).fadeOut();
+	//Remove neutral tag when element is assesed.
+	element.classList.remove("color-change-neutral");
 
 	// Handle empty input for optional fields
 	if (element.value.trim() === "") {
 		element.removeAttribute("style");
 		if (element.name === "githubToken" || element.name === "courseGitURL") {
+			$(messageElement).fadeOut();
+			element.classList.add("color-change-neutral");
+    		element.classList.remove("color-change-invalid");
 			return true; // Optional fields
 		}
 	}
 
 	// Check against regex and handle special cases
 	if (!element.value.match(regex[element.name])) {
-		element.classList.add("bg-color-change-invalid");
-		element.style.borderColor = "#E54";
 		$(messageElement).fadeIn();
+		element.classList.add("color-change-invalid");
+		element.classList.remove("color-change-valid");
 		if (element.name === "githubToken") {
 			messageElement.innerHTML = "A GitHub key should be 40 characters";
 		} else if (element.name === "coursecode") {
@@ -777,7 +779,9 @@ function elementIsValid(element) {
 	}
 
 	// If the input passes validation
-	element.style.borderColor = "#383";
+	$(messageElement).fadeOut();
+	element.classList.add("color-change-valid");
+    element.classList.remove("color-change-invalid");
 	return true;
 }
 

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -746,7 +746,7 @@ function elementIsValid(element) {
 	// Stop any ongoing animations
 	$(messageElement).stop(true, true);
 
-	//Remove neutral tag when element is assesed.
+	//Remove neutral tag when element is assessed.
 	element.classList.remove("color-change-neutral");
 
 	// Handle empty input for optional fields

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2754,6 +2754,11 @@ label.login-label {
   border-width: 2px;
 }
 
+.color-change-neutral{
+  border-color: var(--color-border-2);
+  border-width: 2px;
+}
+
 input.option {
   float: left;
 }


### PR DESCRIPTION
`$(messageElement).stop(true, true);` does not exist in other form validations and seems to be very useful in stopping spam causing repeat fade-ins and -outs

Affected forms: Edit Course and New Course in courseed.php (quickValidateForm in courseed.js)

Extra:
* Added an neutral class for when optional fields are empty.

Note that the save button does not get disabled due to it currently being dynamic.
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/1cd715bd-84a4-42af-b3ae-22ebcb01de21)