### PR TITLE
Fixed css class names (refactoring)

### DIFF
--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -63,9 +63,9 @@
 
 	<!-- Add User Dialog START -->
 	<div id='createUser' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox' style='width:494px;'>
+		<div class='formBox' style='width:494px;'>
 			<div>
-				<div class='loginBoxheader'>
+				<div class='formBoxHeader'>
 					<h3>Add user</h3>
 					<div class='cursorPointer' onclick='closeWindows();'>x</div>
 				</div>
@@ -100,8 +100,8 @@
 	</div>
 
 	<div id='createClass' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox' style='width:464px;'>
-			<div class='loginBoxheader'>
+		<div class='formBox' style='width:464px;'>
+			<div class='formBoxHeader'>
 				<h3>Add class</h3>
 				<div class='cursorPointer' onclick='closeWindows();'>x</div>
 			</div>
@@ -121,6 +121,63 @@
 				<div id='classErrorText' style='color:rgb(199, 80, 80); margin-top:10px; text-align:center;'></div>
 			</div>
 		</div>
+	</div>
+
+	<div id='addUser' class='loginBoxContainer'>
+		<div class='formBox'>
+			<div>
+				<div class='formBoxHeader'>
+					<h3>Add user</h3>
+					<div class='cursorPointer' onclick='closeWindows();'>x</div>
+				</div>
+				<div class="content-wrapper">
+					<input type='hidden' id='uid' value='Toddler' />
+					<div class='flexwrapper'>
+						<span>Choose user:</span>
+						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
+						<input type="text" name="product" list="users_dropdown_add" class='textinput' type='text' id='addUsernameAdd' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<datalist id="users_dropdown_add">
+						</datalist>
+					</div>
+					<div class='flexwrapper'>
+						<span>Term:</span>
+						<div class="tooltipDugga"><span id="tooltipTerm" style="display: none;" class="tooltipDuggatext">  </span></div>
+						<input placeholder="HT-11" class='textinput' id='addTermAdd' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
+					</div>
+					<div class="flex-end">
+						<input class='submit-button' type='button' value='Save' onclick='addUserToCourse();' />
+					</div>
+				</div>
+      		</div>
+     	</div>
+	</div>
+
+	<div id='removeUser' class='loginBoxContainer'>
+		<div class='formBox'>
+			<div>
+				<div class='formBoxHeader'>
+					<h3>Remove user</h3>
+					<div class='cursorPointer' onclick='closeWindows();'>x</div>
+				</div>
+				<div class="content-wrapper">
+					<input type='hidden' id='uid' value='Toddler' />
+					<div class='flexwrapper'>
+						<span>Choose user:</span>
+						<div class="tooltipDugga"><span id="tooltipFirst" class="tooltipDuggatext">  </span></div>
+						<input type="text" name="product" list="users_dropdown_remove" class='textinput' type='text' id='addUsernameRemove' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
+						<datalist id="users_dropdown_remove"></datalist>
+					</div>
+					<div class='flexwrapper'>
+						<span>Term:</span>
+						<div class="tooltipDugga"><span id="tooltipTerm" style="display: none;" class="tooltipDuggatext">  </span></div>
+						<input placeholder="HT-11" class='textinput' id='addTermRemove' onchange="tooltipTerm(this)" onkeyup="tooltipTerm(this)">
+					</div>
+					<div class="flex-end">
+						<input class='submit-button' type='button' value='Save' onclick='removeUserFromCourse();' />
+					</div>
+				</div>
+      		</div>
+     	</div>
 	</div>
 
 	<!-- Add User Dialog END -->

--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -4807,18 +4807,18 @@ $(document).mousedown(function (e) {
 	var box = $(e.target);
 	if ($('#burgerMenu').is(e.target) || $('#burgerMenu').has(e.target).length !== 0) { //is the burger menu or its descendants clicked?
 		isClickedElementBox = true;
-	} else if (box[0].classList.contains("loginBox")) { // is the clicked element a loginbox?
+	} else if (box[0].classList.contains("formBox")) { // is the clicked element a formBox?
 		isClickedElementBox = true;
-	} else if ((findAncestor(box[0], "loginBox") != null) // or is it inside a loginbox?
+	} else if ((findAncestor(box[0], "formBox") != null) // or is it inside a formBox?
 		&&
-		(findAncestor(box[0], "loginBox").classList.contains("loginBox"))) {
+		(findAncestor(box[0], "formBox").classList.contains("formBox"))) {
 		isClickedElementBox = true;
 	} else {
 		isClickedElementBox = false;
 	}
 });
 
