### PR TITLE
Making the elements stop jumping when SnapToGrid is activated

### DIFF
--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -11,10 +11,9 @@ function updateCSSForAllElements() {
             left -= deltaX;
             top -= deltaY;
         }
-        const includedElementTypes = [elementTypesNames.EREntity, elementTypesNames.IEEntity, elementTypesNames.UMLEntity, elementTypesNames.SDEntity, elementTypesNames.UMLRelation, 
-            elementTypesNames.IERelation, elementTypesNames.ERRelation, elementTypesNames.ERAttr, elementTypesNames.UMLInitialState, elementTypesNames.UMLFinalState, elementTypesNames.UMLSuperState, 
-            elementTypesNames.sequenceActor, elementTypesNames.sequenceObject, elementTypesNames.sequenceActivation, elementTypesNames.sequenceLoopOrAlt];
-       
+        
+        const includedElementTypes = Object.values(elementTypesNames);
+
             if (settings.grid.snapToGrid && useDelta) {
             if (includedElementTypes.includes(element.kind)) {
                 // The element coordinates with snap point

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -11,16 +11,19 @@ function updateCSSForAllElements() {
             left -= deltaX;
             top -= deltaY;
         }
-
-        if (settings.grid.snapToGrid && useDelta) {
-            if (element.kind == elementTypesNames.EREntity) {
+        const includedElementTypes = [elementTypesNames.EREntity, elementTypesNames.IEEntity, elementTypesNames.UMLEntity, elementTypesNames.SDEntity, elementTypesNames.UMLRelation, 
+            elementTypesNames.IERelation, elementTypesNames.ERRelation, elementTypesNames.ERAttr, elementTypesNames.UMLInitialState, elementTypesNames.UMLFinalState, elementTypesNames.UMLSuperState, 
+            elementTypesNames.sequenceActor, elementTypesNames.sequenceObject, elementTypesNames.sequenceActivation, elementTypesNames.sequenceLoopOrAlt];
+       
+            if (settings.grid.snapToGrid && useDelta) {
+            if (includedElementTypes.includes(element.kind)) {
                 // The element coordinates with snap point
                 let objX = Math.round((elementData.x + elementData.width / 2 - (deltaX * (1.0 / zoomfact))) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
                 let objY = Math.round((elementData.y + elementData.height / 2 - (deltaY * (1.0 / zoomfact))) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
 
                 // Add the scroll values
                 left = Math.round(((objX - zoomOrigo.x) * zoomfact) + (scrollx * (1.0 / zoomfact)));
-                top = Math.round((((objY - zoomOrigo.y) - (settings.grid.gridSize / 2)) * zoomfact) + (scrolly * (1.0 / zoomfact)));
+                top = Math.round(((objY - zoomOrigo.y) * zoomfact) + (scrolly * (1.0 / zoomfact)));
 
                 // Set the new snap point to center of element
                 left -= ((elementData.width * zoomfact) / 2);
@@ -38,6 +41,7 @@ function updateCSSForAllElements() {
                 left -= ((elementData.width * zoomfact) / 2);
                 top -= ((elementData.height * zoomfact) / 2);
             }
+
         }
         divObject.style.left = left + "px";
         divObject.style.top = top + "px";


### PR DESCRIPTION

While solving this problem there were two issues. The first issue was that the calculation for vertical movements when snap to grid was enabled was incorrect. I fixed this by removing the part of the calculation that caused the element to jump up a few pixels. The second issue was that only ER entities were considered in the selection, which made only the ER entity function correctly. To address this I created a list of all the different elements that the selection then went through. This way all elements are taken into the calculation.