### PR TITLE
Make Name input change the codeexample name #15231

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -4185,6 +4185,7 @@ function storeCodeExamples(cid, codeExamplesContent, githubURL, fileName){
       }
     });   
     confirmBox('closeConfirmBox');
+    location.replace(location.href);
 }
 function updateTemplate() {
   templateNo = $("#templateno").val();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -4044,7 +4044,7 @@ function fetchGitCodeExamples(courseid){
     }
     fetchFileContent(githubURL,filteredFiles, folderPath).then(function(codeExamplesContent){
       //Test here to view content in console. codeExamplesContent array elements contains alot of info.
-      storeCodeExamples(cid, codeExamplesContent, githubURL);
+      storeCodeExamples(cid, codeExamplesContent, githubURL, fileName);
     }).catch(function(error){
       console.error('Failed to fetch file contents:', error)
     });
@@ -4138,7 +4138,7 @@ function fetchGitCodeExamples(courseid){
     });
   }
 //Function to store Code Examples in directory and in database (metadata2.db)
-function storeCodeExamples(cid, codeExamplesContent, githubURL){
+function storeCodeExamples(cid, codeExamplesContent, githubURL, fileName){
     var templateNo = updateTemplate();
     var decodedContent=[], shaKeys=[], fileNames=[], fileURL=[], downloadURL=[], filePath=[], fileType=[], fileSize=[];
     //Push all file data into separate arrays and add them into one single array.
@@ -4173,6 +4173,7 @@ function storeCodeExamples(cid, codeExamplesContent, githubURL){
        data: {
         courseid: cid,
         githubURL: githubURL,
+        codeExampleName: fileName,
         opt: 'GITCODEEXAMPLE',
         codeExampleData: AllJsonData
        },

--- a/DuggaSys/sectionedservice.php
+++ b/DuggaSys/sectionedservice.php
@@ -69,6 +69,7 @@ $url=getOP('url');
 $githubURL=getOP('githubURL');
 $codeExampleData=getOP('codeExampleData');
 $lid=getOP('lid');
+$codeExampleName=getOP('codeExampleName');
 $visbile = 0;
 $avgfeedbackscore = 0;
 
@@ -1029,17 +1030,29 @@ if(checklogin()){
 			}
 
 			//Edit codeexample. Can update later to allow the Name input from user in gitpopup to update the codeExample here? also sectionname?
-			$query = $pdo->prepare( "UPDATE codeexample SET runlink = :playlink, templateid = :templateno WHERE exampleid = :exampleid AND cid = :cid AND cversion = :cvers;");
+			$query = $pdo->prepare( "UPDATE codeexample SET runlink = :playlink, templateid = :templateno, examplename = :examplename WHERE exampleid = :exampleid AND cid = :cid AND cversion = :cvers;");
 			$query->bindParam(':playlink', $fileNames[0]);
 			$query->bindParam(':templateno', $templateid);
 			$query->bindParam(':exampleid', $codeExamplesLinkParam[0]);
 			$query->bindParam(':cid', $courseid);
 			$query->bindParam(':cvers', $codeExamplesLinkParam[3]);
+			$query->bindParam('examplename', $codeExampleName);
 			if(!$query->execute()) {
 				$error=$query->errorInfo();
 				echo "Error updating entries in codeexample" . $error[2];
 			} else{
 				echo "Row updated successfully in codeexample";
+			}
+			//Edit listentries to update list entry name.
+			$query = $pdo->prepare( "UPDATE listentries SET entryname = :exampleName WHERE lid = :lid AND cid = :cid;");
+			$query->bindParam(':exampleName', $codeExampleName);
+			$query->bindParam(':lid', $codeExamplesLinkParam[4]);
+			$query->bindParam(':cid', $courseid);
+			if(!$query->execute()) {
+				$error=$query->errorInfo();
+				echo "Error updating listentry in listentries" . $error[2];
+			} else{
+				echo "Row updated successfully in listentries";
 			}
 
 			$boxContent = "Code";


### PR DESCRIPTION
The Name input is now updated to the list entry name and the codeexample name.

Testing:
Create a new code example.
Fetch a file/files from the github icon.
Click Save.
![image](https://github.com/HGustavs/LenaSYS/assets/129263393/89cf4603-7893-4280-a225-b7a5814fe4f5)

The Name input should now be displayed as the list entry name and code example name.
![image](https://github.com/HGustavs/LenaSYS/assets/129263393/0919fe1f-4b01-44a9-9fe2-4a383fa2e182)

Title is also updated (codeexample name)
![image](https://github.com/HGustavs/LenaSYS/assets/129263393/04313119-b7f1-4d31-bc43-44a7193323fd)

This can be doublechecked in the db table "listentries" and "codeexample"
