### PR TITLE
Updated daywidth

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2440,9 +2440,9 @@ function drawSwimlanes() {
   // var weekLength = weeksBetween(startdate, enddate);
   var weekLength = Math.ceil((enddate - startdate) / (7 * 24 * 60 * 60 * 1000));
   var currentWeek = weeksBetween(current, startdate);
-  var daywidth = 10;
+  var daywidth = 12.7;
   var weekwidth = daywidth * 7;
-  var colwidth = 60;
+  var colwidth = 20;
   var weekheight = 25;
 
   var str = "";

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2442,7 +2442,7 @@ function drawSwimlanes() {
   var currentWeek = weeksBetween(current, startdate);
   var daywidth = 12.7;
   var weekwidth = daywidth * 7;
-  var colwidth = 20;
+  var colwidth = 60;
   var weekheight = 25;
 
   var str = "";


### PR DESCRIPTION
Updated daywidth so now the collums fill the entire svg. Due to the hardcoded nature of the weekwidth calculation there is a possibility that tihis solution only works when theres 9 weeks in a course. I havn't found another course with the same layout where my theory can be tested unfortunately