### PR TITLE
fixed SD Entity Stroke Not Visible in Dark Mode

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -313,6 +313,7 @@ function drawElementSDEntity(element, boxw, boxh, linew, texth) {
     let height = texth * 2;
     let headPath = `
         <path 
+        class="text"
             d="M ${linew + cornerRadius},${linew}
                 h ${boxw - linew * 2 - cornerRadius * 2}
                 a ${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}


### PR DESCRIPTION
The box for the SD Entity wasn't showing its top border correctly because the top part didn’t have the class="text" attribute, which helps control how the box looks. The bottom part had this attribute, so it looked fine. To fix this, I added class="text" to the top part of the box in the code too. This made the stroke show up correctly around the entire box.