### PR TITLE
Update Microservices.md

### DIFF
--- a/DuggaSys/microservices/Microservices.md
+++ b/DuggaSys/microservices/Microservices.md
@@ -88,7 +88,6 @@ __Shared microservices:__
 - retrieveUsername_ms.php __==finished==__ New filename: "readUsername_ms.php" according to new nameconvention based on CRUD.
 - createNewCodeExample_ms.php __==finished==__ Should keep existing name according to new nameconvention based on CRUD.
 - createNewListentry_ms.php __==finished==__ Should keep existing name according to new nameconvention based on CRUD
-- createNewVersionOfCourse_ms.php __==UNFINISHED==__
 - setAsActiveCourse_ms.php __==finished==__ New filename: "updateActiveCourse_ms.php" according to new nameconvention based on CRUD and the actual function of the ms.
 
 <br>


### PR DESCRIPTION
createNewVersionOfCourse_ms.php in the "shared microservices" section has been deleted from the microservice documentation. I assume line 452-471 should still be included regarding createNewVersionOfCourse as it is not specified in the issue description that this section should be deleted. 