### PR TITLE
Brought back the smoothness of the modeling page

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -424,7 +424,7 @@ function getData() {
     document.getElementById("diagram-toolbar").addEventListener("mouseup", tup);
     document.getElementById("container").addEventListener("mousedown", mdown);
     document.getElementById("container").addEventListener("mouseup", mup);
-    document.getElementById("container").addEventListener("mousemove", debounce(mmoving, 100));
+    document.getElementById("container").addEventListener("mousemove", mmoving);
     document.getElementById("container").addEventListener("wheel", mwheel);
     document.getElementById("options-pane").addEventListener("mousedown", mdown);
     // debugDrawSDEntity(); // <-- debugfunc to show an sd entity
@@ -2145,13 +2145,5 @@ function resetDiagramAlert() {
  */
 function resetDiagram() {
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
-}
-
-function debounce(func, wait) {
-    let timeout;
-    return function (...args) {
-        clearTimeout(timeout);
-        timeout = setTimeout(() => func.apply(this, args), wait);
-    };
 }
 //#endregion =====================================================================================


### PR DESCRIPTION
Fixed the smoothness of the modeling page by removing the debounce function that slowed down the page and making everything slower.