### PR TITLE
Toggling hidden items now work (#16181)

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1371,6 +1371,17 @@ function duggaRowClick(rowElement) {
     }
   }
 }
+
+//
+function toggleButtonClickHandler() {
+  if (showHidden === true) {
+    showHidden = false;
+  } else {
+    showHidden = true;
+  }
+  toggleHidden();
+}
+
 var itemKinds = [];
 function returnedSection(data) {
   retdata = data;
@@ -2111,51 +2122,40 @@ function returnedSection(data) {
     addClasses();
     showMOTD();
   }
-
-  // Functions for toggling hidden elements
-  document.getElementById('toggleElements').addEventListener('click', function () {
-      if (showHidden === true) {
-        showHidden = false;
-      }
-      else {
-        showHidden = true;
-      }
-    toggleHidden();
-  });
-
-  function toggleHidden() { //Look for all td's that have the class "hidden"
-    const hiddenTds = document.querySelectorAll('#Sectionlistc td.hidden');
-    const hiddenDivs = [];
-    const uniqueAncestorIds = [];
-
-    hiddenTds.forEach(td => { // Find the closest ancestor div and push its ID into hiddenDivs
-      const ancestorDiv = td.closest('div');
-      hiddenDivs.push(ancestorDiv.id);
-    });
-
-    hiddenDivs.forEach(id => { //add unique IDs from hiddenDivs to uniqueAncestorIds
-      if (!uniqueAncestorIds.includes(id)) {
-        uniqueAncestorIds.push(id);
-      }
-    });
-
-    if (showHidden === true) {
-      uniqueAncestorIds.forEach(element => {
-        document.getElementById(element).classList.remove('displayNone');
-        document.getElementById(element).classList.add('displayBlock');
-      });
-
-    }
-    else {
-      uniqueAncestorIds.forEach(element => {
-        document.getElementById(element).classList.remove('displayBlock');
-        document.getElementById(element).classList.add('displayNone');
-      });
-    }
-  }
+  document.getElementById('toggleElements').addEventListener('click', toggleButtonClickHandler);
   toggleHidden();
 }
  
