### PR TITLE
Added toggling option for large swimlanes (#16185)

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1377,48 +1377,46 @@ function SwimlaneToggleFunction() {
   const swimlaneDiv = document.getElementById('statisticsSwimlanes');
   const swimlaneSvgElement = document.getElementById('swimlaneSVG');
   const currentChoiceIndex = swimLaneViewOptions.indexOf(swimlaneViewChoice);
+  const toggleButton = document.getElementById('swimlaneToggleButton');
 
   let nextChoiceIndex = (currentChoiceIndex + 1);
   if (nextChoiceIndex > 2) {
     nextChoiceIndex = 0;
   }
-    swimlaneViewChoice = swimLaneViewOptions[nextChoiceIndex];
-  console.log(nextChoiceIndex);
-  let toggleButton = document.getElementById('swimlaneToggleButton');
+  swimlaneViewChoice = swimLaneViewOptions[nextChoiceIndex];
 
+  switch (swimlaneViewChoice) {
+    case 'normal':
+      toggleButton.title = 'Toggle to scroll view';
+      swimlaneDiv.style.maxHeight = 'None';
+      swimlaneDiv.style.height = 'Auto';
+      swimlaneDiv.style.width = 'Auto';
+      swimlaneDiv.style.overflowY = 'None';
+      swimlaneSvgElement.style.height = '';
+      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
+      break;
+    case 'scroll':
+      swimlaneDiv.style.maxHeight = '70vh';
+      swimlaneDiv.style.overflowY = 'Scroll';
+      swimlaneDiv.style.width = 'Auto';
+      toggleButton.title = 'Toggle to screenfit view';
+      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
+      break;
+    case 'screenfit':
+      swimlaneDiv.style.maxHeight = '65vh';
+      swimlaneDiv.style.height = '65vh';
+      swimlaneDiv.style.width = 'Auto';
+      swimlaneDiv.style.overflow = 'hidden';
+      swimlaneSvgElement.style.height = '100%';
+      swimlaneSvgElement.style.margin = '0';
 
-    switch (swimlaneViewChoice) {
-      case 'normal':
-        toggleButton.title = 'Toggle to scroll view';
-        swimlaneDiv.style.maxHeight = 'None';
-        swimlaneDiv.style.height = 'Auto';
-        swimlaneDiv.style.width = 'Auto';
-        swimlaneDiv.style.overflowY = 'None';
-        swimlaneSvgElement.style.height = '';
-        console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
-        break;
-      case 'scroll':
-        swimlaneDiv.style.maxHeight = '70vh';
-        swimlaneDiv.style.overflowY = 'Scroll';
-        swimlaneDiv.style.width = 'Auto';
-        toggleButton.title = 'Toggle to screenfit view';
-        console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
-        break;
-      case 'screenfit':      
-          swimlaneDiv.style.maxHeight = '65vh';
-          swimlaneDiv.style.height = '65vh';
-          swimlaneDiv.style.width = 'Auto';
-          swimlaneDiv.style.overflow = 'hidden';
-          swimlaneSvgElement.style.height = '100%';
-          swimlaneSvgElement.style.margin = '0';
-  
-        toggleButton.title = 'Toggle to normal view';
-        console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
-        break;
-      default:
-        console.log('Something went wrong');
-        break;
-    }
+      toggleButton.title = 'Toggle to normal view';
+      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
+      break;
+    default:
+      console.log('Something went wrong');
+      break;
+  }
 }
 
 var itemKinds = [];
@@ -2161,7 +2159,59 @@ function returnedSection(data) {
     addClasses();
     showMOTD();
   }
-  document.getElementById('swimlaneToggleButton').addEventListener('click', SwimlaneToggleFunction);
+
+  //Check if the swimlane has more height than 65vh
+  const swimlaneDivElement = document.getElementById('statisticsSwimlanes');
+  const swimlaneDivHeight = swimlaneDivElement.clientHeight;
+  const viewportHeight = window.innerHeight / 100;
+  const heightInPixels = 70 * viewportHeight;
+  const swimlaneToggleButtonElement = document.getElementById('swimlaneToggleButton');
+
+  //if more than 65vh, activate eventlistener and button
+  if (swimlaneDivHeight > heightInPixels) {
+    document.getElementById('swimlaneToggleButton').addEventListener('click', SwimlaneToggleFunction);
+    swimlaneToggleButtonElement.disabled = false;
+    swimlaneToggleButtonElement.style.display = 'Block';
+    swimlaneToggleButtonElement.title = 'Toggle to scroll view';
+  }
+  else {
+    swimlaneToggleButtonElement.disabled = true;
+    swimlaneToggleButtonElement.style.display = 'None';
+  }
+
+  const swimlaneSvgElement = document.getElementById('swimlaneSVG');
+  const toggleButtonElement = document.getElementById('swimlaneToggleButton');
+  
+  //initialize toggler correctly if returnedSection is run
+  switch (swimlaneViewChoice) {
+    case 'normal':
+      toggleButtonElement.title = 'Toggle to scroll view';
+      swimlaneDivElement.style.maxHeight = 'None';
+      swimlaneDivElement.style.height = 'Auto';
+      swimlaneDivElement.style.width = 'Auto';
+      swimlaneDivElement.style.overflowY = 'None';
+      swimlaneSvgElement.style.height = '';
+      break;
+    case 'scroll':
+      swimlaneDivElement.style.maxHeight = '70vh';
+      swimlaneDivElement.style.overflowY = 'Scroll';
+      swimlaneDivElement.style.width = 'Auto';
+      toggleButtonElement.title = 'Toggle to screenfit view';
+      break;
+    case 'screenfit':
+      swimlaneDivElement.style.maxHeight = '65vh';
+      swimlaneDivElement.style.height = '65vh';
+      swimlaneDivElement.style.width = 'Auto';
+      swimlaneDivElement.style.overflow = 'hidden';
+      swimlaneSvgElement.style.height = '100%';
+      swimlaneSvgElement.style.margin = '0';
+
+      toggleButtonElement.title = 'Toggle to normal view';
+      break;
+    default:
+      console.log('Something went wrong');
+      break;
+  }
 }
  
 function openCanvasLink(btnobj) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -29,7 +29,8 @@ var numberOfItems;
 var backgroundColorTheme;
 var isLoggedIn = false;
 var inputColorTheme;
