### PR TITLE
Documented Basic.php investigation #16551

### DIFF
--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -169,6 +169,8 @@ $dbVersion = 6;
 $metadataDbVersion = 2;
 //---------------------------------------------------------------------------------------------------------------
 
+
+// This section might be doing more than scaffolding.
 try {
 	$log_db = new PDO('sqlite:../../log/loglena'.$dbVersion.'.db');
 } catch (PDOException $e) {

--- a/Shared/basic.php
+++ b/Shared/basic.php
@@ -170,7 +170,7 @@ $metadataDbVersion = 2;
 //---------------------------------------------------------------------------------------------------------------
 
 
-// This section might be doing more than scaffolding.
+// This section might be doing more than scaffolding. It's doing a specific job rather than general-purpose. 
 try {
 	$log_db = new PDO('sqlite:../../log/loglena'.$dbVersion.'.db');
 } catch (PDOException $e) {


### PR DESCRIPTION
I reviewed basic.php for issue #16551, which is about making sure the file only contains scaffolding (general purpose & reusable code). Most of the file looks fine, functions like getOP(), logging helpers, and error handling are generic and reusable.

However, I flagged a section that I don't think is scaffolding, database setup and table creation (logEntries, userLogEntries, etc.). This sections feel more like app-specific logic and might be better placed in separate files.