### PR TITLE
added functionality to open toolbar by rightclicking on the buttons instead of having to hold click

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -457,6 +457,17 @@ window.addEventListener("DOMContentLoaded", () => {
     document.getElementById("loadingSpinner").style.display = "none";
 });
 
+//event listeners for when one of the elementPlacement buttons are clicked, this will call the rightClickOpenToolbar function with the right parameters
+for (let i = 0; i <= 20; i++) { // Assuming the range is from 0 to 20
+    let element = document.getElementById("elementPlacement" + i);
+    if (element) {
+        // Add event listener for contextmenu
+        element.addEventListener("contextmenu", function(event) {
+            rightClickOpenToolbar(event, i);
+        });
+    }
+}
+
 /**
  * @description Called from getData() when the window is loaded. This will initialize all neccessary data and create elements, setup the state machine and vise versa.
  * @see getData() For the VERY FIRST function called in the file.
@@ -1765,6 +1776,14 @@ function holdPlacementButtonDown(num) {
             togglePlacementTypeBox(num);
         }
     }, 500);
+}
+
+/**
+ * @description Function to open a bubtoolbar when rightclicking a button
+ */
+function rightClickOpenToolbar(event, num) {
+    event.preventDefault();
+    togglePlacementTypeBox(num);
 }
 
 /**

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -58,7 +58,7 @@
     <script src="./diagram/helpers/mouse.js"></script>
     <script src="./diagram/helpers/mouseMode.js"></script>
     <script src="./diagram/events/mouse.js"></script>
-    <script src="diagram.js"></script>
+    <script defer src="diagram.js"></script>
     <script src="./assets/js/fetchDiagramInfo.js"></script>
 </head>
 <!-- instead of onload on body there is an event listener for loaded in diagram.js at the top of the INIT AND SETUP REGION -->


### PR DESCRIPTION
added event listener to the buttons that call a function which opens the toolbar, also defered the calling of diagram.js so that its loaded at the end, otherwise this fix wont work.