### PR TITLE
[re-merge] Added a confirm toast to the toast roster G3 2024 v7 #14813

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1372,4 +1372,8 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 .error {
   background-color: rgb(243, 129, 129);
 }
+
+.confirm { 
+    background-color: #ecf7ff;
+}
 /*/ END /*/

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9642,8 +9642,29 @@ margin:2px;
   grid-area: "closeDiv";
 }
 
-.toast div:first-child, .toast div:nth-child(3) {
-  width: fit-content;
+.toastNo, .toastYes {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 5px 10px;
+  color: white;
+}
+
+.toastNo {
+ background-color: var(--color-red);
+}
+
+.toastNo:hover {
+  background-color: var(--color-red-hover);
+}
+.toastYes {
+  background-color: var(--color-green);
+}
+
+.toastYes:hover {
+  background-color: #008000;
 }
 
 .warning {
@@ -9656,6 +9677,17 @@ margin:2px;
 
 .error {
   background-color: rgb(243, 129, 129);
+}
+
+.confirm {
+  background-color: #ecf7ff;
+}
+
+.toastButtonBox {
+  display: flex;
+  justify-content: space-around;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .toast.show {

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -3,8 +3,9 @@
         WARNING: "warning", 
         ERROR: "error", 
         SUCCESS: "success",
-        UNDO: "undo"
-    }); 
+        UNDO: "undo",
+        CONFIRM: "confirm"
+        }); 
     // Close the toast by clicking the X icon
     function closeToast(toastDiv) {
         const toastContainer = document.getElementById('toastContainer');
@@ -14,7 +15,7 @@
         }
     }
     // Create a toast notification
-    function toast(type, text, duration, arguments = null) {
+    function toast(type, text, duration, arguments = null, arguments2 = null) {
         // We locate the container for all toasts
         const toastContainer = document.getElementById('toastContainer');
         // The toast div is created
@@ -51,6 +52,39 @@
         let toastText = document.createElement('p');
         toastText.classList.add('toastText');
 
+        // The toast confirm options are created
+        // toastYes / toastNo = the toast confirm buttons (used for CONFIRM type)
+        let toastYes = document.createElement('span');
+        let toastNo = document.createElement('span');
+
+        // Creates the icon-element for each option.
+        let yesIcon = document.createElement('span');
+        let noIcon = document.createElement('span');
+
+        // Creates the text-element for each option (yes / no)
+        let yesText = document.createElement('span');
+        let noText = document.createElement('span');
+
+        // Inserts the text into each option
+        yesText.innerHTML = "Yes";
+        noText.innerHTML = "No";
+
+        // Creates an icon for each option
+        yesIcon.innerHTML = "done";
+        noIcon.innerHTML = "close";
+
+        yesIcon.classList.add('material-symbols-outlined');
+        noIcon.classList.add('material-symbols-outlined');
+
+        // Adds the styling to each button
+        toastYes.classList.add('toastYes');
+        toastNo.classList.add('toastNo');
+
+        // The toast buttonbox is created
+        // toastButtonBox = the toast confirm button
+        let toastButtonBox = document.createElement('div');
+        toastButtonBox.classList.add('toastButtonBox');
+
         // Adds the smaller toast divs to the bigger toast div
         toastDiv.appendChild(toastLeft);
         toastDiv.appendChild(toastCenter);
@@ -62,6 +96,13 @@
         toastCenter.appendChild(toastText);
         toastRight.appendChild(closeIcon);
          
+        // Add the icon and text to the button elements
+        toastYes.appendChild(yesIcon);
+        toastYes.appendChild(yesText);
+
+        toastNo.appendChild(noIcon);
+        toastNo.appendChild(noText);
+
         // Add the toast div to the toast container (containing all toasts)
         toastContainer.appendChild(toastDiv);
        
@@ -91,6 +132,16 @@
                 toastLeft.setAttribute( "onClick", "javascript: "+arguments);
                 typeText.innerHTML = "Notice";
                 toastDiv.classList.add(types.UNDO);
+                break;
+            case types.CONFIRM:
+                typeIcon.innerHTML = "Help";
+                typeText.innerHTML = "Confirm";
+                toastCenter.appendChild(toastButtonBox);
+                toastButtonBox.appendChild(toastYes);
+                toastButtonBox.appendChild(toastNo);
+                toastYes.setAttribute( "onClick", "javascript: "+arguments);
+                toastNo.setAttribute( "onClick", "javascript: "+arguments2);
+                toastDiv.classList.add(types.CONFIRM);
                 break;
             // We create a default situation in case no type is given.
             // The default toast will not have an icon nor heading.


### PR DESCRIPTION
@a22edvbu commented [May 10, 2024] (https://github.com/HGustavs/LenaSYS/pull/15574#issue-2289339746) •

Now there is a confirm toast available to be used among the rest of the toasts. I did this through adding additional elements to toastContainer that shows the two buttons (thanks Moa). To pass the arguments for the buttons, the last two arguments in the toast functioned are used for this (arguments and arguments2).

![329528532-6be947c8-93f3-4006-b6f7-8e971af787d2](https://github.com/HGustavs/LenaSYS/assets/129257945/2de82cf3-a908-4432-bb8b-01a357f4341f)

To call this function, you just add the following code to a php-file that implements toast.php (for example courseed.php):
```javascript
toast("confirm", "Are you sure you want to do that?", 0, "", "");
```