### PR TITLE
Sequence Actor name disappearing when selected

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -511,12 +511,12 @@ function drawElementSequenceActor(element, textWidth, boxw, boxh, linew, texth) 
                         fill='${element.fill}'
                     />
                     <text 
-                        class='text' 
+                        class='nameLabel' 
                         x='${boxw / 2}' 
                         y='${boxw + texth / 2 + linew * 2}' 
                         dominant-baseline='middle' 
                         text-anchor='middle'
-                    > ${element.name} </text>
+                    >${element.name}</text>
                 </g>`;
     return drawSvg(boxw, boxh, content);
 }
@@ -573,6 +573,7 @@ function drawElementSequenceActivation(element, boxw, boxh, linew) {
 }
 
 function drawElementSequenceLoopOrAlt(element, boxw, boxh, linew, texth) {
+    
     let fontColor = (isDarkTheme()) ? color.WHITE : color.GREY;
     element.altOrLoop = (element.alternatives.length > 1) ? "Alt" : "Loop";
 
@@ -602,7 +603,7 @@ function drawElementSequenceLoopOrAlt(element, boxw, boxh, linew, texth) {
                         />`;
             content += drawText(linew * 2,
                 (boxh / element.alternatives.length) * i + texth / 1.5 + linew * 2,
-                'auto', element.alternatives[i], `fill='${fontColor}'`
+                'auto', element.alternatives[i], `fill='${fontColor.BLACK}'`
             );
         }
     }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2443,6 +2443,11 @@ label.login-label {
   font-size: 0.8em;
 }
 
+.nameLabel {
+  pointer-events: none;
+  fill: #000; /* Sets the text color */
+}
+
 .loginBox .submit {
   width: 80px;
   height: 25px;


### PR DESCRIPTION
The text element for the Sequence Actor name was given a class of 'text' and to ensure that the name remains visible even when several objects is selected, I changed the class of the text element to 'nameLabel'. Then added a CSS rule to ensure that the text color is set to black (#000) and won't change.