### PR TITLE
G1 2025 v2 issue #16196 elements ghost hover behind

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -60,7 +60,7 @@ function drawElement(element, ghosted = false) {
             cssClass = 'ie-element';
             style = element.name == "Inheritance" ?
              `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:2;` :
-             `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:1;`;
+             `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:2;`;
             break;
         case elementTypesNames.UMLInitialState:
             let initVec = `
@@ -69,7 +69,7 @@ function drawElement(element, ghosted = false) {
                 </g>`;
             divContent = drawElementState(element, initVec);
             cssClass = 'uml-state';
-            style = `width:${boxw}px; height:${boxh}px; z-index:1;`;
+            style = `width:${boxw}px; height:${boxh}px; z-index:2;`;
             break;
         case elementTypesNames.UMLFinalState:
             let finalVec = `
@@ -92,7 +92,7 @@ function drawElement(element, ghosted = false) {
                 </g>`;
             divContent = drawElementState(element, finalVec);
             cssClass = 'uml-state';
-            style = `width:${boxw}px; height:${boxh}px; z-index:1;`;
+            style = `width:${boxw}px; height:${boxh}px; z-index:2;`;
             break;
         case elementTypesNames.UMLSuperState:
             divContent = drawElementSuperState(element, textWidth, boxw, boxh, linew);

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -102,12 +102,12 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.sequenceActor:
             divContent = drawElementSequenceActor(element, textWidth, boxw, boxh, linew, texth);
             mouseEnter = 'mouseEnterSeq(event);';
-            zLevel = 1;
+            zLevel = 2;
             break;
         case elementTypesNames.sequenceObject:
             divContent = drawElementSequenceObject(element, boxw, boxh, linew);
             mouseEnter = 'mouseEnterSeq(event);';
-            zLevel = 1;
+            zLevel = 2;
             break;
         case elementTypesNames.sequenceActivation:
             divContent = drawElementSequenceActivation(element, boxw, boxh, linew);


### PR DESCRIPTION
The problem was that the objects Z value where set to low to be able to appear above when hovering as ghost.
Setting these values to 2 seems to have fixed it.
<img src="https://github.com/user-attachments/assets/a94b21ce-71dc-4623-bce9-5bad44838794" width="500">

