### PR TITLE
Added a view mode toggle (Normal / Scroll / Overview)#16185

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -4443,3 +4443,18 @@ function getLocalStorage() {
     dropdown.value = selectedValue;
   }
 }
+
+// Toggle betwwen different view modes for the section list
+function setViewMode(mode){
+  const section = document.getElementById("Sectionlisti")
+
+  // Remove previously applie mode
+  section.classList.remove("scroll-mode", "overview-mode");
+
+  // Apply selecte view mode
+  if (mode == 'scroll'){
+    section.classList.add("scroll-mode");
+  }else if (mode == 'overview') {
+    section.classList.add("overview-mode");
+  }
+}

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -50,6 +50,40 @@
 	<title id="sectionedPageTitle">Section Editor</title>
 
 	<link type="text/css" href="../Shared/css/style.css" rel="stylesheet">
+	<style>
+		/* Adds scroll mode to sectionedTble if the content is to tall */
+		#Sectionlisti.scroll-mode {
+			max-height: 75vh;
+			overflow-y:  auto;
+			border: 1px solid #ccc;
+		}
+		
+		/* View mode: Zooms out the list */
+		#Sectionlisti.overview-mode {
+  			max-height: none;
+  			overflow-y: visible;
+  			transform: scale(0.6);           
+  			transform-origin: top left;      
+		}
+
+		/* Style adjustments for items when using overview mode*/
+		#Sectionlisti.overview-mode .listentry {
+  			font-size: 0.7em;
+ 			padding: 2px;
+  			margin-bottom: 1px;
+		}
+
+		/* Style for the "View" labe" */
+		.view-label {
+  			background-color: #5e4776;  
+  			color: white;               
+  			padding: 8px 16px;          
+  			border-radius: 1px;
+  			font-weight: normal;
+  			display: inline-block;      
+		}
+	</style>
+
 	<!-- <link type="text/css" href="../Shared/css/blackTheme.css" rel="stylesheet"> -->
 	<link type="text/css" href="../Shared/css/jquery-ui-1.10.4.min.css" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -62,9 +96,9 @@
 	<script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
 	<script src="../Shared/dugga.js"></script>
 	<script src="sectioned.js"></script>
-	<script src="backToTop.js"></script>
-	
+	<script src="backToTop.js"></script>	
 </head>
+
 <body onload="setup();">
 
 	<?php
@@ -249,8 +283,15 @@
 
 		<div id='courseList'>
 
-		<!-- Section List -->
+		<!-- View mode toggle buttons -->
+		<div style="margin: 10px 0;">
+			<span class="view-label">View</span><br>
+  			<button class="submit-button" onclick="setViewMode('normal')">Normal</button>
+  			<button class="submit-button" onclick="setViewMode('scroll')">Scroll</button>
+ 			<button class="submit-button" onclick="setViewMode('overview')">Overview</button>
+		</div>
 
+		<!-- Section List -->
 		<div id='Sectionlisti'>
 		
 		</div>


### PR DESCRIPTION
A small feature was added that allows the user to change how the section list is displayed. The user can switch between:
- Normal (default view)
- Scroll (limits height and adds internal scroll)
- Overview (zooms out to give a bird's-eye view of all items)

![Skärmavbild 2025-04-09 kl  16 11 44](https://github.com/user-attachments/assets/dfba9a0e-1d8f-4ec1-8097-44e66249e3ba)
![Skärmavbild 2025-04-09 kl  16 11 57](https://github.com/user-attachments/assets/99627dce-916c-41d7-a1f6-fc879b48a24e)
