### PR TITLE
G2 2024 v7 issue#15891

### DIFF
--- a/DuggaSys/microservices/sectionedService/retrieveAllCourseVersions_ms.php
+++ b/DuggaSys/microservices/sectionedService/retrieveAllCourseVersions_ms.php
@@ -18,6 +18,7 @@ session_start();
 $opt=getOP('opt');
 $courseid=getOP('courseid');
 $coursevers=getOP('coursevers');
+$debug = "NONE!";
 
 if (strcmp($coursevers, "null")!==0) {
 	// Fetches the course versions for a particular course id

--- a/DuggaSys/microservices/sectionedService/retrieveSectionedService_ms.php
+++ b/DuggaSys/microservices/sectionedService/retrieveSectionedService_ms.php
@@ -11,7 +11,7 @@ include_once "getCourseVersions_ms.php";
 // Retrieve Information
 //------------------------------------------------------------------------------------------------
 
-function retrieveSectionedService($debug = "NONE!", $opt, $pdo, $userid, $courseid, $coursevers, $log_uuid)
+function retrieveSectionedService($debug, $opt, $pdo, $userid, $courseid, $coursevers, $log_uuid)
 {
     date_default_timezone_set("Europe/Stockholm");
     include_once "../../../Shared/sessions.php";


### PR DESCRIPTION
The `$debug` parameter has been made mandatory in the function retrieveSectionedService.