### PR TITLE
Fixed positioning of "New Item"-dropdown

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -186,17 +186,17 @@
 				<img src="../Shared/icons/desc_complement.svg" alt='Hide List Content' id="sectionList_arrowStatisticsClosed">
 			</div>
 			<div class='fixed-action-button2 sectioned2'  id="FABStatic2" style="display:none">
-				<input id='addElement'  type='button' value='+' style="margin-right:20px; top:-493px" class='submit-button-newitem' title='New Item' >
+				<input id='addElement'  type='button' value='+' style="margin-right:20px; top:-493px; position:fixed;" class='submit-button-newitem' title='New Item' >
 				<ol class='fab-btn-list2' style='display: block;'  reversed id='fabBtnList2'>
-							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Heading' onclick='createFABItem("0","New Heading","TOP");'><img alt='heading format icon' class='fab-icon' src='../Shared/icons/heading-icon.svg'></a></li>
-							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Section' onclick='createFABItem("1","New Section","TOP");'><img alt='section format icon' class='fab-icon' src='../Shared/icons/section-icon.svg'></a></li>
-							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Moment' onclick='createFABItem("4","New Moment","TOP");'><img alt='moment format icon' class='fab-icon' src='../Shared/icons/moment-icon.svg'></a></li>
-							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Test' onclick='createFABItem("3","New Test","TOP");'><img alt='test document icon' class='fab-icon' src='../Shared/icons/test-icon.svg'></a></li>
-							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out noselect centered-icon' tabindex='0' data-tooltip='Link' onclick='createFABItem("5","New Link","TOP");'><i alt='link chain icon' class='material-icons'>link</i></a></li>
-							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Code' onclick='createFABItem("2","New Code","TOP");'><img alt='code tag icon' class='fab-icon' src='../Shared/icons/code-icon.svg'></a></li>
-							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Group activity' onclick='createFABItem("6","New Group","TOP");'><img alt='multiple users icon' class='fab-icon' src='../Shared/icons/group-icon.svg'></a></li>
-							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out noselect' tabindex='0' data-tooltip='Message' onclick='createFABItem("7","New Quote","TOP");'><i alt='quotation mark icon' class='material-icons'>format_quote</i></a></li>
-					</ol>
+					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Heading' onclick='createFABItem("0","New Heading","TOP");'><img alt='heading format icon' class='fab-icon' src='../Shared/icons/heading-icon.svg'></a></li>
+					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Section' onclick='createFABItem("1","New Section","TOP");'><img alt='section format icon' class='fab-icon' src='../Shared/icons/section-icon.svg'></a></li>
+					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Moment' onclick='createFABItem("4","New Moment","TOP");'><img alt='moment format icon' class='fab-icon' src='../Shared/icons/moment-icon.svg'></a></li>
+					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Test' onclick='createFABItem("3","New Test","TOP");'><img alt='test document icon' class='fab-icon' src='../Shared/icons/test-icon.svg'></a></li>
+					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out noselect centered-icon' tabindex='0' data-tooltip='Link' onclick='createFABItem("5","New Link","TOP");'><i alt='link chain icon' class='material-icons'>link</i></a></li>
+					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Code' onclick='createFABItem("2","New Code","TOP");'><img alt='code tag icon' class='fab-icon' src='../Shared/icons/code-icon.svg'></a></li>
+					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Group activity' onclick='createFABItem("6","New Group","TOP");'><img alt='multiple users icon' class='fab-icon' src='../Shared/icons/group-icon.svg'></a></li>
+					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out noselect' tabindex='0' data-tooltip='Message' onclick='createFABItem("7","New Quote","TOP");'><i alt='quotation mark icon' class='material-icons'>format_quote</i></a></li>
+				</ol>
 			</div>
 			
 			<!-- Hide button -->

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -187,7 +187,7 @@
 			</div>
 			<div class='fixed-action-button2 sectioned2'  id="FABStatic2" style="display:none">
 				<input id='addElement'  type='button' value='+' style="margin-right:20px; top:-493px; position:fixed;" class='submit-button-newitem' title='New Item' >
-				<ol class='fab-btn-list2' style='display: block;'  reversed id='fabBtnList2'>
+				<ol class='fab-btn-list2' id='olFabBtnList2' style='display: block;'  reversed id='fabBtnList2'>
 					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Heading' onclick='createFABItem("0","New Heading","TOP");'><img alt='heading format icon' class='fab-icon' src='../Shared/icons/heading-icon.svg'></a></li>
 					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Section' onclick='createFABItem("1","New Section","TOP");'><img alt='section format icon' class='fab-icon' src='../Shared/icons/section-icon.svg'></a></li>
 					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Moment' onclick='createFABItem("4","New Moment","TOP");'><img alt='moment format icon' class='fab-icon' src='../Shared/icons/moment-icon.svg'></a></li>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -187,7 +187,7 @@
 			</div>
 			<div class='fixed-action-button2 sectioned2'  id="FABStatic2" style="display:none">
 				<input id='addElement'  type='button' value='+' style="margin-right:20px; top:-493px" class='submit-button-newitem' title='New Item' >
