### PR TITLE
G2 2024 v7 issue#15856

### DIFF
--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -154,7 +154,6 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid) || has
 //------------------------------------------------------------------------------------------------
 $mass=array();
 $entries=array();
-$variants=array();
 $files=array();
 $duggaPages = array();
 
@@ -211,8 +210,6 @@ if(checklogin() && (hasAccess($userid, $cid, 'w') || isSuperUser($userid) || has
 				"cogwheelVariant" => $rowz["vid"],
 				"trashcanVariant" => $rowz["vid"]
 				);
-
-			array_push($variants, html_entity_decode($rowz["variantanswer"]));
 			array_push($mass, $entryz);
 		}
 
@@ -254,7 +251,6 @@ $array = array(
 	'duggaPages' => $duggaPages,
 	'coursecode' => $coursecode,
 	'coursename' => $coursename,
-	'variants' => $variants
 );
 
 echo json_encode($array);

--- a/DuggaSys/microservices/duggaedService/retrieveDuggaedService_ms.php
+++ b/DuggaSys/microservices/duggaedService/retrieveDuggaedService_ms.php
@@ -23,7 +23,6 @@ function retrieveDuggaedService($pdo, $debug = "NONE!", $userid, $cid, $courseve
 
     // Initialize arrays
     $entries = array();
-    $variants = array();
     $files = array();
     $duggaPages = array();
 
@@ -82,8 +81,6 @@ function retrieveDuggaedService($pdo, $debug = "NONE!", $userid, $cid, $courseve
                     "cogwheelVariant" => $rowz["vid"],
                     "trashcanVariant" => $rowz["vid"]
                 );
-
-                array_push($variants, html_entity_decode($rowz["variantanswer"]));
                 array_push($mass, $entryz);
             }
 
@@ -133,7 +130,6 @@ function retrieveDuggaedService($pdo, $debug = "NONE!", $userid, $cid, $courseve
         'duggaPages' => $duggaPages,
         'coursecode' => $coursecode,
         'coursename' => $coursename,
-        'variants' => $variants
     );
 
     logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "retrieveDuggaedService_ms.php", $userid, $info);

