### PR TITLE
G2 2024 v7 issue#16092

### DIFF
--- a/DuggaSys/accessed.php
+++ b/DuggaSys/accessed.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();
-	include_once "../../coursesyspw.php";
 	include_once "../Shared/sessions.php";
 	include_once "../Shared/toast.php";
 	pdoConnect();

--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();
-	include_once("../../coursesyspw.php");
 	include_once("../Shared/basic.php");
 	include_once("../Shared/sessions.php");
 	include_once("../Shared/database.php");

--- a/DuggaSys/codeviewerService.php
+++ b/DuggaSys/codeviewerService.php
@@ -20,7 +20,6 @@
 	date_default_timezone_set("Europe/Stockholm");
 
 	// Include basic application services
-	include_once ("../../coursesyspw.php");
 	include_once ("../Shared/sessions.php");
 	include_once ("../Shared/basic.php");
 	include_once ("../Shared/courses.php");

--- a/DuggaSys/contribution.php
+++ b/DuggaSys/contribution.php
@@ -1,6 +1,5 @@
 <?php
 session_start();
-include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 include_once "../Shared/basic.php";
 pdoConnect();

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -1,6 +1,5 @@
 <?php
 session_start();
-include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 include_once "../Shared/toast.php";
 pdoConnect();

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1,6 +1,5 @@
 <?php
     session_start();
-    include_once "../../coursesyspw.php";
     include_once "../Shared/sessions.php";
 	include_once "../Shared/basic.php";
 	#general vars regarding current dugga.

--- a/DuggaSys/diagram_IOHandler.php
+++ b/DuggaSys/diagram_IOHandler.php
@@ -18,7 +18,6 @@ of which folder in the repository 'save' on the server to load.
     -'Upload Canvas' and 'Example canvas' options does not seem to do anything.
 -------------==============######## Documentation End ###########==============-------------*/
   session_start();
-  include_once "../../coursesyspw.php";
   include_once "../Shared/sessions.php";
   pdoConnect();
 ?>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -2,7 +2,6 @@
 // Start the session
 session_start();
 
-include_once "../../coursesyspw.php";
 include_once "../Shared/basic.php";
 include_once "../Shared/sessions.php";
 

--- a/DuggaSys/microservices/sectionedService/readCourseGroupsAndMembers_ms.php
+++ b/DuggaSys/microservices/sectionedService/readCourseGroupsAndMembers_ms.php
@@ -9,7 +9,6 @@ date_default_timezone_set("Europe/Stockholm");
 // Include basic application services!
 include_once "../../../Shared/basic.php";
 include_once "../../../Shared/sessions.php";
-include_once "../../../Shared/coursesyspw.php";
 include_once "./retrieveSectionedService_ms.php";
 
 // Connect to database and start session

--- a/DuggaSys/profile.php
+++ b/DuggaSys/profile.php
@@ -1,6 +1,5 @@
 <?php
 session_start();
-include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 pdoConnect();
 ?>

--- a/DuggaSys/pushnotifications.php
+++ b/DuggaSys/pushnotifications.php
@@ -1,6 +1,5 @@
 <?php
 session_start();
-include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 pdoConnect();
 

--- a/DuggaSys/resulted.php
+++ b/DuggaSys/resulted.php
@@ -7,7 +7,6 @@ in this page.
 Execution: resulted.js has an ajax call that runs at start up and displays the returned data on this page.
 -------------==============######## Documentation End ###########==============-------------*/
 session_start();
-include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 pdoConnect();
 ?>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -2,7 +2,6 @@
 	session_start();
 	include_once "../Shared/basic.php";
 	include_once "../Shared/sessions.php";
-	//include_once "../../coursesyspw.php";
 	include_once "../Shared/toast.php";
 	pdoConnect();
 

--- a/DuggaSys/tests/duggaedService_test.php
+++ b/DuggaSys/tests/duggaedService_test.php
@@ -1,7 +1,6 @@
 <?php
 
 include "../../Shared/test.php";
-include_once "../../../coursesyspw.php";
 
 $testsData = array(
 

--- a/DuggaSys/tests/fileedService_test.php
+++ b/DuggaSys/tests/fileedService_test.php
@@ -1,6 +1,5 @@
 <?php
 include "../../Shared/test.php";
-include_once "../../../coursesyspw.php";
 
 $testsData = array(
 	'Edit file test' => array(

--- a/Shared/loginlogout.php
+++ b/Shared/loginlogout.php
@@ -4,7 +4,6 @@ session_start();
 
 // Includes
 include_once "../Shared/basic.php";
-include_once "../../coursesyspw.php";
 
 $opt = getOP('opt');
 

--- a/Shared/resetpw.php
+++ b/Shared/resetpw.php
@@ -3,7 +3,6 @@
 include_once "../Shared/sessions.php";
 include_once "../Shared/basic.php";
 
-include_once "../../coursesyspw.php";
 
 $opt=getOP('opt');
 

--- a/errorpages/404.php
+++ b/errorpages/404.php
@@ -1,7 +1,6 @@
 <?php
 
 session_start();
-//include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 include_once "../Shared/basic.php";
 

--- a/testingdb/testingdb_setup.php
+++ b/testingdb/testingdb_setup.php
@@ -1,5 +1,4 @@
 <?php
-include_once "../../coursesyspw.php";
 include_once "../Shared/sessions.php";
 
 pdoConnect();


### PR DESCRIPTION
I have removed the include of "coursesyspw.php" at the top of files that already includes "sessions.php". 
I checked if this broke anything by navigating to the part of the sites that is still used in LenaSYS. Tests and files like e.g. codeview.php still works without any issues.