### PR TITLE
G2 2024 v7 issue #16056

### DIFF
--- a/DuggaSys/microservices/accessedService/updateUser_ms.php
+++ b/DuggaSys/microservices/accessedService/updateUser_ms.php
@@ -1,54 +1,77 @@
 <?php
-date_default_timezone_set("Europe/Stockholm");
-// Include basic application services!
-include_once "../../../Shared/sessions.php";     
+include_once "../../../Shared/sessions.php";
 include_once "../sharedMicroservices/getUid_ms.php";
-// connect to database
+include_once "retrieveAccessedService_ms.php";
+
+date_default_timezone_set("Europe/Stockholm");
+
 pdoConnect();
 session_start();
-// get userId
-$userid = getUid(); 
 
-// get the rest of values
-$prop=getOP('prop');
+$opt = getOP('opt');
+$prop = getOP('prop');
+$cid = getOP('courseid');
 $uid = getOP('uid');
 $firstname = getOP('firstname');
 $lastname = getOP('lastname');
 $ssn = getOP('ssn');
-$username = getOP('username');
+$username = getOP('user_name');
 $className = getOP('className');
+$log_uuid = getOP('log_uuid');
+$userid = getUid();
+$debug = "NONE!";
 
+if (!(checklogin() && isSuperUser($userid) == true)) {
+    $debug = "Access not granted.";
+    $array = retrieveAccessedService($pdo, $debug, $userid, $cid, $log_uuid, $opt, null);
+    echo json_encode($array);
+    return;
+}
 
+if (!(strcmp($opt, "UPDATEUSER") == 0)) {
+    $debug = "OPT does not match.";
+    $array = retrieveAccessedService($pdo, $debug, $userid, $cid, $log_uuid, $opt, null);
+    echo json_encode($array);
+    return;
+}
 
