### PR TITLE
Drawswimlane error gone

### DIFF
--- a/DuggaSys/darkmodeToggle.js
+++ b/DuggaSys/darkmodeToggle.js
@@ -33,8 +33,6 @@ document.addEventListener('DOMContentLoaded', () => {
       themeStylesheet.href = "../Shared/css/blackTheme.css";
       localStorage.setItem('themeBlack',themeStylesheet.href);
     }
-	// Redraw course schedule / planner SVG to get the appropriate color scheme
-	// Course schedule = the SVG that displays the weeks and how far into a course we are	
   })
 })
 

--- a/DuggaSys/darkmodeToggle.js
+++ b/DuggaSys/darkmodeToggle.js
@@ -34,8 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('themeBlack',themeStylesheet.href);
     }
 	// Redraw course schedule / planner SVG to get the appropriate color scheme
-	// Course schedule = the SVG that displays the weeks and how far into a course we are
-	drawSwimlanes();		
+	// Course schedule = the SVG that displays the weeks and how far into a course we are	
   })
 })
 


### PR DESCRIPTION
The drawswimlane function were called then toggling between night and day mode, the function is now gone from pages where it does not need to be called and should not appear as a error in the console anymore. 

Function:
drawSwimLane()

Error in the console before: 
'drawswimlane is not defined'