### PR TITLE
[Issue #16216] Implemented functionality for resizing IE Inheritance elements

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1072,6 +1072,7 @@ function mmoving(event) {
                 deltaY = (startNode.downLeft) ? -delta : delta;
             }
 
+            //ToDo: Most likely change in here to make the IERelation resize properly
             let xChange, yChange, widthChange, heightChange;
             if (elementData.kind == elementTypesNames.sequenceActor || elementData.kind == elementTypesNames.sequenceObject) { // Special resize for sequenceActor and sequenceObject
                 const maxRatio = 0.8;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1057,7 +1057,7 @@ function mmoving(event) {
             deltaY = startY - event.clientY;
 
             // Resize equally in both directions by modifying delta
-            if (elementData.kind == elementTypesNames.UMLInitialState || elementData.kind == elementTypesNames.UMLFinalState) {
+            if (elementData.kind == elementTypesNames.UMLInitialState || elementData.kind == elementTypesNames.UMLFinalState || elementData.kind == elementTypesNames.IERelation) {
                 let delta;
                 if (startNode.upLeft) {
                     delta = Math.max(deltaX, deltaY);
@@ -1068,11 +1068,17 @@ function mmoving(event) {
                 } else if (startNode.upRight) {
                     delta = Math.max(-deltaX, deltaY);
                 }
+
                 deltaX = (startNode.upRight) ? -delta : delta;
-                deltaY = (startNode.downLeft) ? -delta : delta;
+
+                //Special resizing for IERelation elements, width needs to be double the height. Modifying height felt better during usage than modifying width.
+                if(elementData.kind == elementTypesNames.IERelation) {
+                    deltaY = (startNode.downLeft) ? -(delta * 0.5) : delta * 0.5;
+                } else {
+                    deltaY = (startNode.downLeft) ? -delta : delta;
+                }
             }
 
-            //ToDo: Most likely change in here to make the IERelation resize properly
             let xChange, yChange, widthChange, heightChange;
             if (elementData.kind == elementTypesNames.sequenceActor || elementData.kind == elementTypesNames.sequenceObject) { // Special resize for sequenceActor and sequenceObject
                 const maxRatio = 0.8;
@@ -1163,7 +1169,6 @@ function movementWidthChange(element, start, delta, isR) {
 function movementHeightChange(element, start, delta, isUp) {
     element.height = (isUp) ? start + delta - element.y : start - delta / zoomfact;
     return element.height;
-
 }
 
 /**

--- a/DuggaSys/diagram/defaults.js
+++ b/DuggaSys/diagram/defaults.js
@@ -69,9 +69,9 @@ const defaults = {
         type: entityType.IE,
         kind: elementTypesNames.IERelation,
         width: 62,
-        height: 62,
+        height: 31,
         minWidth: 50,
-        minHeight: 50,
+        minHeight: 25,
     },
     SDEntity: {
         name: "SD Entity",

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -59,8 +59,8 @@ function drawElement(element, ghosted = false) {
             divContent = drawElementIERelation(element, boxw, boxh, linew);
             cssClass = 'ie-element';
             style = element.name == "Inheritance" ?
-             `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:2;` :
-             `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:1;`;
+             `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:2;` :
+             `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:1;`;
             break;
         case elementTypesNames.UMLInitialState:
             let initVec = `
@@ -571,13 +571,14 @@ function drawElementUMLRelation(element, boxw, boxh, linew) {
 function drawElementIERelation(element, boxw, boxh, linew) {
     let content = "";
     content += `<circle cx="${boxw / 2}" cy="0" r="${boxw / 2.08}" fill='white' stroke='black' /> 
-                <line x1="0" y1="${boxw / 50}" x2="${boxw}" y2="${boxw / 50}" stroke='black' />`;
+                <line x1="${boxw / 2}" y1="${linew / 2}" x2="${(boxw / 2) + (boxw / 2.08)}" y2="${linew / 2}" stroke='black' />
+                <line x1="${(boxw / 2) + 1}" y1="${linew / 2}" x2="${(boxw / 2) - (boxw / 2.08) + 1}" y2="${linew / 2}" stroke='black' />`;
 
     if (element.state != inheritanceStateIE.OVERLAPPING) {
         content += `<line x1="${boxw / 1.6}" y1="${boxw / 2.9}" x2="${boxw / 2.6}" y2="${boxw / 12.7}" stroke='black' />
                     <line x1="${boxw / 2.6}" y1="${boxw / 2.87}" x2="${boxw / 1.6}" y2="${boxw / 12.7}" stroke='black' />`;
     }
-    return drawSvg(boxw, boxh / 2, content, `style='transform:rotate(180deg); stroke-width:${linew};'`);
+    return drawSvg(boxw, boxh, content, `style='transform:rotate(180deg); stroke-width:${linew};'`);
 }
 
 /**

--- a/DuggaSys/diagram/draw/node.js
+++ b/DuggaSys/diagram/draw/node.js
@@ -27,7 +27,7 @@ function addNodes(element) {
         nodes += `<span id='${name}' class='node ${name}' style="height: ${nodeSize}px; width: ${nodeSize}px; ${sideA}: 0%; ${sideB}: 0%;"></span>`;
     };
 
-    if (element.kind != elementTypesNames.UMLInitialState && element.kind != elementTypesNames.UMLFinalState) {
+    if (element.kind != elementTypesNames.UMLInitialState && element.kind != elementTypesNames.UMLFinalState && element.kind != elementTypesNames.IERelation) {
         createNode("mr", "top");
         createNode("ml", "top");
         createNode("mu", "left");

--- a/DuggaSys/diagram/draw/update.js
+++ b/DuggaSys/diagram/draw/update.js
@@ -20,8 +20,7 @@ function updatepos() {
     removeNodes();
     if (context.length === 1 &&
         mouseMode == mouseModes.POINTER &&
-        context[0].kind != elementTypesNames.UMLRelation &&
-        context[0].kind != elementTypesNames.IERelation
+        context[0].kind != elementTypesNames.UMLRelation
     ) {
         addNodes(context[0]);
     }


### PR DESCRIPTION
**This element wasn't created with the purposes of being resizable, so an amount of reworking of the element had to be made for it to be possible to resize.** 

Nodes were added to the element to allow resizing, and special functionality for this specific element was added so that it would resize properly, without leaving vertical empty space when the height was increased. Only corner resizing is allowed for this element since it's implemented as half a circle, which made for errors when trying to only manipulate height/width. Most likely possible to add separate manipulation of height and width but that would require a lot more changes to the element and how it works.

Base size shape before resizing, with nodes:
![image](https://github.com/user-attachments/assets/2f897ae9-2dcd-4213-961f-4d5255bc1a2d)

Shape after resizing, with visible nodes and size comparison with base size:
![image](https://github.com/user-attachments/assets/b84df41d-88ea-4257-9b34-e257e05d5afd)

After having added nodes to the element, allowing it to be resized, some tweaks had to be made to how the element was drawn to accommodate the change. The single bottom line of the shape wasn't aligned with the half circle, leading to very obvious misalignment when it was made bigger, so it was replaced with two lines originating from the center of the circle.

Enlarged shape before tweaks:
![image](https://github.com/user-attachments/assets/a8d78198-bc5b-42a6-b736-e676e88dfdeb)

Shape after tweaks:
![image](https://github.com/user-attachments/assets/08ebb00c-efd9-4794-a718-649dee0869e6)
