### PR TITLE
recursive arrow issue fix

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -83,7 +83,9 @@
         if (line.kind == lineKind.RECURSIVE) {
             str += drawRecursive(fx, fy, offset, line, lineColor);
         }
-        str += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
+        else {
+            str += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
+        }
     }
     str += drawLineIcon(line.startIcon, line.ctype, fx, fy, lineColor, line);
     str += drawLineIcon(line.endIcon, line.ctype.split('').reverse().join(''), tx, ty, lineColor, line);

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -61,6 +61,7 @@
     } else if ((line.type == entityType.SD && line.innerType != SDLineType.SEGMENT)) {
         if (line.kind == lineKind.RECURSIVE) {
             str += drawRecursive(fx, fy, offset, line, lineColor);
+
         } else if ((fy > ty) && (line.ctype == lineDirection.UP)) {
             offset.y1 = 1;
             offset.y2 = -7 + 3 / zoomfact;
@@ -68,14 +69,16 @@
             offset.y1 = -7 + 3 / zoomfact;
             offset.y2 = 1;
         }
-        str += `<line 
-                    id='${line.id}' 
-                    x1='${fx + offset.x1 * zoomfact}' 
-                    y1='${fy + offset.y1 * zoomfact}' 
-                    x2='${tx + offset.x2 * zoomfact}' 
-                    y2='${ty + offset.y2 * zoomfact}' 
-                    fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'
-                />`;
+        if (line.kind != lineKind.RECURSIVE) {
+            str += `<line
+                        id='${line.id}'
+                        x1='${fx + offset.x1 * zoomfact}' 
+                        y1='${fy + offset.y1 * zoomfact}' 
+                        x2='${tx + offset.x2 * zoomfact}' 
+                        y2='${ty + offset.y2 * zoomfact}' 
+                        fill='none' stroke='${lineColor}' stroke-width='${strokewidth}' stroke-dasharray='${strokeDash}'
+                    />`;
+        }
     } else { // UML, IE or SD
         if (line.kind == lineKind.RECURSIVE) {
             str += drawRecursive(fx, fy, offset, line, lineColor);


### PR DESCRIPTION
The problem was that the normal line that usually connects two object would be drawn behind the elements. This was also not just a problem for the SD entities but for all the entities. By adding a clause that checks if the line type is not a recursive this was then fixed