--- a/DuggaSys/tests/duggaedService_test.php
+++ b/DuggaSys/tests/duggaedService_test.php
@@ -114,7 +114,7 @@ $testsData = array(
     ),
 
     'add variant' => array(
-    'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","","","Test text"]}',
+    'expected-output' => '{"entries":[{"variants":[{"variantanswer":"{\"danswer\":\"00000010 0 2\"}"},{"variantanswer":"{\"danswer\":\"00000101 0 5\"}"},{"variantanswer":"{\"danswer\":\"00002 0 A\"}"}]},{"variants":[{"variantanswer":"{\"danswer\":\"00011001 1 9\"}"},{"variantanswer":"{\"danswer\":\"02111 5 7\"}"},{"variantanswer":"{\"danswer\":\"11000000 C 0\"}"}]},{"variants":[{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"B"},{"variantanswer":"A"},{"variantanswer":"C"},{"variantanswer":"A"}]},{"variants":[{"variantanswer":""}]},{"variants":[{"variantanswer":""}]},{"variants":[{"variantanswer":""},{"variantanswer":"Test text"}]}],"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik"}',
         'service' => 'http://localhost/LenaSYS/DuggaSys/duggaedservice.php',
         'service-data' => serialize(
             array(
@@ -137,14 +137,17 @@ $testsData = array(
                 'writeaccess',
                 'coursename',
                 'coursecode',
-                'variants',
-                
+                'entries' => array(
+                    'variants' => array(
+                        'variantanswer',
+                    )
+                )
             )
         ),
     ),
 
     'update a variant' => array(
-        'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","","","Test text updated"]}',
+        'expected-output' => '{"entries":[{"variants":[{"variantanswer":"{\"danswer\":\"00000010 0 2\"}"},{"variantanswer":"{\"danswer\":\"00000101 0 5\"}"},{"variantanswer":"{\"danswer\":\"00002 0 A\"}"}]},{"variants":[{"variantanswer":"{\"danswer\":\"00011001 1 9\"}"},{"variantanswer":"{\"danswer\":\"02111 5 7\"}"},{"variantanswer":"{\"danswer\":\"11000000 C 0\"}"}]},{"variants":[{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"B"},{"variantanswer":"A"},{"variantanswer":"C"},{"variantanswer":"A"}]},{"variants":[{"variantanswer":""}]},{"variants":[{"variantanswer":""}]},{"variants":[{"variantanswer":""},{"variantanswer":"Test text updated"}]}],"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik"}',
         'query-before-test-1' => "SELECT vid FROM variant WHERE variantanswer = 'Test text'",
         'service' => 'http://localhost/LenaSYS/DuggaSys/duggaedservice.php',
         'service-data' => serialize(
@@ -168,13 +171,17 @@ $testsData = array(
                 'writeaccess',
                 'coursename',
                 'coursecode',
-                'variants',
+                'entries' => array(
+                    'variants' => array(
+                        'variantanswer',
+                    )
+                )
             )
         ),
     ),
 
     'delete variant' => array(
-        'expected-output' => '{"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik","variants":["{\"danswer\":\"00000010 0 2\"}","{\"danswer\":\"00000101 0 5\"}","{\"danswer\":\"00002 0 A\"}","{\"danswer\":\"00011001 1 9\"}","{\"danswer\":\"02111 5 7\"}","{\"danswer\":\"11000000 C 0\"}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","{Variant}","B","A","C","A","","",""]}',
+        'expected-output' => '{"entries":[{"variants":[{"variantanswer":"{\"danswer\":\"00000010 0 2\"}"},{"variantanswer":"{\"danswer\":\"00000101 0 5\"}"},{"variantanswer":"{\"danswer\":\"00002 0 A\"}"}]},{"variants":[{"variantanswer":"{\"danswer\":\"00011001 1 9\"}"},{"variantanswer":"{\"danswer\":\"02111 5 7\"}"},{"variantanswer":"{\"danswer\":\"11000000 C 0\"}"}]},{"variants":[{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"},{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"{Variant}"}]},{"variants":[{"variantanswer":"B"},{"variantanswer":"A"},{"variantanswer":"C"},{"variantanswer":"A"}]},{"variants":[{"variantanswer":""}]},{"variants":[{"variantanswer":""}]},{"variants":[{"variantanswer":""}]}],"debug":"NONE!","writeaccess":true,"coursecode":"IT118G","coursename":"Webbutveckling - datorgrafik"}',
         'query-before-test-1' => "SELECT vid FROM variant WHERE variantanswer = 'Test text updated'",
         'service' => 'http://localhost/LenaSYS/DuggaSys/duggaedservice.php',
         'service-data' => serialize(
@@ -195,7 +202,11 @@ $testsData = array(
                 'writeaccess',
                 'coursename',
                 'coursecode',
-                'variants',
+                'entries' => array(
+                    'variants' => array(
+                        'variantanswer',
+                    )
+                ),
             )
         ),
     ),

--- a/DuggaSys/tests/microservices/duggaedService/createDuggaVariant_ms_test.php
+++ b/DuggaSys/tests/microservices/duggaedService/createDuggaVariant_ms_test.php
@@ -27,6 +27,7 @@ $testsData = array(
         ),
         'filter-output' => serialize(
             array(
+                // Filter what output to use in assert test, use none to use all ouput from service
                 'entries' => array(
                     'variants' => array(
                         'param',

--- a/DuggaSys/tests/microservices/duggaedService/createDuggaVariant_ms_test.php
+++ b/DuggaSys/tests/microservices/duggaedService/createDuggaVariant_ms_test.php
@@ -4,7 +4,7 @@ include_once "../../../../Shared/test.php";
 
 $testsData = array(
     'createDuggaVariant_ms' => array(
-        'expected-output' => '{"variants":["Answer3"]}',
+        'expected-output' => '{"entries":[{"variants":[{"param":"{question\"What is the correct answer?: A\"Answer1: B\"Answer2: C\"Answer3}","variantanswer":"Answer3"}]}]}',
         
         'query-before-test-1' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (2147483645, 1885, 'createDuggaVariantTestQuiz', 1337)",
         'query-after-test-1' => "DELETE FROM variant WHERE quizID = 2147483645",
@@ -25,9 +25,15 @@ $testsData = array(
                 'password' => 'password'
             )
         ),
-        'filter-output' => serialize(array(
-                'variants'
-            )     
+        'filter-output' => serialize(
+            array(
+                'entries' => array(
+                    'variants' => array(
+                        'param',
+                        'variantanswer'
+                    )
+                )
+            )
         ),
     ),
 );

--- a/DuggaSys/tests/microservices/duggaedService/createDuggaVariant_ms_test.php
+++ b/DuggaSys/tests/microservices/duggaedService/createDuggaVariant_ms_test.php
@@ -6,9 +6,9 @@ $testsData = array(
     'createDuggaVariant_ms' => array(
         'expected-output' => '{"entries":[{"variants":[{"param":"{question\"What is the correct answer?: A\"Answer1: B\"Answer2: C\"Answer3}","variantanswer":"Answer3"}]}]}',
         
-        'query-before-test-1' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (2147483645, 1885, 'createDuggaVariantTestQuiz', 1337)",
-        'query-after-test-1' => "DELETE FROM variant WHERE quizID = 2147483645",
-        'query-after-test-2' => "DELETE FROM quiz WHERE id = 2147483645",
+        'query-before-test-1' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (99999, 1885, 'createDuggaVariantTestQuiz', 1337)",
+        'query-after-test-1' => "DELETE FROM variant WHERE quizID = 99999",
+        'query-after-test-2' => "DELETE FROM quiz WHERE id = 99999",
 
         'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/duggaedService/createDuggaVariant_ms.php',
         'service-data' => serialize(
@@ -16,7 +16,7 @@ $testsData = array(
                 // Data that service needs to execute function
                 'opt' => 'ADDVARI',
                 'cid' => 1885,
-                'qid' => 2147483645,
+                'qid' => 99999,
                 'disabled' => 0,
                 'parameter' =>'{question"What is the correct answer?: A"Answer1: B"Answer2: C"Answer3}',
                 'variantanswer' => 'Answer3',

--- a/DuggaSys/tests/microservices/duggaedService/deleteDuggaVariant_ms_test.php
+++ b/DuggaSys/tests/microservices/duggaedService/deleteDuggaVariant_ms_test.php
@@ -4,7 +4,7 @@ include "../../../../Shared/test.php";
 
 $testsData = array(
     'delete variant' => array(
-        'expected-output' => '{"variants":["othervariant"]}',
+        'expected-output' => '{"entries":[{"variants":[{"param":"param","variantanswer":"othervariant"}]}]}',
         'query-before-test-1' => "INSERT INTO quiz(id, cid,vers, qname) VALUES (333,1885,1337,'testQuiz')",
         'query-before-test-2' => "INSERT INTO variant(quizID, param, variantanswer) VALUES (333,'param','deletevariant');",
         'query-before-test-3' => "INSERT INTO variant(quizID, param, variantanswer) VALUES (333,'param','othervariant');",
@@ -26,7 +26,12 @@ $testsData = array(
         'filter-output' => serialize(
             array(
                 // Filter what output to use in assert test, use none to use all ouput from service
-                'variants',
+                'entries' => array(
+                    'variants' => array(
+                        'param',
+                        'variantanswer'
+                    )
+                )
             )
         ),
     ),

--- a/DuggaSys/tests/microservices/duggaedService/deleteDugga_ms_test.php
+++ b/DuggaSys/tests/microservices/duggaedService/deleteDugga_ms_test.php
@@ -7,10 +7,10 @@ $testsData = array(
     'deleteDugga_ms' => array(
         'expected-output' => '{"entries":[{"qname":"deleteDuggaTest"}]}',
         
-        'query-before-test-1' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (2147483646, 1885, 'deleteDuggaTest', 1337);",
-        'query-before-test-2' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (2147483647, 1885, 'IShouldBeDeleted', 1337);",
-        'query-after-test-1' => "DELETE FROM quiz WHERE id = 2147483646;",
-        'query-after-test-2' => "DELETE FROM quiz WHERE id = 2147483647;", // In case the microservice fails
+        'query-before-test-1' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (99999, 1885, 'deleteDuggaTest', 1337);",
+        'query-before-test-2' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (99999, 1885, 'IShouldBeDeleted', 1337);",
+        'query-after-test-1' => "DELETE FROM quiz WHERE id = 99999;",
+        'query-after-test-2' => "DELETE FROM quiz WHERE id = 99999;", // In case the microservice fails
         
         'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/duggaedService/deleteDugga_ms.php',
         'service-data' => serialize(
@@ -18,7 +18,7 @@ $testsData = array(
                 // Data that service needs to execute function
                 'opt' => 'DELDU',
                 'cid' => 1885,
-                'qid' => 2147483647,
+                'qid' => 99999,
                 'coursevers' => 1337,
                 'username' => 'brom',
                 'password' => 'password'

--- a/DuggaSys/tests/microservices/duggaedService/deleteDugga_ms_test.php
+++ b/DuggaSys/tests/microservices/duggaedService/deleteDugga_ms_test.php
@@ -7,9 +7,9 @@ $testsData = array(
     'deleteDugga_ms' => array(
         'expected-output' => '{"entries":[{"qname":"deleteDuggaTest"}]}',
         
-        'query-before-test-1' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (99999, 1885, 'deleteDuggaTest', 1337);",
+        'query-before-test-1' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (99998, 1885, 'deleteDuggaTest', 1337);",
         'query-before-test-2' => "INSERT INTO quiz (id, cid, qname, vers) VALUES (99999, 1885, 'IShouldBeDeleted', 1337);",
-        'query-after-test-1' => "DELETE FROM quiz WHERE id = 99999;",
+        'query-after-test-1' => "DELETE FROM quiz WHERE id = 99998;",
         'query-after-test-2' => "DELETE FROM quiz WHERE id = 99999;", // In case the microservice fails
         
         'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/duggaedService/deleteDugga_ms.php',

--- a/DuggaSys/tests/microservices/duggaedService/updateDuggaVariant_ms_test.php
+++ b/DuggaSys/tests/microservices/duggaedService/updateDuggaVariant_ms_test.php
@@ -30,6 +30,7 @@ $testsData = array(
         ),
         'filter-output' => serialize(
             array(
+                // Filter what output to use in assert test, use none to use all ouput from service
                 'entries' => array(
                     'variants' => array(
                         'param',


### PR DESCRIPTION
Removed the $variants output from duggaedservice.php and retrieveDuggaedService_ms.php and updated all tests using it to instead use the $entries array. 

Deleting the $variants variable should not break any systems since it was not used for anything other than testing, I added it a few weeks ago to make tests work before double nested arrays were possible in the testing API. 