### PR TITLE
Band-aid solution for fixing issue confirmation popup not closing

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -668,8 +668,8 @@ function confirmBox(operation, item = null) {
     $("#sectionShowConfirmBox").css("display", "flex");
     $('#close-item-button').focus();
   } else if (operation == "deleteItem") {
-    deleteItem(selectedItemList);
     $("#sectionConfirmBox").css("display", "none");
+    deleteItem(selectedItemList);
   } else if (operation == "hideItem" && !selectedItemList.length == 0) {
     hideMarkedItems(selectedItemList)
     $("#sectionHideConfirmBox").css("display", "none");

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -353,7 +353,7 @@
 					<p>(You can always undo!)</p>
 			</div>
 			<div id="deleteBtnPlacement" class="formFooter" >
-				<input class='submit-button' id="delete-item-button" type='button' value='Yes' title='Yes' onclick='confirmBox("deleteItem");' />
+				<input class='submit-button' id="delete-item-button" type='button' value='Yes' title='Yes' onclick='confirmBox("closeConfirmBox"); confirmBox("deleteItem");' />
 				<input class='submit-button' id="close-item-button" type='button' value='No' title='No' onclick='confirmBox("closeConfirmBox");' />
 			</div>
 		</div>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -353,7 +353,7 @@
 					<p>(You can always undo!)</p>
 			</div>
 			<div id="deleteBtnPlacement" class="formFooter" >
-				<input class='submit-button' id="delete-item-button" type='button' value='Yes' title='Yes' onclick='confirmBox("closeConfirmBox"); confirmBox("deleteItem");' />
+				<input class='submit-button' id="delete-item-button" type='button' value='Yes' title='Yes' onclick='confirmBox("deleteItem");' />
 				<input class='submit-button' id="close-item-button" type='button' value='No' title='No' onclick='confirmBox("closeConfirmBox");' />
 			</div>
 		</div>


### PR DESCRIPTION
This is a quite bad solution that fixes the issue with not being able to close the conformation pop-up-window when deleting a dugga. It's bad since it doesn't solve the underlying issue that caused an error in the function deleteitem. see screenshot for log of this error 
![image](https://github.com/user-attachments/assets/79b6ce47-a6de-411f-a654-5c2a148c2c02)
