### PR TITLE
Lines are correctly adjusted to correct anchor points between entities

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -22,38 +22,38 @@ function drawLine(line, targetGhost = false) {
     let isSelected = contextLine.includes(line);
     if (isSelected) lineColor = color.SELECTED;
     let fx, fy, tx, ty, offset;
-
+    
     // Sets the to-coordinates to the same as the from-coordinates after getting line attributes
     // if the line is recursive
-    if (line.kind === lineKind.RECURSIVE) {
+    if (line.kind === lineKind.RECURSIVE){
 
         [fx, fy, tx, ty, offset] = getLineAttrubutes(felem, felem, line.ctype);
         [fx, fy, tx, ty, offset] = [fx, fy, fx, fy, offset];
     }
-    else {
+    else{
         [fx, fy, tx, ty, offset] = getLineAttrubutes(felem, telem, line.ctype);
     }
-
+    
     // Follows the cursor while drawing the line
-    if (isCurrentlyDrawing) {
+    if (isCurrentlyDrawing){
         tx = event.clientX;
         ty = event.clientY;
     }
 
 
-    //Looks if the lines have gotta an index value from the function getLineAttrubutes
-    //If so then there are multiple lines on the same row and the offset is changed
-    if (typeof line.multiLineOffset === 'number' && typeof line.numberOfLines === 'number') {
-        const lineSpacing = 30; //Can be changed to change the spacing between lines
-        const offsetIncrease = (line.multiLineOffset - (line.numberOfLines - 1) / 2) * lineSpacing;
-        if (line.ctype === lineDirection.UP || line.ctype === lineDirection.DOWN) {
-            offset.x1 += offsetIncrease;
-            offset.x2 += offsetIncrease;
-        } else if (line.ctype === lineDirection.LEFT || line.ctype === lineDirection.RIGHT) {
-            offset.y1 += offsetIncrease;
-            offset.y2 += offsetIncrease;
-        }
+//Looks if the lines have gotta an index value from the function getLineAttrubutes
+//If so then there are multiple lines on the same row and the offset is changed
+if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'number') {
+    const lineSpacing = 30; //Can be changed to change the spacing between lines
+    const offsetIncrease = (line.multiLineOffset- (line.numberOfLines - 1) / 2) * lineSpacing;
+    if (line.ctype === lineDirection.UP || line.ctype === lineDirection.DOWN) {
+        offset.x1 += offsetIncrease;
+        offset.x2 += offsetIncrease;
+    } else if (line.ctype === lineDirection.LEFT || line.ctype === lineDirection.RIGHT) {
+        offset.y1 += offsetIncrease;
+        offset.y2 += offsetIncrease;
     }
+}
 
     if (targetGhost && line.type == entityType.SD) line.endIcon = SDLineIcons.ARROW;
     if (line.type == entityType.ER) {
@@ -71,7 +71,7 @@ function drawLine(line, targetGhost = false) {
             let len = Math.sqrt((dx * dx) + (dy * dy));
             dy /= len;
             dx /= len;
-
+            
             const double = (a, b) => {
                 return `<line 
                 id='${line.id}-${b}' 
@@ -108,30 +108,30 @@ function drawLine(line, targetGhost = false) {
         if (line.kind == lineKind.RECURSIVE) {
             str += drawRecursive(fx, fy, offset, line, lineColor, strokewidth, strokeDash);
             str += drawRecursiveLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
-
+            
         }
-        else {
+        else{
             str += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
         }
-
+        
     }
     str += drawLineIcon(line.startIcon, line.ctype, fx + offset.x1, fy + offset.y1, lineColor, line);
-    if (line.kind === lineKind.RECURSIVE) {
+    if (line.kind === lineKind.RECURSIVE){
         str += drawLineIcon(line.endIcon, line.ctype, tx, ty + 40 * zoomfact, lineColor, line);
     }
-    else {
+    else{
         str += drawLineIcon(line.endIcon, line.ctype.split('').reverse().join(''), tx + offset.x2, ty + offset.y2, lineColor, line);
     }
-
+  
     if ((line.type == entityType.SD && line.innerType != SDLineType.SEGMENT) || (line.type == entityType.SE && line.innerType != SELineType.SEGMENT)) {
         let to = new Point(tx + offset.x2 * zoomfact, ty + offset.y2 * zoomfact);
         let from = new Point(fx + offset.x1 * zoomfact, fy + offset.y1 * zoomfact);
         if (line.startIcon == SDLineIcons.ARROW) {
-
+            
             str += drawArrowPoint(calculateArrowBase(to, from, 10 * zoomfact), from, fx, fy, lineColor, line, line.ctype);
         }
         if (line.endIcon == SDLineIcons.ARROW) {
-
+            
             str += drawArrowPoint(calculateArrowBase(from, to, 10 * zoomfact), to, tx, ty, lineColor, line, line.ctype.split('').reverse().join(''));
         }
     }
@@ -276,10 +276,10 @@ function drawLine(line, targetGhost = false) {
 function recursiveERCalc(ax, ay, bx, by, elem, isFirst, line) {
     if (line.ctype == lineDirection.UP || line.ctype == lineDirection.DOWN) {
         ay = elem.cy;
-        ax = isFirst ? elem.x1 : elem.x2;
+        ax = isFirst? elem.x1 : elem.x2;
     } else if (line.ctype == lineDirection.LEFT || line.ctype == lineDirection.RIGHT) {
         ax = elem.cx;
-        ay = isFirst ? elem.y1 : elem.y2;
+        ay = isFirst? elem.y1 : elem.y2;
     }
     if (isFirst) {
         elem.recursivePos = 0;
@@ -314,38 +314,33 @@ function recursiveERRelation(felem, telem, line) {
 }
 
 function getLineAttrubutes(f, t, ctype) {
-    let result;
-    let px = 3;
-    let offset = {
-        x1: 0,
-        x2: 0,
-        y1: 0,
-        y2: 0,
-    };
-    switch (ctype) {
+    const px = -1; // Don't touch
+    const offset = { x1: 0, x2: 0, y1: 0, y2: 0 };
+
+    switch (ctype) { 
         case lineDirection.UP:
             offset.y1 = px;
             offset.y2 = -px * 2;
-            result = [f.cx, f.y1, t.cx, t.y2, offset];
-            break;
+            return [f.cx, f.y1, t.cx, t.y2, offset];
+
         case lineDirection.DOWN:
             offset.y1 = -px * 2;
             offset.y2 = px;
-            result = [f.cx, f.y2, t.cx, t.y1, offset];
-            break;
+            return [f.cx, f.y2, t.cx, t.y1, offset];
+
         case lineDirection.LEFT:
-            offset.x1 = px;
-            offset.x2 = px * 4;
-            result = [f.x1, f.cy, t.x1, t.cy, offset];
-            break;
+            offset.x1 = -px;          
+            offset.x2 = px * 2;       
+            return [f.x1, f.cy, t.x2, t.cy, offset];
+
         case lineDirection.RIGHT:
-            offset.x1 = 0;
-            offset.x2 = px;
-            result = [f.x2, f.cy, t.x1, t.cy, offset];
+            offset.x1 = px;           
+            offset.x2 = -px * 2;      
+            return [f.x2, f.cy, t.x1, t.cy, offset];
     }
-    return result;
 }
 
+ 
 /**
  * @description Draw the label for the line.
  * @param {Object} line The line object for the label to be drawn.
@@ -527,10 +522,10 @@ function drawRecursiveLineSegmented(fx, fy, tx, ty, offset, line, lineColor, str
     let dx = (line.ctype == lineDirection.LEFT || line.ctype == lineDirection.RIGHT) ? (((fx + offset.x1) - (tx + offset.x2)) / 2) : 0;
     return `<polyline id="${line.id}"
     points='${fx + offset.x1},${fy + offset.y1} ${fx + offset.x1 - dx},${fy + offset.y1 - dy} ${tx + offset.x2 + dx},${ty + offset.y2 + dy} ${tx + offset.x2},${ty + offset.y2}' 
-                points="${fx + offset.x1},${fy + offset.y1} 
-                        ${fx + offset.x1 + 40},${fy + offset.y1} 
-                        ${fx + offset.x1 + 40},${fy + offset.y1 + 40} 
-                        ${fx + offset.x1},${fy + offset.y1 + 40}"
+                points="${fx + offset.x1 },${fy + offset.y1 } 
+                        ${fx + offset.x1 + 40 },${fy + offset.y1} 
+                        ${fx + offset.x1 + 40 },${fy + offset.y1 + 40 } 
+                        ${fx + offset.x1 },${fy + offset.y1 + 40 }"
                 fill="none" 
                 stroke="${lineColor}" stroke-width="${strokewidth}" stroke-dasharray="${strokeDash}" 
             />`;
@@ -649,7 +644,7 @@ function iconPoly(arr, x, y, lineColor, fill) {
     let s = "";
     for (let i = 0; i < arr.length; i++) {
         const [a, b] = arr[i];
-        s += `${x + a * zoomfact} ${y + b * zoomfact} `;
+        s += `${x + a * zoomfact} ${y + b * zoomfact}, `;
     }
     return `<polyline 
                 points='${s}' 
@@ -688,16 +683,16 @@ function calculateArrowBase(from, to, size) {
  * @returns Returns the calculated coordinate for rotate the arrow point.
  */
 function rotateArrowPoint(base, point, clockwise) {
-    const angle = Math.PI / 4;
-    const direction = clockwise ? 1 : -1;
+    const angle = Math.PI / 4; 
+    const direction = clockwise ? 1 : -1; 
     const dx = point.x - base.x;
     const dy = point.y - base.y;
-    return {
-        x: base.x + (dx * Math.cos(direction * angle) - dy * Math.sin(direction * angle)),
-        y: base.y + (dx * Math.sin(direction * angle) + dy * Math.cos(direction * angle))
-    };
+        return {
+            x: base.x + (dx * Math.cos(direction * angle) - dy * Math.sin(direction * angle)),
+            y: base.y + (dx * Math.sin(direction * angle) + dy * Math.cos(direction * angle))
+        };
 }
-
+     
 /**
  * @description Draw the arraow head for the line.
  * @param {Point} base The start x and y coordinate.
@@ -714,7 +709,7 @@ function drawArrowPoint(base, point, lineColor, strokeWidth) {
         <polygon points='${base.x},${base.y} ${right.x},${right.y} ${left.x},${left.y}'
             stroke='${lineColor}' fill='none' stroke-width='${strokeWidth}' />
     </svg>`;
-}
+ }
 
 
 /**
@@ -846,44 +841,43 @@ function sortElementAssociations(element) {
     //it will then sort them and give them an index and number of lines.
     //This is used to draw the lines in the right order and to give them a offset if they are on the same side.
     //the offset is done is done in the function drawLine.
-    try {
+    try{
         ['top', 'bottom', 'right', 'left'].forEach(side => {
 
             //First we got to sort out recusive lines, dont want them to move about
             const linesOfTargetSide = element[side];
             const filteredLines = linesOfTargetSide.filter(lineID => {
-                const lineIdIndex = findIndex(lines, lineID);
-                // Check if the line exists in the lines array.
-                if (lineIdIndex === -1) {
-                    return false;
-                }
-                const lineObject = lines[lineIdIndex];
-                if (lineObject.ghostLine || lineObject.targetGhost) {
-                    return lineObject.kind === lineKind.NORMAL;
-                }
-                return lineObject.kind !== lineKind.RECURSIVE;
+            const lineIdIndex = findIndex(lines, lineID);
+            // Check if the line exists in the lines array.
+            if (lineIdIndex === -1) {
+                return false; }
+            const lineObject = lines[lineIdIndex]; 
+            if (lineObject.ghostLine || lineObject.targetGhost) {
+                return lineObject.kind === lineKind.NORMAL;
+            }
+            return lineObject.kind !== lineKind.RECURSIVE;
             });
-
+        
             //If there are more then one line at one side
             //sort them and give them an index and numberOfLines values
             if (filteredLines.length > 1) {
                 filteredLines.sort((line_1, line_2) =>
-                    sortvectors(line_1, line_2, filteredLines, element.id, 2)
+                sortvectors(line_1, line_2, filteredLines, element.id, 2)
                 );
                 filteredLines.forEach((lineID, index) => {
-                    const lineIdIndex = findIndex(lines, lineID);
-                    if (lineIdIndex === -1) {
-                        return;   //Checks if enmpty
-                    }
-                    //Give lineObject the variables of multiLineOffset and numberOfLines
-                    //To be used in the function drawLine
-                    const lineObject = lines[lineIdIndex];
-                    lineObject.multiLineOffset = index;
-                    lineObject.numberOfLines = filteredLines.length;
-                });
+                const lineIdIndex = findIndex(lines, lineID); 
+                if (lineIdIndex === -1){
+                    return;   //Checks if enmpty
+                } 
+                //Give lineObject the variables of multiLineOffset and numberOfLines
+                //To be used in the function drawLine
+                const lineObject = lines[lineIdIndex]; 
+                lineObject.multiLineOffset = index;
+                lineObject.numberOfLines = filteredLines.length;
+            });
             }
         });
-    } catch (error) {
+    }catch (error) {
         console.error("Error in sortElementAssociations, Multi-line sorting:", error);
     }
 }


### PR DESCRIPTION
Anchor points are now correct, before the fix lines anchored at the wrong edges when placed next to each other. This led to lines getting stuck underneath entities which was faulty behavior. The problem were faulty offsets in the getLineAttributes() method, they've been corrected.

The lines are now correctly adjusting to the placement of entities and anchors at the correct edges, the closest possible.
![image](https://github.com/user-attachments/assets/428d0994-9364-4fb6-92c3-57706df81060)

Element moved to the other side: 
![image](https://github.com/user-attachments/assets/711177e8-81aa-49f2-a474-6d530d97c224)
