### PR TITLE
Add handling of http status codes in the bfs()-method from gitfetchService

### DIFF
--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -143,7 +143,6 @@ function getIndexFile($url) {
 
 function bfs($url, $cid, $opt) 
 {
-    $counter = 0;
     // Different URL depending on operation
     date_default_timezone_set("Europe/Stockholm");
     if($opt == "GETCOMMIT"){
@@ -206,7 +205,6 @@ function bfs($url, $cid, $opt)
                 if($opt == "GETCOMMIT"){
                     return $json['sha'];
                 }
-                $counter += 1;
                 // Loops through each item fetched in the JSON data
                 if ($json) {
                     foreach ($json as $item) {

--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -143,6 +143,7 @@ function getIndexFile($url) {
 
 function bfs($url, $cid, $opt) 
 {
+    $counter = 0;
     // Different URL depending on operation
     date_default_timezone_set("Europe/Stockholm");
     if($opt == "GETCOMMIT"){
@@ -172,109 +173,116 @@ function bfs($url, $cid, $opt)
     $handles = array();
 
     while (!empty($fifoQueue)) {
-        $currentUrl = array_shift($fifoQueue);
-        $ch = curl_init($currentUrl);
-        $curlOptions = array(
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_USERAGENT => 'PHP',
-            CURLOPT_HTTPHEADER => isset($token) ? array('Authorization: Bearer ' . $token) : [],
-        );
-        curl_setopt_array($ch, $curlOptions);
-        curl_multi_add_handle($mh, $ch);
-        $handles[$currentUrl] = $ch;
-    }
+        while (!empty($fifoQueue)) {
+            $currentUrl = array_shift($fifoQueue);
+            $ch = curl_init($currentUrl);
+            $curlOptions = array(
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_FOLLOWLOCATION => true,
+                CURLOPT_USERAGENT => 'PHP',
+                CURLOPT_HTTPHEADER => isset($token) ? array('Authorization: Bearer ' . $token) : [],
+            );
+            curl_setopt_array($ch, $curlOptions);
+            curl_multi_add_handle($mh, $ch);
+            $handles[$currentUrl] = $ch;
+        }
 
-    // Execute the multi-handle requests
-    $active = null;
-    do {
-        $status = curl_multi_exec($mh, $active);
-        curl_multi_select($mh);
-    } while ($status === CURLM_CALL_MULTI_PERFORM || $active);
+        // Execute the multi-handle requests
+        $active = null;
+        do {
+            $status = curl_multi_exec($mh, $active);
+            curl_multi_select($mh);
+        } while ($status === CURLM_CALL_MULTI_PERFORM || $active);
 
-    // Process the responses
-    foreach ($handles as $currentUrl => $ch) {
-        $data = curl_multi_getcontent($ch);
-        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_multi_remove_handle($mh, $ch);
+        // Process the responses
+        foreach ($handles as $currentUrl => $ch) {
+            $data = curl_multi_getcontent($ch);
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_multi_remove_handle($mh, $ch);
 
-        if ($httpCode == 200) {
-            // Decodes the fetched data into JSON
-            $json = json_decode($data, true);
-            if($opt == "GETCOMMIT"){
-                return $json['sha'];
-            }
-            // Loops through each item fetched in the JSON data
-            if ($json) {
-                foreach ($json as $item) {
-                    // Checks if the fetched item is of type 'file'
-                    if ($item['type'] == 'file') {
-                        //If an index file has been found, check against the content of the index file
-                        if ($item['name'] != ".gitignore") {
-                            if ($filesToIgnore) {
-                                // If the file is not part of files to ignore, resume (Index file)
-                                if (!in_array($item['name'], $filesToIgnore) && !in_array($item['name'], $filesVisited)) {
-                                    if ($opt == "REFRESH") {
-                                        insertToMetaData($cid, $item);
-                                        array_push($filesVisited,$item['name']);
-                                    } else if ($opt == "DOWNLOAD") {
-                                        insertToFileLink($cid, $item);
-                                        insertToMetaData($cid, $item);
-                                        downloadToWebserver($cid, $item);
-                                        array_push($filesVisited,$item['name']);
+            if ($httpCode == 200) {
+                // Decodes the fetched data into JSON
+                $json = json_decode($data, true);
+                if($opt == "GETCOMMIT"){
+                    return $json['sha'];
+                }
+                $counter += 1;
+                // Loops through each item fetched in the JSON data
+                if ($json) {
+                    foreach ($json as $item) {
+                        // Checks if the fetched item is of type 'file'
+                        if ($item['type'] == 'file') {
+                            //If an index file has been found, check against the content of the index file
+                            if ($item['name'] != ".gitignore") {
+                                if ($filesToIgnore) {
+                                    // If the file is not part of files to ignore, resume (Index file)
+                                    if (!in_array($item['name'], $filesToIgnore) && !in_array($item['name'], $filesVisited)) {
+                                        if ($opt == "REFRESH") {
+                                            insertToMetaData($cid, $item);
+                                            array_push($filesVisited,$item['name']);
+                                        } else if ($opt == "DOWNLOAD") {
+                                            insertToFileLink($cid, $item);
+                                            insertToMetaData($cid, $item);
+                                            downloadToWebserver($cid, $item);
+                                            array_push($filesVisited,$item['name']);
+                                        }
                                     }
-                                }
-                                // Otherwise, fetch and download all files
-                            } else {
-                                if (!in_array($item['name'], $filesVisited)) {
-                                    if ($opt == "REFRESH") {
-                                        insertToMetaData($cid, $item);
-                                        array_push($filesVisited,$item['name']);
-                                    } else if ($opt == "DOWNLOAD") {
-                                        insertToFileLink($cid, $item);
-                                        insertToMetaData($cid, $item);
-                                        downloadToWebserver($cid, $item);
-                                        array_push($filesVisited,$item['name']);
+                                    // Otherwise, fetch and download all files
+                                } else {
+                                    if (!in_array($item['name'], $filesVisited)) {
+                                        if ($opt == "REFRESH") {
+                                            insertToMetaData($cid, $item);
+                                            array_push($filesVisited,$item['name']);
+                                        } else if ($opt == "DOWNLOAD") {
+                                            insertToFileLink($cid, $item);
+                                            insertToMetaData($cid, $item);
+                                            downloadToWebserver($cid, $item);
+                                            array_push($filesVisited,$item['name']);
+                                        }
                                     }
                                 }
                             }
+                            // Checks if the fetched item is of type 'dir'
+                        } else if ($item['type'] == 'dir') {
+                            if (!in_array($item['url'], $visited)) {
+                                array_push($visited, $item['url']);
+                                array_push($fifoQueue, $item['url']);
+                            }
                         }
-                        // Checks if the fetched item is of type 'dir'
-                    } else if ($item['type'] == 'dir') {
-                        if (!in_array($item['url'], $visited)) {
-                            array_push($visited, $item['url']);
-                            array_push($fifoQueue, $item['url']);
-                        }
-                    }
-              }
-            } else {
-                //422: Unprocessable entity
-                http_response_code(422);
-                header('Content-type: application/json');
-                $response = array(
-                    'message' => "The JSON-file is invalid"
-                );
-                echo json_encode($response);
-            }
-        } else {
-            // If unable to get file contents then it is logged into the specified textfile with
-            // the specific http error code
-            if($data === false || !$data) {
+                }
+                } else {
+                    //422: Unprocessable entity
+                    http_response_code(422);
+                    header('Content-type: application/json');
+                    $response = array(
+                        'message' => "The JSON-file is invalid"
+                    );
+                    echo json_encode($response);
+                }
+            } 
+            else {
+                // If unable to get file contents then it is logged into the specified textfile with
+                // the specific http error code
+                curl_multi_close($mh);
+                $curl = curl_init($url);
+                curl_setopt($curl, CURLOPT_USERAGENT, 'curl/7.48.0');
+                curl_setopt($curl, CURLOPT_HEADER, 0);
+                curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+                $response = json_decode(curl_exec($curl));
+                $http_response_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
                 if(strlen($token)<1) {
                     setcookie("missingToken", 1, time() + (5), "/");
-                } else {
-                    $curl = curl_init($url);
-                    curl_setopt($curl, CURLOPT_USERAGENT, 'curl/7.48.0');
-                    curl_setopt($curl, CURLOPT_HEADER, 0);
-                    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-                    $response = json_decode(curl_exec($curl));
-                    $http_response_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-                    $message = "\n" . date("Y-m-d H:i:s",time()) . " - Error: connection failed - Error code: ".$http_response_code."\n";
-                    $file = '../../LenaSYS/log/gitErrorLog.txt';
-                    
-                    http_response_code($http_response_code);
-                    error_log($message, 3, $file);
+                    $message = "\n" . date("Y-m-d H:i:s",time()) . " - Error: connection failed - Error code: ".$http_response_code." Consider setting a token\n";
                 }
+                else {
+                    $message = "\n" . date("Y-m-d H:i:s",time()) . " - Error: connection failed - Error code: ".$http_response_code."\n";
+                }
+                $file = '../../LenaSYS/log/gitErrorLog.txt';
+                
+                http_response_code($http_response_code);
+                error_log($message, 3, $file);
+                return;
             }
         }
     }


### PR DESCRIPTION
Essentially the error logging that was put in when bfs() was made asynchronous was outdated. This meant that an issue with it that i had previously fixed was there again (it would simply not log if there was no key).

Other than that I also made the bfs function download more files, as it was very annoying trying to trigger the 403 error when it only downloaded roughly 8 files every time the button was pressed. For that I have simply made it run the download part until it has exhausted its queue by adding a while loop. Unsure if there is a better solution for this, but it is only tangentially related to this issue anyhow.

Testing:
download a github repo until you hit the rate limit (make sure it is actually downloading files and you do not have a key set, as otherwise you will not get anywhere)
see if there is a 403 error and also check the error log in LenaSYS/log/errorlog.txt (it will appear if you do not already have it there)
