### PR TITLE
Removed a call to function

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3596,7 +3596,6 @@ function validateDate2(ddate, dialogid) {
 }
 
 function validateSectName(name) {
-  initInputColorTheme();
   var element = document.getElementById(name);
   var errorMsg = document.getElementById("dialog10");
   if (element.value.match(/^[A-Za-zÅÄÖåäö\s\d():_-]+$/)) {


### PR DESCRIPTION
Removed the call to the function "initInputColorTheme" from the validateSectName that is supposed to check the local storage if it is blacktheme or not. This seemed to get called wrong or something. After this was removed I wasn't able to get the fault of color for the input.

Check original issue for the sequence to manipulate the fault of input-background color.