### PR TITLE
G2 2024 v7 issue #16096

### DIFF
--- a/DuggaSys/accessedservice.php
+++ b/DuggaSys/accessedservice.php
@@ -11,10 +11,11 @@ session_start();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 
-if(isset($_SESSION['uid'])){
-	$userid=$_SESSION['uid'];
-}else{
-	$userid="1";//to make tests work, same is also done duggaedservice.php
+checklogin();
+if (isset($_SESSION['uid'])) {
+    $userid = $_SESSION['uid'];
+} else {
+    $userid = "guest";
 }
 
 $pw = getOP('pw');

--- a/DuggaSys/codeviewerService.php
+++ b/DuggaSys/codeviewerService.php
@@ -43,11 +43,13 @@
 	$exampleName=getOP('examplename');
 	$playlink=getOP('playlink');
 	$debug="NONE!";
+
 	// Checks user id, if user has none a guest id is set
-	if(isset($_SESSION['uid'])){
-		$userid=$_SESSION['uid'];
-	}else{
-		$userid="1";
+	checklogin();
+	if (isset($_SESSION['uid'])) {
+		$userid = $_SESSION['uid'];
+	} else {
+		$userid = "guest";
 	}
 
 	$log_uuid = getOP('log_uuid');

--- a/DuggaSys/contributionservice.php
+++ b/DuggaSys/contributionservice.php
@@ -97,7 +97,7 @@ if(strcmp($opt,"get")==0) {
 		$userid=$_SESSION['uid'];
 		$loginname=$_SESSION['loginname'];
 	}else{
-		$userid=1;
+		$userid="guest";
 		$loginname="UNK";
 		$lastname="UNK";
 		$firstname="UNK";

--- a/DuggaSys/diagramservice.php
+++ b/DuggaSys/diagramservice.php
@@ -15,13 +15,15 @@
     // Connect to database and start session
     pdoConnect();
     session_start();
+    
+    checklogin();
     if (isset($_SESSION['uid'])) {
         $userid = $_SESSION['uid'];
         $loginname = $_SESSION['loginname'];
         $lastname = $_SESSION['lastname'];
         $firstname = $_SESSION['firstname'];
     } else {
-        $userid = 1;
+        $userid = "guest";
         $loginname = "UNK";
         $lastname = "UNK";
         $firstname = "UNK";

--- a/DuggaSys/duggaedservice.php
+++ b/DuggaSys/duggaedservice.php
@@ -9,10 +9,11 @@ include_once "../Shared/basic.php";
 pdoConnect();
 session_start();
 
-if(isset($_SESSION['uid'])){
-	$userid=$_SESSION['uid'];
-}else{
-	$userid="1";
+checklogin();
+if (isset($_SESSION['uid'])) {
+    $userid = $_SESSION['uid'];
+} else {
+    $userid = "guest";
 }
 
 $cid = getOP('cid');

--- a/DuggaSys/fileedservice.php
+++ b/DuggaSys/fileedservice.php
@@ -6,10 +6,12 @@ include_once "../Shared/basic.php";
 
 pdoConnect();
 session_start();
+
+checklogin();
 if (isset($_SESSION['uid'])) {
     $userid = $_SESSION['uid'];
 } else {
-    $userid = "1";
+    $userid = "guest";
 }
 
 // Gets username based on uid, USED FOR LOGGING

--- a/DuggaSys/highscoreservice.php
+++ b/DuggaSys/highscoreservice.php
@@ -14,12 +14,12 @@ include_once "../Shared/basic.php";
 pdoConnect();
 session_start();
 
-if(isset($_SESSION['uid'])){
-	$userid=$_SESSION['uid'];
-}else{
-	$userid="1";		
-} 
-
+checklogin();
+if (isset($_SESSION['uid'])) {
+    $userid = $_SESSION['uid'];
+} else {
+    $userid = "guest";
+}
 
 $opt=getOP('opt');
 $courseid=getOP('courseid');

--- a/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
+++ b/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
@@ -9,17 +9,12 @@ date_default_timezone_set("Europe/Stockholm");
 // Include basic application services!
 include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
+include_once "../sharedMicroservices/getUid_ms.php";
 include_once "retrieveHighscoreService_ms.php";
 
 // Connect to database and start session
 pdoConnect();
 session_start();
-
-if(isset($_SESSION['uid'])){
-	$userid=$_SESSION['uid'];
-}else{
-	$userid="1";		
-} 
 
 $opt=getOP('opt');
 $courseid=getOP('courseid');
@@ -29,6 +24,7 @@ $duggaid=getOP('did');
 $variant=getOP('lid');
 $moment=getOP('moment');
 $hash=getOP("hash");
+$userid = getUid();
 
 $debug="NONE!";	
 

--- a/DuggaSys/profileservice.php
+++ b/DuggaSys/profileservice.php
@@ -16,12 +16,12 @@ include_once "../Shared/sessions.php";
 pdoConnect();
 session_start();
 
-if(isset($_SESSION['uid'])){
-	$userid=$_SESSION['uid'];
-}else{
-	$userid="1";		
-} 
-
+checklogin();
+if (isset($_SESSION['uid'])) {
+    $userid = $_SESSION['uid'];
+} else {
+    $userid = "guest";
+}
 
 $password= getOP('password');
 $question = getOP('question');


### PR DESCRIPTION
```$userid``` was changed from "1" to "guest" in several php files. To make this work, ```checklogin()``` had to be added before setting ```$userid```.

Markdown files were not changed.