### PR TITLE
G2 2024 v7 issue #15908

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -984,7 +984,7 @@ function deleteItem(item_lid = []) {
 // Permanently delete elements.
 function deleteAll() {
   for (var i = delArr.length - 1; i >= 0; --i) {
-    AJAXService("DELETE", {
+    AJAXService("DEL", {
       lid: delArr.pop()
     }, "SECTION");
   }


### PR DESCRIPTION
I don't think the "undo" button not working is our group's problem. There seems to be some code in sectioned.js which is supposed to handle undoing by using classes, arrays, and timers.

I changed sectioned.js to use deleteListEntries instead of removeListEntries, which fixes the deleting issue. Unless I am misunderstanding something I think deleteListEntries is actually the correct microservices to use. But then I am not sure what removeListEntries should be used for.

It's almost like 2 different groups had different ideas on how to implement the "undo" function and implemented both at the same time.

See issue comments for more information.