### PR TITLE
Fix tooltip for "Edit section" form

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -285,7 +285,7 @@
 					<input onkeyup="quickValidateForm('editSection', 'saveBtn');" onchange="validateSectName('sectionname')" placeholder='Enter section name'  type='text' class='textinput' id='sectionname' value='sectionname' maxlength="64"/>
 				</div>
 				<div class="formDialog" style="display: block; margin-left:40px; top:-35px;">
-  		      		<span id="dialog10" class="formDialogText">Illegal characters found in the title!<br>Valid characters: A-Ö, 0-9.</span>
+  		      		<span id="dialog10" style="display: none; left: 0px;" class="formDialogText">Illegal characters found in the title!<br>Valid characters: A-Ö, 0-9.</span>
   		      	</div>
 				<div id='inputwrapper-type' class='inputwrapper'>
 					<span>Type:</span>
@@ -691,14 +691,14 @@
 						<div class='inputwrapper'>
 							<span>Name:</span>
 							<div class="formDialog">
-								<span id="fileNameError"  class="formDialogText">Please use letters and digits, only</span>
+								<span id="fileNameError" style="left: -100px;"  class="formDialogText">Please use letters and digits, only</span>
 							</div>
 							<input onkeyup="quickValidateForm('gitHubTemplate','saveCourse')" class='textinput validate' type='text' id='fileName' placeholder='Name.type' value=''/>
 						</div>
 						<div class='inputwrapper'>
 							<span>GithubUrl:</span>
 							<div class="formDialog">
-								<span id="gitHubError" class="formDialogText">Enter a valid github url</span>
+								<span id="gitHubError" style="left: -100px;" class="formDialogText">Enter a valid github url</span>
 							</div>
 							<input onkeyup="quickValidateForm('gitHubTemplate','saveCourse')" class='textinput validate' type='text' id='githubURL' placeholder='GitHubDownloadUrl' value=''/>
 						</div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -285,7 +285,7 @@
 					<input onkeyup="quickValidateForm('editSection', 'saveBtn');" onchange="validateSectName('sectionname')" placeholder='Enter section name'  type='text' class='textinput' id='sectionname' value='sectionname' maxlength="64"/>
 				</div>
 				<div class="formDialog" style="display: block; margin-left:40px; top:-35px;">
-  		      		<span id="dialog10" style="display: none; left:0px;" class="formDialogText">Illegal characters found in the title!<br>Valid characters: A-Ö, 0-9.</span>
+  		      		<span id="dialog10" class="formDialogText">Illegal characters found in the title!<br>Valid characters: A-Ö, 0-9.</span>
   		      	</div>
 				<div id='inputwrapper-type' class='inputwrapper'>
 					<span>Type:</span>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3080,6 +3080,11 @@ div.submit-button:disabled {
 
 /* Form Pointing Dialogs */
 
+#dialog10 {
+  display: none;
+  left: 100px;
+}
+
 .formDialog {
   position: relative;
   display: inline-block;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3080,15 +3080,9 @@ div.submit-button:disabled {
 
 /* Form Pointing Dialogs */
 
-#dialog10 {
-  display: none;
-  left: 100px;
-}
-
 .formDialog {
   position: relative;
   display: inline-block;
-  left: -100px;
 }
 
 .formDialog .formDialogText {


### PR DESCRIPTION
removed the inline styling and put it in style.css. and because im not allowed to change the css using class selectors i added 100px on the id dialog10 instead.

Testing:

go into a course and press the cog wheel on a moment:
<img width="1098" alt="bild" src="https://github.com/HGustavs/LenaSYS/assets/129262677/0cc94dc3-11e9-4653-8d07-a5182d69b09e">

then add an "illegal" character in the Name inputfield:
<img width="1117" alt="bild" src="https://github.com/HGustavs/LenaSYS/assets/129262677/2cff4cfc-10cd-49f5-890d-26df38f23c58">