-let swimlaneViewChoice = 0;
+const swimLaneViewOptions = ['normal', 'scroll', 'screenfit'];
+let swimlaneViewChoice = swimLaneViewOptions[0];
 
 function initInputColorTheme() {
   if(localStorage.getItem('themeBlack').includes('blackTheme')){
@@ -1373,28 +1374,32 @@ function duggaRowClick(rowElement) {
 }
 
 function SwimlaneToggleFunction() {
-  console.log(swimlaneViewChoice);
-  let testElement = document.getElementById('swimlaneToggleButton');
-  console.log('swimlaneToggleButton');
+
+  const currentChoiceIndex = swimLaneViewOptions.indexOf(swimlaneViewChoice);
+  let nextChoiceIndex = (currentChoiceIndex + 1);
+  if (nextChoiceIndex > 2) {
+    nextChoiceIndex = 0;
+  }
+    swimlaneViewChoice = swimLaneViewOptions[nextChoiceIndex];
+  console.log(nextChoiceIndex);
+  let toggleButton = document.getElementById('swimlaneToggleButton');
 
   switch (swimlaneViewChoice) {
-    case 0:
-      testElement.title = 'Toggle mode 1';
+    case 'normal':
+      toggleButton.title = 'Toggle to scroll view';
+      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
       break;
-    case 1:
-      testElement.title = 'Toggle mode 2';
+    case 'scroll':
+      toggleButton.title = 'Toggle to screenfit view';
+      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
       break;
-    case 2:
-      testElement.title = 'Toggle mode 3';
+    case 'screenfit':
+      toggleButton.title = 'Toggle to normal view';
+      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
       break;
     default:
       console.log('Something went wrong');
       break;
-  }
-
-  swimlaneViewChoice++;
-  if (swimlaneViewChoice > 2) {
-    swimlaneViewChoice = 0;
   }
 }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1393,14 +1393,12 @@ function SwimlaneToggleFunction() {
       swimlaneDiv.style.width = 'Auto';
       swimlaneDiv.style.overflowY = 'None';
       swimlaneSvgElement.style.height = '';
-      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
       break;
     case 'scroll':
       swimlaneDiv.style.maxHeight = '70vh';
       swimlaneDiv.style.overflowY = 'Scroll';
       swimlaneDiv.style.width = 'Auto';
       toggleButton.title = 'Toggle to screenfit view';
-      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
       break;
     case 'screenfit':
       swimlaneDiv.style.maxHeight = '65vh';
@@ -1411,10 +1409,9 @@ function SwimlaneToggleFunction() {
       swimlaneSvgElement.style.margin = '0';
 
       toggleButton.title = 'Toggle to normal view';
-      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
       break;
     default:
-      console.log('Something went wrong');
+      console.log('Something went wrong with the toggler');
       break;
   }
 }
@@ -2181,7 +2178,7 @@ function returnedSection(data) {
 
   const swimlaneSvgElement = document.getElementById('swimlaneSVG');
   const toggleButtonElement = document.getElementById('swimlaneToggleButton');
-  
+
   //initialize toggler correctly if returnedSection is run
   switch (swimlaneViewChoice) {
     case 'normal':
@@ -2209,7 +2206,7 @@ function returnedSection(data) {
       toggleButtonElement.title = 'Toggle to normal view';
       break;
     default:
-      console.log('Something went wrong');
+      console.log('Something went wrong with the toggler');
       break;
   }
 }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1391,7 +1391,7 @@ function SwimlaneToggleFunction() {
       swimlaneDiv.style.maxHeight = 'None';
       swimlaneDiv.style.height = 'Auto';
       swimlaneDiv.style.width = 'Auto';
-      swimlaneDiv.style.overflowY = 'None';
+      swimlaneDiv.style.overflow = 'None';
       swimlaneSvgElement.style.height = '';
       break;
     case 'scroll':
@@ -2185,7 +2185,7 @@ function returnedSection(data) {
       swimlaneDivElement.style.maxHeight = 'None';
       swimlaneDivElement.style.height = 'Auto';
       swimlaneDivElement.style.width = 'Auto';
-      swimlaneDivElement.style.overflowY = 'None';
+      swimlaneDivElement.style.overflow = 'None';
       swimlaneSvgElement.style.height = '';
       break;
     case 'scroll':

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1374,8 +1374,10 @@ function duggaRowClick(rowElement) {
 }
 
 function SwimlaneToggleFunction() {
-
+  const swimlaneDiv = document.getElementById('statisticsSwimlanes');
+  const swimlaneSvgElement = document.getElementById('swimlaneSVG');
   const currentChoiceIndex = swimLaneViewOptions.indexOf(swimlaneViewChoice);
+
   let nextChoiceIndex = (currentChoiceIndex + 1);
   if (nextChoiceIndex > 2) {
     nextChoiceIndex = 0;
@@ -1384,23 +1386,39 @@ function SwimlaneToggleFunction() {
   console.log(nextChoiceIndex);
   let toggleButton = document.getElementById('swimlaneToggleButton');
 
-  switch (swimlaneViewChoice) {
-    case 'normal':
-      toggleButton.title = 'Toggle to scroll view';
-      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
-      break;
-    case 'scroll':
-      toggleButton.title = 'Toggle to screenfit view';
-      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
-      break;
-    case 'screenfit':
-      toggleButton.title = 'Toggle to normal view';
-      console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
-      break;
-    default:
-      console.log('Something went wrong');
-      break;
-  }
+
+    switch (swimlaneViewChoice) {
+      case 'normal':
+        toggleButton.title = 'Toggle to scroll view';
+        swimlaneDiv.style.maxHeight = 'None';
+        swimlaneDiv.style.height = 'Auto';
+        swimlaneDiv.style.width = 'Auto';
+        swimlaneDiv.style.overflowY = 'None';
+        swimlaneSvgElement.style.height = '';
+        console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
+        break;
+      case 'scroll':
+        swimlaneDiv.style.maxHeight = '70vh';
+        swimlaneDiv.style.overflowY = 'Scroll';
+        swimlaneDiv.style.width = 'Auto';
+        toggleButton.title = 'Toggle to screenfit view';
+        console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
+        break;
+      case 'screenfit':      
+          swimlaneDiv.style.maxHeight = '65vh';
+          swimlaneDiv.style.height = '65vh';
+          swimlaneDiv.style.width = 'Auto';
+          swimlaneDiv.style.overflow = 'hidden';
+          swimlaneSvgElement.style.height = '100%';
+          swimlaneSvgElement.style.margin = '0';
+  
+        toggleButton.title = 'Toggle to normal view';
+        console.log('mode: ', swimLaneViewOptions[nextChoiceIndex]);
+        break;
+      default:
+        console.log('Something went wrong');
+        break;
+    }
 }
 
 var itemKinds = [];

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1407,7 +1407,6 @@ function SwimlaneToggleFunction() {
       swimlaneDiv.style.overflow = 'hidden';
       swimlaneSvgElement.style.height = '100%';
       swimlaneSvgElement.style.margin = '0';
-
       toggleButton.title = 'Toggle to normal view';
       break;
     default:
@@ -2202,7 +2201,6 @@ function returnedSection(data) {
       swimlaneDivElement.style.overflow = 'hidden';
       swimlaneSvgElement.style.height = '100%';
       swimlaneSvgElement.style.margin = '0';
-
       toggleButtonElement.title = 'Toggle to normal view';
       break;
     default:

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -29,6 +29,7 @@ var numberOfItems;
 var backgroundColorTheme;
 var isLoggedIn = false;
 var inputColorTheme;
+let swimlaneViewChoice = 0;
 
 function initInputColorTheme() {
   if(localStorage.getItem('themeBlack').includes('blackTheme')){
@@ -1370,6 +1371,33 @@ function duggaRowClick(rowElement) {
     }
   }
 }
+
+function SwimlaneToggleFunction() {
+  console.log(swimlaneViewChoice);
+  let testElement = document.getElementById('swimlaneToggleButton');
+  console.log('swimlaneToggleButton');
+
+  switch (swimlaneViewChoice) {
+    case 0:
+      testElement.title = 'Toggle mode 1';
+      break;
+    case 1:
+      testElement.title = 'Toggle mode 2';
+      break;
+    case 2:
+      testElement.title = 'Toggle mode 3';
+      break;
+    default:
+      console.log('Something went wrong');
+      break;
+  }
+
+  swimlaneViewChoice++;
+  if (swimlaneViewChoice > 2) {
+    swimlaneViewChoice = 0;
+  }
+}
+
 var itemKinds = [];
 function returnedSection(data) {
   retdata = data;
@@ -2110,7 +2138,7 @@ function returnedSection(data) {
     addClasses();
     showMOTD();
   }
-
+  document.getElementById('swimlaneToggleButton').addEventListener('click', SwimlaneToggleFunction);
 }
  
 function openCanvasLink(btnobj) {

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -170,7 +170,7 @@
 			<!-- Hide button -->
 		
 			<div class='fixed-action-button3 sectioned3 display_none'  id="HIDEStatic">
-			<input id="swimlaneToggleButton" type='image' src='../Shared/icons/rotateButton.svg' class='submit-button-newitem' title='Toggle swimlane view'>
+			<input id="swimlaneToggleButton" type='image' src='../Shared/icons/rotateButton.svg' class='submit-button-newitem' title='Toggle to scroll view'>
 
 				<!-- <input id='tabElement'  type='button' value="&#8633;" class='submit-button-newitem' title='Tab items' onclick='confirmBox("openTabConfirmBox");'> -->
 				<input id='showElements'  type='image' src='../Shared/icons/eye_icon.svg'  class='submit-button-newitem' title='Show hidden items' onclick='confirmBox("openItemsConfirmBox");'>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -170,6 +170,8 @@
 			<!-- Hide button -->
 		
 			<div class='fixed-action-button3 sectioned3 display_none'  id="HIDEStatic">
+			<input id="swimlaneToggleButton" type='image' src='../Shared/icons/rotateButton.svg' class='submit-button-newitem' title='Toggle swimlane view'>
+
 				<!-- <input id='tabElement'  type='button' value="&#8633;" class='submit-button-newitem' title='Tab items' onclick='confirmBox("openTabConfirmBox");'> -->
 				<input id='showElements'  type='image' src='../Shared/icons/eye_icon.svg'  class='submit-button-newitem' title='Show hidden items' onclick='confirmBox("openItemsConfirmBox");'>
 				<input id='hideElement'  type='image' src='../Shared/icons/ghost_icon.svg' class='submit-button-newitem' title='Hide marked items' onclick='confirmBox("openHideConfirmBox");'>


### PR DESCRIPTION
If a swimlane is large enough (> 70vh) a button will appear and give the user a choice to toggle between different views of the swimlane. One is the normal view, one is a cut height with a scrollbar for the overflow, and the last one is a smaller version of the swimlane that will fit the viewport.

Apart from the eventhandler, there is a switch at the end of returnedSection. This has to be there since returnedSection will run if any draggable item gets moved. Which originally caused the view to reset for the user. I had thought of making this section and the eventhandler share the code since they are very alike, but I didn't get it to work. Maybe I'm too tired now.

**For testing**
Enter a sectioned.php where the swimlane has enough height, the demo course seems good for this. Try toggling around and move some items in the list.

Now enter a course where it doesn't have enough height. Datorgrafik has one of these. The button shouldn't be visible here.