### PR TITLE
If a user is logged out in profile.php, they should be taken to the home page and no errors should appear

### DIFF
--- a/DuggaSys/profile.php
+++ b/DuggaSys/profile.php
@@ -24,7 +24,13 @@ pdoConnect();
 	<script src="../Shared/dugga.js"></script>
 	<script src="profile.js"></script>
 
-	<script src="pushnotifications.js"></script>
+	<?php
+	if (defined('PUSH_NOTIFICATIONS_VAPID_PUBLIC_KEY')) {
+	?>
+		<script src="pushnotifications.js"></script>
+	<?php
+	}
+	?>
 </head>
 <body>
 

--- a/DuggaSys/pushnotifications.js
+++ b/DuggaSys/pushnotifications.js
@@ -2,7 +2,7 @@
 
 $(function() {
 
-	var sendPushRegistrationToServer = function(subscription, deregister) {
+	let sendPushRegistrationToServer = function(subscription, deregister) {
 		$.ajax({
 			url: "pushnotifications.php",
 			type: "POST",
@@ -17,7 +17,7 @@ $(function() {
 	};
 
 
-	var subscribe = function() {
+	let subscribe = function() {
 		$("#notificationsToggle")[0].disabled = true;
 
 		navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
@@ -44,7 +44,7 @@ $(function() {
 		});
 	};
 
-	var unsubscribe = function() {
+	let unsubscribe = function() {
 		$("#notificationsToggle")[0].disabled = true;
 
 		navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
@@ -62,7 +62,7 @@ $(function() {
 		});
 	};
 
-	var updateTextAndButton = function(subscribed) {
+	let updateTextAndButton = function(subscribed) {
 		if (subscribed) {
 			$("#notificationsText").html("Push notifications are activated on this device.");
 			$("#notificationsToggle").off("click").on("click", unsubscribe).html("Deactivate push notifications");
@@ -74,7 +74,7 @@ $(function() {
 		}
 	};
 
-	var initialiseState = function() {
+	let initialiseState = function() {
 		if (!('showNotification' in ServiceWorkerRegistration.prototype) || !('PushManager' in window)) {
 			$("#notificationsText").html("Push notifications not supported in this browser").css('color', '#a00'); // Notification or PushManager support not found
 			return;
@@ -84,11 +84,12 @@ $(function() {
 			return;
 		}
 		navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
-			serviceWorkerRegistration.pushManager.getSubscription()
-				.then(function(subscription) {
-					updateTextAndButton(subscription !== null);
+			serviceWorkerRegistration.pushManager
+				.getSubscription()
+				.then((subscription) => {
+					updateTextAndButton(subscription);
 				})
-				.catch(function(err) {
+				.catch((err) => {
 					console.log('Error during getSubscription()', err);
 				});
 		});

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1775,7 +1775,12 @@ function processLogout() {
 		success:function(data) {
 			localStorage.removeItem("ls-security-question");
 			localStorage.removeItem("securitynotification");
-			reloadPage();
+			if(window.location.pathname == "/LenaSYS/DuggaSys/profile.php"){
+				window.location.href = "courseed.php";
+			}
+			else{
+				reloadPage();
+			}
 		},
 		error:function() {
 			console.log("error");


### PR DESCRIPTION
Copied over previously merged changes and made sure they still worked.

See #15546 for more detailed information.

**Testing:**
- Go to profile, you may be stopped by requiring a secure http connection - to solve this, comment out lines 212-214 in profile.js
- log out
- see if it takes you to homepage or not
- the pushnotification changes are harder to test, but the box at the bottom of profile saying "Notifications subsystems not installed, notifications unavailable." means that it has fully ran without crashing, although it can be more in-depth tested through console logging in InitialiseState in pushnotifications.js, again see the other pull request for more info.