### PR TITLE
G1 2025 v2 #15637 impossible to draw two arrows separately in sequence diagram

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -968,7 +968,7 @@ function mouseMode_onMouseUp(event) {
                             elementTypeSelected = elementTypes.Ghost;
                             makeGhost();
                             // Create ghost line
-                            ghostLine = { id: makeRandomID(), fromID: context[0].id, toID: ghostElement.id, kind: "Normal" };
+                            ghostLine = { id: makeRandomID(), fromID: context[0].id, toID: ghostElement.id, kind: "Normal", ghostLine: true };
                         }
                     } else if (ghostElement !== null) {
                         clearContext();

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -29,17 +29,12 @@ function drawLine(line, targetGhost = false) {
         ty = event.clientY;
     }
 
+
 //Looks if the lines have gotta an index value from the function getLineAttrubutes
-//If so then there are multiple lines on the same row 
-
-// For example, in drawLine, after computing the base coordinates:
-//Looks if the line object have gotten the extra variable multiLineOffset from getLineAttrubutes
-//If so then there exists multiplelines on the same row and the offset should be changed
-
+//If so then there are multiple lines on the same row and the offset is changed
 if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'number') {
-    const lineSpaceing = 30; //Can be changed to change the spacing between lines
-    const offsetIncrease = (line.multiLineOffset- (line.numberOfLines - 1) / 2) * lineSpaceing;
-    // Add offsets based on the line connection direction
+    const lineSpacing = 30; //Can be changed to change the spacing between lines
+    const offsetIncrease = (line.multiLineOffset- (line.numberOfLines - 1) / 2) * lineSpacing;
     if (line.ctype === lineDirection.UP || line.ctype === lineDirection.DOWN) {
         offset.x1 += offsetIncrease;
         offset.x2 += offsetIncrease;
@@ -806,42 +801,45 @@ function sortElementAssociations(element) {
     //it will then sort them and give them an index and number of lines.
     //This is used to draw the lines in the right order and to give them a offset if they are on the same side.
     //the offset is done is done in the function drawLine.
-    ['top', 'bottom', 'right', 'left'].forEach(side => {
+    try{
+        ['top', 'bottom', 'right', 'left'].forEach(side => {
 
-        //First we got to sort out recusive lines, dont want them to move about
-        const linesOfTargetSide = element[side];
-        const filteredLines = linesOfTargetSide.filter(lineID => {
-        const lineIdIndex = findIndex(lines, lineID);
-        // Check if the line exists in the lines array.
-        if (lineIdIndex === -1) {
-            return false; }
-        const lineObject = lines[lineIdIndex]; 
-        if (lineObject.ghostLine || lineObject.targetGhost) {
-            return lineObject.kind === lineKind.NORMAL;
-        }
-        return lineObject.kind !== lineKind.RECURSIVE;
-        });
-      
-        //If there are more then one line at one side
-        //sort them and give them an index and numberOfLines values
-        if (filteredLines.length > 1) {
-            filteredLines.sort((line_1, line_2) =>
-            sortvectors(line_1, line_2, filteredLines, element.id, 2)
-            );
-            filteredLines.forEach((lineID, index) => {
-            const lineIdIndex = findIndex(lines, lineID); 
-            if (lineIdIndex === -1){
-                return;   //Checks if enmpty
-            } 
-            //Give lineObject the variables of multiLineOffset and numberOfLines
-            //To be used in the function drawLine
+            //First we got to sort out recusive lines, dont want them to move about
+            const linesOfTargetSide = element[side];
+            const filteredLines = linesOfTargetSide.filter(lineID => {
+            const lineIdIndex = findIndex(lines, lineID);
+            // Check if the line exists in the lines array.
+            if (lineIdIndex === -1) {
+                return false; }
             const lineObject = lines[lineIdIndex]; 
-            lineObject.multiLineOffset = index;
-            lineObject.numberOfLines = filteredLines.length;
-          });
-        }
-      });
-
+            if (lineObject.ghostLine || lineObject.targetGhost) {
+                return lineObject.kind === lineKind.NORMAL;
+            }
+            return lineObject.kind !== lineKind.RECURSIVE;
+            });
+        
+            //If there are more then one line at one side
+            //sort them and give them an index and numberOfLines values
+            if (filteredLines.length > 1) {
+                filteredLines.sort((line_1, line_2) =>
+                sortvectors(line_1, line_2, filteredLines, element.id, 2)
+                );
+                filteredLines.forEach((lineID, index) => {
+                const lineIdIndex = findIndex(lines, lineID); 
+                if (lineIdIndex === -1){
+                    return;   //Checks if enmpty
+                } 
+                //Give lineObject the variables of multiLineOffset and numberOfLines
+                //To be used in the function drawLine
+                const lineObject = lines[lineIdIndex]; 
+                lineObject.multiLineOffset = index;
+                lineObject.numberOfLines = filteredLines.length;
+            });
+            }
+        });
+    }catch (error) {
+        console.error("Error in sortElementAssociations, Multi-line sorting:", error);
+    }
 }
 
 /**

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -105,8 +105,6 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
     }
     str += drawLineIcon(line.startIcon, line.ctype, fx + offset.x1, fy + offset.y1, lineColor, line);
     str += drawLineIcon(line.endIcon, line.ctype.split('').reverse().join(''), tx + offset.x2, ty + offset.y2, lineColor, line);
-
-
     if ((line.type == entityType.SD && line.innerType != SDLineType.SEGMENT) || (line.type == entityType.SE && line.innerType != SELineType.SEGMENT)) {
         let to = new Point(tx + offset.x2 * zoomfact, ty + offset.y2 * zoomfact);
         let from = new Point(fx + offset.x1 * zoomfact, fy + offset.y1 * zoomfact);
@@ -843,7 +841,6 @@ function sortElementAssociations(element) {
           });
         }
       });
-
 
 }
 

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -58,8 +58,26 @@ function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, su
         addObjectToLines(newLine, stateMachineShouldSave);
         if (successMessage) displayMessage(messageTypes.SUCCESS, `Created new line between: ${fromElement.name} and ${toElement.name}`);
         result = newLine;
+
+    //separe statement when more than 2 lines are created
+    //Moastly the same from above but with a check for 3 lines
+    } else if(numOfExistingLines < 3 || (specialCase && numOfExistingLines < 4)){
+        let newLine = {
+            id: makeRandomID(),
+            fromID: fromElement.id,
+            toID: toElement.id,
+            kind: kind
+        };
+        // If the new line has an entity FROM or TO, add a cardinality ONLY if it's passed as a parameter.
+        if (isLineConnectedTo(newLine, elementTypesNames.EREntity)) {
+            if (cardinal) newLine.cardinality = cardinal;
+        }
+        preProcessLine(newLine);
+        addObjectToLines(newLine, stateMachineShouldSave);
+        if (successMessage) displayMessage(messageTypes.SUCCESS, `Created aditional lines between ${fromElement.name} and ${toElement.name}`);
+        result = newLine;
     } else {
-        displayMessage(messageTypes.ERROR, `Maximum amount of lines between: ${fromElement.name} and ${toElement.name}`);
+        displayMessage(messageTypes.ERROR, `Maximum amount of lines between! ${fromElement.name} and ${toElement.name}`);
     }
     return result;
 }


### PR DESCRIPTION
Added functionality for all elements to have up to 3 lines on each side.
Arrows and figures on each line should work as well.
Cardinality does not work at the moment, but there is a issue for that that I'm planing on resolving in the future.

The lines themself can behave oddly when when crossing each other, possible a future issue.
Another future issue is the placement of the recursive line. When having a recursive line and multiple lines they do overlap, possible issue to move the recursive line to a safe space.

![Screenshot from 2025-04-14 09-20-22](https://github.com/user-attachments/assets/dc15cfc3-055b-44cc-9b8e-bd2660d2ae49)