-// Close the loginbox when clicking outside it.
+// Close the formBox when clicking outside it.
 $(document).mouseup(function (e) {
 	// Click outside the burger menu
 	var notTarget = !$('#burgerMenu').is(e.target) && !$('#codeBurger').is(e.target) // if the burger menu is visible and the target of the click isn't the container or button...
@@ -4827,10 +4827,10 @@ $(document).mouseup(function (e) {
 		closeBurgerMenu();
 	}
 
-	// Click outside the loginBox
-	if ($('.loginBox').is(':visible') && !$('.loginBox').is(e.target) // if the target of the click isn't the container...
+	// Click outside the formBox
+	if ($('.formBox').is(':visible') && !$('.formBox').is(e.target) // if the target of the click isn't the container...
 		&&
-		$('.loginBox').has(e.target).length === 0 // ... nor a descendant of the container
+		$('.formBox').has(e.target).length === 0 // ... nor a descendant of the container
 		&&
 		(!isClickedElementBox)) // or if we have clicked inside box and dragged it outside and released it
 	{
@@ -4937,7 +4937,7 @@ function showIframe(path, name, kind) {
         
         // Display the preview window and append hideIframe() to the close window button 
         previewWindow = document.querySelector(".previewWindow");
-		previewWindow.classList.add("loginBox");
+		previewWindow.classList.add("formBox");
         previewWindow.style.display = "block";
         document.querySelector(".editFilePart").style.display = "none";
 

--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -239,8 +239,8 @@ Testing Link:
 		<!-- Dropdowns END -->
 		<!-- Example Content Cog Wheel Dialog START -->
 		<div id='editContentContainer' class="loginBoxContainer" style="display:none;">
-				<div id='editContent' class='loginBox DarkModeBackgrounds' style='width:510px;'>
-					<div class='loginBoxheader'>
+				<div id='editContent' class='formBox DarkModeBackgrounds' style='width:510px;'>
+					<div class='formBoxHeader'>
 						<h3>Edit Content</h3>
 						<div class='cursorPointer' onclick='closeEditContent();'>x</div>
 					</div>
@@ -292,8 +292,8 @@ Testing Link:
 		<!-- Example Content Cog Wheel Dialog END -->
 		<!-- Code Example Cog Wheel Dialog START -->
 		<div id='editExampleContainer' class="loginBoxContainer" style="display:none;">
-				<div id='editExample' class='loginBox DarkModeBackgrounds' style='width:650px;'>
-					<div class='loginBoxheader'>
+				<div id='editExample' class='formBox DarkModeBackgrounds' style='width:650px;'>
+					<div class='formBoxHeader'>
 						<h3>Edit Example</h3>
 						<div class='cursorPointer' onclick='closeEditExample();'>x</div>
 					</div>
@@ -322,8 +322,8 @@ Testing Link:
 		</div>
 		<!-- Code Example Cog Wheel Dialog END -->
 		<div id='chooseTemplateContainer' class="loginBoxContainer" style="display:none;">
-				<div id='chooseTemplate' class='loginBox DarkModeBackgrounds' style='width:464px;'>
-					<div class='loginBoxheader'>
+				<div id='chooseTemplate' class='formBox DarkModeBackgrounds' style='width:464px;'>
+					<div class='formBoxHeader'>
 						<h3>Choose Template</h3>
 						<div class='cursorPointer' onclick='closeTemplateWindow();'>x</div>
 					</div>
@@ -365,8 +365,8 @@ Testing Link:
 			include '../Shared/loginbox.php';
 		?>
 	<div class="previewWindowContainer loginBoxContainer">
-    <div class="previewWindow loginBox">
-	<div class="loginBoxheader">
+    <div class="previewWindow formBox">
+	<div class="formBoxHeader">
             <h3 class ="fileName"></h3>
             <div style="cursor:pointer;" onclick="hideIframe();">x</div>
         </div>

--- a/DuggaSys/contribution_loginbox.js
+++ b/DuggaSys/contribution_loginbox.js
@@ -79,7 +79,7 @@ function contribution_showLoginPopup()
 {
   contribution_addEventListeners();
   $("#login").css("display",""); // show inital login box
-  $("#loginBox").css("display","flex"); // show background
+  $("#formBox").css("display","flex"); // show background
   $("#username").focus();     
 }
 

--- a/DuggaSys/contribution_loginbox.php
+++ b/DuggaSys/contribution_loginbox.php
@@ -58,9 +58,9 @@
 <div id="overlay" style="display:none"></div>
 
 	<!-- Login Box Start! -->
-<div id='loginBox' class='loginBoxContainer' style="display:none;">
-        <div id='login' class='loginBox' style="display:"> <!-- Initial login screen display -->
-            <div class="loginBoxheader">
+<div id='formBox' class='loginBoxContainer' style="display:none;">
+        <div id='login' class='formBox' style="display:"> <!-- Initial login screen display -->
+            <div class="formBoxHeader">
                 <h3>Login</h3>
                 <div class="cursorPointer" onclick="contribution_closeLogin();">x</div>
             </div>
@@ -97,8 +97,8 @@
 
     <!-- User exists login start -->
 
-    <div id='UserExistslogin' class='loginBox' style="display:none"> <!-- Initial login screen display -->
-            <div class="loginBoxheader">
+    <div id='UserExistslogin' class='formBox' style="display:none"> <!-- Initial login screen display -->
+            <div class="formBoxHeader">
                 <h3>Login</h3>
                 <div class="cursorPointer" onclick="contribution_closeLogin();">x</div>
             </div>
@@ -142,8 +142,8 @@
 
     <!-- New git-user creation start -->
 
-    <div id='newGit-UserCreation' class='loginBox' style="display:none"> <!-- Initial login screen display -->
-            <div class="loginBoxheader">
+    <div id='newGit-UserCreation' class='formBox' style="display:none"> <!-- Initial login screen display -->
+            <div class="formBoxHeader">
                 <h3>Login</h3>
                 <div class="cursorPointer" onclick="contribution_closeLogin();">x</div>
             </div>

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -72,8 +72,8 @@ if(isset($_SESSION['uid'])){
 
 <!-- New Course Section Dialog START -->
 <div id='newCourse' class='loginBoxContainer' style='display:none;'>
-    <div class='loginBox DarkModeBackgrounds DarkModeText' style='width:464px;  overflow:hidden;'>
-    		<div class='loginBoxheader'>
+    <div class='formBox DarkModeBackgrounds DarkModeText' style='width:464px;  overflow:hidden;'>
+    		<div class='formBoxHeader'>
     			<h3>New Course</h3>
     			<div class="cursorPointer" onclick='closeWindows();' title='Close window'>x</div>
     		</div>
@@ -111,8 +111,8 @@ if(isset($_SESSION['uid'])){
 
 	<!-- Edit Section Dialog START -->
 	<div id='editCourse' class='loginBoxContainer' style='display:none;'>
-      <div class='loginBox DarkModeBackgrounds DarkModeText' style='width:464px;  overflow:hidden;'>
-    		<div class='loginBoxheader'>
+      <div class='formBox DarkModeBackgrounds DarkModeText' style='width:464px;  overflow:hidden;'>
+    		<div class='formBoxHeader'>
     			<h3>Edit Course</h3>
     			<div class="cursorPointer" onclick='closeWindows();'>x</div>
     		</div>
@@ -166,9 +166,9 @@ if(isset($_SESSION['uid'])){
 	<!-- Edit Server Settings START -->
 
 	<div id='editSettings' onmouseover="validateMOTD('motd','dialog51', 'dialog52', 'submitMotd');" class='loginBoxContainer' style='display:none;' >
-    <div class='loginBox DarkModeBackgrounds DarkModeText' style='width:464px; overflow:hidden;'>
+    <div class='formBox DarkModeBackgrounds DarkModeText' style='width:464px; overflow:hidden;'>
 
-    		<div class='loginBoxheader'>
+    		<div class='formBoxHeader'>
     			<h3>Edit Server Settings</h3>
     			<div class="cursorPointer" onclick='closeWindows();'>x</div>
     		</div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1027,8 +1027,8 @@
     <div class="loadModalOverlay hiddenLoad"></div>
 
     <div id="overrideContainer" class="loginBoxContainer" style="display:none">
-        <div class="loginBox">
-            <div class="loginBoxheader">
+        <div class="formBox">
+            <div class="formBoxHeader">
                 <h3>
                     Filename already exists
                 </h3>
@@ -1207,8 +1207,8 @@
         <p>Press "ESCAPE" to exit the replay-mode.</p>
     </div>
     <div id="savePopoutContainer" class="loginBoxContainer" style="display:none">
-        <div class="loginBox">
-            <div class="loginBoxheader">
+        <div class="formBox">
+            <div class="formBoxHeader">
                 <h3>
                     Save current diagram as
                 </h3>

--- a/DuggaSys/diagram_IOHandler.php
+++ b/DuggaSys/diagram_IOHandler.php
@@ -146,8 +146,8 @@ of which folder in the repository 'save' on the server to load.
       ?>
 
       <!-- The Appearance menu. Default state is display: none; -->
-      <div id="appearance" class='loginBox' style='display: none;'>
-          <div class='loginBoxheader'>
+      <div id="appearance" class='formBox' style='display: none;'>
+          <div class='formBoxHeader'>
               <h3>Apperance</h3>
               <div class='cursorPointer' onclick='toggleApperanceElement()'>x</div>
           </div>

--- a/DuggaSys/duggaed.js
+++ b/DuggaSys/duggaed.js
@@ -68,10 +68,10 @@ function leaveSearch() {
 // Detects clicks
 $(document).mousedown(function (e) {
 	var box = $(e.target);
-	if (box[0].classList.contains("loginBox")) { // is the clicked element a loginbox?
+	if (box[0].classList.contains("formBox")) { // is the clicked element a formBox?
 		isClickedElementBox = true;
-	} else if ((findAncestor(box[0], "loginBox") != null) // or is it inside a loginbox?
-		&& (findAncestor(box[0], "loginBox").classList.contains("loginBox"))) {
+	} else if ((findAncestor(box[0], "formBox") != null) // or is it inside a formBox?
+		&& (findAncestor(box[0], "formBox").classList.contains("formBox"))) {
 		isClickedElementBox = true;
 	} else {
 		isClickedElementBox = false;
@@ -79,9 +79,9 @@ $(document).mousedown(function (e) {
 });
 
 $(document).mouseup(function (e) {
-	// Click outside the loginBox
-	if ($('.loginBox').is(':visible') && !$('.loginBox').is(e.target) // if the target of the click isn't the container...
-		&& $('.loginBox').has(e.target).length === 0 // ... nor a descendant of the container
+	// Click outside the formBox
+	if ($('.formBox').is(':visible') && !$('.formBox').is(e.target) // if the target of the click isn't the container...
+		&& $('.formBox').has(e.target).length === 0 // ... nor a descendant of the container
 		&& (!isClickedElementBox)) // or if we have clicked inside box and dragged it outside and released it
 	{
 		closeWindows();

--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -75,8 +75,8 @@ $vers=getOPG('coursevers');
 
     <!-- Edit Dugga Dialog START -->
   	<div id='editDugga' class='loginBoxContainer' style='display:none;'>
-        <div class='loginBox' style='width:464px; overflow:hidden;'>
-        		<div class='loginBoxheader'>
+        <div class='formBox' style='width:464px; overflow:hidden;'>
+        		<div class='formBoxHeader'>
         			<h3 id="editDuggaTitle">Edit Dugga</h3>
         			<div class='cursorPointer' onclick='closeWindows();'>x</div>
         		</div>
@@ -118,8 +118,8 @@ $vers=getOPG('coursevers');
 
     <!-- Confirm Section Dialog START -->
   		<div id='sectionConfirmBox' class='loginBoxContainer' style='display:none; z-index: 9999;'>
-  	    <div class='loginBox' style='width:460px;'>
-  				<div class='loginBoxheader'>
+  	    <div class='formBox' style='width:460px;'>
+  				<div class='formBoxHeader'>
   				    <h3>Confirm deletion</h3>
   				    <div class="cursorPointer" onclick='closeWindows();' title="Close window">x</div>
   				</div>
@@ -136,8 +136,8 @@ $vers=getOPG('coursevers');
 
     <!-- Result Dialog START -->
     <div id='resultpopover' class='loginBoxContainer' style='display:none; overflow:hidden; z-index: 9999;'>
-      <div class='loginBox' id='resultpopoverBox' style='overflow:auto;';>
-        <div class='loginBoxheader'>
+      <div class='formBox' id='resultpopoverBox' style='overflow:auto;';>
+        <div class='formBoxHeader'>
           <h3 id="resultpopoverTitle">PREVIEW</h3>
           <div class='cursorPointer' onclick='closeWindows();'>x</div>
         </div>
@@ -150,8 +150,8 @@ $vers=getOPG('coursevers');
 
   	<!-- Edit Variant Dialog START -->
   	<div id='editVariant' class='loginBoxContainer' style='display:none;'>
-      <div class='loginBox' id='variantBox'>
-        <div class='loginBoxheader'>
+      <div class='formBox' id='variantBox'>
+        <div class='formBoxHeader'>
           <h3 id="editVariantTitle">Edit Variant</h3>
           <div class='cursorPointer' onclick='closeWindows();'>x</div>
         </div>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -223,8 +223,8 @@ $js = array(
 
     <!-- Add File Dialog START -->
     <div id='addFile' class='loginBoxContainer' style='display:none;'>
-        <div class='loginBox' style='width:464px; overflow-y: visible'>
-            <div class='loginBoxheader' style='cursor:default;'>
+        <div class='formBox' style='width:464px; overflow-y: visible'>
+            <div class='formBoxHeader' style='cursor:default;'>
                 <h3 class="fileHeadline" id="eFileHeadline">Add Dummy Empty File</h3>
 
                 <h3 class="fileHeadline" id="mFileHeadline">Add Course Local File</h3>
@@ -304,7 +304,7 @@ $js = array(
 <!-- File View Window START -->
 <div class="fileViewContainer">
     <div class="fileViewWindow">
-        <div class="loginBoxheader fileViewHeader">
+        <div class="formBoxHeader fileViewHeader">
             <h3 class="fileName"></h3>
             <div style="cursor: pointer" onclick="filePreviewClose()">x</div>
         </div>
@@ -317,7 +317,7 @@ $js = array(
 <!-- Markdown-preview and edit file functionality START -->
 <div class="previewWindowContainer">
     <div class="previewWindow">
-        <div class="loginBoxheader">
+        <div class="formBoxHeader">
             <h3 class ="fileName"></h3>
             <div style="cursor:pointer;" onclick="closePreview();">x</div>
         </div>
@@ -474,7 +474,7 @@ $js = array(
 </div>
 
 <div class="confirmationWindow">
-    <div class="loginBoxheader">
+    <div class="formBoxHeader">
         <h3 class="fileName"></h3>
         <div style="cursor:pointer;" onclick="closeConfirmation();">x</div>
     </div>

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -111,7 +111,7 @@ pdoConnect();
 	<!-- -------------------=============####### Result Popover #######=============------------------- -->
 
 	<div id='resultpopover' class='resultPopover' style='display: none'>
-		<div class='loginBoxheader'>
+		<div class='formBoxHeader'>
 			<span id="hoverRes" ></span>
 			<h3 style='width:100%;' id='Nameof' onmouseover="hoverResult();"
 			onmouseout="hideHover();" >Show Results</h3>
@@ -132,13 +132,13 @@ pdoConnect();
   <!-- -------------------=============####### Statistics Popover #######=============------------------- -->
 
 	<div id='statisticspopover' class='previewpopover' style='display:none;'>
-		<div class='loginBoxheader'>
+		<div class='formBoxHeader'>
 			<h3 style='width:100%;' id='Nameof'>Collective results</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
 		</div>
 	</div>
 
 	<div id='resultlistpopover' class='previewpopover' style='display:none;flex-direction:column;'>
-		<div class='loginBoxheader'>
+		<div class='formBoxHeader'>
 			<h3 style='width:100%;' id='resultlistheader'>Collective results</h3><div class='cursorPointer' onclick='closeWindows();'>x</div>
     </div>
     <div style='display:flex;flex-direction:column;flex:1;'>
@@ -155,7 +155,7 @@ pdoConnect();
 
 	<!-- This popup is for alerts about LadExport -->
 	<div id="gradeExportPopUp" style="display: none;">
-		<div class="loginBoxheader">
+		<div class="formBoxHeader">
 			<h3>Alert</h3>
 			<div class='cursorPointer' onclick="closeWindows()" title="Close window">x</div>
 		</div>

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -614,7 +614,7 @@ function closeOpenPopupForm(){
     "#tabConfirmBox",
     "#gitHubTemplate",
     "#gitHubBox",
-    "#loginBox",
+    "#formBox",
     "#loadDuggaBox",
     "#sectionHideConfirmBox",
     "#sectionShowConfirmBox"
@@ -2512,11 +2512,11 @@ function mouseDown(e) {
 
   var box = $(e.target);
 
-  // Is the clicked element a loginbox? or is it inside a loginbox?
-  if (box[0].classList.contains("loginBox")) {
+  // Is the clicked element a formBox? or is it inside a formBox?
+  if (box[0].classList.contains("formBox")) {
     isClickedElementBox = true;
-  } else if ((findAncestor(box[0], "loginBox") != null) &&
-    (findAncestor(box[0], "loginBox").classList.contains("loginBox"))) {
+  } else if ((findAncestor(box[0], "formBox") != null) &&
+    (findAncestor(box[0], "formBox").classList.contains("formBox"))) {
     isClickedElementBox = true;
   } else {
     isClickedElementBox = false;
@@ -2531,8 +2531,8 @@ function mouseDown(e) {
 function mouseUp(e) {
   /* If the target of the click isn't the container nor a descendant of the container,
      or if we have clicked inside box and dragged it outside and released it */
-  if ($('.loginBox').is(':visible') && !$('.loginBox').is(e.target) &&
-    $('.loginBox').has(e.target).length === 0 && (!isClickedElementBox)) {
+  if ($('.formBox').is(':visible') && !$('.formBox').is(e.target) &&
+    $('.formBox').has(e.target).length === 0 && (!isClickedElementBox)) {
 
     event.preventDefault();
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -271,9 +271,9 @@
 		<!-- Edit Section Dialog START -->
 
 		<div id='editSection' onmouseover=" validateDate2('setDeadlineValue','dialog8');"  class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
+		<div class='formBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
 
-			<div class='loginBoxheader'>
+			<div class='formBoxHeader'>
 				<h3 id='editSectionDialogTitle'>Edit Item</h3>
 				<div class='cursorPointer' onclick='closeWindows(); closeSelect();showSaveButton();'>x</div>
 			</div>
@@ -290,7 +290,7 @@
 				<div id='inputwrapper-type' class='inputwrapper'>
 					<span>Type:</span>
 					 <!-- If you want to change the names of the spans, make sure that they fit with the dropdown box.
-						If they don't, change the width of loginbox select in the CSS file -->
+						If they don't, change the width of formBox select in the CSS file -->
 					<select id='type' value='type' onchange='changedType(document.getElementById("type").value);'></select>
 					</div>
 					<div id='inputwrapper-link' class='inputwrapper'><span>Link:</span><select id='link' ></select></div>
@@ -339,8 +339,8 @@
 
 	<!-- Confirm Section Dialog START -->
 	<div id='sectionConfirmBox' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
-			<div class='loginBoxheader'>
+		<div class='formBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
+			<div class='formBoxHeader'>
 					<h3>Confirm deletion</h3>
 					<div class="cursorPointer" onclick='confirmBox("closeConfirmBox");' title="Close window">x</div>
 			</div>
@@ -358,8 +358,8 @@
 
 	<!-- Canvas Link Dialog -->
 	<div id='canvasLinkBox' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox DarkModeBackgrounds DarkModeText' style='min-width:250px;'>
-			<div class='loginBoxheader'>
+		<div class='formBox DarkModeBackgrounds DarkModeText' style='min-width:250px;'>
+			<div class='formBoxHeader'>
 					<h3 style='text-align: center;'>Link Copied To Clipboard</h3>
 					<div class="cursorPointer" onclick='showCanvasLinkBox("close",this);' title="Close window">x</div>
 			</div>
@@ -373,8 +373,8 @@
 
 	<!-- Confirm Section Hide Dialog START -->
 	<div id='sectionHideConfirmBox' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
-			<div class='loginBoxheader'>
+		<div class='formBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
+			<div class='formBoxHeader'>
 					<h3>Confirm hiding</h3>
 					<div class="cursorPointer" onclick='confirmBox("closeConfirmBox");' title="Close window">x</div>
 			</div>
@@ -391,8 +391,8 @@
 
 	<!-- Confirm Section Hide Dialog START -->
 	<div id='sectionShowConfirmBox' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
-			<div class='loginBoxheader'>
+		<div class='formBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
+			<div class='formBoxHeader'>
 					<h3>Confirm show items</h3>
 					<div class="cursorPointer" onclick='confirmBox("closeConfirmBox");' title="Close window">x</div>
 			</div>
@@ -409,8 +409,8 @@
 
 	<!-- Cofirm Section Tab Dialog START -->
 	<div id='tabConfirmBox' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox' style='width:460px;'>
-			<div class='loginBoxheader'>
+		<div class='formBox' style='width:460px;'>
+			<div class='formBoxHeader'>
 					<h3>Confirm tab</h3>
 					<div class="cursorPointer" onclick='confirmBox("closeConfirmBox");' title="Close window">x</div>
 			</div>
@@ -439,8 +439,8 @@
 
 	<!-- Confirm Missing Material Dialog START -->
 	<div id='noMaterialConfirmBox' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox' style='width:460px;'>
-				<div class='loginBoxheader'>
+		<div class='formBox' style='width:460px;'>
+				<div class='formBoxHeader'>
 					<h3>Error: Missing material</h3>
 					<div class="cursorPointer" onclick='confirmBox("closeConfirmBox");' title="Close window">x</div>
 				</div>
@@ -456,8 +456,8 @@
 
 		<!-- New Version Dialog START -->
 		<div id='newCourseVersion' class='loginBoxContainer' style='display:none;'>
-    	<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:464px; overflow:hidden;'>
-			<div class='loginBoxheader'>
+    	<div class='formBox DarkModeBackgrounds DarkModeText' style='width:464px; overflow:hidden;'>
+			<div class='formBoxHeader'>
 				<h3>New Course Version</h3>
 				<div class="cursorPointer" onclick='closeWindows();' title="Close window">x</div>
 			</div>
@@ -508,9 +508,9 @@
 <!-- Edit Version Dialog START -->
 
 <div id='editCourseVersion' onmouseover="quickValidateForm('editCourseVersion', 'submitEditCourse');" class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:464px; overflow:hidden;'>
+		<div class='formBox DarkModeBackgrounds DarkModeText' style='width:464px; overflow:hidden;'>
 
-			<div class='loginBoxheader'>
+			<div class='formBoxHeader'>
 				<h3>Edit Course Version</h3>
 				<div class='cursorPointer' onclick='closeWindows();'>x</div>
 			</div>
@@ -536,8 +536,8 @@
 
 <!-- Group Members Table START -->
 <div id='grptblContainer' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox'>
-			<div class='loginBoxheader'>
+		<div class='formBox'>
+			<div class='formBoxHeader'>
 				<h3>Group Members</h3>
 				<div class='cursorPointer' onclick='closeWindows();'>x</div>
 			</div>
@@ -551,8 +551,8 @@
 
 	<!-- HighscoreBox START -->
 	<div id='HighscoreBox' class='loginBoxContainer' style='display:none;'>
-		<div class='loginBox' style='width:500px;'>
-			<div class='loginBoxheader'>
+		<div class='formBox' style='width:500px;'>
+			<div class='formBoxHeader'>
 				<h3>Highscore</h3>
 				<div class='cursorPointer' onclick='closeWindows();'>x</div>
 			</div>
@@ -565,8 +565,8 @@
 
 	<!-- User Feedback Dialog START -->
     <div id='userFeedbackDialog' class='loginBoxContainer' style='display:none;'>
-      <div class='loginBox' id='variantBox'>
-        <div class='loginBoxheader'>
+      <div class='formBox' id='variantBox'>
+        <div class='formBoxHeader'>
           <h3 id="userFeedbackTitle">User Feedback</h3> 
           <div class='cursorPointer' onclick='closeWindows();'>x</div>
         </div>
@@ -585,8 +585,8 @@
 	
 	<!-- Load Dugga Popup (Enter hash to get redirected to specified dugga) -->
 	<div id='loadDuggaBox' class="loginBoxContainer" style="display:none">
-	  <div class="loadDuggaBox loginBox DarkModeBackgrounds DarkModeText" style="max-width:400px; overflow-y:visible;">
-			<div class='loginBoxheader'><h3>Load dugga with hash</h3><div class='cursorPointer' onclick="hideLoadDuggaPopup()">x</div></div>
+	  <div class="loadDuggaBox formBox DarkModeBackgrounds DarkModeText" style="max-width:400px; overflow-y:visible;">
+			<div class='formBoxHeader'><h3>Load dugga with hash</h3><div class='cursorPointer' onclick="hideLoadDuggaPopup()">x</div></div>
 			<div id='loadDuggaInfo'></div>
     		<div id='loadDuggaPopup' style="display:block">
 				<div class='inputwrapper'><span>Enter your hash:</span><input class='textinput' type='text' id='hash' placeholder='Hash' value=''/></div>
@@ -603,8 +603,8 @@
 	<!-- github moments box  -->
 	<form action="" method="POST" id="form">
 		<div id='gitHubBox' class='loginBoxContainer' style='display:none;'>
-			<div class='loginBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
-				<div class='loginBoxheader'>
+			<div class='formBox DarkModeBackgrounds DarkModeText' style='width:460px;'>
+				<div class='formBoxHeader'>
 					<h3>Github Moment</h3>
 					<div class="cursorPointer" onclick='confirmBox("closeConfirmBox");' title="Close window">x</div>
 				</div>
@@ -634,8 +634,8 @@
 	
 	<!--error window opened when github repo not found-->
 	<div id="githubPopupWindow" class="loginBoxContainer" style="display: none;">
-		<div class="loginBox DarkModeBackgrounds" style='width:464px;overflow:hidden;'>	
-			<div class= "loginBoxheader">
+		<div class="formBox DarkModeBackgrounds" style='width:464px;overflow:hidden;'>	
+			<div class= "formBoxHeader">
   					<h3>Github repo</h3>
 		  			<div class='cursorPointer'	onclick='closeWindows();'>x</div>
 			</div>
@@ -656,8 +656,8 @@
 
 	<!-- github template  -->
 		<div id='gitHubTemplate' class="loginBoxContainer"  style="display:none;">
-				<div id='chooseTemplate' class='loginBox DarkModeBackgrounds' style='width:464px;'>
-					<div class='loginBoxheader'>
+				<div id='chooseTemplate' class='formBox DarkModeBackgrounds' style='width:464px;'>
+					<div class='formBoxHeader'>
 						<h3>Choose Template</h3>
 						<div class='cursorPointer' onclick='confirmBox("closeConfirmBox");'>x</div>
 					</div>

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -213,10 +213,10 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 		?>
 	</div>
 	
-	<!-- LoginBox (receipt&Feedback-box ) Start! -->
+	<!-- FormBox (receipt&Feedback-box ) Start! -->
 	<div id='receiptBox' class="loginBoxContainer" style="display:none">
-	  <div class="receiptBox loginBox" style="max-width:400px; overflow-y:visible;">
-			<div class='loginBoxheader'><h3>Dugga Submission Receipt</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
+	  <div class="receiptBox formBox" style="max-width:400px; overflow-y:visible;">
+			<div class='formBoxHeader'><h3>Dugga Submission Receipt</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
 			<div id='feedbackbox'>
 				<span id='feedbackquestion'></span>
 					<div id="ratingbox">
@@ -303,8 +303,8 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 	</div>
 
 	<div id='loadDuggaBox' class="loginBoxContainer" style="display:none">
-	  <div class="loadDuggaBox loginBox" style="max-width:400px; overflow-y:visible;">
-			<div class='loginBoxheader'><h3>Load dugga with hash</h3><div class='cursorPointer' onclick="hideLoadDuggaPopup()">x</div></div>
+	  <div class="loadDuggaBox formBox" style="max-width:400px; overflow-y:visible;">
+			<div class='formBoxHeader'><h3>Load dugga with hash</h3><div class='cursorPointer' onclick="hideLoadDuggaPopup()">x</div></div>
 			<div id='loadDuggaInfo'></div>
     		<div id='loadDuggaPopup' style="display:block">
 				<div class='inputwrapper'><span>Enter hash:</span><input class='textinput' type='text' id='hash' placeholder='Hash' value='' autocomplete="off"/></div>

--- a/DuggaSys/templates/3d-dugga.html
+++ b/DuggaSys/templates/3d-dugga.html
@@ -120,8 +120,8 @@
     </div>
     </div>
     
-    <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-        <div class='loginBoxheader'>
+    <div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+        <div class='formBoxHeader'>
             <h3>Dugga Stats</h3>
             <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
         </div>

--- a/DuggaSys/templates/XMLAPI_report1.html
+++ b/DuggaSys/templates/XMLAPI_report1.html
@@ -45,8 +45,8 @@
 		</div>	
 	</div>
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/bit-dugga.html
+++ b/DuggaSys/templates/bit-dugga.html
@@ -89,8 +89,8 @@
 				</tr>
 		</table>												
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/boxmodell.html
+++ b/DuggaSys/templates/boxmodell.html
@@ -7,16 +7,16 @@
 <div id="container">
     <canvas id='myCanvas' width="625" height="625" style='background-color:#FFFFFF; border:2px solid black;margin:0 auto;'></canvas>
     <div class='floatRightBox' style="min-width:300px;">
-	    <div class='loginBoxheader'>
+	    <div class='formBoxHeader'>
 	        <h3>Uppgiften</h3>
 	    </div>
 	    <p id="duggaQuery"></p>
 	</div>
 </div>
 
-<div id='duggaInfoBox' class="loginBox" style="display:none">
+<div id='duggaInfoBox' class="formBox" style="display:none">
   <div>
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3 style="width: 75%;">Dugga - Boxmodellen</h3>
             <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
         </div>
@@ -38,8 +38,8 @@
     </div>
 </div>
 
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/clipping_masking_dugga.html
+++ b/DuggaSys/templates/clipping_masking_dugga.html
@@ -18,14 +18,14 @@
 </div> -->
 <div style="width:1000px;margin: auto;">
     <div id='duggaInfoBox3' style="margin:0 4px 0 4px;width:300px;display: inline-block;vertical-align: top;">
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3>Målbild</h3>
         </div>
         <p style="margin-left: 4px;">Rita följande:</p>
         <img id="target-img" src="" style="display:block;width:100%;height:300px;overflow: hidden;">
     </div>
     <div style="margin:0 4px 0 4px;width:300px;display: inline-block;vertical-align: top;">
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3>Rityta</h3>
         </div>
         <p style="margin-left: 4px;">&nbsp;</p>
@@ -34,7 +34,7 @@
             width="300" height="300"></canvas>
     </div>
     <div id="toolbox" style="width:350px;display: inline-block;vertical-align: top;">
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3>Ritverktyg</h3>
         </div>
         <p style="margin-left: 4px;">&nbsp;</p>
@@ -88,8 +88,8 @@
             </div>
         </div>
     </div>
-    <div id="feedback" class="loginBox" style="display:none;flex-grow: 1">
-        <div class='loginBoxheader'>
+    <div id="feedback" class="formBox" style="display:none;flex-grow: 1">
+        <div class='formBoxHeader'>
             <h3>Feedback Log</h3>
         </div>
         <div class="table-wrap" id="feedbackTable">
@@ -101,8 +101,8 @@
             </table>
         </div>
     </div>
-    <div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-        <div class='loginBoxheader'>
+    <div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+        <div class='formBoxHeader'>
             <h3>Dugga Stats</h3>
             <div onclick="hideReceiptPopup()">x</div>
         </div>

--- a/DuggaSys/templates/color-dugga.html
+++ b/DuggaSys/templates/color-dugga.html
@@ -73,8 +73,8 @@
 				</tr>
 		</table>												
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/curve-dugga.html
+++ b/DuggaSys/templates/curve-dugga.html
@@ -5,7 +5,7 @@
 		</div>
 </div>
 <div id='curveInfoBox'>
-	<div class='loginBoxheader'>
+	<div class='formBoxHeader'>
 			<h3>Kurv-duggan</h3>
 	</div>
 	<p style="margin-left: 4px;">Kurv-duggan går ut på att fylla i det gråa streck som är ritat med hjälp av linjer och kurvor.</p> 
@@ -16,7 +16,7 @@
 <canvas id='a' style='background-color:#FFFFFF; border:2px solid black; cursor:none; display:inline-block;vertical-align:top;margin: 0px 10px;' width="400" height="400"></canvas>
 <div id="infobox" style="padding:4px;display:inline-block;vertical-align:top;">
 	<div id="quizInstructions"></div>
-	<div class='loginBoxheader'>
+	<div class='formBoxHeader'>
 			<h3>Ritverktyg</h3>
 	</div>
 
@@ -32,7 +32,7 @@
 		<input type="button" class="submit-button" value="FLYTTA NER" onclick="movedownbutton();">                
 		<input type="button" class="submit-button" value="TA BORT" onclick="deletebutton();">
 	</div>
-	<div class='loginBoxheader'>
+	<div class='formBoxHeader'>
 		<h3>Variera bredden på pennan</h3>
 	</div>
 	<div>
@@ -51,8 +51,8 @@
 <div id="debugCanvas" style="display:none;font-size: 8px; position: fixed; bottom: 60px; left: 90%;"></div>
 <div id="debugActiveObj" style="display:none;font-size: 8px; position: fixed; bottom: 80px; left: 90%;"></div>
 
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/daily-minutes.html
+++ b/DuggaSys/templates/daily-minutes.html
@@ -15,8 +15,8 @@
 </div>
 <!-- end of Fab-button-->
 
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/dugga1.html
+++ b/DuggaSys/templates/dugga1.html
@@ -94,8 +94,8 @@
 				</tr>
 		</table>												
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/dugga2.html
+++ b/DuggaSys/templates/dugga2.html
@@ -73,8 +73,8 @@
 				</tr>
 		</table>												
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/dugga3.html
+++ b/DuggaSys/templates/dugga3.html
@@ -24,7 +24,7 @@
         <div id="infobox" class="floatleftBox" style="padding:4px; z-index: 2;">
             <div id="quizInstructions"></div>
 
-            <div class='loginBoxheader'>
+            <div class='formBoxHeader'>
                 <h3>Ritverktyg</h3>
             </div>
 
@@ -45,7 +45,7 @@
 </div>
 <div style="display:none">
   <div>
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3>Dugga 3 - Geometri</h3>
             <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
         </div>
@@ -75,8 +75,8 @@
 <div id="debugCanvas" style="display:none;font-size: 8px; position: fixed; bottom: 60px; left: 90%;"></div>
 <div id="debugActiveObj" style="display:none;font-size: 8px; position: fixed; bottom: 80px; left: 90%;"></div>
 
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/dugga4.html
+++ b/DuggaSys/templates/dugga4.html
@@ -18,7 +18,7 @@
     <canvas id='a' style='background-color:#FFFFFF; border:2px solid black; display:block;'></canvas>
 
     <div id="toolbox" style="min-width:340px;width:340px;display:inline-block;">
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3>Ritverktyg</h3>
         </div>
      	<div style="display:flex;justify-content:center; margin-top:20px;">
@@ -82,9 +82,9 @@
 
 </div>
 
-<div id='duggaInfoBox' class="loginBox" style="display:none">
+<div id='duggaInfoBox' class="formBox" style="display:none">
   <div>
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3 style="width: 75%;">Dugga 4 - Transformationer</h3>
             <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
         </div>
@@ -107,8 +107,8 @@
     </div>
 </div>
 
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/dugga5.html
+++ b/DuggaSys/templates/dugga5.html
@@ -11,7 +11,7 @@
 <div>
     <div id="infobox" class="floatRightBox" style="width:300px;">
     <div id="quizInstructions"></div>
-    <div class='loginBoxheader'>
+    <div class='formBoxHeader'>
         <h3>Ritverktyg</h3>
     </div>
     <div id="vertexPane" class='submit-button' type="button" style="float:left;" onclick="toggleControl();">Vertice<span id="vertexPaneNumber" style="display:none" class='badge'></span></div>
@@ -90,9 +90,9 @@
         </div>
         <div id="result"></div>
     </div>
-<div id='duggaInfoBox' class="loginBox" style="display:block">
+<div id='duggaInfoBox' class="formBox" style="display:block">
   <div>
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3>3D-dugga</h3>
             <div class='cursorPointer' onclick="hideDuggaInfoPopup();">x</div>
         </div>
@@ -115,8 +115,8 @@
     </div>
 </div>
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/duggaTest.html
+++ b/DuggaSys/templates/duggaTest.html
@@ -86,8 +86,8 @@
 				</tr>
 		</table>												
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/feedback_dugga.html
+++ b/DuggaSys/templates/feedback_dugga.html
@@ -13,8 +13,8 @@
       <div class='instructions-container' style=" -webkit-columns: 1; -moz-columns: 1; columns: 1; flex:1">
       		<div class='instructions-button' onclick='toggleInstructions(this)'><h3 id="feedback-header">Feedback</h3></div>	
       		<div class="" id="tomten">      			
-        			<div id="feedbackBoxy" class="loginBox" style="display:none;">
-        	    <div class='loginBoxheader'>
+        			<div id="feedbackBoxy" class="formBox" style="display:none;">
+        	    <div class='formBoxHeader'>
         	        <h3>Feedback Log</h3>
         	        <div class='cursorPointer' onclick="hideReceiptPopup()">x</div>
         	    </div>
@@ -28,8 +28,8 @@
   	   </div>
    </div>
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/feedback_dugga.js
+++ b/DuggaSys/templates/feedback_dugga.js
@@ -361,7 +361,7 @@ function createFileUploadArea(fileuploadfileds){
 		form +="</form>";
 		
 		str += "<div style='border:1px solid #614875; margin: 5px auto;'>";
-		str += "<div class='loginBoxheader'>";
+		str += "<div class='formBoxHeader'>";
 		if (type === "pdf"){
 			str += "<h3>Pdf Submission and Preview</h3>";
 		} else if (type === "link"){

--- a/DuggaSys/templates/generic_dugga_file_receive.html
+++ b/DuggaSys/templates/generic_dugga_file_receive.html
@@ -11,8 +11,8 @@
 		<div class="instructions-content" id="tomten"></div>	
 	</div>
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/group-assignment.html
+++ b/DuggaSys/templates/group-assignment.html
@@ -12,8 +12,8 @@
 		<div class="instructions-content" style=" -webkit-columns: 1; -moz-columns: 1; columns: 1; " id="tomten"></div>	
 	</div>
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/html_css_dugga.html
+++ b/DuggaSys/templates/html_css_dugga.html
@@ -19,13 +19,13 @@
          
             <div id="target-col" class="dugga-col" >
                 <div>
-                    <div><h2 class='loginBoxheader' >Webbplatsutseende som skall skapas</h2><p style="margin:10px;"><strong>Extrakrav: </strong><span id="target-text"></span></p></div>
+                    <div><h2 class='formBoxHeader' >Webbplatsutseende som skall skapas</h2><p style="margin:10px;"><strong>Extrakrav: </strong><span id="target-text"></span></p></div>
                     <div id="target-window" ><img id="target-window-img" src="" /></div>
                 </div>
             </div> 
             <div id="input-col" class="dugga-col">
                 <div style="width:100%; height:100%; position:relative;">
-                    <div><h2 class='loginBoxheader'>Skriv/klistra in kod</h2></div>
+                    <div><h2 class='formBoxHeader'>Skriv/klistra in kod</h2></div>
                     <div id="input-col-content"><textarea id="content-window" onkeyup="processpreview(); canSaveController();"></textarea></div>
                     <div id="input-col-URL"><label>Adress (URL) till din publicerad version:</label><br>
                         <input id="url-input" type="text" name="url" placeholder="http://wwwlab.iit.his.se/<ditt login>/<sökvägen till din dugga>" onkeyup="canSaveController();">
@@ -35,15 +35,15 @@
             </div> 
             <div id="preview-col" class="dugga-col">
                 <div>
-                    <div id="code-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av inklistrad programkod</h2></div>
+                    <div id="code-preview-label"><h2 class='formBoxHeader'>Förhandsgranskning av inklistrad programkod</h2></div>
                     <div  id="code-preview-window-wrapper"><iframe id="code-preview-window"></iframe></div>
-                    <div id="url-preview-label"><h2 class='loginBoxheader'>Förhandsgranskning av publicerad kod</h2><p>Skall se identisk ut med ovan ovanstående.</p></div>
+                    <div id="url-preview-label"><h2 class='formBoxHeader'>Förhandsgranskning av publicerad kod</h2><p>Skall se identisk ut med ovan ovanstående.</p></div>
                     <div id="url-preview-window-wrapper"><div id="url-preview-window"></div></div>
                 </div>
             </div> 
             <div id="validation-col" class="dugga-col">
                 <div>
-                    <div id="validation-label"><h2 class='loginBoxheader'>Validering</h2></div>
+                    <div id="validation-label"><h2 class='formBoxHeader'>Validering</h2></div>
                     <div id="validation-content">
                         <div id="url-validation-window"></div>
                 </div>
@@ -54,8 +54,8 @@
 
 <!-- <div id='duggaInfoBox' class="loginBoxContainer" style="display:none"> -->
     <div style="display:none">
-  <div class="loginBox"  style="max-width:350px;">
-    <div class='loginBoxheader'>
+  <div class="formBox"  style="max-width:350px;">
+    <div class='formBoxHeader'>
         <h3>Dugga - HTML/CSS</h3>
         <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
     </div>
@@ -78,8 +78,8 @@
 </div>
 
 <div id="duggaStats" class="loginBoxContainer" style="display:none;position:absolute;top:0;right:0;">
-  <div class="loginBox">
-    <div class='loginBoxheader'>
+  <div class="formBox">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/html_css_dugga.js
+++ b/DuggaSys/templates/html_css_dugga.js
@@ -290,7 +290,7 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 			var iframeX = $("#preview-col").width();
 			var iframeY = $("#preview-col").height();
 
-			document.getElementById("url-preview-label").innerHTML = '<div id="url-preview-label" style=""><h2 class="loginBoxheader" style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Förhandsgranskning av publicerad kod</h2></div>';
+			document.getElementById("url-preview-label").innerHTML = '<div id="url-preview-label" style=""><h2 class="formBoxHeader" style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Förhandsgranskning av publicerad kod</h2></div>';
 			document.getElementById("url-preview-window").innerHTML= '<iframe style="pointer-events: none; width: '+800+'px; height:'+768+'px; border: 1px solid black; overflow:scroll; transform:scale('+iframeX/800+'); transform-origin:0 0; box-sizing:border-box;" src="'+userUrl+'"></iframe>';
 
 			document.getElementById("validation-col").style.height = (markWindowHeight-55)+"px";

--- a/DuggaSys/templates/html_css_dugga_light.html
+++ b/DuggaSys/templates/html_css_dugga_light.html
@@ -9,25 +9,25 @@
         <tr>
             <td id="target-col" class="dugga-col" style="max-width:400px;min-width:350px;vertical-align:top; background-color:#FFF;box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:scroll;">
                 <div>
-                    <div><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Uppgiftsbeskrivning</h2><p style="margin:10px;"><span id="target-text"></span></p></div>
+                    <div><h2 class='formBoxHeader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Uppgiftsbeskrivning</h2><p style="margin:10px;"><span id="target-text"></span></p></div>
                     <div id="target-window" style="min-width:200px;min-height:400px;max-width:600px;overflow:scroll;"><div id="snus"></div></div>
                 </div>
             </td>
             <td id="input-col" class="dugga-col" style="min-width:400px;vertical-align:top; background-color:#FFF;vertical-align:top; box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:hidden;">
                 <div style="width:100%; height:100%; position:relative;">
-                    <div><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Skriv/klistra in kod</h2></div>
+                    <div><h2 class='formBoxHeader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Skriv/klistra in kod</h2></div>
                     <div style="position:absolute;top:45px;left:15px;right:15px;bottom:100px;"><textarea id="content-window" onkeyup="processpreview();" style="resize: none;display:block;width:100%;height:100%;box-sizing:border-box; "></textarea></div></div>
                 </div>
             </td>
             <td id="preview-col" class="dugga-col" style="width:400px;vertical-align:top; background-color:#FFF;vertical-align:top; box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:hidden;">
                 <div>
-                    <div id="code-preview-label"><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; margin-bottom:10px; color:#FFF;overflow:hidden; text-align:center;">Förhandsgranskning av inklistrad programkod</h2></div>
+                    <div id="code-preview-label"><h2 class='formBoxHeader' style="padding:5px; padding-bottom:10px; margin-top:0; margin-bottom:10px; color:#FFF;overflow:hidden; text-align:center;">Förhandsgranskning av inklistrad programkod</h2></div>
                     <div  id="code-preview-window-wrapper" style="width:400px;height:265px;"><iframe id="code-preview-window" style="transform:scale(0.5); transform-origin:0 0; box-sizing:border-box; border:2px solid red;overflow:hidden;margin:1px; width:796px; min-height:530px; box-shadow: 0 2px 5px 0 rgba(0,0,0,0.3),0 2px 5px 0 rgba(0,0,0,0.1);"></iframe></div>
                 </div>
             </td>
             <td id="validation-col" class="dugga-col" style="width:400px;vertical-align:top;display:none; background-color:#FFF;vertical-align:top;box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);overflow:hidden;">
                 <div>
-                    <div id="validation-label"><h2 class='loginBoxheader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Validering</h2></div>
+                    <div id="validation-label"><h2 class='formBoxHeader' style="padding:5px; padding-bottom:10px; margin-top:0; color:#FFF;overflow:hidden; text-align:center;">Validering</h2></div>
                     <div id="validation-content" style="width:400px;height:265px;">
                         <div id="url-validation-window"></div>
                 </div>
@@ -39,7 +39,7 @@
 <!-- <div id='duggaInfoBox' class="loginBox" style="display:none"> -->
 <div style="display:none">
   <div>
-    <div class='loginBoxheader'>
+    <div class='formBoxHeader'>
         <h3 style="width: 75%;">Dugga - HTML/CSS</h3>
         <div class='cursorPointer' onclick="hideDuggaInfoPopup()">x</div>
     </div>
@@ -61,8 +61,8 @@
 </div>
 </div>
 
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/new-assignment.html
+++ b/DuggaSys/templates/new-assignment.html
@@ -135,8 +135,8 @@
 		<div class="instructions-content" style=" -webkit-columns: 1; -moz-columns: 1; columns: 1; " id="tomten"></div>	
 	</div>
 </div>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/shapes-dugga.html
+++ b/DuggaSys/templates/shapes-dugga.html
@@ -5,8 +5,8 @@
 		</div>
 </div>
 <div class='instructions-container'>
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/svg-dugga.html
+++ b/DuggaSys/templates/svg-dugga.html
@@ -29,8 +29,8 @@
     </div>
 </div>
 
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div class='cursorPointer' onclick="hideDuggaStatsPopup()">x</div>
     </div>

--- a/DuggaSys/templates/transforms-dugga.html
+++ b/DuggaSys/templates/transforms-dugga.html
@@ -22,7 +22,7 @@
     <div id="transformToolbox" style="min-width:340px;width:340px;display: flex;flex-direction: column;justify-content: flex-start;">
         <!-- Draw tools -->
         <div id="toolboxTransform" style="flex-grow: 1">     
-            <div class='loginBoxheader'>
+            <div class='formBoxHeader'>
                 <h3>Ritverktyg</h3>
             </div>
             <div style="display:flex;justify-content:center;align-items: baseline;">
@@ -87,9 +87,9 @@
 
 </div>
 
-<div id='duggaInfoBox' class="loginBox" style="display:none">
+<div id='duggaInfoBox' class="formBox" style="display:none">
   <div>
-        <div class='loginBoxheader'>
+        <div class='formBoxHeader'>
             <h3 style="width: 75%;">Dugga 4 - Transformationer</h3>
             <div onclick="hideDuggaInfoPopup()">x</div>
         </div>
@@ -112,8 +112,8 @@
     </div>
 </div>
 
-<div id="duggaStats" class="loginBox" style="display:none;position:absolute;top:0;right:0;">
-    <div class='loginBoxheader'>
+<div id="duggaStats" class="formBox" style="display:none;position:absolute;top:0;right:0;">
+    <div class='formBoxHeader'>
         <h3>Dugga Stats</h3>
         <div onclick="hideReceiptPopup()">x</div>
     </div>

--- a/DuggaSys/testDugga.php
+++ b/DuggaSys/testDugga.php
@@ -92,9 +92,9 @@
 
 	</div>
 
-	<!-- LoginBox (receiptbox) Start! -->
-	<div id='receiptBox' class="loginBox" style="display:none">
-		<div class='loginBoxheader'><h3>Receipt - Dugga answers</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
+	<!-- FormBox (receiptbox) Start! -->
+	<div id='receiptBox' class="formBox" style="display:none">
+		<div class='formBoxHeader'><h3>Receipt - Dugga answers</h3><div class='cursorPointer' onclick="hideReceiptPopup()">x</div></div>
 		<div id='receiptInfo'></div>
 		<textarea id="receipt" autofocus readonly></textarea>
 		<div class="button-row">

--- a/DuggaSys/validateHash.php
+++ b/DuggaSys/validateHash.php
@@ -69,8 +69,8 @@
 ?>
 
 	<div id='loadDuggaBox' class="loginBoxContainer" style="display:flex">
-	  <div class="loadDuggaBox loginBox" style="max-width:400px; overflow-y:visible;">
-			<div class='loginBoxheader'><h3>Load dugga with hash</h3><div class='cursorPointer' onclick="hideLoadDuggaPopup()">x</div></div>
+	  <div class="loadDuggaBox formBox" style="max-width:400px; overflow-y:visible;">
+			<div class='formBoxHeader'><h3>Load dugga with hash</h3><div class='cursorPointer' onclick="hideLoadDuggaPopup()">x</div></div>
 			<div id='loadDuggaInfo'></div>
     		<div id='loadDuggaPopup' style="display:block">
                 <form method="post" >

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -558,7 +558,7 @@ body {
     box-shadow: none;
 }
 
-.loginBox,
+.formBox, .loginBox,
 .logoutBox{
   background-color: var(--color-background);
   color: var(--color-text-light);
@@ -997,12 +997,12 @@ input{
 /* END */
 
 /* Style for fieldset elements in #Show Test" editor.  START */
-.loginBox select{
+.formBox select, .loginBox select{
     background-color: #212121;
     color:white;
 }
 
-.loginBox textarea, #receipt{
+.formBox textarea, .loginBox textarea, #receipt{
     background-color: #212121;
     color:white;
 }

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -874,7 +874,7 @@
     height: 30px;
 }
 
-.loginBox {
+.formBox, .loginBox {
     top: 25%;
 }
 

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -524,7 +524,7 @@ svg text {
     box-shadow: 0 2px 5px 0 rgba(0,0,0,0.5),0 2px 10px 0 rgba(0,0,0,0.1);
     overflow:scroll;
 }
-.dugga-col .loginBoxheader{
+.dugga-col .formBoxHeader, .loginBoxheader{
     padding:5px;
     padding-bottom:10px;
     margin-top:0; 
@@ -692,7 +692,7 @@ svg text {
  #transformInfoBox {
 	 width: 100%;
  }
- #transformInfoBox .loginBoxheader {
+ #transformInfoBox .formBoxHeader, .loginBoxheader {
 	 width: 100%;
  }
  .transformContainer {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1888,6 +1888,11 @@ div .navButt:hover {
   margin: 10px 0px;
 }
 
+#login, #logout {
+  max-width: fit-content;
+}
+
+.formBox, 
 .loginBox,
 .logoutBox{
   padding: 4px;
@@ -2043,6 +2048,7 @@ div .navButt:hover {
   border-radius: 2px;
 }
 
+.formBox textarea, 
 .loginBox textarea,
 #import {
   width: 100%;
@@ -2055,6 +2061,7 @@ div .navButt:hover {
   padding: 5px;
 }
 
+.formBox textarea, 
 .loginBox textarea,
 #receipt {
   width: 100%;
@@ -2092,6 +2099,7 @@ Dialog Box END
 /* --------------===============################================-------------- *
  *                                    Generic functions                            *
  * --------------================################================--------------*/
+.formBox .inputwrapper, 
 .loginBox .inputwrapper {
   clear: both;
   width: 100%;
@@ -2099,16 +2107,19 @@ Dialog Box END
   line-height: 30px;
 }
 
-.inputwrapper #startdate, .inputwrapper #enddate {
+.inputwrapper #startdate, 
+.inputwrapper #enddate {
   font-family:"Roboto";
   color:#7f7f7f;
 }
 
+.formBox .inputwrapper span, 
 .loginBox .inputwrapper span {
   float: left;
 }
 
 
+.formBox .inputwrapperSmall, 
 .loginBox .inputwrapperSmall {
   clear: both;
   width: 100%;
@@ -2117,27 +2128,34 @@ Dialog Box END
   line-height: 30px;
 }
 
+.formBox .inputwrapperSmall span, 
 .loginBox .inputwrapperSmall span {
   float: right;
 }
 
+.formBox .inputwrapperSmall input,
+.formBox .inputwrapperSmall select,
 .loginBox .inputwrapperSmall input,
 .loginBox .inputwrapperSmall select {
   float: right;
   width: 50px;
 }
 
-.loginBox .inputwrapperSmall input[type="checkbox"] {
+.formBox .inputwrapperSmall input[type="checkbox"],
+.loginBox .inputwrapperSmall input[type="checkbox"]{
   height: 24px;
 }
 
 
+.formBox .inputwrapper input,
+.formBox .inputwrapper select,
 .loginBox .inputwrapper input,
 .loginBox .inputwrapper select {
   float: right;
   width: 195px;
 }
 
+.formBox .inputwrapper input[type="checkbox"],
 .loginBox .inputwrapper input[type="checkbox"] {
   margin-right: 171px;
   float: right;
@@ -2145,6 +2163,7 @@ Dialog Box END
   width: 24px;
 }
 
+.formBox select,
 .loginBox select {
   width: 195px;
   height: 30px;
@@ -2160,6 +2179,7 @@ Dialog Box END
   font-size: 14px;
 }
 
+.formBoxHeader,
 .loginBoxheader,
 .logoutBoxheader {
   background-color: var(--color-primary);
@@ -2170,6 +2190,7 @@ Dialog Box END
   justify-content: space-between;
 }
 
+.formBoxHeader h3,
 .loginBoxheader h3,
 .logoutBoxheader h3 {
   font-size: 14px;
@@ -2179,6 +2200,7 @@ Dialog Box END
   width: 100%;
 }
 
+.formBoxHeader div,
 .loginBoxheader div,
 .logoutBoxheader div {
   padding: 4px 20px;
@@ -2189,7 +2211,9 @@ Dialog Box END
   font-weight: bold;
 }
 
-.loginBoxheader div:hover, .logoutBoxheader div:hover {
+.formBoxHeader div:hover, 
+.loginBoxheader div:hover,
+.logoutBoxheader div:hover {
   background-color: #ce3d3d;
 }
 
@@ -2433,17 +2457,20 @@ label.login-label {
   overflow: auto;
 }
 
+.formBox form,
 .loginBox form,
 .logoutBox form {
   padding-bottom: 20px;
 }
 
+.formBox .text,
 .loginBox .text,
 .logoutBox .text {
   font-size: 0.8em;
 }
 
-.loginBox .submit {
+.formBox .submit,
+ .loginBox .submit {
   width: 80px;
   height: 25px;
   color: var(--color-text-header);
@@ -2453,6 +2480,7 @@ label.login-label {
   margin-left: 1px;
 }
 
+.formBox .cancel,
 .loginBox .cancel {
   width: 80px;
   height: 25px;
@@ -2464,7 +2492,8 @@ label.login-label {
   margin-left: 1px;
 }
 
-.loginBox .forgotPw {
+.formBox .forgotPw,
+.loginBox .forgotPw  {
   cursor: pointer;
   text-decoration: underline;
 }
@@ -2481,17 +2510,21 @@ label.login-label {
 }
 
 
+.formBox .form-control,
 .loginBox .form-control {
   margin: 3px 0px 3px 0px;
 }
 
+.formBox .hide,
 .loginBox .hide {
   display: none;
 }
+
 #undoButton {
   position: absolute; padding-right:5px; margin-right:164px; display: none;
 }
 
+.formBox td,
 .loginBox td {
   margin-left: 4px;
   margin-right: 4px;
@@ -2500,6 +2533,7 @@ label.login-label {
 .logoutBox p {
   text-align: center;
 }
+
 .buttonLoginBox,
 .buttonLogoutBox {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -5751,11 +5785,6 @@ only screen and (max-device-width: 568px) {
     transform: scale(0.6, 0.6);
     left: 4px;
   }
-
-  .loginBox {
-    /*top: 8%;
-    left: 10%;*/
-  }
   
   #searchNavButt{
     display: none;
@@ -7369,7 +7398,7 @@ only screen and (max-device-width: 568px) {
   display: none;
 }
 
-.loginBoxheade, .fileViewHeader {
+.formBoxHeader, .loginBoxheader, .fileViewHeader {
   text-align:left;
 }
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -155,7 +155,7 @@ function toggleloginnewpass(){
   //Shows the New password-box (username input)
 	if(status == 0){
 		$("#newpassword").css("display", "block");
-		$("#loginBox").css("display", "flex");
+		$("#formBox").css("display", "flex");
     $("#login").hide();
 		$("#showsecurityquestion").css("display", "none");
 		$("#resetcomplete").css("display", "none");
@@ -172,7 +172,7 @@ function toggleloginnewpass(){
     //Shows the Sequrity question-box (answer for question input)
 	}else if(status == 2){
 		$("#newpassword").css("display", "none");
-		$("#loginBox").css("display", "flex");
+		$("#formBox").css("display", "flex");
 		$("#showsecurityquestion").css("display", "block");
 		$("#resetcomplete").css("display", "none");
 		status= 1;
@@ -181,7 +181,7 @@ function toggleloginnewpass(){
   //Shows the Reset complete-box
 	else if(status == 3){
 		$("#newpassword").css("display", "none");
-		$("#loginBox").css("display", "flex");
+		$("#formBox").css("display", "flex");
 		$("#showsecurityquestion").css("display", "none");
 		$("#resetcomplete").css("display", "block");
 		status= 1;
@@ -1789,7 +1789,7 @@ function processLogout() {
 
 function showLoginPopup()
 {
-	$("#loginBox").css("display","flex");
+	$("#formBox").css("display","flex");
 	/*$("#overlay").css("display","block");*/
 	$("#username").focus();
 
@@ -1805,7 +1805,7 @@ function showLoginPopup()
 
 function hideLoginPopup()
 {
-		$("#loginBox").css("display","none");
+		$("#formBox").css("display","none");
 		/*$("#overlay").css("display","none");*/
 
 		window.removeEventListener("keypress", loginEventHandler, false);

--- a/Shared/loginbox.php
+++ b/Shared/loginbox.php
@@ -27,9 +27,9 @@
 
 	<!-- Login Box Start! -->
   <!--  <div id='loginBox' class="loginBox" style="display:none;display:flex;justify-content:center;align-items:center;">-->
-    <div id='loginBox' class="loginBoxContainer" style="display:none;">
-		<div id='login' class="loginBox DarkModeBackgrounds DarkModeText">
-			<div class='loginBoxheader'>
+    <div id='formBox' class="loginBoxContainer" style="display:none;">
+		<div id='login' class="formBox DarkModeBackgrounds DarkModeText">
+			<div class='formBoxHeader'>
 				<h3>Login</h3>
 				<div class="cursorPointer" onclick="closeWindows()" title="Close window">x</div>
 			</div>
@@ -68,7 +68,7 @@
 			</form>
 		</div>
 		<div id='newpassword' class='newpassword DarkModeBackgrounds DarkModeText' style="display:none">
-			<div class='loginBoxheader'>
+			<div class='formBoxHeader'>
 				<h3> Reset Password</h3>
 				<div class="cursorPointer" onclick="closeWindows(); resetLoginStatus();" title="Close window">x</div>
 			</div>
@@ -102,7 +102,7 @@
 			</tr>
 		</div>
 		<div id='showsecurityquestion' class='showsecurityquestion' style="display:none">
-			<div class='loginBoxheader'>
+			<div class='formBoxHeader'>
 				<h3> Reset Password</h3>
 				<div class="cursorPointer" onclick="closeWindows();resetLoginStatus()" title="Close window">x</div>
 			</div>
@@ -144,7 +144,7 @@
 
 		</div>
 		<div id='resetcomplete' class='resetcomplete' style="display:none">
-			<div class='loginBoxheader' id="completeid">
+			<div class='formBoxHeader' id="completeid">
 				<h3>Request complete</h3>
 				<div class='cursorPointer' onclick="closeWindows()" title="Close window">x</div>
 			</div>
@@ -168,8 +168,8 @@
 	<!-- Login Box End! -->
 
   <!-- Security question notifaction -->
-    <div class="loginBox" id="securitynotification" style="display:none;">
-         <div class='loginBoxheader'>
+    <div class="formBox" id="securitynotification" style="display:none;">
+         <div class='formBoxHeader'>
           <h3>Choose a challenge question</h3>
           <div class='cursorPointer' onclick="closeWindows(); setSecurityNotifaction('off');" title="Close window">x</div>
         </div>
@@ -179,7 +179,7 @@
 
   <!-- Session expire message -->
   <div class="expiremessagebox" style="display:none">
-    <div class='loginBoxheader'>
+    <div class='formBoxHeader'>
       <h3>Alert</h3>
       <div class='cursorPointer' onclick="closeWindows()" title="Close window">x</div>
     </div>
@@ -188,7 +188,7 @@
   </div>
 
   <div class="endsessionmessagebox" style="display:none">
-    <div class='loginBoxheader'>
+    <div class='formBoxHeader'>
       <h3>Alert</h3>
       <div onclick="closeWindows(); reloadPage(); processLogout()">x</div>
     </div>


### PR DESCRIPTION
The previous pull request and solution was done on an old branch. This pull request contains the new changes from the weekly merge and the changes requested in the previous pull request. The changes include adding "loginBox" and "loginBoxheader" to the css files in which they were removed in the first pull request. The idea behind this is to have them act as "safety measures", just in case I missed changing any of the refactoring, therefore, the css will not be affected since both class names are used for the same styling. 