### PR TITLE
Toast implemented to fileed.php for #16169

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -789,6 +789,7 @@ function deleteFile(fileid, filename, filekind) {
     if (confirm("Do you really want to delete the file/link: " + filename)) {
         AJAXService("DELFILE", tempData, "FILE");
     }
+    toast("success", "Item deleted", 6);
 }
 
 

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -4,6 +4,7 @@ session_start();
 
 include_once "../Shared/basic.php";
 include_once "../Shared/sessions.php";
+include "../Shared/toast.php";
 
 // Connect to database
 pdoConnect();


### PR DESCRIPTION
Toast is now included in fileed.php. The toast function has also been added to fileed.js under the deleteFile-function. As of now, it always toasts when clicking "yes" due to a more fundamental aspect in how confirmation is handled on this particular page. I tried implementing conditionals by wrapping the the ajax-call in a promise but was ultimately unsuccessful. As this would require more research on promise objects in order to increase my own understanding - this issue would be lengthier and would therefore be better handled in a follow-up issues.

**Testing:**
Delete an item fileed.js (those that can be deleted, some are tied to code examples) and see the toast appear.