### PR TITLE
Fixed recursive line adding to elements

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -953,19 +953,28 @@ function mouseMode_onMouseUp(event) {
                     updatepos();
                 } else if (context.length === 1) {
                     if (event.target.id != "container") {
-                        elementTypeSelected = elementTypes.Ghost;
-                        makeGhost();
-                        // Create ghost line
-                        ghostLine = { id: makeRandomID(), fromID: context[0].id, toID: ghostElement.id, kind: "Normal" };
+                        // cheks if a ghostline already exists and if so sets the relation recursively.
+                        if (ghostLine != null) {
+                            // create a line from the element to itself
+                            addLine(context[0], context[0], "Recursive");
+                            clearContext();
+                            // Bust the ghosts
+                            ghostElement = null;
+                            ghostLine = null;
+                            showdata();
+                            updatepos();
+                        }
+                        else {
+                            elementTypeSelected = elementTypes.Ghost;
+                            makeGhost();
+                            // Create ghost line
+                            ghostLine = { id: makeRandomID(), fromID: context[0].id, toID: ghostElement.id, kind: "Normal" };
+                        }
                     } else if (ghostElement !== null) {
-                        // create a line from the element to itself
-                        addLine(context[0], context[0], "Recursive");
                         clearContext();
-                        // Bust the ghosts
                         ghostElement = null;
                         ghostLine = null;
                         showdata();
-                        updatepos();
                     } else {
                         clearContext();
                         ghostElement = null;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -953,7 +953,7 @@ function mouseMode_onMouseUp(event) {
                     updatepos();
                 } else if (context.length === 1) {
                     if (event.target.id != "container") {
-                        // cheks if a ghostline already exists and if so sets the relation recursively.
+                        // checks if a ghostline already exists and if so sets the relation recursively.
                         if (ghostLine != null) {
                             // create a line from the element to itself
                             addLine(context[0], context[0], "Recursive");


### PR DESCRIPTION
When clicking a line and choosing the same element it will now make an arrow from and to the element. It is also made so that if no second element is chosen, that line will be destroyed.

[Screencast_20250410_101319.webm](https://github.com/user-attachments/assets/37773e4e-753e-444a-85fa-92b291598df3)
