### PR TITLE
G1 2025 v2 #16191 the example diagrams doesnt load correctly

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -9,7 +9,8 @@ function drawElement(element, ghosted = false) {
     let texth = Math.round(zoomfact * textheight);
     let linew = Math.round(strokewidth * zoomfact);
     let boxw = Math.round(element.width * zoomfact);
-    let boxh = Math.round(element.height * zoomfact); // Only used for extra whitespace from resize
+    let boxh = element.height ? 
+    Math.round(element.height * zoomfact) : 0; // Only used for extra whitespace from resize
     let zLevel = 2;
     let mouseEnter = '';
 
@@ -217,7 +218,7 @@ function drawSvg(w, h, s, extra = '') {
  * @param {String} extra Extra attributes to be added to the rectangle tag.
  * @returns Returns a string containing a svg rectangle for the element that is drawn.
  */
-function drawRect(w, h, l, e, extra = `fill='${e.fill}'`) {
+function drawRect(w, h, l, e, extra = e.fill ? `fill='${e.fill}'` : `fill=#ffffff`) {
     return `<rect 
                 class='text' x='${l}' y='${l}' 
                 width='${w - l * 2}' height='${h - l * 2}' 
@@ -434,7 +435,7 @@ function drawElementSDEntity(element, boxw, boxh, linew, texth) {
                 z"
             stroke-width='${linew}'
             stroke='${element.stroke}'
-            fill='${element.fill}'
+            fill='${element.fill ? element.fill : "#ffffff"}'
         />`;
     let headText = drawText(boxw / 2, texth * lineHeight, 'middle', element.name);
     let headSvg = drawSvg(boxw, height, headPath + headText);
@@ -459,7 +460,7 @@ function drawElementSDEntity(element, boxw, boxh, linew, texth) {
                     z"
                 stroke-width='${linew}'
                 stroke='${element.stroke}'
-                fill='${element.fill}'
+                fill='${element.fill ? element.fill : "#ffffff"}'
             />`;
         let contentSvg = drawSvg(boxw, height, path + text);
         let style = `height:${height}px`;


### PR DESCRIPTION
Example state diagram is now fixed, lines and elements now load correctly without any problem