### PR TITLE
Solution for text not fitting in the "note" and "UML super state" elements 

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -477,11 +477,18 @@ function drawElementState(element, vectorGraphic) {
 }
 
 function drawElementSuperState(element, textWidth, boxw, boxh, linew) {
+    const MAX_TEXT_LENGTH = 30;
     element.stroke = (isDarkTheme()) ? color.WHITE : color.BLACK;
 
-    let rectOne = drawRect(boxw, boxh, linew, element, `fill='none' fill-opacity='0' rx='20'`);
-    let rectTwo = drawRect(textWidth + 40 * zoomfact, 50 * zoomfact, linew, element, `fill='${element.fill}' fill-opacity="1"`);
-    let text = drawText(20 * zoomfact, 30 * zoomfact, 'start', element.name, `font-size='${20 * zoomfact}px'`);
+    let displayText = element.name.length > MAX_TEXT_LENGTH ? element.name.substring(0, MAX_TEXT_LENGTH) + '...' : element.name;
+
+    // Beräkna rektangeln för texten och se till att den inte överstiger elementets bredd
+    let rectTwoWidth = Math.min(textWidth + 80 * zoomfact, boxw - 10);
+
+    let rectOne = drawRect(boxw, boxh, linew, element, `fill='none' fill-opacity='0' rx='5'`);
+    let rectTwo = drawRect(rectTwoWidth, 50 * zoomfact, linew, element, `fill='${element.fill}' fill-opacity="1"`);
+    let text = drawText(20 * zoomfact, 30 * zoomfact, 'start', displayText, `font-size='${20 * zoomfact}px'`);
+    
     return drawSvg(boxw, boxh, rectOne + rectTwo + text);
 }
 
@@ -642,7 +649,7 @@ function drawElementSequenceLoopOrAlt(element, boxw, boxh, linew, texth) {
 }
 
 function drawElementNote(element, boxw, boxh, linew, texth) {
-    const maxCharactersPerLine = Math.floor((boxw / texth) * 1.75);
+    const maxCharactersPerLine = Math.floor((boxw / texth) * 1.05);
     const lineHeight = 1.5;
     const text = splitFull(element.attributes, maxCharactersPerLine);
     let length = (text.length > 4) ? text.length : 4;


### PR DESCRIPTION
Text in the UML super state and note elements are fixed to fit within their containers

Taken from the old pull request #16264, and fit with the updated version for 2025. The text in "note" and "UML super state" are fixed to be able to handle longer text . The note element adjusts to fit the content without overlapping the borders, and the UML super state ends with an elipsis ("...").

![image](https://github.com/user-attachments/assets/83667650-478d-4b13-b7d9-ba5673b88cb5)
