### PR TITLE
Fixing snap on Sequence Actor and Sequence Object

### DIFF
--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -203,9 +203,23 @@ function snapSAToLifeline(targetId) {
     if (lifeline) {
         for (let i = 0; i < data.length; i++) {
             const element = data[i];
-            if ((element.kind === "sequenceActor" || element.kind === "sequenceObject") && element.id === targetId) {
+            if ((element.kind === "sequenceActor") && element.id === targetId) {
                 let boxHeight = getTopHeight(element);
-                let minY = element.y + boxHeight;
+                let minY = element.y + boxHeight + 70;
+
+                // Fix the x position
+                ghostElement.x = element.x + (element.width / 2) - (ghostElement.width / 2);
+
+                // Check and adjust the y position if necessary
+                if (ghostElement.y < minY) {
+                    ghostElement.y = minY;
+                }
+                updatepos();
+                break;
+            }
+            if ((element.kind === "sequenceObject") && element.id === targetId) {
+                let boxHeight = getTopHeight(element);
+                let minY = element.y + boxHeight - 70;
 
                 // Fix the x position
                 ghostElement.x = element.x + (element.width / 2) - (ghostElement.width / 2);


### PR DESCRIPTION

I split a selection that handled the snapping for the sequence actor and the sequence object. This function calculated the position of the sequence activation incorrectly, so it worked the opposite way for the sequence actor and the sequence object. By splitting the selection into two, I was able to adjust the calculation individually for the sequence actor and the sequence object.