### PR TITLE
G3-2024-a22chrfa-#16167

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -30,15 +30,6 @@ var backgroundColorTheme;
 var isLoggedIn = false;
 var inputColorTheme;
 
-document.addEventListener('keydown', function(event) {
-  if (event.key === 'm') {
-      console.log("eventLOG: ", selectedItemList);
-      // Add any action you want to perform here
-  }
-});
-
-
-
 function initInputColorTheme() {
   if(localStorage.getItem('themeBlack').includes('blackTheme')){
     inputColorTheme = "#212121";

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -975,7 +975,7 @@ function prepareItem() {
 
 function deleteItem(item_lid) {
   // for (var i = 0; i < item_lid.length; i++) {
-  lid = item_lid ? item_lid : $("#lid").val();
+  // lid = item_lid ? item_lid : $("#lid").val();
   //   item = document.getElementById("lid" + lid[i]);
   //   item.style.display = "none";
   //   item.classList.add("deleted");
@@ -983,9 +983,7 @@ function deleteItem(item_lid) {
     // document.querySelector("#undoButton").style.display = "block";
   // }
 
-  // lid = item_lid;
-
-  console.log("delArr: ", delArr);
+  lid = item_lid;
 
   toast("undo", "Undo deletion?", 15, "cancelDelete();");
   // Makes deletefunction sleep for 60 sec so it is possible to undo an accidental deletion
@@ -993,7 +991,6 @@ function deleteItem(item_lid) {
     delArr.push(lid[i]);
   }
   
-  console.log("delArr: ", delArr);
   clearTimeout(delTimer);
   delTimer = setTimeout(() => {
     

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -30,6 +30,15 @@ var backgroundColorTheme;
 var isLoggedIn = false;
 var inputColorTheme;
 
+document.addEventListener('keydown', function(event) {
+  if (event.key === 'm') {
+      console.log("eventLOG: ", selectedItemList);
+      // Add any action you want to perform here
+  }
+});
+
+
+
 function initInputColorTheme() {
   if(localStorage.getItem('themeBlack').includes('blackTheme')){
     inputColorTheme = "#212121";
@@ -964,34 +973,44 @@ function prepareItem() {
 // deleteItem: Deletes Item from Section List
 //----------------------------------------------------------------------------------
 
-function deleteItem(item_lid = []) {
-  for (var i = 0; i < item_lid.length; i++) {
-    lid = item_lid ? item_lid : $("#lid").val();
-    item = document.getElementById("lid" + lid[i]);
-    item.style.display = "none";
-    item.classList.add("deleted");
+function deleteItem(item_lid) {
+  // for (var i = 0; i < item_lid.length; i++) {
+  lid = item_lid ? item_lid : $("#lid").val();
+  //   item = document.getElementById("lid" + lid[i]);
+  //   item.style.display = "none";
+  //   item.classList.add("deleted");
   
-    document.querySelector("#undoButton").style.display = "block";
-  }
+    // document.querySelector("#undoButton").style.display = "block";
+  // }
+
+  // lid = item_lid;
+
+  console.log("delArr: ", delArr);
 
   toast("undo", "Undo deletion?", 15, "cancelDelete();");
   // Makes deletefunction sleep for 60 sec so it is possible to undo an accidental deletion
-  delArr.push(lid);
+  for(let i = 0; i < lid.length; i++) {
+    delArr.push(lid[i]);
+  }
+  
+  console.log("delArr: ", delArr);
   clearTimeout(delTimer);
   delTimer = setTimeout(() => {
-    deleteAll();
+    
   }, 60);
+  deleteAll();
 }
 
 // Permanently delete elements.
 function deleteAll() {
-  for (var i = delArr.length - 1; i >= 0; --i) {
+  for (let i = 0; i < delArr.length; i++) {
     AJAXService("DEL", {
-      lid: delArr.pop()
+      lid: delArr[i]
     }, "SECTION");
   }
+  delArr = [];
   $("#editSection").css("display", "none");
-  document.querySelector("#undoButton").style.display = "none";
+  // document.querySelector("#undoButton").style.display = "none";
 }
 
 // Cancel deletion


### PR DESCRIPTION
It is now possible to select multiple items and deleting them with the trashcan. Unlike before, the array containing the selected items is also cleared after deletion, which means you can select n items, delete them, and then do the same to a new set of items. This required reloading the page before since the array wasn't cleared.

**NOTE:**
1. The undo button wasn't showing before, but is thanks to the code not stopping because of errors. It is not working however.
2. The styling (which was the cause of log errors) are not working properly. Hence the log errors, which is why they've been commented out.
3. It's a bit weird that you have to select a row when each row has a trashcan. It's also non-intuitive that after selecting multiple rows, you can click any trashcan belonging to an item row (rather than a separated trashcan that would be more in line with UXD principles). But this is the design laid out.

Those issues are considered outside the scope here, but had to be commented out due to them not functioning. Be aware when testing that UNDO is not working and is NOT inside the scope here.

**For testing:**
Select a few items in the and click a trashcan, they should now disappear. Now do it one more time without reloading the page.