### PR TITLE
Fixed deletion of duggor

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -647,10 +647,7 @@ function showSaveButton() {
 // Displaying and hidding the dynamic comfirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
 
-  // console.log("Clicked id" + active_lid)
-  // console.log("Selected IDs:" + selectedItemList)
   if (operation == "openConfirmBox") {
-    // console.log(collectedLid);
     active_lid = item ? $(item).parents('table').attr('value') : null;
     $("#sectionConfirmBox").css("display", "flex");
   } else if (operation == "openHideConfirmBox") {
@@ -666,10 +663,8 @@ function confirmBox(operation, item = null) {
     $('#close-item-button').focus();
   } else if (operation == "deleteItem") {
     if(!selectedItemList.includes(active_lid)){
-      selectedItemList.push(active_lid); // Push clicked item to selectedItemList before it's items are deleted
+      selectedItemList.push(active_lid); // Push clicked item to selectedItemList before its items are deleted
     }
-    // console.log("Clicked id" + active_lid)
-    // console.log("Selected IDs:" + selectedItemList)
     deleteItem(selectedItemList);
     $("#sectionConfirmBox").css("display", "none");
   } else if (operation == "hideItem" && !selectedItemList.length == 0) {
@@ -755,11 +750,10 @@ function markedItems(item = null) {
         }
       } else if (tempItem == active_lid) sectionStart = true;
     });
-
   }
 
-
   console.log("Active lid: " + active_lid);
+  
   if (selectedItemList.length != 0) {
     for (let i = 0; i < selectedItemList.length; i++) {
       if (selectedItemList[i] === active_lid) {
@@ -772,7 +766,6 @@ function markedItems(item = null) {
         if (selectedItemList[i] === subItems[j]) {
           $("#" + selectedItemList[i] + "-checkbox").prop("checked", false);
           selectedItemList.splice(i, 1);
-          //console.log(subItems[j]+" Removed from list");
         }
       }
     } if (removed != true) {
@@ -984,6 +977,7 @@ function deleteItem(selectedItemList) {
   delTimer = setTimeout(() => {
     deleteAll();
   }, undoTime * 1000);
+  
 }
 
 // Permanently delete elements.

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -991,9 +991,9 @@ function deleteItem(selectedItemList) {
 
 // Permanently delete elements.
 function deleteAll() {
-  for (var i = delArr.length - 1; i >= 0; --i) {
-    AJAXService("DELETE", {
-      lid: delArr.pop()
+  for (var i = selectedItemList.length - 1; i >= 0; --i) {
+    AJAXService("DEL", {
+      lid: selectedItemList.pop()
     }, "SECTION");
   }
   $("#editSection").css("display", "none");

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -646,7 +646,11 @@ function showSaveButton() {
 
 // Displaying and hidding the dynamic comfirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
+
+  // console.log("Clicked id" + active_lid)
+  // console.log("Selected IDs:" + selectedItemList)
   if (operation == "openConfirmBox") {
+    // console.log(collectedLid);
     active_lid = item ? $(item).parents('table').attr('value') : null;
     $("#sectionConfirmBox").css("display", "flex");
   } else if (operation == "openHideConfirmBox") {
@@ -661,6 +665,11 @@ function confirmBox(operation, item = null) {
     $("#sectionShowConfirmBox").css("display", "flex");
     $('#close-item-button').focus();
   } else if (operation == "deleteItem") {
+    if(!selectedItemList.includes(active_lid)){
+      selectedItemList.push(active_lid); // Push clicked item to selectedItemList before it's items are deleted
+    }
+    // console.log("Clicked id" + active_lid)
+    // console.log("Selected IDs:" + selectedItemList)
     deleteItem(selectedItemList);
     $("#sectionConfirmBox").css("display", "none");
   } else if (operation == "hideItem" && !selectedItemList.length == 0) {
@@ -956,23 +965,28 @@ function prepareItem() {
 // deleteItem: Deletes Item from Section List
 //----------------------------------------------------------------------------------
 
-function deleteItem(item_lid = []) {
-  for (var i = 0; i < item_lid.length; i++) {
-    lid = item_lid ? item_lid : $("#lid").val();
-    item = document.getElementById("lid" + lid[i]);
-    item.style.display = "none";
-    item.classList.add("deleted");
-  
-    document.querySelector("#undoButton").style.display = "block";
-  }
+function deleteItem(selectedItemList) {
+  // lid = item_lid ? item_lid : $("#lid").val();
+  // item = document.getElementById("lid" + lid);
+  // console.log(item);
 
-  toast("undo", "Undo deletion?", 15, "cancelDelete();");
-  // Makes deletefunction sleep for 60 sec so it is possible to undo an accidental deletion
+  for(id of selectedItemList) {
+    let row = document.getElementById(`I${id}`).parentNode;
+    console.log(row);
+    row.style.display = "none";
+    row.classList.add("deleted");
+  }
+  
+  // Makes deletefunction sleep for the amount of time toast is active(value of undoTime).
+  let undoTime = 5;
+
+  document.querySelector("#undoButton").style.display = "block";
+  toast("undo", "Undo deletion?", undoTime, "cancelDelete();");
   delArr.push(lid);
   clearTimeout(delTimer);
   delTimer = setTimeout(() => {
     deleteAll();
-  }, 60);
+  }, undoTime * 1000);
 }
 
 // Permanently delete elements.

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -966,13 +966,10 @@ function prepareItem() {
 //----------------------------------------------------------------------------------
 
 function deleteItem(selectedItemList) {
-  // lid = item_lid ? item_lid : $("#lid").val();
-  // item = document.getElementById("lid" + lid);
-  // console.log(item);
 
   for(id of selectedItemList) {
     let row = document.getElementById(`I${id}`).parentNode;
-    console.log(row);
+    // console.log(row);
     row.style.display = "none";
     row.classList.add("deleted");
   }
@@ -991,7 +988,7 @@ function deleteItem(selectedItemList) {
 
 // Permanently delete elements.
 function deleteAll() {
-  for (var i = selectedItemList.length - 1; i >= 0; --i) {
+  for (let i = selectedItemList.length - 1; i >= 0; --i) {
     AJAXService("DEL", {
       lid: selectedItemList.pop()
     }, "SECTION");
@@ -1003,8 +1000,8 @@ function deleteAll() {
 // Cancel deletion
 function cancelDelete() {
   clearTimeout(delTimer);
-  var deletedElements = document.querySelectorAll(".deleted")
-  for (i = 0; i < deletedElements.length; i++) {
+  let deletedElements = document.querySelectorAll(".deleted")
+  for (let i = 0; i < deletedElements.length; i++) {
     deletedElements[i].classList.remove("deleted");
   }
   location.reload();
@@ -2064,15 +2061,6 @@ function returnedSection(data) {
 
     document.getElementById('Sectionlist').innerHTML += str;
     $("#newCourseVersion").css("display", "block");
-
-
-
-
-  }
-  
-  //Force elements that are deletet to not show up unless pressing undo delete or reloading the page
-  for(var i = 0; i < delArr.length; i++){
-    document.getElementById("lid"+delArr[i]).style.display="none";
   }
 
   // Reset checkboxes


### PR DESCRIPTION
**Co-commit with @d22isaka** 

We have now fixed the deletion of duggor. The selected duggas get added to the "selectedItemList" array, from which all items are deleted and hidden when a user click "yes" in the confirmation box.  This happens in "deleteItem()" and in "deleteAll()" functions. "Undo" still works as usual.

The only bug that still persist is that duggas come back if the page is refreshed while the "undo" toast is still active. At the moment we have not found a way to combat this issue.