-
-if(checklogin() && isSuperUser($userid) == true) {
-
-    if($prop=="firstname"){
+switch ($prop) {
+    case "firstname":
         $query = $pdo->prepare("UPDATE user SET firstname=:firstname WHERE uid=:uid;");
         $query->bindParam(':firstname', $firstname);
         $query->bindParam(':uid', $uid);
-    }else if($prop=="lastname"){
+        break;
+    case "lastname":
         $query = $pdo->prepare("UPDATE user SET lastname=:lastname WHERE uid=:uid;");
         $query->bindParam(':lastname', $lastname);
         $query->bindParam(':uid', $uid);
-    }else if($prop=="ssn"){
+        break;
+    case "ssn":
         $query = $pdo->prepare("UPDATE user SET ssn=:ssn WHERE uid=:uid;");
         $query->bindParam(':ssn', $ssn);
         $query->bindParam(':uid', $uid);
-    }else if($prop=="username"){
+        break;
+    case "username":
         $query = $pdo->prepare("UPDATE user SET username=:username WHERE uid=:uid;");
         $query->bindParam(':username', $username);
         $query->bindParam(':uid', $uid);
-    }else if($prop=="class"){
+        break;
+    case "class":
         $query = $pdo->prepare("UPDATE user SET class=:class WHERE uid=:uid;");
         $query->bindParam(':class', $className);
         $query->bindParam(':uid', $uid);
-    }
-   
-    if(!$query->execute()) {
-        $error=$query->errorInfo();
-        $debug="Error updating entries\n".$error[2];
-    }
+        break;
+    default:
+        $debug = "Invalid property.";
+        $array = retrieveAccessedService($pdo, $debug, $userid, $cid, $log_uuid, $opt, null);
+        echo json_encode($array);
+        return;
 }
 
-?>
+if (!$query->execute()) {
+    $error = $query->errorInfo();
+    $debug = "Error updating entries\n" . $error[2];
+}
+
+$array = retrieveAccessedService($pdo, $debug, $userid, $cid, $log_uuid, $opt, null);
+echo json_encode($array);

--- a/DuggaSys/tests/microservices/accessedService/updateUser_ms_test.php
+++ b/DuggaSys/tests/microservices/accessedService/updateUser_ms_test.php
@@ -4,162 +4,167 @@
 // Tests that updating firstname, lastname, ssn, username and class works as expected
 //------------------------------------------------------------------------------------------
 
-include "../../../../Shared/test.php";   // Include the test file where this is sent to
+include "../../../../Shared/test.php";
 
-$testsData = array(   // Test-data is saved on this array that is then tested in test.php file
+$testsData = array(
+    //TEST #1 - Update firstname
+    'Update-firstname' => array(
+        'expected-output' => '{"entries":[{"username":"{\"username\":\"Grimling\"}","firstname":"{\"firstname\":\"testfirstname\"}"}],"debug":"NONE!"}',
 
-    //TEST #1
-    //Update firstname
-    'Update-firstname' => array(  
-        'expected-output' => '{"entries":[{"username":"{\"username\":\"testuser1\"}","firstname":"{\"firstname\":\"testfirstname\"}"}]}',
-        //Pre-values
-        'query-before-test-1' => "INSERT INTO user(uid, username, password) VALUES (9997, 'testuser1', 'testpwd');",
-        'query-before-test-2' => "INSERT INTO user_course(uid, cid, access) VALUES (9997, 1885, 'R');",
-        'query-after-test-1' => "DELETE FROM user_course WHERE uid = '9997';",
-        'query-after-test-2' => "DELETE FROM user WHERE uid = '9997';",
-        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUsers_ms.php',
+        'query-before-test-1' => "INSERT INTO user_course(uid, cid, access) VALUES (1, 1885, 'R');",
+        'query-after-test-1' => "DELETE FROM user_course WHERE cid = 1885;",
+        'query-after-test-2' => "UPDATE user SET firstname = 'Johan' WHERE uid = 1;",
+        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUser_ms.php',
         'service-data' => serialize(
             array(
                 // Data that service needs to execute function
                 'username' => 'brom',
                 'password' => 'password',
                 'courseid' => '1885',
-                'opt' => 'UPDATE',
-                'uid' => '9997',
+                'opt' => 'UPDATEUSER',
+                'uid' => '1',
                 'prop' => 'firstname',
-                'val' => 'testfirstname',
-            )),
-        'filter-output' => serialize(array(
+                'firstname' => 'testfirstname',
+            )
+        ),
+        'filter-output' => serialize(
+            array(
                 // Filter what output to use in assert test, use none to use all ouput from service
                 'entries' => array(
                     'username',
                     'firstname'
                 ),
-            )),
+                'debug'
+            )
         ),
+    ),
 
-    //TEST #2
-    //Update lastname
+    //TEST #2 - Update lastname
     'Update-lastname' => array(
-        'expected-output' => '{"entries":[{"username":"{\"username\":\"testuser1\"}","lastname":"{\"lastname\":\"testlastname\"}"}]}',
-        //Pre-values
-        'query-before-test-1' => "INSERT INTO user(uid, username, password) VALUES (9997, 'testuser1', 'testpwd');",
-        'query-before-test-2' => "INSERT INTO user_course(uid, cid, access) VALUES (9997, 1885, 'R');",
-        'query-after-test-1' => "DELETE FROM user_course WHERE uid = '9997';",
-        'query-after-test-2' => "DELETE FROM user WHERE uid = '9997';",
-        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUsers_ms.php',
+        'expected-output' => '{"entries":[{"username":"{\"username\":\"Grimling\"}","lastname":"{\"lastname\":\"testlastname\"}"}],"debug":"NONE!"}',
+
+        'query-before-test-1' => "INSERT INTO user_course(uid, cid, access) VALUES (1, 1885, 'R');",
+        'query-after-test-1' => "DELETE FROM user_course WHERE cid = 1885;",
+        'query-after-test-2' => "UPDATE user SET lastname = 'Grimling' WHERE uid = 1;",
+        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUser_ms.php',
         'service-data' => serialize(
             array(
                 // Data that service needs to execute function
                 'username' => 'brom',
                 'password' => 'password',
                 'courseid' => '1885',
-                'opt' => 'UPDATE',
-                'uid' => '9997',
+                'opt' => 'UPDATEUSER',
+                'uid' => '1',
                 'prop' => 'lastname',
-                'val' => 'testlastname',
-            )),
-        'filter-output' => serialize(array(
+                'lastname' => 'testlastname',
+            )
+        ),
+        'filter-output' => serialize(
+            array(
                 // Filter what output to use in assert test, use none to use all ouput from service
                 'entries' => array(
                     'username',
                     'lastname'
                 ),
-        )),
+                'debug'
+            )
+        ),
     ),
 
