### PR TITLE
Fixed ER relations disappear

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -337,7 +337,7 @@
                     </div> 
                     <div id="diagramPopOut">
                         <div id="togglePlacementTypeBox1" class="togglePlacementTypeBox togglePlacementTypeBoxRI"><!--<-- UML functionality start-->
-                            <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(0,1); setElementPlacementType(1); setMouseMode(2);'>
+                            <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER relation"/>
                                 <span class="placementTypeToolTipText"><b>ER relation</b><br>
                                     <p>Represents how entities are associated with each other.</p>


### PR DESCRIPTION
Changed the value from 0 to 1, since there is no element matching "0" of "type 1" in the togglePlacementType() function. As a result, the menu disappeared. But when "1", there is a match and the ER relation element stays and the menu remains.
<img width="827" alt="Skärmavbild 2025-04-11 kl  09 47 20" src="https://github.com/user-attachments/assets/361e7b11-24f9-47b2-ac58-ba154c3c65d8" />

**Before:**

https://github.com/user-attachments/assets/a6ce4d11-76bd-4d62-a893-c633c0d86d81

**After:**

https://github.com/user-attachments/assets/8586f5da-7412-4f0f-88b2-d301853d6020

