### PR TITLE
New styling and separation of groups in Sectionlistc (#16179)

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2006,6 +2006,27 @@ function returnedSection(data) {
     var slist = document.getElementById('Sectionlisti');
     slist.innerHTML = str;
 
+
+    //Code testing
+    const sectionListDivs = document.querySelectorAll('#sectionlistc > div');
+    const divFullIdArr = [];
+    const divShortIdArr = [];
+    const regexId = /\d.*$/; //matches the first digit and everything following
+
+    for (let i = 0; i < sectionListDivs.length; i++) {
+      divFullIdArr.push(sectionListDivs[i].id);
+      let currentId = sectionListDivs[i].id;
+      let newId = currentId.replace(regexId, '');
+      divShortIdArr.push(newId);
+    }
+
+    console.log('divFullIdArr: ', divFullIdArr);
+    console.log('divShortIdArr: ', divShortIdArr);
+
+    //Code testing
+
+
+
     if (resave == true) {
       str = "";
       $("#Sectionlist").find(".item").each(function (i) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2007,8 +2007,6 @@ function returnedSection(data) {
     slist.innerHTML = str;
 
 
-    //Code testing
-
     //Creates ordered array of "rows"
     const sectionListDivs = document.querySelectorAll('#sectionlistc > div');
     const divFullIdArr = [];
@@ -2022,14 +2020,41 @@ function returnedSection(data) {
     for (let i = 0; i < divFullIdArr.length; i++) {
       if (divFullIdArr[i].includes('header')) {
         if (firstHeader == true) {
-          document.getElementById(divFullIdArr[i]).classList.add('headerMargin');
+          document.getElementById(divFullIdArr[i]).classList.add('sectionlistCMargin');
         }
         firstHeader = true;
       }
     }
 
-    //Code testing
+    //adds border to the side of each row
+    for (let i = 0; i < sectionListDivs.length; i++) {
+      document.getElementById(divFullIdArr[i]).classList.add('sectionlistCsideBorder');
+    }
 
+    //adds a small bottom margin to every moment that isn't preceded by a header. Also adds a bottom border to the preceding row
+    for (let i = 1; i < divFullIdArr.length; i++) {
+      if (!divFullIdArr[i - 1].includes('header') && divFullIdArr[i].includes('moment')) {
+        document.getElementById(divFullIdArr[i]).classList.add('sectionlistCSmallMargin');
+        document.getElementById(divFullIdArr[i - 1]).classList.add('sectionlistCbottomBorder');
+      }
+    }
+
+    //adds bottom border to any row that precedes a header row
+    for (let i = 0; i < divFullIdArr.length - 1; i++) {
+      if (divFullIdArr[i + 1].includes('header')) {
+        document.getElementById(divFullIdArr[i]).classList.add('sectionlistCbottomBorder');
+      }
+    }
+
+    //adds bottom border and bottom margin to the last item in the array
+    document.getElementById(divFullIdArr[divFullIdArr.length - 1]).classList.add('sectionlistCbottomBorder', 'sectionlistCbottomMargin');
+
+    //adds width class to every row except the header
+    for (let i = 0; i < divFullIdArr.length; i++) {
+      if (!divFullIdArr[i].includes('header')) {
+        document.getElementById(divFullIdArr[i]).classList.add('sectionlistCWidth');
+      }
+    }
 
 
     if (resave == true) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2008,20 +2008,25 @@ function returnedSection(data) {
 
 
     //Code testing
+
+    //Creates ordered array of "rows"
     const sectionListDivs = document.querySelectorAll('#sectionlistc > div');
     const divFullIdArr = [];
-    const divShortIdArr = [];
-    const regexId = /\d.*$/; //matches the first digit and everything following
 
     for (let i = 0; i < sectionListDivs.length; i++) {
       divFullIdArr.push(sectionListDivs[i].id);
-      let currentId = sectionListDivs[i].id;
-      let newId = currentId.replace(regexId, '');
-      divShortIdArr.push(newId);
     }
 
-    console.log('divFullIdArr: ', divFullIdArr);
-    console.log('divShortIdArr: ', divShortIdArr);
+    //gives every header except for the first one a margin
+    let firstHeader = false;
+    for (let i = 0; i < divFullIdArr.length; i++) {
+      if (divFullIdArr[i].includes('header')) {
+        if (firstHeader == true) {
+          document.getElementById(divFullIdArr[i]).classList.add('headerMargin');
+        }
+        firstHeader = true;
+      }
+    }
 
     //Code testing
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1332,10 +1332,32 @@ p {
 }
 
 /* Sectionlistc */
-.headerMargin {
-  margin-top: 20px;
+.sectionlistCMargin {
+  margin-top: 30px;
  }
 
+ .sectionlistCSmallMargin {
+  margin-top: 10px;
+ }
+
+ .sectionlistCsideBorder {
+  border-left: 1px solid var(--color-primary);
+  border-right: 1px solid var(--color-primary);
+ }
+
+ .sectionlistCbottomBorder {
+  border-bottom: 1px solid var(--color-primary);
+ }
+
+ .sectionlistCbottomMargin {
+  margin-bottom: 20px;
+ }
+
+ .sectionlistCWidth {
+  width: calc(100% - 30px);
+  margin-left: auto;
+  margin-right: auto;
+ }
 
 
 #errorBox{

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1331,6 +1331,10 @@ p {
   display: block;
 }
 
+/* Sectionlistc */
+.headerMargin {
+  margin-top: 20px;
+ }
 
 
 


### PR DESCRIPTION
Added logic to the styling and grouping, along with necessary class and CSS. This is based on the assumptions made from the prod version of canvas. Essentially, a header seems optional and a section seems to be used within a moment.

The added logic does the following:
1. Every header div except the first one gets a top margin
2. Every row div gets a left and a right border
3. Every moment div that isn't preceded by a header gets a small top margin
4. Every row div that precedes a moment div but isn't a header gets a bottom border
5. Every row div that precedes a header row also gets a bottom border
6. The very last row div in the array gets a bottom border
7. Every row div except for the header gets a class for shorter width

This will give us a box-like interface where a header is considered a group, and a moment (that includes sections) is considered a subgroup. If however it turns out that a section should be a parent of a moment, then this could easily be flipped. Also keep in mind that this is not a beauty contest. The purpose is to view a header as a group, and moments as subgroups.

![image](https://github.com/HGustavs/LenaSYS/assets/128893264/0ee3a748-ab65-49bb-a81a-46eccacafc52)

**For testing**
Create different items and move them around. Make sure the borders change as expected (a moment is a box that includes all rows until a new moment or a header). Keep in mind the assumptions made, structuring the list in other ways will give the result that this is coded for.

