### PR TITLE
Moved the "First Name" label to the correct place

### DIFF
--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -128,12 +128,12 @@
 			<div>
 				<div class='formBoxHeader'>
 					<h3>Edit user (placeholder)</h3>
-					<span>First Name:</span>
-          <div class='cursorPointer' onclick='closeWindows();'>x</div>
+          		<div class='cursorPointer' onclick='closeWindows();'>x</div>
 				</div>
 				<div class="content-wrapper">
 					<input type='hidden' id='uid' value='Toddler' />
 					<div class='flexwrapper'>
+						<span>First Name:</span>
 						<div class="tooltipDugga"><span id="tooltipFirst" style="display: none;" class="tooltipDuggatext">  </span></div>
 						<input placeholder="Greger" class='textinput' type='text' id='placeholderID4' onchange="tooltipFirst()" onkeyup="tooltipFirst()"/>
 					</div>


### PR DESCRIPTION
Moved the "First Name" label to the correct place since it was in the header element previously. To access this, go into a course and press the keylock button. This is what it looked like before:
<img width="319" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129295853/7f417564-6215-4f02-b583-8850eb03e5d3">

And this is what it looks like now:
<img width="304" alt="image" src="https://github.com/HGustavs/LenaSYS/assets/129295853/c3226793-3130-4af1-9ac2-07fef9240107">
