### PR TITLE
Remerge after revert

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -5098,3 +5098,30 @@ function toggleTitleDescription(toCheck){
       	box.classList.remove('visuallyhidden');
 	}
 }
+//-------------------------------------------------
+// EventListener for Escape keyup
+//-------------------------------------------------
+document.addEventListener('keyup', function(event){
+	if (event.key === 'Escape') {
+		let link = document.getElementById("upIcon").href;
+		let isOpenPopup = checkIfPopupIsOpen();
+		if (!isOpenPopup) {
+			window.location.assign(link);
+		}
+	}
+});
+function checkIfPopupIsOpen() {
+	let allPopups = [
+		"#editExampleContainer",
+		"#editContentContainer",
+		"#chooseTemplateContainer",
+		"#burgerMenu",
+		".previewWindowContainer.loginBoxContainer"
+	];
+	for (let popup of allPopups) {
+		if ($(popup).css("display") !== "none"){
+			return true;
+		}
+	}
+	return false;
+}


### PR DESCRIPTION
Implemented keyup event for esc.
Integrated a check if popups are open in codeviewer.
Should work on all popups.

For testing:
Try opening a popup and press the ESC key.
Try pressing the ESC key without a popup open.

If a popup is open it should only close.
If a popup is not open it should redirect to sectioned.php.

Problem when pressing esc while previewWindow loginBox is open.
Its container "previewWindowContainer loginBoxContainer" is set to none while "previewWindow loginBox" is still not changed from block to none. Circumvented this in this pullrequest but this will be looked into in another issue.

