### PR TITLE
Updated IE-entity header

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -366,12 +366,16 @@ function drawElementIEEntity(element, boxw, boxh, linew, texth) {
     let totalHeight = tHeight - linew * 2 + texth * 2;
     updateElementHeight(IEHeight, element, totalHeight + boxh);
 
-    let height = texth * 2;
+    const headerLines = splitFull([element.name], maxCharactersPerLine);
+    let height = texth * (headerLines.length + 1) * lineHeight;
     let headRect = drawRect(boxw, height, linew, element);
-    let headText = drawText(boxw / 2, texth * lineHeight, 'middle', element.name);
+    let headText = "";
+    for (let i = 0; i < headerLines.length; i++) {
+        const y = texth * (i + 1) * lineHeight;
+        headText += drawText(boxw / 2, y, 'middle', headerLines[i]);
+    }
     let headSvg = drawSvg(boxw, height, headRect + headText);
     str += drawDiv('uml-header', `width: ${boxw}; height: ${height - linew * 2}px`, headSvg);
-
 
     // Content, Attributes
     const textBox = (s, css) => {


### PR DESCRIPTION
The IE-entity is now updated in the "drawElementIEEntity"-function to be able to print longer names in the header without the svg clipping the text.

![image](https://github.com/user-attachments/assets/017add02-09f9-4c45-a333-0ee28dd20de8)
