### PR TITLE
Added an location.reload() to createNewCourse() to #15837

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -163,6 +163,7 @@ function createNewCourse() {
 		AJAXService("NEW", { coursename: coursename, coursecode: coursecode, courseGitURL: courseGitURL }, "COURSE");
 		toast("success", "New course, " + coursename + " added!", 5);
 	}
+	setTimeout("location.reload()", 200) // refreshes the page after 0.2 seconds
 }
 
 //Send valid GitHub-URL to PHP-script which fetches the contents of the repo


### PR DESCRIPTION
Courseed.php has not been reloading after creating a new course for some time now. To fix this, i added location.reload() to createNewCourse(). This location.reload() is inside of a setTimeout() to give the site enough time to save the new course. 

To test this, just create a new course and see if the site reloads and that the new course appear in the list.