### PR TITLE
G1-2025-v2-#15647 snap to lifeline or object after placement

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1001,11 +1001,6 @@ function mouseMode_onMouseUp(event) {
  * @description Event function triggered when the mouse has moved on top of the container.
  * @param {MouseEvent} event Triggered mouse event.
  */
-
-function snapToLifeline(container, lifeline) {
-    const snapThreshold = 10; // Max distance for snaping
-}
-
 function mmoving(event) {
     lastMousePos = new Point(event.clientX, event.clientY);
     switch (pointerState) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1001,6 +1001,11 @@ function mouseMode_onMouseUp(event) {
  * @description Event function triggered when the mouse has moved on top of the container.
  * @param {MouseEvent} event Triggered mouse event.
  */
+
+function snapToLifeline(container, lifeline) {
+    const snapThreshold = 10; // Max distance for snaping
+}
+
 function mmoving(event) {
     lastMousePos = new Point(event.clientX, event.clientY);
     switch (pointerState) {

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -298,7 +298,24 @@ function mup(event) {
 
                 // Normal mode
             } else if (deltaExceeded) {
-                if (context.length > 0) setPos(context, deltaX, deltaY);
+                // If there are elements selected in the context
+            if (context.length > 0) {
+                // Loop through each selected element
+                context.forEach(el => {
+                // Find the nearest lifeline to the element's center position
+                const nearestLifelineId = findNearestLifeline(
+                el.x + el.width / 2, // X-center of the element
+                el.y + el.height / 2 // Y-center of the element
+            );
+
+        // If a nearby lifeline is found, snap the element to it
+        if (nearestLifelineId) {
+            snapElementToLifeline(el, nearestLifelineId);
+        }
+    });
+}
+
+                
             }
             break;
         case pointerStates.CLICKED_NODE:

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -300,6 +300,7 @@ function mup(event) {
             } else if (deltaExceeded) {
                 // If there are elements selected in the context
             if (context.length > 0) {
+                setPos(context, deltaX, deltaY);
                 // Loop through each selected element
                 context.forEach(el => {
                 // Find the nearest lifeline to the element's center position

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -209,18 +209,8 @@ function snapElementToLifeline(element, targetId) {
     for (let i = 0; i < data.length; i++) {
         const ll = data[i];
         if ((ll.kind === "sequenceActor" || ll.kind === "sequenceObject") && ll.id === targetId) {
-            // Calculate the minimum Y position based on the top box height
-            let boxHeight = getTopHeight(ll);
-            let minY = ll.y + boxHeight + (ll.kind === "sequenceActor" ? 70 : -70);
-
             // Snap the element horizontally to the center of the lifeline
             element.x = ll.x + (ll.width / 2) - (element.width / 2);
-
-            // Adjust vertical position if the element is too high
-            if (element.y < minY) {
-                element.y = minY;
-            }
-
             updatepos(); // Refresh position on screen
             break;
         }

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -203,30 +203,39 @@ function snapSAToLifeline(targetId) {
     if (lifeline) {
         for (let i = 0; i < data.length; i++) {
             const element = data[i];
+            console.log("Checking element:", element);  // Logs the current element
+
             if ((element.kind === "sequenceActor") && element.id === targetId) {
+                console.log("Matched sequenceActor:", element);  // Logs when a sequenceActor element is found
                 let boxHeight = getTopHeight(element);
                 let minY = element.y + boxHeight + 70;
 
                 // Fix the x position
                 ghostElement.x = element.x + (element.width / 2) - (ghostElement.width / 2);
+                console.log("Adjusted x position for ghostElement:", ghostElement.x);
 
                 // Check and adjust the y position if necessary
                 if (ghostElement.y < minY) {
                     ghostElement.y = minY;
+                    console.log("Adjusted y position for ghostElement:", ghostElement.y);
                 }
                 updatepos();
                 break;
             }
+
             if ((element.kind === "sequenceObject") && element.id === targetId) {
+                console.log("Matched sequenceObject:", element);  // Logs when a sequenceObject element is found
                 let boxHeight = getTopHeight(element);
                 let minY = element.y + boxHeight - 70;
 
                 // Fix the x position
                 ghostElement.x = element.x + (element.width / 2) - (ghostElement.width / 2);
+                console.log("Adjusted x position for ghostElement:", ghostElement.x);
 
                 // Check and adjust the y position if necessary
                 if (ghostElement.y < minY) {
                     ghostElement.y = minY;
+                    console.log("Adjusted y position for ghostElement:", ghostElement.y);
                 }
                 updatepos();
                 break;
@@ -234,6 +243,8 @@ function snapSAToLifeline(targetId) {
         }
     }
 }
+
+
 
 /**
  * @description Gets the height of the top object of sequence actor and sequence object

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -196,53 +196,106 @@ function mouseEnterSeq(event) {
 
 /**
  * @description Snaps the sequenceActivation to a lifeline (currently only works for ghosts)
- * @param {string} targetId - The ID of the target lifeline.
+/**
+ * Snaps a given element to the center of a lifeline and adjusts its Y-position if necessary.
+ * @param {Object} element - The element to snap (a placed object).
+ * @param {string} targetId - The ID of the lifeline to snap to.
  */
-function snapSAToLifeline(targetId) {
+function snapElementToLifeline(element, targetId) {
     const lifeline = document.getElementById(targetId);
-    if (lifeline) {
-        for (let i = 0; i < data.length; i++) {
-            const element = data[i];
-            console.log("Checking element:", element);  // Logs the current element
+    if (!lifeline) return; // Exit if the DOM element doesn't exist
 
-            if ((element.kind === "sequenceActor") && element.id === targetId) {
-                console.log("Matched sequenceActor:", element);  // Logs when a sequenceActor element is found
-                let boxHeight = getTopHeight(element);
-                let minY = element.y + boxHeight + 70;
+    // Search for the lifeline data in the main data array
+    for (let i = 0; i < data.length; i++) {
+        const ll = data[i];
+        if ((ll.kind === "sequenceActor" || ll.kind === "sequenceObject") && ll.id === targetId) {
+            // Calculate the minimum Y position based on the top box height
+            let boxHeight = getTopHeight(ll);
+            let minY = ll.y + boxHeight + (ll.kind === "sequenceActor" ? 70 : -70);
 
-                // Fix the x position
-                ghostElement.x = element.x + (element.width / 2) - (ghostElement.width / 2);
-                console.log("Adjusted x position for ghostElement:", ghostElement.x);
+            // Snap the element horizontally to the center of the lifeline
+            element.x = ll.x + (ll.width / 2) - (element.width / 2);
 
-                // Check and adjust the y position if necessary
-                if (ghostElement.y < minY) {
-                    ghostElement.y = minY;
-                    console.log("Adjusted y position for ghostElement:", ghostElement.y);
-                }
-                updatepos();
-                break;
+            // Adjust vertical position if the element is too high
+            if (element.y < minY) {
+                element.y = minY;
             }
 
-            if ((element.kind === "sequenceObject") && element.id === targetId) {
-                console.log("Matched sequenceObject:", element);  // Logs when a sequenceObject element is found
-                let boxHeight = getTopHeight(element);
-                let minY = element.y + boxHeight - 70;
-
-                // Fix the x position
-                ghostElement.x = element.x + (element.width / 2) - (ghostElement.width / 2);
-                console.log("Adjusted x position for ghostElement:", ghostElement.x);
-
-                // Check and adjust the y position if necessary
-                if (ghostElement.y < minY) {
-                    ghostElement.y = minY;
-                    console.log("Adjusted y position for ghostElement:", ghostElement.y);
-                }
-                updatepos();
-                break;
-            }
+            updatepos(); // Refresh position on screen
+            break;
         }
     }
 }
+
+/**
+ * Snaps the ghostElement (hover preview) to the center of a lifeline and adjusts its Y-position.
+ * @param {string} targetId - The ID of the lifeline to snap to.
+ */
+function snapSAToLifeline(targetId) {
+    const lifeline = document.getElementById(targetId);
+    if (!lifeline) return; // Exit if no such DOM element
+
+    const lifelineData = data.find(el => el.id === targetId);
+    if (!lifelineData) return; // Exit if no such object in data array
+
+    // Snap ghost X to the center of the lifeline
+    const centerX = lifelineData.x + lifelineData.width / 2;
+    ghostElement.x = centerX - ghostElement.width / 2;
+
+    // Adjust ghost Y if it's above the allowed minimum
+    const minY = lifelineData.y + getTopHeight(lifelineData) + 70;
+    if (ghostElement.y < minY) {
+        ghostElement.y = minY;
+    }
+
+    updatepos(); // Update preview position
+}
+
+/**
+ * Creates a new element and places it at the specified position.
+ * If it's close to a lifeline, it will snap to it.
+ * @param {number} x - X coordinate to place the element.
+ * @param {number} y - Y coordinate to place the element.
+ */
+function placeElementAt(x, y) {
+    const newElement = Element.Default(elementTypeSelected);
+    newElement.x = x;
+    newElement.y = y;
+
+    // Check if it's near a lifeline and snap to it
+    const lifelineId = findNearestLifeline(x, y);
+    if (lifelineId) {
+        snapElementToLifeline(newElement, lifelineId);
+    }
+
+    data.push(newElement); // Add the new element to the diagram
+    draw(); // Redraw the canvas or SVG
+}
+
+/**
+ * Finds the nearest lifeline (within a horizontal threshold) to a given position.
+ * @param {number} x - X position to compare with lifelines.
+ * @param {number} y - Y position (unused but could be used later).
+ * @returns {string|null} - The ID of the closest lifeline, or null if none are within threshold.
+ */
+function findNearestLifeline(x, y) {
+    let minDistance = Infinity;
+    let closestId = null;
+
+    data.forEach(el => {
+        if (el.kind === "sequenceActor" || el.kind === "sequenceObject") {
+            const centerX = el.x + el.width / 2;
+            const dx = Math.abs(centerX - x);
+            if (dx < 50 && dx < minDistance) { // Use 50px as snapping threshold
+                minDistance = dx;
+                closestId = el.id;
+            }
+        }
+    });
+
+    return closestId;
+}
+
 
 
 


### PR DESCRIPTION
**helper/mouse.js:**
Extracted ghost-snapping logic into a reusable function: snapElementToLifeline(element, targetId) to allow both ghost elements and placed elements to snap to the center of the nearest lifeline.
     snapSAToLifeline() still handles ghost snapping on hover, but its logic now matches the real element snapping logic more closely.
     When placing a new element (placeElementAt(x, y)), the code creates a new element, finds the nearest lifeline using findNearestLifeline(x, y) and snaps the element to that lifeline before adding it to the diagram.

**events/mouse.js:**
Modified the mouse release (mouseup) behavior. If elements were moved (context.length > 0), each is snapped to the nearest lifeline after release using the same snapElementToLifeline() logic.


Uploading Inspelning 2025-04-11 170037.mp4…

