### PR TITLE
Making it possible to resize IERelation

### DIFF
--- a/DuggaSys/ace.js
+++ b/DuggaSys/ace.js
@@ -16374,8 +16374,8 @@
             return (row - layerConfig.firstRowScreen) * layerConfig.lineHeight;
         };
     
-        function getBorderClass(tl, tr, br, bl) {
-            return (tl ? 1 : 0) | (tr ? 2 : 0) | (br ? 4 : 0) | (bl ? 8 : 0);
+        function getBorderClass(tl, tr, br, bl, br1, bl1) {
+            return (tl ? 1 : 0) | (tr ? 2 : 0) | (br ? 4 : 0) | (bl ? 8 : 0)| (br1 ? 4 : 0) | (bl1 ? 8 : 0);
         }
         this.drawTextMarker = function(stringBuilder, range, clazz, layerConfig, extraStyle) {
             var session = this.session;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -330,6 +330,15 @@
     cursor: nesw-resize;
 }
 
+.node.br1{
+    cursor: nwse-resize;
+    top: 60%;
+}
+.node.bl1{
+    cursor: nesw-resize;
+    top: 60%;
+}
+
 .underline{
     text-underline-offset: 0.15em;
     text-decoration: underline;

--- a/DuggaSys/diagram/draw/node.js
+++ b/DuggaSys/diagram/draw/node.js
@@ -8,6 +8,7 @@ function addNodes(element) {
     let nodeSize = defaultNodeSize * zoomfact;
     let nodes = "";
 
+
     /**
     * @description creates node using name and side
     * @param {string} name - The name of the node.
@@ -16,6 +17,7 @@ function addNodes(element) {
     const createNode = (name, side) => {
         nodes += `<span id='${name}' class='node ${name}' style="height: ${nodeSize}px; width: ${nodeSize}px; ${side}: calc(50% - ${nodeSize / 2}px);"></span>`;
     };
+
 
     /**
     * @description creates corner node using name, sideA and sideB
@@ -27,16 +29,27 @@ function addNodes(element) {
         nodes += `<span id='${name}' class='node ${name}' style="height: ${nodeSize}px; width: ${nodeSize}px; ${sideA}: 0%; ${sideB}: 0%;"></span>`;
     };
 
-    if (element.kind != elementTypesNames.UMLInitialState && element.kind != elementTypesNames.UMLFinalState) {
-        createNode("mr", "top");
-        createNode("ml", "top");
-        createNode("mu", "left");
-        createNode("md", "left");
-    }
     createCorner("tl", "top", "left");
     createCorner("tr", "top", "right");
-    createCorner("bl", "bottom", "left");
-    createCorner("br", "bottom", "right");
 
+    if (element.kind == elementTypesNames.IERelation) { 
+        // Creating special nodes for IERelation, it occurs problems when using the original nodes
+        createCorner("bl1", "bottom", "left");
+        createCorner("br1", "bottom", "right");
+    } else {
+        
+        createCorner("bl", "bottom", "left");
+        createCorner("br", "bottom", "right");
+
+        if (element.kind != elementTypesNames.UMLInitialState && element.kind != elementTypesNames.UMLFinalState) {
+            createNode("mr", "top");
+            createNode("ml", "top");
+            createNode("mu", "left");
+            createNode("md", "left");
+        }
+    }
+    
     elementDiv.innerHTML += nodes;
 }
+
+

--- a/DuggaSys/diagram/draw/update.js
+++ b/DuggaSys/diagram/draw/update.js
@@ -13,15 +13,16 @@ function removeNodes() {
  * @param {number || null} deltaX The amount of pixels on the screen the mouse has been moved since the mouse was pressed down in the X-axis.
  * @param {number || null} deltaY The amount of pixels on the screen the mouse has been moved since the mouse was pressed down in the Y-axis.
  */
+
 function updatepos() {
     updateCSSForAllElements();
     document.getElementById("svgbacklayer").innerHTML = redrawArrows();
     document.getElementById("svgoverlay").innerHTML = (mouseButtonDown) ? boxSelect_Draw() : drawSelectionBox();
     removeNodes();
     if (context.length === 1 &&
-        mouseMode == mouseModes.POINTER &&
-        context[0].kind != elementTypesNames.UMLRelation &&
-        context[0].kind != elementTypesNames.IERelation
+        mouseMode == mouseModes.POINTER
+
+
     ) {
         addNodes(context[0]);
     }

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -155,6 +155,9 @@ function mdown(event) {
             startNode.upLeft = event.target.classList.contains("tl");
             startNode.downRight = event.target.classList.contains("br");
             startNode.downLeft = event.target.classList.contains("bl");
+            startNode.downRight = event.target.classList.contains("br1");
+            startNode.downLeft = event.target.classList.contains("bl1");
+
 
             startX = event.clientX;
             startY = event.clientY;


### PR DESCRIPTION
To make it possible to resize IE Relation the same way as other objects, I tried using the existing nodes. I quickly noticed that there were a lot of problems when I tried to reuse them. The nodes that worked normally were the edge nodes but the bottom edge nodes were positioned incorrectly and I found no way to only change the position for these on IE Relation. Therefore I created two new bottom nodes and positioned them correct. There are small errors that I can't fix, for example, what is shown in the image with the selection area. Apart from the small errors, it works as it should.

![image](https://github.com/user-attachments/assets/89811e1e-a579-4cdb-970a-536e38dd72a8)
