### PR TITLE
Updated theme.js

### DIFF
--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -12,15 +12,17 @@ function updateCSSForAllElements() {
             top -= deltaY;
         }
 
+        const includedElementTypes = Object.values(elementTypesNames);
+
         if (settings.grid.snapToGrid && useDelta) {
-            if (element.kind == elementTypesNames.EREntity) {
+            if (includedElementTypes.includes(element.kind)){
                 // The element coordinates with snap point
                 let objX = Math.round((elementData.x + elementData.width / 2 - (deltaX * (1.0 / zoomfact))) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
                 let objY = Math.round((elementData.y + elementData.height / 2 - (deltaY * (1.0 / zoomfact))) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
 
                 // Add the scroll values
                 left = Math.round(((objX - zoomOrigo.x) * zoomfact) + (scrollx * (1.0 / zoomfact)));
-                top = Math.round((((objY - zoomOrigo.y) - (settings.grid.gridSize / 2)) * zoomfact) + (scrolly * (1.0 / zoomfact)));
+                top  = Math.round(((objY - zoomOrigo.y) * zoomfact) + (scrolly * (1.0 / zoomfact)));
 
                 // Set the new snap point to center of element
                 left -= ((elementData.width * zoomfact) / 2);


### PR DESCRIPTION
issue #16224.
Elements no longer jump when 'snap to grid' is active. Replaced hardcoded condition for EREntity with all different element type check. Changed also the top position calculation to stop elements from jumping when clicked in 'snap to grid' mode.