### PR TITLE
Adding a github repo to a Moment should now spawn the items right under it.  #15319

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ gitErrorLog.txt
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 *.db
+.vscode
 
 *diff*.txt
 *branch*.txt

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -945,16 +945,22 @@ function prepareItem() {
     param.feedbackquestion = null;
   }
 
-  // Places new items at appropriate places by measuring the space between FABStatic2 and the top of the scrren
-  var elementBtnTop = document.getElementById("FABStatic2").getBoundingClientRect();
-  screenPos = Math.round((-1 * elementBtnTop.top) / 350);
-  if (screenPos < 1) {
-    screenPos = 5;
-  } else {
-    screenPos = 4 * screenPos;
+  // Places new items at appropriate places by measuring the space between FABStatic2 and the top of the scrren (Old solution)
+  //var elementBtnTop = document.getElementById("FABStatic2").getBoundingClientRect();
+  //screenPos = Math.round((-1 * elementBtnTop.top) / 350);
+  //if (screenPos < 1) {
+  //  screenPos = 5;
+  //} else {
+  //  screenPos = 4 * screenPos;
+  //}
+
+  //Place element at bottom if the user has scrolled all the way down, otherwise at the top. (Stopgap solution)
+  let screenPos = 0
+  if(Math.floor(window.scrollY) === (document.documentElement.scrollHeight - document.documentElement.offsetHeight) 
+  && document.documentElement.scrollHeight > document.documentElement.clientHeight) {
+   screenPos = document.getElementById("Sectionlistc").childElementCount;
   }
   param.pos = screenPos;
-
   return param;
 }
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -745,7 +745,7 @@ function insertIntoSqLiteGitRepo($cid, $githubURL){
 function insertIntoSqLiteGitFiles($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $SHA){
     $pdoLite = new PDO('sqlite:../../githubMetadata/metadata2.db');
     $successInsert = true;
-    $count = count($fileNames);
+    $count = $fileNames == null ? 0 : count($fileNames);
     for($i = 0; $i < $count; $i++){
         $query = $pdoLite->prepare('REPLACE INTO gitFiles (cid, fileName, fileType, fileURL, downloadURL, fileSHA, filePath) VALUES (:cid, :fileName, :fileType, :fileURL, :downloadURL, :fileSHA, :filePath)');
         $query->bindParam(':cid', $cid);
@@ -785,7 +785,7 @@ function writeCoursesDir($path, $pathCoursesRoot){
 function writeFilesInDir($path, $fileNames, $content){
     $WriteFilesSuccess = true;
     $success = true;
-    $count = count($content);
+	$count = $content == null ? 0 : count($content);
     for($i = 0; $i < $count; $i++){
         $WriteFilesSuccess = file_put_contents($path . '/' . $fileNames[$i], $content[$i]);
         if($WriteFilesSuccess === false){
@@ -802,7 +802,7 @@ function writeFilesInDir($path, $fileNames, $content){
 
 function insertIntoFileLinkDB($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $CeHiddenParam, $fileSizes) {
 	global $pdo;
-	$count = count($fileNames);
+	$count = $fileNames == null ? 0 : count($fileNames);
 	for($i = 0; $i < $count; $i ++) {
 		$query = $pdo->prepare("SELECT count(*) FROM fileLink WHERE cid=:cid AND UPPER(filename)=UPPER(:filename);");
 		$query->bindParam(':filename', $fileNames[$i]);
@@ -844,7 +844,7 @@ function updateCodeExampleDB($cid, $fileNames, $filePaths, $fileURLS, $downloadU
 
 function insertIntoBoxDB($cid, $fileNames, $filePaths, $fileURLS, $downloadURLS, $fileTypes, $CeHiddenParam, $templateid){
 	global $pdo;
-	$count = count($fileNames);
+	$count = $fileNames == null ? 0 : count($fileNames);
 	$boxContent = "Code";
 	$wordlistID = "3";
 	$y = 1;

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -256,6 +256,12 @@ if(checklogin()){
 
 					$link=$pdo->lastInsertId();
 			}
+			//Change position of elements one increment up to make space for insertion.
+			$query = $pdo->prepare("UPDATE listentries SET pos = pos+1 WHERE cid = :cid and vers = :cvs and pos >= :pos");
+			$query->bindParam(":cid", $courseid);
+			$query->bindParam(":cvs", $coursevers);
+			$query->bindParam(":pos", $pos);
+			$query->execute();
 
 			$query = $pdo->prepare("INSERT INTO listentries (cid,vers, entryname, link, kind, pos, visible,creator,comments, gradesystem, highscoremode, groupKind) 
 														VALUES(:cid,:cvs,:entryname,:link,:kind,:pos,:visible,:usrid,:comment, :gradesys, :highscoremode, :groupkind)");
@@ -566,12 +572,20 @@ if(checklogin()){
 				if ($counted == 0) {
 					
 
-					//Get the last position in the listenries to add new course at the bottom
-					$query = $pdo->prepare("SELECT pos FROM listentries WHERE cid=:cid ORDER BY pos DESC;");
+					//Get the position of the related moment
+					$query = $pdo->prepare("SELECT pos FROM listentries WHERE cid = :cid and lid = :lid");
 					$query->bindParam(":cid", $courseid);
+					$query->bindParam(":lid", $lid);
 					$query->execute();
 					$e = $query->fetchAll();
-					$pos = $e[0]['pos'] + 1; //Gets the last filled position+1 to put the new codexample at
+					$pos = $e[0]['pos'] + 1; //Get position under the moment
+
+					//Move elements up from insertion.
+					$query = $pdo->prepare("UPDATE listentries SET pos = pos+1 WHERE cid = :cid and vers = :cvs and pos >= :pos");
+					$query->bindParam(":cid", $courseid);
+					$query->bindParam(":cvs", $coursevers);
+					$query->bindParam(":pos", $pos);
+					$query->execute();
 
 					//select the files that has should be in the codeexample
 					$fileCount = count($groupedFiles);


### PR DESCRIPTION
Current v6 solved the halting issue. 
Copied from last pull request #15600

Extra:
* Added .vscode to .gitignore to make it easier to debug using visual studio code.
* Fixed errors occurring in sectioned.php due to them obscuring important footer texts.
* Fixed sections not inserting with correct positions or duplicate positions which would break functionality.

### Testing (new)
0. Reinstall using install.php but make sure to clear the folder `/LenaSYS/courses` before so that earlier GitHub files gest cleared.
Should like this after a clean install.
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/e4997eb9-fc4d-4f83-9448-7fbbcca5b760)

1. Create a empty test course or use an existing empty course like `Distribuerade system`
2. Connect https://github.com/LenaSYS/Webbprogrammering-Examples as github URL
3. Create a course version and add 7 Moments with some few random elements sprinkled in. (ajax_api_index, booking and README have a chance of showing up after refreshing moments without choosing anything. The bug can be found before my issue.)
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/66074118-a0b6-4317-a539-f3b851034cb8)

4. Ensure that the positions `pos` are correct in `listentries` in the database
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/f0382ce6-f89f-4bb7-8fc2-cf881a6626d9)
5. (One at a time) Choose GitHub moment and then press the refresh moment example icon on the moment. After a site refresh the codeexamples should pop up.
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/3ba827af-6b0d-46b6-b823-899f733f7ffe)
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/ff90df20-13d4-47cf-ac61-28958136bc74)
6. Verify  `pos` in the database

