### PR TITLE
fixed UML Inheritance Diagram Disappearance

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -434,10 +434,11 @@ function drawElementERAttr(element, textWidth, boxw, boxh, linew, texth) {
 
 function drawElementUMLRelation(element, boxw, boxh, linew) {
     let fill = (element.state == 'overlapping') ? 'black' : 'white';
+    let strokeColor = (fill === 'black') ? 'white' : 'black'; 
     let poly = `
         <polygon 
             points='${linew},${boxh - linew} ${boxw / 2},${linew} ${boxw - linew},${boxh - linew}' 
-            style='fill:${fill}; stroke:black; stroke-width:${linew};'
+            style='fill:${fill}; stroke:${strokeColor}; stroke-width:${linew};'
         />`;
     return drawSvg(boxw, boxh, poly);
 }


### PR DESCRIPTION
Changed stroke colors in drawElementUMLRelation. I added logic for the stroke color in the new code. Now, if the fill is black (fill === 'black'), the stroke is white ('white'), and if the fill is white, the stroke is black ('black'). This adjustment makes the overlapping element clearer and easier to see with black background in the diagram.php.