### PR TITLE
fixed "You don't have anything to save." appearing when reloading/leaving the site when you havent added anything to the diagram #15527

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2007,7 +2007,6 @@ function loadDiagramFromLocalStorage(key) {
 function saveDiagramBeforeUnload() {
     if(data.length) {
         window.addEventListener("beforeunload", (e) => {
-            e.returnValue = "";
             storeDiagramInLocalStorage("AutoSave");
         })
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1726,7 +1726,7 @@ function exportWithHistory() {
  */
 function storeDiagramInLocalStorage(key) {    
     if (stateMachine.currentHistoryIndex == -1) {
-        displayMessage(messageTypes.ERROR, "You don't have anything to save!");
+        return;
     } else {
         // Remove all future states to the history
         stateMachine.removeFutureStates();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2005,9 +2005,8 @@ function loadDiagramFromLocalStorage(key) {
 
 // Save current diagram when user leaves the page
 function saveDiagramBeforeUnload() {
-    if(data.length > 0) {
+    if(data.length) {
         window.addEventListener("beforeunload", (e) => {
-            e.preventDefault();
             e.returnValue = "";
             storeDiagramInLocalStorage("AutoSave");
         })

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1725,7 +1725,7 @@ function exportWithHistory() {
  * @param {string} key The name/key of the diagram
  */
 function storeDiagramInLocalStorage(key) {
-
+    
     if (stateMachine.currentHistoryIndex == -1) {
         displayMessage(messageTypes.ERROR, "You don't have anything to save!");
     } else {
@@ -2006,11 +2006,13 @@ function loadDiagramFromLocalStorage(key) {
 
 // Save current diagram when user leaves the page
 function saveDiagramBeforeUnload() {
-    window.addEventListener("beforeunload", (e) => {
-        e.preventDefault();
-        e.returnValue = "";
-        storeDiagramInLocalStorage("AutoSave");
-    })
+    if(data.length > 0) {
+        window.addEventListener("beforeunload", (e) => {
+            e.preventDefault();
+            e.returnValue = "";
+            storeDiagramInLocalStorage("AutoSave");
+        })
+    }
 }
 
 function disableIfDataEmpty() {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1724,8 +1724,7 @@ function exportWithHistory() {
  * @description Stores the current diagram as JSON in localstorage
  * @param {string} key The name/key of the diagram
  */
-function storeDiagramInLocalStorage(key) {
-    
+function storeDiagramInLocalStorage(key) {    
     if (stateMachine.currentHistoryIndex == -1) {
         displayMessage(messageTypes.ERROR, "You don't have anything to save!");
     } else {


### PR DESCRIPTION
added a check to make sure that data isnt empty before trying to autosave, this stopped the error message from appearing