### PR TITLE
G3 2025 v2 issue #16348 white space on mobile devices

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1508,10 +1508,10 @@ function returnedSection(data) {
         var valarr = ["header", "section", "code", "test", "moment", "link", "group", "message"];
         // New items added get the class glow to show they are new
         if ((Date.parse(item['ts']) - dateToday) > compareWeek) {
-          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " glow displayBlock'>";
+          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " glow courseRow'>";
         }
         else {
-          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " displayBlock'>";
+          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " courseRow'>";
         }
 
         menuState.idCounter++;
@@ -1519,13 +1519,13 @@ function returnedSection(data) {
 
         // Content table
         str += `<table id='lid${item['lid']}' value='${item['lid']}'
-        style='width:100%;table-layout:fixed;'><tr value='${makeTextArray(item['kind'], valarr)}' style='height:32px;' `;
+        style='width:100%;table-layout:fixed;'><tr value='${makeTextArray(item['kind'], valarr)}'`;
 
-        if (kk % 2 == 0) {
-          str += " class='hi' ";
-        } else {
-          str += " class='lo' ";
-        }
+        //if (kk % 2 == 0) {
+        //  str += " class='hi' ";
+        //} else {
+        //  str += " class='lo' ";
+        //}
         str += " >";
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1519,7 +1519,7 @@ function returnedSection(data) {
 
         // Content table
         str += `<table id='lid${item['lid']}' value='${item['lid']}'
-        style='width:100%;table-layout:fixed;'><tr value='${makeTextArray(item['kind'], valarr)}'`;
+        ><tr value='${makeTextArray(item['kind'], valarr)}'`;
 
         //if (kk % 2 == 0) {
         //  str += " class='hi' ";

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -275,7 +275,7 @@ p {
 
 #content {
   background: var(--color-background);
-  margin: 5px 10px 15px 10px;
+  margin: 5px 0px 15px 0px;
 }
 
 #accessedcontent {
@@ -854,6 +854,10 @@ p {
 }
 
 @media screen and (max-width : 570px) {
+
+  #SectionList {
+    margin: 10px 0px 10px 0px;
+  }
 
   .item {
     font-size: 10pt;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -855,7 +855,7 @@ p {
 @media screen and (max-width : 570px) {
 
   #SectionList {
-    margin: 10px 0px 10px 0px;
+    margin: 10px 0;
   }
   
   .item {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1333,15 +1333,20 @@ p {
   /* Move up later*/
   display: block;
 
+  --rowHeight: 3rem;
+
+  & table {
+    table-layout: fixed;
+    width: 100%;
+  }
+
   & .courseRow {
     background-color: var(--color-sectioned-table-hi);
-    height: fit-content;
-    display: block;
+    height: var(--rowHeight);
     
-    & tr {
-      height: 100%;
+    & td {
       font-size: 1.5rem;
-      padding: 0.25rem;
+      line-height: var(--rowHeight); /*Suboptimal solution because display:flex breaks the site*/
     }
 
     &:first-child {
@@ -1356,6 +1361,25 @@ p {
   & .courseRow:hover {
     background-color: var(--color-background-2);
     cursor: pointer;
+  }
+
+  @media screen and (max-width : 570px) {
+    --adjustedRowHeight: calc(var(--rowHeight) - 1.5rem)
+
+    display: block;
+
+    & div {
+      margin: 0;
+    }
+    
+    & .courseRow {   
+      height: var(--adjustedRowHeight);
+
+      & td {
+        font-size: 1rem;
+        line-height: var(--adjustedRowHeight);
+      }
+    }
   }
 }
 
@@ -1383,9 +1407,9 @@ p {
  }
 
  .sectionlistCWidth {
-  width: calc(100% - 30px);
-  margin-left: auto;
-  margin-right: auto;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0;
  }
 
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -845,7 +845,6 @@ p {
   cursor: pointer;
 }
 
-
 .item {
   /*padding-top: 4px;*/
   min-height: 30px;
@@ -858,7 +857,7 @@ p {
   #SectionList {
     margin: 10px 0px 10px 0px;
   }
-
+  
   .item {
     font-size: 10pt;
   }
@@ -1333,8 +1332,34 @@ p {
 #Sectionlistc {
   /* Move up later*/
   display: block;
+
+  & .courseRow {
+    background-color: var(--color-sectioned-table-hi);
+    height: fit-content;
+    display: block;
+    
+    & tr {
+      height: 100%;
+      font-size: 1.5rem;
+      padding: 0.25rem;
+    }
+
+    &:first-child {
+      height: fit-content;
+    }
+    
+    &:nth-child(odd) {
+      background-color: var(--color-sectioned-table-lo);
+    }
+  }
+
+  & .courseRow:hover {
+    background-color: var(--color-background-2);
+    cursor: pointer;
+  }
 }
 
+/*TODO: Clean up section classes? */
 /* Sectionlistc */
 .sectionlistCMargin {
   margin-top: 30px;


### PR DESCRIPTION
Unnecessary white space have now been removed. I have left the white space between the header and course title and code. I have only changed styling for mobile screens (width <= 570px). A separate issue for white screen on desktop will need to be created. I have also changed some HTML  and moved inline styling to the external stylesheet. More courses is also visible on mobile devices now per the request, although this feels a tad bit excessive for mobile platforms. Future issues include reviewing the different SectionList ID's, egregious use of inline styling as well as creating tables correctly.

# Before:
![before](https://github.com/user-attachments/assets/b54aff68-7db9-4437-88e9-44424a36a70d)

# After:
![after](https://github.com/user-attachments/assets/51d74926-0bcc-4879-a794-e4ec07d76229)
