### PR TITLE
create service getAccessedService_ms.php

### DIFF
--- a/DuggaSys/microservices/accessedService/getAccessedService_ms.php
+++ b/DuggaSys/microservices/accessedService/getAccessedService_ms.php
@@ -1,0 +1,25 @@
+<?php
+/*
+* Retrieives ALL serviceData 
+*/
+
+date_default_timezone_set("Europe/Stockholm");
+
+// Include basic application services
+include_once "../../../Shared/basic.php";
+include_once "../../../Shared/sessions.php";
+include_once "../sharedMicroservices/getUid_ms.php";
+include_once "./retrieveAccessedService_ms.php";
+
+// Connect to database and start session
+pdoConnect();
+session_start();
+
+// Global variables
+$userid = getUid();
+$opt=getOP('opt');
+$cid = getOP('courseid');
+$log_uuid=getOP('log_uuid');
+$debug="NONE!";
+
+echo json_encode(retrieveAccessedService($pdo, $debug, $userid, $cid, $log_uuid, $opt="", $newusers=""));


### PR DESCRIPTION
This service should run when the GET opt is called. The point of this service is to run the retrieve service without running an other microservice before, this has been implemented in sectioned and showDugga as well.

The service only gathers the opts, makes the necessary includes and runs the retrieve service.