### PR TITLE
Fix for issuie #15036, overlapping cardinalities on UML

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -137,9 +137,13 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
     }
     if (felem.type != entityType.ER || telem.type != entityType.ER) {
         if (line.startLabel && line.startLabel != '') {
+                fx += offset.x1;
+                fy += offset.y1;
             str += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fx, fy, true);
         }
         if (line.endLabel && line.endLabel != '') {
+            tx += offset.x1;
+            ty += offset.y2;
             str += drawLineLabel(line, line.endLabel, lineColor, 'endLabel', tx, ty, false);
         }
     } else {
@@ -428,6 +432,7 @@ function drawRecursive(fx, fy, offset, line, lineColor, strokewidth, strokeDash)
  * @param {Object} t It's for the object telem and it's stands for "to element".
  * @returns Returns the cardinality label for the line.
  */
+
 function drawLineCardinality(line, lineColor, fx, fy, tx, ty, f, t) {
     let posX, posY;
     // Used to tweak the cardinality position when the line gets very short.


### PR DESCRIPTION
Added the line offset value to the from x, to x, from y and to y values before the cardinality is added. 
![Screenshot from 2025-04-14 12-39-46](https://github.com/user-attachments/assets/80bed467-422b-4e28-af72-e90bf5f0b874)
