### PR TITLE
Komplettering-b22samer-#16161

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -315,6 +315,7 @@
 .node.mu {
     right: calc(50% - 4px);
     cursor: ns-resize;
+    top: 0;
 }
 .node.tr{
     cursor: nesw-resize;


### PR DESCRIPTION
For most of the time, I thought the problem was that the node wasn't being drawn for all elements except the "er entity." However, after testing various changes to how the nodes are drawn, I realized that this code has no errors. Finally, I was able to see that the node was being drawn but was hidden behind the bottom node in the middle, and only a position adjustment was needed to solve the problem.