### PR TITLE
komplettering b22jonan 15751

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -301,7 +301,6 @@ function drawLineProperties(line) {
             });
             str += select('propertyCardinality', optER, true, false);
             str += `</label>`;
-            str += includeLabel(line);
             break;
         case entityType.UML:
             str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);


### PR DESCRIPTION
removed the ability to add lables to lines between ER elements, labels are still available to other lines. 
the solution was to remove 
"str += includeLabel(line);"
from the ER case in drawlineproperties in options.js