### PR TITLE
fixed the id on the lock button

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -45,7 +45,7 @@ function generateContextProperties() {
     if (context.length > 0) {
         showProperties(true, propSet, menuSet);
         let locked = context.some(e => e.isLocked);
-        str += saveButton('toggleEntityLocked();', `id='lockbtn'`, locked ? "Unlock" : "Lock");
+        str += saveButton('toggleEntityLocked();', 'lockbtn', locked ? "Unlock" : "Lock");
     }
     propSet.innerHTML = str;
     multipleColorsTest();


### PR DESCRIPTION
the ID being passed to the button was `id='lockbtn'`, so the ID the button got was `id="id="`, which caused it to not be found by the toggle function