### PR TITLE
Added ESC button to go back in fileed.php

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -445,7 +445,7 @@ function fileDownload(name, path, extension){
 
 // Close the file preview window by 'x' button or ESC key ----
 function filePreviewClose(){
-    var fileview = document.querySelector(".fileView");
+    let fileview = document.querySelector(".fileView");
     $(".fileViewContainer").hide();
     $(".fileViewWindow").hide();
     while(fileview.firstChild){
@@ -453,14 +453,30 @@ function filePreviewClose(){
     }
 }
 
-document.addEventListener('keydown', function (event) {
-    var fileview = document.querySelector(".fileView");
+document.addEventListener('keyup', function (event) {
     if (event.key === 'Escape') {
-        $(".fileViewContainer").hide();
-        $(".fileViewWindow").hide();
-        while (fileview.firstChild) {
-            fileview.removeChild(fileview.firstChild);
+        let link = document.getElementById("upIcon").href;
+        let isPopupOpen = checkIfPopupIsOpen();
+        if (!isPopupOpen) {
+            window.location.assign(link);
         }
+        filePreviewClose();
+    }
+    if (event.key === 'x') {
+        filePreviewClose();
+    }
+    // ---------------------------------------------------
+    // Toggle to hide fab-button to click through it with CTRL
+    //----------------------------------------------------
+    if (event.key === 'Control') {
+        let element = document.getElementById('fabButton');
+        if (window.getComputedStyle(element, null).getPropertyValue("opacity") != "1") {
+            element.style.opacity = "1";
+            element.style.pointerEvents = "auto";
+        } else {
+            element.style.opacity = "0.3";
+            element.style.pointerEvents = "none";
+        }	
     }
 });
 
@@ -1024,18 +1040,18 @@ document.addEventListener('DOMContentLoaded', function (){
 // ---------------------------------------------------
 // Toggle to hide fab-button to click through it with CTRL
 //----------------------------------------------------
-
-document.addEventListener('keydown', function(e) {
-	var element = document.getElementById('fabButton');
-	if(e.keyCode === 17){
-		if(window.getComputedStyle(element, null).getPropertyValue("opacity") != "1"){
-			element.style.opacity = "1";
-			element.style.pointerEvents = "auto";
-		}else{
-            element.style.opacity = "0.3";
-			element.style.pointerEvents = "none";
-		}	
-	}
-});
+function checkIfPopupIsOpen() {
+    let allPopups = [
+        "#addFile",
+        ".fileViewWindow",
+        ".previewWindow"
+    ];
+    for (let popup of allPopups) {
+        if ($(popup).css("display") !== "none") {
+            return true;
+        }
+    }
+    return false;
+}
 
 


### PR DESCRIPTION
d22mikwe
Collaborator
[d22mikwe](https://github.com/d22mikwe) commented [last week](https://github.com/HGustavs/LenaSYS/pull/15560#issue-2288509174)
Fixed current iteration of keyup for esc and control.
Integrated current filePreviewClose() call when pressing esc and popup is open.
Integrated a check if popups are open in this eventlistener.
Current popups are when adding a file, previewWindow (Edit file icon) and fileViewPreview (clicking on the file name).
Added intended integration with "x" key. this was not implemented but previous devs had intended for it.
Also fixed previous indentation.

For testing:
Try opening a popup and press the ESC key.
Try pressing the ESC key without a popup open.

If a popup is open it should only close.
If a popup is not open it should redirect to sectioned.php.

Also try closing fileView with x key. It should not produce duplicates in view if opened again.