### PR TITLE
Implemented overlap-detection for pasting elements.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1334,7 +1334,7 @@ function saveProperties() {
  * @param {Array<Object>} elements List of all elements to paste into the data array.
  */
 function pasteClipboard(elements, elementsLines) {
-    // If elements does is empty, display error and return null
+    // If elements is empty, display error and return null
     if (elements.length == 0) {
         displayMessage("error", "You do not have any copied elements");
         return;
@@ -1397,8 +1397,6 @@ function pasteClipboard(elements, elementsLines) {
         displayMessage(messageTypes.ERROR, "Error: You can't paste elements on top of eachother.");
         console.error("Failed to paste the element as it overlaps other element(s)");
         return;
-    } else {
-        newElements.forEach(element => addObjectToData(element, false));
     }
 
     // Create the new lines but do not saved in stateMachine

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1381,9 +1381,20 @@ function pasteClipboard(elements, elementsLines) {
         elementObj.x = mousePosInPixels.x + (element.x - x1);
         elementObj.y = mousePosInPixels.y + (element.y - y1);
 
-        newElements.push(elementObj);
         addObjectToData(elementObj, false);
+        if (entityIsOverlapping(elementObj.id, elementObj.x, elementObj.y)) {
+            displayMessage(messageTypes.ERROR, "Error: You can't paste elements on top of eachother.");
+            console.error("Failed to create an element as it overlaps other element(s)");
+            overlapDetected = true;  // Set flag to stop further pasting
+            showdata();
+        }else{
+            newElements.push(elementObj);
+        }
     });
+
+    if (overlapDetected) {
+        return;  // Prevent further pasting of lines and finishing the operation
+    }
 
     // Create the new lines but do not saved in stateMachine
     // TODO: Using addLine removes labels and arrows. Find way to save lines with all attributes.

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1366,6 +1366,8 @@ function pasteClipboard(elements, elementsLines) {
     const newElements = [];
     const newLines = [];
 
+    let overlapDetected = false;
+
     // For every copied element create a new one and add to data
     elements.forEach(element => {
         // Make a new id and save it in an object
@@ -1381,19 +1383,22 @@ function pasteClipboard(elements, elementsLines) {
         elementObj.x = mousePosInPixels.x + (element.x - x1);
         elementObj.y = mousePosInPixels.y + (element.y - y1);
 
-        addObjectToData(elementObj, false);
-        if (entityIsOverlapping(elementObj.id, elementObj.x, elementObj.y)) {
-            displayMessage(messageTypes.ERROR, "Error: You can't paste elements on top of eachother.");
-            console.error("Failed to create an element as it overlaps other element(s)");
-            overlapDetected = true;  // Set flag to stop further pasting
-            showdata();
-        }else{
-            newElements.push(elementObj);
-        }
+        // Check for overlap before adding
+        addObjectToData(elementObj, false); // Add to data
+
+    if (entityIsOverlapping(elementObj.id, elementObj.x, elementObj.y)) {
+        data.splice(data.findIndex(e => e.id === elementObj.id), 1); // Remove the just-added element
+        overlapDetected = true;
+    }
     });
 
+    // If overlap is detected, abort pasting the elements, otherwise add 
     if (overlapDetected) {
-        return;  // Prevent further pasting of lines and finishing the operation
+        displayMessage(messageTypes.ERROR, "Error: You can't paste elements on top of eachother.");
+        console.error("Failed to paste the element as it overlaps other element(s)");
+        return;
+    } else {
+        newElements.forEach(element => addObjectToData(element, false));
     }
 
     // Create the new lines but do not saved in stateMachine


### PR DESCRIPTION
Elements could previously be pasted on top of each other, as shown in the picture below.
![image](https://github.com/user-attachments/assets/8a74665f-6cab-446d-8395-06e1e748ef7d)

The entityIsOverlapping() method, which detects entity overlaps, has been added to the pasteClipboard() method. This allows the parent function to flag the overlap, deny pasting and notify the user. Trying to paste objects on top of eachother will result in an error as shown in the picture below.
![image](https://github.com/user-attachments/assets/192fe506-0671-4c0c-90c2-9b883cab2825)

