### PR TITLE
Edited styling for files table in fileed.php (#16176)

### DIFF
--- a/DuggaSys/fileed.js
+++ b/DuggaSys/fileed.js
@@ -112,7 +112,7 @@ function returnedFile(data) {
         renderSortOptionsCallback: renderSortOptions,
         rowFilterCallback: rowFilter,
         columnOrder: colOrder,
-        hasRowHighlight: true,
+        hasRowHighlight: false,
         hasMagicHeadings: false,
         hasCounterColumn: true
     });

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -449,8 +449,8 @@
 }
 
 .list td {
-    border-left: 2px solid var(--color-primary);
-    border-right: 2px solid var(--color-primary);
+    border-top: 1px solid var(--color-primary);
+    border-bottom: 1px solid var(--color-primary);
 }
 
 .changeColorInDarkModeTable:nth-of-type(even) { 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3814,9 +3814,17 @@ div.submit-button:disabled {
 }
 
 .list td {
-  border-left: 2px solid var(--color-border-list);
-  border-right: 2px solid var(--color-border-list);
+  border-top: 1px solid var(--color-border-list);
+  border-bottom: 1px solid var(--color-border-list);
   padding: 0 8px 0 8px;
+}
+
+.list tr:nth-child(even) {
+  background-color: #61487520;
+}
+
+.list tr:hover{
+  background-color: #61487560;
 }
 
 .list th {


### PR DESCRIPTION
1. fileed.js instantiates a new SortableTable object. This also had its property "hasRowHighLight" set to true which I instead set to false.
2. I added a new css rule for all even table rows which uses the same color as the color-primary variable, but it uses an 8 digit hex code to include the alpha channel.
3. I changed the styling of the td-elements to the tr-elements, and set the border on top an bottom instead of left and right.

It works for both black and white theme. This is the result:
![image](https://github.com/HGustavs/LenaSYS/assets/128893264/fd77b746-9ed3-4317-9c57-45e042c30a1a)

**For testing:**
Go to fileed.php and see the list. Hover your pointer over the list to check the highlight. Check for both themes.