### PR TITLE
Added missing session_start() #15760

### DIFF
--- a/DuggaSys/duggaed.php
+++ b/DuggaSys/duggaed.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 include_once "../Shared/sessions.php";
 include_once "../Shared/basic.php";
 include_once "../Shared/toast.php";


### PR DESCRIPTION
It turned out to be more simple than I thought. session.start() was missing in duggaed.php.
Login now stays when going into duggaed and through a refresh.
![image](https://github.com/HGustavs/LenaSYS/assets/102598258/0e8caa55-e0e1-44ed-b969-dc0a576e4a62)
