### PR TITLE
G2 2024 v7 issue #16105

### DIFF
--- a/DuggaSys/microservices/fileedService/deleteFileLink_ms.php
+++ b/DuggaSys/microservices/fileedService/deleteFileLink_ms.php
@@ -22,7 +22,7 @@ $kind = getOP('kind');
 $filename = getOP('filename');
 $coursevers = getOP('coursevers');
 $userid = getUid();
-$debug = "The file was deleted";
+$debug = "NONE!";
 $log_uuid = getOP('log_uuid');
 
 // Permission checks

--- a/DuggaSys/microservices/fileedService/getFileedService_ms.php
+++ b/DuggaSys/microservices/fileedService/getFileedService_ms.php
@@ -1,0 +1,25 @@
+<?php
+//---------------------------------------------------------------------------------------------------------------
+// getFileedService_ms - Gets all fileLinks
+//---------------------------------------------------------------------------------------------------------------
+
+include_once "../../../Shared/basic.php";
+include_once "../../../Shared/sessions.php";
+include_once "../sharedMicroservices/getUid_ms.php";
+include_once "./retrieveFileedService_ms.php";
+
+date_default_timezone_set("Europe/Stockholm");
+
+pdoConnect();
+session_start();
+
+$opt = getOP('opt');
+$courseid = getOP('courseid');
+$coursevers = getOP('coursevers');
+$fid = getOP('fid');
+$log_uuid = getOP('log_uuid');
+$userid = getUid();
+$debug = "NONE!";
+
+$retrieveArray = retrieveFileedService($debug, null, null, $pdo, $courseid, $coursevers, $userid, $log_uuid, $opt, $fid, $kind);
+echo json_encode($retrieveArray);

--- a/DuggaSys/tests/microservices/fileedService/deleteFileLink_ms_test.php
+++ b/DuggaSys/tests/microservices/fileedService/deleteFileLink_ms_test.php
@@ -3,9 +3,9 @@
 include_once "../../../../Shared/test.php";
 
 $testsData = array(
-    
+
     'deleteFileLink_ms' => array(
-        'expected-output' => '{"debug":"The file was deleted"}',
+        'expected-output' => '{"debug":"NONE!"}',
 
         'query-before-test-1' => "INSERT INTO fileLink (fileid, filename, kind, cid, uploaddate) VALUES (9999, 'testFile.html', 1, 1885, NOW())",
         'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/fileedService/deleteFileLink_ms.php',
@@ -24,8 +24,7 @@ $testsData = array(
         'filter-output' => serialize(
             array(
                 // Filter what output to use in assert test, use none to use all ouput from service
-                    'debug'
-             
+                'debug'
             )
         ),
     ),

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -1135,13 +1135,31 @@ function AJAXService(opt,apara,kind)
 				success: returnedHighscore
 			});
 	}else if(kind=="FILE"){
-			$.ajax({
-				url: "fileedservice.php",
-				type: "POST",
-				data: "cid="+querystring['courseid']+"&coursevers="+querystring['coursevers']+"&opt="+opt+para,
-				dataType: "json",
-				success: returnedFile
-			})
+		let serviceURL = "fileedservice.php";
+		
+		switch (opt) {
+			case "GET":
+				serviceURL = "fileedservice.php"; // CHANGE WHEN WORKING
+				// serviceURL= "../DuggaSys/microservices/fileedService/getFileedService_ms.php";
+				break;
+			case "SAVEFILE":
+				serviceURL= "../DuggaSys/microservices/fileedService/updateFileLink_ms.php";
+				break;
+			case "DELFILE":
+				serviceURL= "../DuggaSys/microservices/fileedService/deleteFileLink_ms.php";
+				break;
+			default:
+				serviceURL= "fileedservice.php";
+				break;
+		}
+
+		$.ajax({
+			url: serviceURL,
+			type: "POST",
+			data: "cid="+querystring['courseid']+"&coursevers="+querystring['coursevers']+"&opt="+opt+para,
+			dataType: "json",
+			success: returnedFile
+		});
 	}else if(kind=="ACCESS"){
 			$.ajax({
 				url: "accessedservice.php",


### PR DESCRIPTION
The microservices have been integrated. See dugga.js at ```kind=="FILE"```.

I tried creating getFileedService_ms.php, however I couldn't get it to work. I didn't want to broaden the scope of this issue too much so it will be looked at in another issue. Because of this the "GET" opt still uses the monolith.

You can test the integration by going into a course, clicking "show files" in the toolbar (the plug icon), and then updating and deleting files. All different kinds of files/links should work correctly (global, etc).