### PR TITLE
Reimplemented fix 'Added reference to icons. g3-2024-v6-#15507'

### DIFF
--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -41,6 +41,7 @@
         <title><?php echo $title; ?></title>
 
 		<link rel="shortcut icon" href="../Shared/icons/favicon.ico"/>
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
 
 		<meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="viewport" content="width=device-width,height=device-height,initial-scale=1.0"/>


### PR DESCRIPTION
Toast now shows correct icons after exiting the template form.
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/b1db1d37-2ff2-4784-a298-2fca34db399c)