### PR TITLE
Removed transaction checkbox

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -248,8 +248,10 @@
           Yes I want to write over an existing database.<br>
           <input title="Write over existing user." id="writeOver2" type="checkbox" name="writeOverUSR" value="Yes" />
           Yes I want to write over an existing user.<br>
+          <!-- Commented out due to a transaction option not being necessary and broken. 
           <input title="Init as transaction." id="transaction" type="checkbox" name="InitTransaction" value="Yes" />
           Yes I want to perform the database-initializing as an transaction.<br>
+          -->
         </div>
             <span id='failText'>(WARNING: THIS WILL REMOVE ALL DATA IN PREVIOUS DATABASE AND/OR USER)</span></b><br>
       </div>
@@ -516,8 +518,10 @@
           $initQueryArray = explode(";", $initQuery);
           $initSuccess = false;
           $completeQuery = null;
+          
           try {
-            if (isset($_POST["InitTransaction"]) && $_POST["InitTransaction"] == 'Yes'){
+            // The checkbox for this option is removed, due to function being broken.
+             if (isset($_POST["InitTransaction"]) && $_POST["InitTransaction"] == 'Yes'){
               $connection->beginTransaction();
             }
             $connection->query("SET NAMES utf8");


### PR DESCRIPTION
This fixes issue #16332 and #16373 .

The html code for the Transaction checkbox has been commented out, since it is broken and there is no real reason to have that option in this instance. The code remains in case anyone wishes to fix it. 