-    
-    //TEST #3
-    //Update ssn
-    'Update-ssn' => array(  
-        'expected-output' => '{"entries":[{"username":"{\"username\":\"testuser1\"}","ssn":"{\"ssn\":\"123456-1234\"}"}]}',
-        //Pre-values
-        'query-before-test-1' => "INSERT INTO user(uid, username, password) VALUES (9997, 'testuser1', 'testpwd');",
-        'query-before-test-2' => "INSERT INTO user_course(uid, cid, access) VALUES (9997, 1885, 'R');",
-        'query-after-test-1' => "DELETE FROM user_course WHERE uid = '9997';",
-        'query-after-test-2' => "DELETE FROM user WHERE uid = '9997';",
-        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUsers_ms.php',
+    //TEST #3 - Update ssn
+    'Update-ssn' => array(
+        'expected-output' => '{"entries":[{"username":"{\"username\":\"Grimling\"}","ssn":"{\"ssn\":\"123456-1234\"}"}],"debug":"NONE!"}',
+
+        'query-before-test-1' => "INSERT INTO user_course(uid, cid, access) VALUES (1, 1885, 'R');",
+        'query-after-test-1' => "DELETE FROM user_course WHERE cid = 1885;",
+        'query-after-test-2' => "UPDATE user SET ssn = '810101-5567' WHERE uid = 1;",
+        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUser_ms.php',
         'service-data' => serialize(
             array(
                 // Data that service needs to execute function
                 'username' => 'brom',
                 'password' => 'password',
                 'courseid' => '1885',
-                'opt' => 'UPDATE',
-                'uid' => '9997',
+                'opt' => 'UPDATEUSER',
+                'uid' => '1',
                 'prop' => 'ssn',
-                'val' => '123456-1234',
-            )),
-        'filter-output' => serialize(array(
+                'ssn' => '123456-1234',
+            )
+        ),
+        'filter-output' => serialize(
+            array(
                 // Filter what output to use in assert test, use none to use all ouput from service
                 'entries' => array(
                     'username',
                     'ssn'
                 ),
-        )),
+                'debug'
+            )
+        ),
     ),
 
