### PR TITLE
Removed line of code preventing property changes for IE-relations.

### DIFF
--- a/DuggaSys/diagram/classes/stateChange.js
+++ b/DuggaSys/diagram/classes/stateChange.js
@@ -184,7 +184,7 @@ class StateChange {
         const newRelation = document.getElementById("propertySelect")?.value || undefined;
         if (newRelation && oldRelation != newRelation) {
             if (element.type == entityType.ER || element.type == entityType.UML || element.type == entityType.IE) {
-                if (element.kind != elementTypesNames.UMLEntity && element.kind != elementTypesNames.IERelation) {
+                if (element.kind != elementTypesNames.UMLEntity) {
                     let property = document.getElementById("propertySelect").value;
                     element.state = property;
                     return element.state;


### PR DESCRIPTION
In the stateChange.js file there was a line of code preventing IE-elements from saving the newly chosen property. This must be old code from when the IE-element had a dropdown that could break the site. This line of code is no longer necessary and only prevents the IE-relation from changing inheritance type.

IE-relations can now properly switch between disjoint and overlapping types.