### PR TITLE
Documented getCourseed in Microservices_inverse_dependencies

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -65,6 +65,8 @@ There is no list of all inverse dependencies
 ### deleteCourseMaterial
 
 ### getCourseed
+    DuggaSys/tests/microservices/courseedService/deleteCourseMaterial_ms.php
+    (replaced with retrieveAllCourseedServiceData)
 
 ### retrieveAllCourseedServiceData
 

--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -65,8 +65,8 @@ There is no list of all inverse dependencies
 ### deleteCourseMaterial
 
 ### getCourseed
-    DuggaSys/tests/microservices/courseedService/deleteCourseMaterial_ms.php
-    (replaced with retrieveAllCourseedServiceData)
+    No inverse dependencies
+    (completely replaced by retrieveAllCourseedServiceData)
 
 ### retrieveAllCourseedServiceData
 


### PR DESCRIPTION
getCourseed is never used as an include. In the Microservices.md it say getCourseed has been replaced with retrieveAllCourseedServiceData

fixes #16454