### PR TITLE
Updated UML-entity header-text

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -319,9 +319,14 @@ function drawElementUMLEntity(element, boxw, boxh, linew, texth) {
     updateElementHeight(UMLHeight, element, totalHeight + boxh);
 
     // Header
-    let height = texth * 2;
+    const headerLines = splitFull([element.name], maxCharactersPerLine);
+    let height = texth * (headerLines.length + 1) * lineHeight;
     let headRect = drawRect(boxw, height, linew, element);
-    let headText = drawText(boxw / 2, texth * lineHeight, 'middle', element.name);
+    let headText = "";
+    for (let i = 0; i < headerLines.length; i++) {
+        const y = texth * (i + 1) * lineHeight;
+        headText += drawText(boxw / 2, y, 'middle', headerLines[i]);
+    }
     let headSvg = drawSvg(boxw, height, headRect + headText);
     str += drawDiv('uml-header', `width: ${boxw}; height: ${height - linew * 2}px`, headSvg);
 


### PR DESCRIPTION
Fixed the issue with the text in the header not fitting the element width. Adjusted the "Header"-portion of the updateElementUMLEntity-function to create line-breaks if the text is wider than the entity. Text no longer goes out of bounds.

![image](https://github.com/user-attachments/assets/e4a7be15-e4f5-4fd7-8eaf-fb64bb06ca94)
