### PR TITLE
DeleteButton scales with size and zoomfact

### DIFF
--- a/DuggaSys/diagram/draw/selection.js
+++ b/DuggaSys/diagram/draw/selection.js
@@ -11,118 +11,51 @@ function drawSelectionBox() {
     if (((context.length != 0 || contextLine.length != 0) && mouseMode != mouseModes.EDGE_CREATION) ||
         (mouseMode == mouseModes.EDGE_CREATION && context.length == 0 && contextLine.length != 0)
     ) {
-        var lowX, highX, lineLowX, lineHighX, x1, x2, lowY, highY, lineLowY, lineHighY, y1, y2;
-        if (context.length != 0) {
-            lowX = context[0].x1;
-            highX = context[0].x2;
-            lowY = context[0].y1;
-            highY = context[0].y2;
-            for (let i = 0; i < context.length; i++) {
-                x1 = context[i].x1;
-                x2 = context[i].x2;
-                y1 = context[i].y1;
-                y2 = context[i].y2;
-                if (x1 < lowX) lowX = x1;
-                if (x2 > highX) highX = x2;
-                if (y1 < lowY) lowY = y1;
-                if (y2 > highY) highY = y2;
-            }
-        }
+        var lowX, highX, lowY, highY;
+        // Calculate the bounding coordinates
+        // Initially set to very large/small values
+        lowX = lowY = Number.POSITIVE_INFINITY;
+        highX = highY = Number.NEGATIVE_INFINITY;
 
-        var tempLines = [];
-        if (contextLine.length > 0) {
-            for (let i = 0; i < contextLine.length; i++) {
-                if (contextLine[i] && contextLine[i].kind !== undefined) {
-                    if (contextLine[i].kind === lineKind.DOUBLE) {
-                        tempLines.push(document.getElementById(contextLine[i].id + "-1"));
-                        tempLines.push(document.getElementById(contextLine[i].id + "-2"));
-                    } else {
-                        tempLines.push(document.getElementById(contextLine[i].id));
-                    }
-                }
-            }
-            var tempX1, tempX2, tempY1, tempY2;
-            var hasPoints = tempLines[0].getAttribute('points'); // Polyline
-            if (hasPoints != null) {
-                var points = hasPoints.split(' ');
-                // Find highest and lowest x and y coordinates of the first element in lines
-                tempX1 = points[0].split(',')[0];
-                tempX2 = points[3].split(',')[0];
-                tempY1 = points[0].split(',')[1];
-                tempY2 = points[3].split(',')[1];
-            } else {
-                // Find highest and lowest x and y coordinates of the first element in lines
-                tempX1 = tempLines[0].getAttribute("x1");
-                tempX2 = tempLines[0].getAttribute("x2");
-                tempY1 = tempLines[0].getAttribute("y1");
-                tempY2 = tempLines[0].getAttribute("y2");
-            }
-            lineLowX = Math.min(tempX1, tempX2);
-            lineHighX = Math.max(tempX1, tempX2);
-            lineLowY = Math.min(tempY1, tempY2);
-            lineHighY = Math.max(tempY1, tempY2);
+        // Loop through all elements and lines to calculate the bounding box
+        context.forEach(item => {
+            lowX = Math.min(lowX, item.x1);
+            highX = Math.max(highX, item.x2);
+            lowY = Math.min(lowY, item.y1);
+            highY = Math.max(highY, item.y2);
+        });
+        contextLine.forEach(line => {
+            var points = document.getElementById(line.id).getAttribute('points').split(' ');
+            points.forEach(point => {
+                var [x, y] = point.split(',').map(Number);
+                lowX = Math.min(lowX, x);
+                highX = Math.max(highX, x);
+                lowY = Math.min(lowY, y);
+                highY = Math.max(highY, y);
+            });
+        });
 
-            // Loop through all selected lines and find highest and lowest x and y coordinates
-            for (let i = 0; i < tempLines.length; i++) {
-                var hasPoints = tempLines[i].getAttribute('points'); // Polyline
-                if (hasPoints != null) {
-                    var points = hasPoints.split(' ');
-                    // Find highest and lowest x and y coordinates of the first element in lines
-                    tempX1 = points[0].split(',')[0];
-                    tempX2 = points[3].split(',')[0];
-                    tempY1 = points[0].split(',')[1];
-                    tempY2 = points[3].split(',')[1];
-                } else {
-                    // Find highest and lowest x and y coordinates of the first element in lines
-                    tempX1 = tempLines[i].getAttribute("x1");
-                    tempX2 = tempLines[i].getAttribute("x2");
-                    tempY1 = tempLines[i].getAttribute("y1");
-                    tempY2 = tempLines[i].getAttribute("y2");
-                }
-                x1 = Math.min(tempX1, tempX2);
-                x2 = Math.max(tempX1, tempX2);
-                y1 = Math.min(tempY1, tempY2);
-                y2 = Math.max(tempY1, tempY2);
-                if (x1 < lineLowX) lineLowX = x1;
-                if (x2 > lineHighX) lineHighX = x2;
-                if (y1 < lineLowY) lineLowY = y1;
-                if (y2 > lineHighY) lineHighY = y2;
-            }
-            // Compare between elements and lines to find lowest and highest x and y coordinates
-            lowX = (lowX < lineLowX) ? lowX : lineLowX;
-            highX = (highX > lineHighX) ? highX : lineHighX;
-            lowY = (lowY < lineLowY) ? lowY : lineLowY;
-            highY = (highY > lineHighY) ? highY : lineHighY;
-        }
-        // Global variables used to determine if mouse was clicked within selection box
-        selectionBoxLowX = lowX - 5;
-        selectionBoxHighX = highX + 5;
-        selectionBoxLowY = lowY - 5;
-        selectionBoxHighY = highY + 5;
+        // Apply a margin around the selection box
+        var margin = 5;
+        lowX -= margin;
+        highX += margin;
+        lowY -= margin;
+        highY += margin;
 
-        // Selection container of selected elements
-        str += `<rect width='${highX - lowX + 10}' height='${highY - lowY + 10}' x= '${lowX - 5}' y='${lowY - 5}' style="fill:transparent; stroke-width:1.5; stroke:${color.SELECTED};" />`;
+        // Draw the selection box
+        str += `<rect width='${highX - lowX}' height='${highY - lowY}' x='${lowX}' y='${lowY}' style="fill:transparent; stroke-width:1.5; stroke:${color.SELECTED};" />`;
 
-        //Determine size and position of delete button
-        if (highX - lowX + 10 > highY - lowY + 10) {
-            deleteBtnSize = (highY - lowY + 10) / 3;
-        } else {
-            deleteBtnSize = (highX - lowX + 10) / 3;
-        }
+        // Calculate delete button size by size and zoomfact
+        deleteBtnSize = Math.min(50, Math.max(15, ((highY - lowY) / 3 * zoomfact)));
 
-        if (deleteBtnSize > 20) {
-            deleteBtnSize = 20;
-        } else if (deleteBtnSize < 15) {
-            deleteBtnSize = 15;
-        }
+        // Place the delete button outside the top-right corner of the selection box
+        deleteBtnX = highX; 
+        deleteBtnY = lowY - deleteBtnSize;  
 
-        // Button possition
-        deleteBtnX = lowX - 5 + highX - lowX + 10 - (deleteBtnSize / 2);
-        deleteBtnY = lowY - 5 - (deleteBtnSize / 2);
-
-        //Delete button visual representation
-        str += `<line x1='${deleteBtnX + 2}' y1='${deleteBtnY + 2}' x2='${deleteBtnX + deleteBtnSize - 2}' y2='${deleteBtnY + deleteBtnSize - 2}' class= "BlackthemeColor"/>`;
-        str += `<line x1='${deleteBtnX + 2}' y1='${deleteBtnY + deleteBtnSize - 2}' x2='${deleteBtnX + deleteBtnSize - 2}' y2='${deleteBtnY + 2}' class= "BlackthemeColor"/>`;
+        // Draw delete button lines
+        str += `<line x1='${deleteBtnX}' y1='${deleteBtnY}' x2='${deleteBtnX + deleteBtnSize}' y2='${deleteBtnY + deleteBtnSize}' style="stroke:black; stroke-width:3"/>`;
+        str += `<line x1='${deleteBtnX}' y1='${deleteBtnY + deleteBtnSize}' x2='${deleteBtnX + deleteBtnSize}' y2='${deleteBtnY}' style="stroke:black; stroke-width:3"/>`;
     }
     return str;
 }
+

--- a/DuggaSys/diagram/draw/selection.js
+++ b/DuggaSys/diagram/draw/selection.js
@@ -46,7 +46,7 @@ function drawSelectionBox() {
         str += `<rect width='${highX - lowX}' height='${highY - lowY}' x='${lowX}' y='${lowY}' style="fill:transparent; stroke-width:1.5; stroke:${color.SELECTED};" />`;
 
         // Calculate delete button size by size and zoomfact
-        deleteBtnSize = Math.min(50, Math.max(15, ((highY - lowY) / 3 * zoomfact)));
+        deleteBtnSize = Math.min(40, Math.max(15, ((highY - lowY) / 5 * zoomfact)));
 
         // Place the delete button outside the top-right corner of the selection box
         deleteBtnX = highX; 


### PR DESCRIPTION
The deleteButton now scales with the size of the element and the zoomfact but with a max-size of 50 and a min-size of 15 (when zoomed out it becomes to small otherwise). i also placed the deletebutton just outside the edge of the bounding box instead of over it so it doesn't overlapp with the upper-right node that would sometimes result in deleting an element instead of resizing it.
Also made the code for calculating the bounding box shorter and more effective and hopefully made the code (just a bit) easier to read.