### PR TITLE
added the corner node code to the start/end if statement

### DIFF
--- a/DuggaSys/diagram/draw/node.js
+++ b/DuggaSys/diagram/draw/node.js
@@ -32,11 +32,11 @@ function addNodes(element) {
         createNode("ml", "top");
         createNode("mu", "left");
         createNode("md", "left");
-    }
-    createCorner("tl", "top", "left");
-    createCorner("tr", "top", "right");
-    createCorner("bl", "bottom", "left");
-    createCorner("br", "bottom", "right");
 
+        createCorner("tl", "top", "left");
+        createCorner("tr", "top", "right");
+        createCorner("bl", "bottom", "left");
+        createCorner("br", "bottom", "right");
+    }
     elementDiv.innerHTML += nodes;
 }


### PR DESCRIPTION
When creating the nodes to all elements there was a if statement that made sure the start/end elements did not get nodes. when the new corner nodes were added, the creation of the corner nodes was placed outside of this if statement. this is now fixed by adding the corner creation to the inside of this if statement.