### PR TITLE
Made the A4 text bigger

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -830,7 +830,6 @@
     z-index: -11;
 }
 
-
 #a4Rect, #vRect {
     display: none; 
 }
@@ -852,7 +851,7 @@
 }
 
 #a4Text {
- /* no styling yet */
+    font-size: 32px;
 }
 
 /****************

--- a/DuggaSys/diagram/draw/update.js
+++ b/DuggaSys/diagram/draw/update.js
@@ -252,6 +252,7 @@ function updateA4Size() {
 function updateA4Pos() {
     const OffsetX = Math.round(-zoomOrigo.x * zoomfact + (scrollx * (1.0 / zoomfact)));
     const OffsetY = Math.round(-zoomOrigo.y * zoomfact + (scrolly * (1.0 / zoomfact)));
+
     const rect = document.getElementById("a4Rect");
     const vRect = document.getElementById("vRect");
     const text = document.getElementById("a4Text");
@@ -261,7 +262,7 @@ function updateA4Pos() {
 
     rect.setAttribute('x', OffsetX.toString());
     rect.setAttribute('y', OffsetY.toString());
-
+    
     text.setAttribute('x', (OffsetX + 8).toString());
     text.setAttribute('y', (OffsetY - 8).toString());
 }


### PR DESCRIPTION
I have come to the conclusion that it is not actually the A4 text scaling upwards and downwards. The A4 text always stays the same size. It is the whole program that is zooming in and that is why the text looks smaller because of the perspective the zoom gives to the ruler and background etc. 

Therefore I updated the diagram.css file and changed the font-size of #a4Text to be a bit bigger to somehow help with the issue. No other file except some enter on update.js has been changed so it shouldn't do any harm to other stuff.