### PR TITLE
fixed ESC button when closing modals in sectioned.php

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -617,7 +617,9 @@ function closeOpenPopupForm(){
     "#loginBox",
     "#loadDuggaBox",
     "#sectionHideConfirmBox",
-    "#sectionShowConfirmBox"
+    "#sectionShowConfirmBox",
+    "#canvasLinkBox",
+    "#editSection"
   ];
   for (let popup of allPopups){
     if ($(popup).css("display") !== "none"){

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -619,12 +619,17 @@ function closeOpenPopupForm(){
     "#sectionHideConfirmBox",
     "#sectionShowConfirmBox",
     "#canvasLinkBox",
-    "#editSection"
+    "#editSection",
+    "#toastContainer"
   ];
   for (let popup of allPopups){
     if ($(popup).css("display") !== "none"){
-      $(popup).css("display","none");
-      return true;
+      if (popup === "#toastContainer"){
+        return true;
+      } else {
+        $(popup).css("display","none");
+        return true;
+      }
     }
   }
   return false; 

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -124,6 +124,14 @@
                 }
             }
         });
+
+        // Close the toast by pressing the ESC button
+        document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+                closeToast(toastDiv);
+            }
+        });
+
         truncateOverflow(toastText); // Truncate overflow text initially
 
         // The duration of a toast decides how long it should be visible for

--- a/Shared/toast.php
+++ b/Shared/toast.php
@@ -8,7 +8,7 @@
     // Close the toast by clicking the X icon
     function closeToast(toastDiv) {
         const toastContainer = document.getElementById('toastContainer');
-        if (toastDiv) {
+        if (toastDiv && toastContainer.contains(toastDiv)) {
             // Delete the toast from the toast container
             toastContainer.removeChild(toastDiv);
         }


### PR DESCRIPTION
just before when you would press ESC you would be transported form sectioned.php to courseed.php when closing these popups with ESC, get canvas link, settings (JS-TEST template 3) and settings (JavaScript-Code) In the issue description it wasn't mentioned which specific popups this happened to but these three popups were however found and fixed.

![Screenshot 2024-05-17 103934](https://github.com/HGustavs/LenaSYS/assets/77882855/121b4d89-2204-45ad-9cb7-f01fa9208d81)
