### PR TITLE
Documented getCourseGroupsAndMembers_ms.php AND getCourseVersions_ms.php

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -223,15 +223,16 @@ This is a list of all inverse dependencies of files in the sectionedService fold
 
 ### deleteListEntries
 
-### getCourseGroupsAndMembers
-
-### getCourseVersions
-
 ### getDeletedListEntries
 
 ### getCourseGroupsAndMembers
+    No inverse dependencies.
+    (Replaced with readCourseGroupsAndMembers_ms.php)
 
 ### getCourseVersions
+    No inverse dependencies.
+    (Replaces with readCourseVersions_ms.php)
+
 
 ### getDeletedListEntries
 


### PR DESCRIPTION
Are not used anywhere. getCourseGroupsAndMembers has been replaced with readCourseGroupsAndMembers, and getCourseVersions has been replaces with readCourseVersions.

fixes #16595