### PR TITLE
G2 2024 v6 issue#15184

### DIFF
--- a/DuggaSys/microservices/sharedMicroservices/getUid_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/getUid_ms.php
@@ -2,7 +2,6 @@
 date_default_timezone_set("Europe/Stockholm");
 
 // Include basic application services
-include_once "../../../Shared/coursesyspw.php";
 include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
 

--- a/DuggaSys/tests/microservices/codeviewerService/editBoxTitle_ms_test.php
+++ b/DuggaSys/tests/microservices/codeviewerService/editBoxTitle_ms_test.php
@@ -3,15 +3,16 @@
 include_once "../../../../Shared/test.php";
 
 $testsData = array(
-    'deleteCodeExample' => array(
-        'expected-output' => '{poopopoo}',
+    'editBoxTitle_ms' => array(
+        'expected-output' => '{"box":[["99","BOXCONTENT","File: testing.php not found.","2","newTitle","testing.php","12",null,null]]}',
         'query-before-test-1' => "INSERT INTO codeexample (exampleid,cid,uid) VALUES (9997,1885,101);",
-        'query-before-test-2' => "INSERT INTO box (boxid,boxtitle,exampleid) VALUES (99,'oldTitle',9997);",
+        'query-before-test-2' => "INSERT INTO box (boxid,boxtitle,exampleid, boxcontent, filename, wordlistid, segment, fontsize) VALUES (99,'oldTitle',9997,'boxcontent','testing.php',2,2,12);",
         'query-after-test-1' => "DELETE FROM box WHERE boxid = 99;",
         'query-after-test-2' => "DELETE FROM codeexample WHERE exampleid = 9997;",
         'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php',
         'service-data' => serialize(
             array(
+                // Data that service needs to execute function
                 'username' => 'brom',
                 'password' => 'password', 
                 'opt' => 'EDITTITLE',
@@ -22,7 +23,8 @@ $testsData = array(
         ),
         'filter-output' => serialize(
             array(
-                'none'
+                // Filter what output to use in assert test, use none to use all ouput from service
+                'box',
             )
         ),
     ),

--- a/DuggaSys/tests/microservices/codeviewerService/editBoxTitle_ms_test.php
+++ b/DuggaSys/tests/microservices/codeviewerService/editBoxTitle_ms_test.php
@@ -1,0 +1,31 @@
+<?php
+
+include_once "../../../../Shared/test.php";
+
+$testsData = array(
+    'deleteCodeExample' => array(
+        'expected-output' => '{poopopoo}',
+        'query-before-test-1' => "INSERT INTO codeexample (exampleid,cid,uid) VALUES (9997,1885,101);",
+        'query-before-test-2' => "INSERT INTO box (boxid,boxtitle,exampleid) VALUES (99,'oldTitle',9997);",
+        'query-after-test-1' => "DELETE FROM box WHERE boxid = 99;",
+        'query-after-test-2' => "DELETE FROM codeexample WHERE exampleid = 9997;",
+        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/codeviewerService/editBoxTitle_ms.php',
+        'service-data' => serialize(
+            array(
+                'username' => 'brom',
+                'password' => 'password', 
+                'opt' => 'EDITTITLE',
+                'exampleid' => '9997', 
+                'boxid' => '99',
+                'boxtitle' => 'newTitle' 
+            )
+        ),
+        'filter-output' => serialize(
+            array(
+                'none'
+            )
+        ),
+    ),
+);
+
+testHandler($testsData, true); // 2nd argument (prettyPrint): true = pretty print (HTML), false = raw JSON


### PR DESCRIPTION
editBoxTitle_ms_test.php has been created.

I had to delete the line: ```include_once "../../../Shared/coursesyspw.php";``` from getUid_ms.php because it was causing errors, breaking the microservice. I can't see any place where the include is actually being used in getUid though so I don't think it should cause any problems deleting it. 

I had some other issues with the assert test failing even though the output and expected output were identical, I made it work by adding a bunch more values to the inserts, so there shouldn't be any problems now.