### PR TITLE
Making a4 appear as it should

### DIFF
--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -157,6 +157,12 @@ function toggleA4Template() {
         document.getElementById("a4TemplateToggle").style.backgroundColor = color.PURPLE;
         document.getElementById("a4TemplateToggle").style.color = color.WHITE;
         document.getElementById("a4TemplateToggle").style.fontWeight = "normal";
+        
+        const vRect = document.getElementById("vRect");
+        const a4Rect = document.getElementById("a4Rect");
+        
+        vRect.style.display = "none";  // Hide horizontal
+        a4Rect.style.display = "block";  // Show vertical
     }
     document.getElementById("a4TemplateToggle").style.border = `3px solid ${color.PURPLE}`;
 }


### PR DESCRIPTION

I used the code that draws a4 vertically and implemented it in the function that is called when the "a4 template" button is activated. By doing this, a4 is drawn correctly when the button is activated.