### PR TITLE
Fixed A4 text to align with the corner of the A4 outline

### DIFF
--- a/DuggaSys/diagram/draw/update.js
+++ b/DuggaSys/diagram/draw/update.js
@@ -263,6 +263,6 @@ function updateA4Pos() {
     rect.setAttribute('x', OffsetX.toString());
     rect.setAttribute('y', OffsetY.toString());
 
-    text.setAttribute('x', (OffsetX + (780 * zoomfact)).toString());
-    text.setAttribute('y', (OffsetY - 5).toString());
+    text.setAttribute('x', (OffsetX + 8).toString());
+    text.setAttribute('y', (OffsetY - 8).toString());
 }


### PR DESCRIPTION
Update update.js
Changed the x coordinate value of the A4 text to only move a little bit but always stay close to 0,0 like the corner of the A4 outline.

![image](https://github.com/user-attachments/assets/dd698624-22bc-4a24-97da-914241f59a6f)
