### PR TITLE
Added class to upper part of SD entity

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -313,6 +313,7 @@ function drawElementSDEntity(element, boxw, boxh, linew, texth) {
     let height = texth * 2;
     let headPath = `
         <path 
+        class="text"
             d="M ${linew + cornerRadius},${linew}
                 h ${boxw - linew * 2 - cornerRadius * 2}
                 a ${cornerRadius},${cornerRadius} 0 0 1 ${cornerRadius},${cornerRadius}

--- a/Hello World
+++ b/Hello World
@@ -13,7 +13,7 @@ nwolC
 hello 2024
 
 ez hello
-
+gg
 
 Hello!!
 


### PR DESCRIPTION
The upper part of the SD entity did not have the class that gives each entity some of their properties, so the color of the line did not change properly when switching to dark mode.

The upper line of the SD entity now works the same as the other elements.


https://github.com/user-attachments/assets/fd23e515-db98-4af6-85bb-d04e8f3722e8

