### PR TITLE
15974 add documentation for microservices in highscoreservice

### DIFF
--- a/DuggaSys/microservices/highscoreService/highscoreService_documentation.md
+++ b/DuggaSys/microservices/highscoreService/highscoreService_documentation.md
@@ -8,6 +8,6 @@ An array is created which stores the highscore information that is returned by m
 ### retrieveHighscoreService_ms.php
 The retrieveHighscoreService is used by highscoreservice to fetch highscore information. The function takes four parameters which are used to create a database query to fetch the correct highscore information.
 
-//add explanation for line 24-34 and line 36-65 (research to understand what is going on first)
+An array "$rows" is created to store user names and scores that were fetched from the database. A "$user" array is then created to store the index of the element in the $rows array that corresponds to the logged in user for this session, if it exists in the $rows array that is. If $user is empty it is instead populated with one row from the database query. According to a comment in the file this is for testing reasons. 
 
-An array is created containing all the relevant highscore infromation, namely the arrays $debug, $rows and $user. The array is returned at the end of the function. 
+An array "$array" is created and populated with all the relevant highscore information, namely the arrays "$debug", "$rows" and "$user". The array is returned at the end of the function.

--- a/DuggaSys/microservices/highscoreService/highscoreService_documentation.md
+++ b/DuggaSys/microservices/highscoreService/highscoreService_documentation.md
@@ -1,0 +1,9 @@
+# HighscoreService Documentation
+This is the documentation for the microservices highscoreservice_ms.php and retrieveHighscoreService_ms.php.
+
+### highscoreservice_ms.php
+The highscoreservice outputs the highscores for the selected dugga. 
+An array is created which stores the highscore information that is returned by making a call to the function retrieveHighscoreService(). json_encode() then returns a JSON representaton of the array with highscore infromation. Events are also logged with the function logServiceEvent().  
+
+### retrieveHighscoreService_ms.php
+

--- a/DuggaSys/microservices/highscoreService/highscoreService_documentation.md
+++ b/DuggaSys/microservices/highscoreService/highscoreService_documentation.md
@@ -6,4 +6,8 @@ The highscoreservice outputs the highscores for the selected dugga.
 An array is created which stores the highscore information that is returned by making a call to the function retrieveHighscoreService(). json_encode() then returns a JSON representaton of the array with highscore infromation. Events are also logged with the function logServiceEvent().  
 
 ### retrieveHighscoreService_ms.php
+The retrieveHighscoreService is used by highscoreservice to fetch highscore information. The function takes four parameters which are used to create a database query to fetch the correct highscore information.
 
+//add explanation for line 24-34 and line 36-65 (research to understand what is going on first)
+
+An array is created containing all the relevant highscore infromation, namely the arrays $debug, $rows and $user. The array is returned at the end of the function. 


### PR DESCRIPTION
Documentation is created for both service files that constitutes the highscoreservice. It is located in the same folder as the microservice highscoreservice. Test to see if markdown syntax behaves as expected and check if documentation looks fine.