### PR TITLE
reFixed dialog fade in/out g3-2024-v6-#15614

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -745,23 +745,26 @@ function elementIsValid(element) {
 	// Stop any ongoing animations
 	$(messageElement).stop(true, true);
 
-	// Reset initial validation styling and messages
-	element.classList.remove("bg-color-change-invalid");
-	$(messageElement).fadeOut();
+	//Remove neutral tag when element is assessed.
+	element.classList.remove("color-change-neutral");
 
 	// Handle empty input for optional fields
 	if (element.value.trim() === "") {
 		element.removeAttribute("style");
 		if (element.name === "githubToken" || element.name === "courseGitURL") {
+			$(messageElement).fadeOut();
+			element.classList.add("color-change-neutral");
+    		element.classList.remove("color-change-invalid");
+			element.classList.remove("color-change-valid");
 			return true; // Optional fields
 		}
 	}
 
 	// Check against regex and handle special cases
 	if (!element.value.match(regex[element.name])) {
-		element.classList.add("bg-color-change-invalid");
-		element.style.borderColor = "#E54";
 		$(messageElement).fadeIn();
+		element.classList.add("color-change-invalid");
+		element.classList.remove("color-change-valid");
 		if (element.name === "githubToken") {
 			messageElement.innerHTML = "A GitHub key should be 40 characters";
 		} else if (element.name === "coursecode") {
@@ -776,7 +779,9 @@ function elementIsValid(element) {
 	}
 
 	// If the input passes validation
-	element.style.borderColor = "#383";
+	$(messageElement).fadeOut();
+	element.classList.add("color-change-valid");
+    element.classList.remove("color-change-invalid");
 	return true;
 }
 

--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -754,7 +754,7 @@ function elementIsValid(element) {
 		if (element.name === "githubToken" || element.name === "courseGitURL") {
 			$(messageElement).fadeOut();
 			element.classList.add("color-change-neutral");
-    		element.classList.remove("color-change-invalid");
+			element.classList.remove("color-change-invalid");
 			element.classList.remove("color-change-valid");
 			return true; // Optional fields
 		}
@@ -781,7 +781,7 @@ function elementIsValid(element) {
 	// If the input passes validation
 	$(messageElement).fadeOut();
 	element.classList.add("color-change-valid");
-    element.classList.remove("color-change-invalid");
+	element.classList.remove("color-change-invalid");
 	return true;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2752,6 +2752,11 @@ label.login-label {
   border-width: 2px;
 }
 
+.color-change-neutral{
+  border-color: var(--color-border-2);
+  border-width: 2px;
+}
+
 input.option {
   float: left;
 }


### PR DESCRIPTION
Copied from #15635
`$(messageElement).stop(true, true);` does not exist in other form validations and seems to be very useful in stopping spam causing repeat fade-ins and -outs

Affected forms: Edit Course and New Course in courseed.php (quickValidateForm in courseed.js)

Extra:
* Added an neutral class for when optional fields are empty.

Note that the save button does not get disabled due to it currently being dynamic.
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/1e9b5b1d-7462-4218-bb32-8a0f66030e2a)