### PR TITLE
Update diagram.css

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -315,6 +315,7 @@
 .node.mu {
     right: calc(50% - 4px);
     cursor: ns-resize;
+    top: 0;
 }
 .node.tr{
     cursor: nesw-resize;


### PR DESCRIPTION
I have now added "top:0;" that seemed to be missing on .node.mu in Diagram.css. With it added it will now make it so that the boxes have the cube on the middle making it possible to modify the boxes from the top middle.
Before:
![image](https://github.com/user-attachments/assets/f620fcc8-271a-4898-aa28-757bca7eb5ee)

After:
![image](https://github.com/user-attachments/assets/27b12707-24f2-4ad4-a2e5-28ece3bb597d)


so in conclusion only 1 code was added and that was "top:0;" to fix this issue.