### PR TITLE
Connect name query to database - Issue #16570

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/nameQuery.php
+++ b/DuggaSys/microservices/endpointDirectory/nameQuery.php
@@ -2,14 +2,19 @@
 
 function getServicesByName($name){
     //get names from database
-/*
+    $dbFile = __DIR__ . '/endpointDirectory_db.sqlite';
+    $pdo = new PDO('sqlite:' . $dbFile);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    echo "pdo connection should be done";
+
     $name = '%' . $name . '%'; 
-    $query = $pdo->prepare("SELECT * FROM microservices WHERE serviceName LIKE :name");
+    $query = $pdo->prepare("SELECT * FROM microservices WHERE ms_name LIKE :name");
 	$query->bindParam(':name', $name);
     $query->execute();
-*/
-    //return $query->fetchAll(PDO::FETCH_ASSOC);
 
+    return $query->fetchAll(PDO::FETCH_ASSOC);
+/*
     return [
         [
             "id" => 1,
@@ -33,4 +38,5 @@ function getServicesByName($name){
             "documentationPath" => "docs/courseDeleter.md"
         ]
     ];
+    */
 }


### PR DESCRIPTION
Added a database connection to name query, now correctly checks database for data.
To test open /endpointDirectory/EndpointDirectory.php and add ?name=example_ms at the end of the url.
Need to install db and fill with data first.

This error is normal and will be fixed by another issue.
Fatal error: Uncaught Error: Call to undefined function render() in C:\xampp\htdocs\LenaSYS\DuggaSys\microservices\endpointDirectory\endpointDirectory.php:32 Stack trace: #0 {main} thrown in C:\xampp\htdocs\LenaSYS\DuggaSys\microservices\endpointDirectory\endpointDirectory.php on line 32

fixes #16570