+function toggleHidden() { //Look for all td's that have the class "hidden"
+  const hiddenTds = document.querySelectorAll('#Sectionlistc td.hidden');
+  const hiddenDivs = [];
+  const uniqueAncestorIds = [];
+
+  hiddenTds.forEach(td => { // Find the closest ancestor div and push its ID into hiddenDivs
+    const ancestorDiv = td.closest('div');
+    hiddenDivs.push(ancestorDiv.id);
+  });
+
+  hiddenDivs.forEach(id => { //add unique IDs from hiddenDivs to uniqueAncestorIds
+    if (!uniqueAncestorIds.includes(id)) {
+      uniqueAncestorIds.push(id);
+    }
+  });
+  if (showHidden === true) {
+    uniqueAncestorIds.forEach(element => {
+      document.getElementById(element).classList.remove('displayNone');
+      document.getElementById(element).classList.add('displayBlock');
+    });
+
+  }
+  else {
+    uniqueAncestorIds.forEach(element => {
+      document.getElementById(element).classList.remove('displayBlock');
+      document.getElementById(element).classList.add('displayNone');
+    });
+  }
+}
+
 function openCanvasLink(btnobj) {
   //Searches closest tr element and then searches for classes that contain the link.
   parentTr = btnobj.closest('tr');

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -29,6 +29,7 @@ var numberOfItems;
 var backgroundColorTheme;
 var isLoggedIn = false;
 var inputColorTheme;
+let showHidden = true;
 
 function initInputColorTheme() {
   if(localStorage.getItem('themeBlack').includes('blackTheme')){
@@ -2006,25 +2007,6 @@ function returnedSection(data) {
     var slist = document.getElementById('Sectionlisti');
     slist.innerHTML = str;
 
-//CODE TESTING
-
-document.addEventListener('keydown', function(e) {
-  if (e.key === 'k') {
-      const testElement = document.getElementById('section4DG666V');
-
-      if (testElement) {
-
-          if (testElement.classList.contains('displayNone')) {
-            testElement.classList.remove('displayNone');
-            testElement.classList.add('displayBlock');
-          } else {
-            testElement.classList.add('displayNone');
-            testElement.classList.remove('displayBlock');
-          }
-      }
-  }
-});
-
     if (resave == true) {
       str = "";
       $("#Sectionlist").find(".item").each(function (i) {
@@ -2130,6 +2112,48 @@ document.addEventListener('keydown', function(e) {
     showMOTD();
   }
 
+  // Functions for toggling hidden elements
+  document.getElementById('toggleElements').addEventListener('click', function () {
+      if (showHidden === true) {
+        showHidden = false;
+      }
+      else {
+        showHidden = true;
+      }
+    toggleHidden();
+  });
+
+  function toggleHidden() { //Look for all td's that have the class "hidden"
+    const hiddenTds = document.querySelectorAll('#Sectionlistc td.hidden');
+    const hiddenDivs = [];
+    const uniqueAncestorIds = [];
+
+    hiddenTds.forEach(td => { // Find the closest ancestor div and push its ID into hiddenDivs
+      const ancestorDiv = td.closest('div');
+      hiddenDivs.push(ancestorDiv.id);
+    });
+
+    hiddenDivs.forEach(id => { //add unique IDs from hiddenDivs to uniqueAncestorIds
+      if (!uniqueAncestorIds.includes(id)) {
+        uniqueAncestorIds.push(id);
+      }
+    });
+
+    if (showHidden === true) {
+      uniqueAncestorIds.forEach(element => {
+        document.getElementById(element).classList.remove('displayNone');
+        document.getElementById(element).classList.add('displayBlock');
+      });
+
+    }
+    else {
+      uniqueAncestorIds.forEach(element => {
+        document.getElementById(element).classList.remove('displayBlock');
+        document.getElementById(element).classList.add('displayNone');
+      });
+    }
+  }
+  toggleHidden();
 }
  
 function openCanvasLink(btnobj) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1496,10 +1496,10 @@ function returnedSection(data) {
         var valarr = ["header", "section", "code", "test", "moment", "link", "group", "message"];
         // New items added get the class glow to show they are new
         if ((Date.parse(item['ts']) - dateToday) > compareWeek) {
-          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " glow" + "' style='display:block'>";
+          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " glow displayBlock'>";
         }
         else {
-          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + "' style='display:block'>";
+          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " displayBlock'>";
         }
 
         menuState.idCounter++;
@@ -2005,6 +2005,25 @@ function returnedSection(data) {
 
     var slist = document.getElementById('Sectionlisti');
     slist.innerHTML = str;
+
+//CODE TESTING
+
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'k') {
+      const testElement = document.getElementById('section4DG666V');
+
+      if (testElement) {
+
+          if (testElement.classList.contains('displayNone')) {
+            testElement.classList.remove('displayNone');
+            testElement.classList.add('displayBlock');
+          } else {
+            testElement.classList.add('displayNone');
+            testElement.classList.remove('displayBlock');
+          }
+      }
+  }
+});
 
     if (resave == true) {
       str = "";

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -170,9 +170,11 @@
 			<!-- Hide button -->
 		
 			<div class='fixed-action-button3 sectioned3 display_none'  id="HIDEStatic">
+			<input id='toggleElements'  type='image' src='../Shared/icons/eye_icon.svg'  class='submit-button-newitem' title='toggle hidden items'>
 				<!-- <input id='tabElement'  type='button' value="&#8633;" class='submit-button-newitem' title='Tab items' onclick='confirmBox("openTabConfirmBox");'> -->
-				<input id='showElements'  type='image' src='../Shared/icons/eye_icon.svg'  class='submit-button-newitem' title='Show hidden items' onclick='confirmBox("openItemsConfirmBox");'>
-				<input id='hideElement'  type='image' src='../Shared/icons/ghost_icon.svg' class='submit-button-newitem' title='Hide marked items' onclick='confirmBox("openHideConfirmBox");'>
+				<input id='showElements'  type='image' src='../Shared/icons/eye_icon.svg' style="display:None"  class='submit-button-newitem' title='Show hidden items' onclick='confirmBox("openItemsConfirmBox");'>
+				<input id='hideElement'  type='image' src='../Shared/icons/ghost_icon.svg' style="display:None"  class='submit-button-newitem' title='Hide marked items' onclick='confirmBox("openHideConfirmBox");'>
+				
 				<input id='addElement'  type='button' value='+' class='submit-button-newitem' title='New Item'>
 			</div>
 		

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -10369,4 +10369,12 @@ button:disabled {
   font-style:italic;
 }
 
+.displayNone {
+  display: none;
+}
+
+.displayBlock {
+  display: block;
+}
+
 /* END */


### PR DESCRIPTION
The previous buttons didnt seem to work, and judging by their behaviour it was a bit hard to determine what they were actually meant to do. The existing "eye"-button did nothing, and the ghost button seems to have been intended to remove the hidden status of the items, but it only managed to remove the strikethrough in the text, not the status. I hid these buttons by setting their display to None. If their functionality is to be looked at, it'll have to be in another issue. This issue is about toggling hidden items in the list.

I created a new button for toggling, it borrows the eye-icon.
![image](https://github.com/HGustavs/LenaSYS/assets/128893264/9f271a5a-e37e-4d1a-9721-0385b4bca9f0)

When clicking this button, the items in the list will now have their visibility toggled.

Toggled on:
![image](https://github.com/HGustavs/LenaSYS/assets/128893264/c8437801-d4d8-4a18-a20a-9ed76a016ffd)

Toggled off:
![image](https://github.com/HGustavs/LenaSYS/assets/128893264/559082ab-c7ae-40f8-84ed-4f5e37d4cfbf)


**For testing**
Try toggling. Without reloading the page, edit, add and remove items and use the toggler. It should work regardless.