### PR TITLE
G1 2025 v2 #16455 the hitbox for some object does not match the object it self

### DIFF
--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -122,11 +122,11 @@ function entityIsOverlapping(id, x, y) {
             // Superstates can be placed on state-diagram elements and vice versa
             else if (!backgroundElement.includes(element.kind) &&
                 (data[i].kind === elementTypesNames.UMLSuperState ||
-                data[i].kind === elementTypesNames.sequenceLoopOrAlt)
+                    data[i].kind === elementTypesNames.sequenceLoopOrAlt)
             ) continue;
             else if (!backgroundElement.includes(data[i].kind) &&
                 (element.kind === elementTypesNames.UMLSuperState ||
-                element.kind === elementTypesNames.sequenceLoopOrAlt)
+                    element.kind === elementTypesNames.sequenceLoopOrAlt)
             ) continue;
         }
 
@@ -138,6 +138,26 @@ function entityIsOverlapping(id, x, y) {
                 if (data[i].id == entity.id) y2 = data[i].y + entity.height;
             });
         });
+
+        if (element.kind === "ERRelation") {
+            const centerAX = x + element.width / 2;
+            const centerAY = y + element.height / 2;
+            const centerBX = data[i].x + data[i].width / 2;
+            const centerBY = data[i].y + data[i].height / 2;
+
+            const dx = Math.abs(centerAX - centerBX);
+            const dy = Math.abs(centerAY - centerBY);
+
+            const sumHalfWidth = (element.width / 2) + (data[i].width / 2);
+            const sumHalfHeight = (element.height / 2) + (data[i].height / 2);
+
+            if ((dx / sumHalfWidth + dy / sumHalfHeight) <= 1) {
+                return true;
+            }
+            else {
+                continue;
+            }
+        }
 
         if (x < x2 &&
             x + element.width > data[i].x &&

--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -139,18 +139,25 @@ function entityIsOverlapping(id, x, y) {
             });
         });
 
+        // Collision detection for the ER Relation element
         if (element.kind === "ERRelation") {
+            // Calculate centre of first element
             const centerAX = x + element.width / 2;
             const centerAY = y + element.height / 2;
+
+            // Calculate centre of second element
             const centerBX = data[i].x + data[i].width / 2;
             const centerBY = data[i].y + data[i].height / 2;
 
+            // Calculate difference of the two elements on x-axis and y-axis
             const dx = Math.abs(centerAX - centerBX);
             const dy = Math.abs(centerAY - centerBY);
 
+            // Calculate maximum half width and height where the elements are still overlapping
             const sumHalfWidth = (element.width / 2) + (data[i].width / 2);
             const sumHalfHeight = (element.height / 2) + (data[i].height / 2);
 
+            // Detects if there is an actual collision
             if ((dx / sumHalfWidth + dy / sumHalfHeight) <= 1) {
                 return true;
             }
@@ -159,6 +166,7 @@ function entityIsOverlapping(id, x, y) {
             }
         }
 
+        // Default collision detection where overlapping is derived from height and width of element in a rectangle shape
         if (x < x2 &&
             x + element.width > data[i].x &&
             y < y2 &&


### PR DESCRIPTION
Solved the hitbox issue for the ER Relation element. Its angled side can now be placed closer to other elements without the collision detection kicking in to reject its position.


https://github.com/user-attachments/assets/5e5002b9-21fb-453b-82aa-14c6e09843fb