-    
-    //TEST #4
-    //Update username
-    'Update-username' => array(  
-        'expected-output' => '{"entries":[{"username":"{\"username\":\"testuser1\"}","username":"{\"username\":\"testuser2\"}"}]}',
-        //Pre-values
-        'query-before-test-1' => "INSERT INTO user(uid, username, password) VALUES (9997, 'testuser1', 'testpwd');",
-        'query-before-test-2' => "INSERT INTO user_course(uid, cid, access) VALUES (9997, 1885, 'R');",
-        'query-after-test-1' => "DELETE FROM user_course WHERE uid = '9997';",
-        'query-after-test-2' => "DELETE FROM user WHERE uid = '9997';",
-        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUsers_ms.php',
+    //TEST #4 - Update username
+    'Update-username' => array(
+        'expected-output' => '{"entries":[{"username":"{\"username\":\"testusername\"}"}],"debug":"NONE!"}',
+
+        'query-before-test-1' => "INSERT INTO user_course(uid, cid, access) VALUES (1, 1885, 'R');",
+        'query-after-test-1' => "DELETE FROM user_course WHERE cid = 1885;",
+        'query-after-test-2' => "UPDATE user SET username = 'Grimling' WHERE uid = 1;",
+        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUser_ms.php',
         'service-data' => serialize(
             array(
                 // Data that service needs to execute function
                 'username' => 'brom',
                 'password' => 'password',
                 'courseid' => '1885',
-                'opt' => 'UPDATE',
-                'uid' => '9997',
+                'opt' => 'UPDATEUSER',
+                'uid' => '1',
                 'prop' => 'username',
-                'val' => 'testuser2',
-            )),
-        'filter-output' => serialize(array(
+                'user_name' => 'testusername',
+            )
+        ),
+        'filter-output' => serialize(
+            array(
                 // Filter what output to use in assert test, use none to use all ouput from service
                 'entries' => array(
-                    'username'
+                    'username',
                 ),
-        )),
+                'debug'
+            )
+        ),
     ),
 
-    
-    //TEST #5
-    //Update class
-    'Update-class' => array(  
-        'expected-output' => '{"entries":[{"username":"{\"username\":\"testuser1\"}","class":"{\"class\":\"DVSUG\"}"}]}',
-        //Pre-values
-        'query-before-test-1' => "INSERT INTO user(uid, username, password) VALUES (9997, 'testuser1', 'testpwd');",
-        'query-before-test-2' => "INSERT INTO user_course(uid, cid, access) VALUES (9997, 1885, 'R');",
-        'query-after-test-1' => "DELETE FROM user_course WHERE uid = '9997';",
-        'query-after-test-2' => "DELETE FROM user WHERE uid = '9997';",
-        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUsers_ms.php',
+    //TEST #5 - Update class
+    'Update-class' => array(
+        'expected-output' => '{"entries":[{"username":"{\"username\":\"Grimling\"}","class":"{\"class\":\"DVSUG\"}"}],"debug":"NONE!"}',
+
+        'query-before-test-1' => "INSERT INTO user_course(uid, cid, access) VALUES (1, 1885, 'R');",
+        'query-after-test-1' => "DELETE FROM user_course WHERE cid = 1885;",
+        'query-after-test-2' => "UPDATE user SET class = NULL WHERE uid = 1;",
+        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/accessedService/updateUser_ms.php',
         'service-data' => serialize(
             array(
                 // Data that service needs to execute function
                 'username' => 'brom',
                 'password' => 'password',
                 'courseid' => '1885',
-                'opt' => 'UPDATE',
-                'uid' => '9997',
+                'opt' => 'UPDATEUSER',
+                'uid' => '1',
                 'prop' => 'class',
-                'val' => 'DVSUG',
-            )),
-        'filter-output' => serialize(array(
+                'className' => 'DVSUG',
+            )
+        ),
+        'filter-output' => serialize(
+            array(
                 // Filter what output to use in assert test, use none to use all ouput from service
                 'entries' => array(
                     'username',
                     'class'
                 ),
-        )),
-    )
+                'debug'
+            )
+        ),
+    ),
 );
 
 testHandler($testsData, true); // 2nd argument (prettyPrint): true = prettyprint (HTML), false = raw JSON
-?>


### PR DESCRIPTION
Both the test and the microservice was updated.

I had to change ```$username = getOP('username');``` to ```$username = getOP('user_name');``` in the MS because of duplicate entries in the service-data. In the monolith they get around this by using ```$val``` instead of separate variables like ```$firstname```.
I wasn't able to find any frontend use for the microservice, but it's possible that further changes need to be made because of the name change.

Perhaps the MS should use ```$val``` instead? I assumed the way it was implemented is how it's supposed to look, so I didn't change it to use ```$val```.

I also added an OPT, but I don't think anything more needs to be changed regarding that since the microservice hasn't been integrated.