### PR TITLE
whitespace tag for the break to work

### DIFF
--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -236,7 +236,7 @@
 							echo "<input type='text' id='adminLoggedin' value='yes' style='display:none;'>";
 
 							// Refresh button for Github repo in nav
-							echo "<td class='refresh' style='display: inline-block;'>";
+							echo "<td class='refresh' style='display: inline-block; white-space: normal;'>";
 							echo "<div class='refresh menuButton tooltip'>";
 								echo "<span id='refreshBTN' value='Refresh' href='#'>";
 									echo "<img alt='refresh icon' id='refreshIMG' class='navButt' onclick='refreshGithubRepo(".$_SESSION['courseid'].",".isSuperUser($_SESSION['uid']).");resetGitFetchTimer(".isSuperUser($_SESSION['uid']).")' src='../Shared/icons/gitrefresh.svg'>";


### PR DESCRIPTION
A white space has been implemented for the paragraph to break. 
Other functions have been implemented, but white space is the only one to have an effect. 

Click on the icon for the hover to apear, inside the hover- check that the paragraph breaks and DO NOT go outside the dropdowns whitelane. 

Screen of how the hoover looked before p break:

![Skärmbild 2024-05-20 141630](https://github.com/HGustavs/LenaSYS/assets/129268487/fd8f53b1-91ea-4b97-9a8e-8752316a8c88)

Should look now:

![Skärmbild 2024-05-20 163043](https://github.com/HGustavs/LenaSYS/assets/129268487/dfa5b068-c17e-49de-bbb9-0f203972d227)
