### PR TITLE
Added styling to dark theme for hash links

### DIFF
--- a/DuggaSys/resulted.js
+++ b/DuggaSys/resulted.js
@@ -247,7 +247,7 @@ function renderCell(col, celldata, cellid) {
 	if (col == "hash"){
 		var url = createUrl(celldata);
 		str += "<div class='resultTableText'>";
-		str += "<a href='" + url + "'>" + celldata + "</a>";
+		str += "<a class='resultTableTextHash' href='" + url + "'>" + celldata + "</a>";
 	}
 	else if(col == "grade"){
 		str += "<div class='gradeContainer resultTableText'>";

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1359,6 +1359,10 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 
 }
 
+.resultTableTextHash{
+    color:#5badff;
+}
+
 /* Toast notifications */
 .toast {
     background-color: #e9e9e9;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4016,6 +4016,7 @@ span.arrow {
     inset -3px 0px 0px 0px rgba(97, 72, 117, 1);
 
 }
+
 .resultTableText {
   margin-left: 3px;
   margin-right: 3px;


### PR DESCRIPTION
Added styling to dark theme for hash links. since they did not appear with good enough contrast previously. To access this go to a course and then edit student results. In light mode it looks like this:

<img width="361" alt="Pasted Graphic" src="https://github.com/HGustavs/LenaSYS/assets/129295853/8e5aeac7-14da-4436-bffd-8aea15546703">

And in dark mode the hash link has now been modified with a lighter color for readability:
<img width="359" alt="Pasted Graphic 1" src="https://github.com/HGustavs/LenaSYS/assets/129295853/8d9a130e-fc9c-48d3-8332-b6608ff44713">