-				<ol class='fab-btn-list2' style='display: none;'  reversed id='fabBtnList2'>
+				<ol class='fab-btn-list2' style='display: block;'  reversed id='fabBtnList2'>
 							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Heading' onclick='createFABItem("0","New Heading","TOP");'><img alt='heading format icon' class='fab-icon' src='../Shared/icons/heading-icon.svg'></a></li>
 							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Section' onclick='createFABItem("1","New Section","TOP");'><img alt='section format icon' class='fab-icon' src='../Shared/icons/section-icon.svg'></a></li>
 							<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Moment' onclick='createFABItem("4","New Moment","TOP");'><img alt='moment format icon' class='fab-icon' src='../Shared/icons/moment-icon.svg'></a></li>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -187,7 +187,7 @@
 			</div>
 			<div class='fixed-action-button2 sectioned2'  id="FABStatic2" style="display:none">
 				<input id='addElement'  type='button' value='+' style="margin-right:20px; top:-493px; position:fixed;" class='submit-button-newitem' title='New Item' >
-				<ol class='fab-btn-list2' id='olFabBtnList2' style='display: block;'  reversed id='fabBtnList2'>
+				<ol class='fab-btn-list2' id='olFabBtnList2' reversed id='fabBtnList2'>
 					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Heading' onclick='createFABItem("0","New Heading","TOP");'><img alt='heading format icon' class='fab-icon' src='../Shared/icons/heading-icon.svg'></a></li>
 					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Section' onclick='createFABItem("1","New Section","TOP");'><img alt='section format icon' class='fab-icon' src='../Shared/icons/section-icon.svg'></a></li>
 					<li><a class='btn-floating fab-btn-sm2 scale-transition scale-out' tabindex='0' data-tooltip='Moment' onclick='createFABItem("4","New Moment","TOP");'><img alt='moment format icon' class='fab-icon' src='../Shared/icons/moment-icon.svg'></a></li>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7085,7 +7085,6 @@ only screen and (max-device-width: 568px) {
 @media only screen and (max-width: 430px) {
   .fab-btn-list2 {
     left: 55px;
-    
   }
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7075,6 +7075,7 @@ only screen and (max-device-width: 568px) {
   width: 100%;
   list-style: none;
   text-align: center;
+  display: none;
 }
 
 #olFabBtnList2{

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7078,6 +7078,10 @@ only screen and (max-device-width: 568px) {
   z-index: 1000;
 }
 
+#FABStatic2{
+  z-index:10000;
+}
+
 @media only screen and (max-width: 430px) {
   .fab-btn-list2 {
     left: 55px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7076,10 +7076,11 @@ only screen and (max-device-width: 568px) {
   list-style: none;
   text-align: center;
   z-index: 1000;
+  height:fit-content;
 }
 
 #FABStatic2{
-  z-index:10000;
+  z-index:2;
 }
 
 @media only screen and (max-width: 430px) {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1677,6 +1677,13 @@ div .navButt:hover {
     }
 }
 
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
+  .fab-btn-list2{
+    position: absolute;
+    left:200px;
+  }
+}
+
 /*MEDIA QUERIES FOR HAMBURGER MENU IN ANALYTICS.PHP*/
 @media only screen and (max-width: 700px) {
   .GS2, .CO2, .PG2, .OP2, .BP2, .SU2, .SS2, .SC2, .FF2, .PF2{display:none;}
@@ -7069,19 +7076,19 @@ only screen and (max-device-width: 568px) {
 
 .fab-btn-list2 {
   position: absolute;
-  padding: 18px 0px 0px;
-  margin: 0px 0px 0px -3px;
+  padding: 0px;
+  margin: 20px 0px 0px -7px;
   left: auto;
   width: 100%;
   list-style: none;
   text-align: center;
-  top: 25px;
+  top:20px;
 }
 
 @media screen and (max-height: 600px) {
   .fab-btn-list2{
     top: 30px;
-    left: 45px;
+    left: 245px;
     transform: rotate(90deg);
     transform-origin: top left;
   }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7078,6 +7078,19 @@ only screen and (max-device-width: 568px) {
   z-index: 100;
 }
 
+@media only screen and (max-width: 430px) {
+  .fab-btn-list2 {
+    position: absolute;
+    padding: 28px 25px 0px 0px;
+    margin: 0px;
+    left: 55px;
+    width: 100%;
+    list-style: none;
+    text-align: center;
+    z-index: 100;
+  }
+}
+
 @media screen and (max-height: 600px) {
   .fab-btn-list2{
     top: 30px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7075,19 +7075,13 @@ only screen and (max-device-width: 568px) {
   width: 100%;
   list-style: none;
   text-align: center;
-  z-index: 100;
+  z-index: 1000;
 }
 
 @media only screen and (max-width: 430px) {
   .fab-btn-list2 {
-    position: absolute;
-    padding: 28px 25px 0px 0px;
-    margin: 0px;
     left: 55px;
-    width: 100%;
-    list-style: none;
-    text-align: center;
-    z-index: 100;
+    
   }
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7075,7 +7075,9 @@ only screen and (max-device-width: 568px) {
   width: 100%;
   list-style: none;
   text-align: center;
-  z-index: 1000;
+}
+
+#olFabBtnList2{
   height:fit-content;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1677,13 +1677,6 @@ div .navButt:hover {
     }
 }
 
-@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
-  .fab-btn-list2{
-    position: absolute;
-    left:200px;
-  }
-}
-
 /*MEDIA QUERIES FOR HAMBURGER MENU IN ANALYTICS.PHP*/
 @media only screen and (max-width: 700px) {
   .GS2, .CO2, .PG2, .OP2, .BP2, .SU2, .SS2, .SC2, .FF2, .PF2{display:none;}
@@ -7076,19 +7069,36 @@ only screen and (max-device-width: 568px) {
 
 .fab-btn-list2 {
   position: absolute;
-  padding: 0px;
-  margin: 20px 0px 0px -7px;
+  padding: 18px 0px 0px;
+  margin: 0px 0px 0px -10px;
   left: auto;
   width: 100%;
   list-style: none;
   text-align: center;
-  top:20px;
+  top:25px;
 }
+
+
+@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
+  .fab-btn-list2{
+    padding: 18px 0px 0px;
+    margin: -15px 0px 0px -57px;
+  }
+}
+
+@media only screen and (max-width: 430px), only screen and (orientation:portrait) {
+  .fab-btn-list2{
+
+  }
+}
+
+/*padding: 18px 0px 0px;
+margin: 0px 0px 0px -3px;*/
 
 @media screen and (max-height: 600px) {
   .fab-btn-list2{
     top: 30px;
-    left: 245px;
+    left: 45px;
     transform: rotate(90deg);
     transform-origin: top left;
   }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7069,31 +7069,14 @@ only screen and (max-device-width: 568px) {
 
 .fab-btn-list2 {
   position: absolute;
-  padding: 18px 0px 0px;
-  margin: 0px 0px 0px -10px;
-  left: auto;
+  padding: 28px 25px 0px 0px;
+  margin: 0px;
+  left: -55px;
   width: 100%;
   list-style: none;
   text-align: center;
-  top:25px;
+  z-index: 100;
 }
-
-
-@media only screen and (max-width: 800px), only screen and (orientation:portrait) {
-  .fab-btn-list2{
-    padding: 18px 0px 0px;
-    margin: -15px 0px 0px -57px;
-  }
-}
-
-@media only screen and (max-width: 430px), only screen and (orientation:portrait) {
-  .fab-btn-list2{
-
-  }
-}
-
-/*padding: 18px 0px 0px;
-margin: 0px 0px 0px -3px;*/
 
 @media screen and (max-height: 600px) {
   .fab-btn-list2{


### PR DESCRIPTION
After fixing this issue, the dropdown now stays centered in relation to the “+” button for new items. The example below shows the menu at full screen.
<img width="333" alt="Pasted Graphic 2" src="https://github.com/HGustavs/LenaSYS/assets/129295853/0fdcbb4d-4ae1-4e0d-b5ad-653b1f428c8e">
The image below presents a more narrow screen size.
<img width="568" alt="Pasted Graphic 3" src="https://github.com/HGustavs/LenaSYS/assets/129295853/db364a20-9d98-454e-b149-fc876933e8bf">

Lastly, the example underneath illustrates the menu with the smallest screen size. Additionally, z-index was added so that the menu does not fall behind the big “+” button at the bottom of the screen. Kindly, made sure that this works on both chrome and firefox.
<img width="270" alt="Pasted Graphic 4" src="https://github.com/HGustavs/LenaSYS/assets/129295853/d673779a-caad-4e42-bc2c-1254e82037ff">
