### PR TITLE
G1 2025 v2 #16191 the example diagrams doesnt load correctly

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -315,6 +315,7 @@
 .node.mu {
     right: calc(50% - 4px);
     cursor: ns-resize;
+    top: 0;
 }
 .node.tr{
     cursor: nesw-resize;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -953,19 +953,28 @@ function mouseMode_onMouseUp(event) {
                     updatepos();
                 } else if (context.length === 1) {
                     if (event.target.id != "container") {
-                        elementTypeSelected = elementTypes.Ghost;
-                        makeGhost();
-                        // Create ghost line
-                        ghostLine = { id: makeRandomID(), fromID: context[0].id, toID: ghostElement.id, kind: "Normal" };
+                        // checks if a ghostline already exists and if so sets the relation recursively.
+                        if (ghostLine != null) {
+                            // create a line from the element to itself
+                            addLine(context[0], context[0], "Recursive");
+                            clearContext();
+                            // Bust the ghosts
+                            ghostElement = null;
+                            ghostLine = null;
+                            showdata();
+                            updatepos();
+                        }
+                        else {
+                            elementTypeSelected = elementTypes.Ghost;
+                            makeGhost();
+                            // Create ghost line
+                            ghostLine = { id: makeRandomID(), fromID: context[0].id, toID: ghostElement.id, kind: "Normal" };
+                        }
                     } else if (ghostElement !== null) {
-                        // create a line from the element to itself
-                        addLine(context[0], context[0], "Recursive");
                         clearContext();
-                        // Bust the ghosts
                         ghostElement = null;
                         ghostLine = null;
                         showdata();
-                        updatepos();
                     } else {
                         clearContext();
                         ghostElement = null;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -424,7 +424,7 @@ function getData() {
     document.getElementById("diagram-toolbar").addEventListener("mouseup", tup);
     document.getElementById("container").addEventListener("mousedown", mdown);
     document.getElementById("container").addEventListener("mouseup", mup);
-    document.getElementById("container").addEventListener("mousemove", debounce(mmoving, 100));
+    document.getElementById("container").addEventListener("mousemove", mmoving);
     document.getElementById("container").addEventListener("wheel", mwheel);
     document.getElementById("options-pane").addEventListener("mousedown", mdown);
     // debugDrawSDEntity(); // <-- debugfunc to show an sd entity
@@ -2145,13 +2145,5 @@ function resetDiagramAlert() {
  */
 function resetDiagram() {
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
-}
-
-function debounce(func, wait) {
-    let timeout;
-    return function (...args) {
-        clearTimeout(timeout);
-        timeout = setTimeout(() => func.apply(this, args), wait);
-    };
 }
 //#endregion =====================================================================================

--- a/DuggaSys/diagram/classes/stateChange.js
+++ b/DuggaSys/diagram/classes/stateChange.js
@@ -184,7 +184,7 @@ class StateChange {
         const newRelation = document.getElementById("propertySelect")?.value || undefined;
         if (newRelation && oldRelation != newRelation) {
             if (element.type == entityType.ER || element.type == entityType.UML || element.type == entityType.IE) {
-                if (element.kind != elementTypesNames.UMLEntity && element.kind != elementTypesNames.IERelation) {
+                if (element.kind != elementTypesNames.UMLEntity) {
                     let property = document.getElementById("propertySelect").value;
                     element.state = property;
                     return element.state;

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -253,6 +253,8 @@ function drawText(x, y, a, t, extra = '') {
  */
 function drawElementEREntity(element, boxw, boxh, linew, texth) {
     const l = linew * 3;
+    const maxCharactersPerLine = Math.floor((boxw / texth) * 1.5);
+    const lineHeight = 1.5;
     
     //check if element height and minHeight is 0, if so set both to 50
     if (element.height == 0 && element.minHeight == 0) {
@@ -262,19 +264,36 @@ function drawElementEREntity(element, boxw, boxh, linew, texth) {
         boxh = 50;
     }
 
+    // Split string into an array of lines based on max characters per line
+    function splitFull(str, maxCharsPerLine) {
+        const result = [];
+        for (let i = 0; i < str.length; i += maxCharsPerLine) {
+            result.push(str.substring(i, i + maxCharsPerLine));
+        }
+        return result;
+    }
+
+    const nameLines = splitFull(element.name, maxCharactersPerLine);
+    const textHeight = texth * nameLines.length * lineHeight;
+    const contentHeight = Math.max(boxh, textHeight + linew * 4);
+
     let weak = '';
     if (element.state == "weak") {
         weak = `<rect
                     x='${l}' 
                     y='${l}' 
                     width='${boxw - l * 2}' 
-                    height='${boxh - l * 2}'
+                    height='${contentHeight - l * 2}'
                     stroke-width='${linew}' stroke='${element.stroke}' fill='${element.fill}' 
                 />`;
     }
-    let rect = drawRect(boxw, boxh, linew, element);
-    let text = drawText(boxw / 2, boxh / 2 + texth / 3, 'middle', element.name);
-    return drawSvg(boxw, boxh, rect + weak + text);
+    let rect = drawRect(boxw, contentHeight, linew, element);
+    let text = "";
+    for (let i = 0; i < nameLines.length; i++) {
+        const y = (contentHeight / 2) - (nameLines.length / 2 - i - 0.5) * texth * lineHeight;
+        text += drawText(boxw / 2, y, 'middle', nameLines[i]);
+    }
+    return drawSvg(boxw, contentHeight, rect + weak + text);
 }
 
 /**

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -552,10 +552,11 @@ function drawElementERAttr(element, textWidth, boxw, boxh, linew, texth) {
  */
 function drawElementUMLRelation(element, boxw, boxh, linew) {
     let fill = (element.state == 'overlapping') ? 'black' : 'white';
+    let strokeColor = (fill === 'black') ? 'white' : 'black';
     let poly = `
         <polygon 
             points='${linew},${boxh - linew} ${boxw / 2},${linew} ${boxw - linew},${boxh - linew}' 
-            style='fill:${fill}; stroke:black; stroke-width:${linew};'
+            style='fill:${fill}; stroke:${strokeColor}; stroke-width:${linew};'
         />`;
     return drawSvg(boxw, boxh, poly);
 }

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -9,7 +9,8 @@ function drawElement(element, ghosted = false) {
     let texth = Math.round(zoomfact * textheight);
     let linew = Math.round(strokewidth * zoomfact);
     let boxw = Math.round(element.width * zoomfact);
-    let boxh = Math.round(element.height * zoomfact); // Only used for extra whitespace from resize
+    let boxh = element.height ? 
+    Math.round(element.height * zoomfact) : 0; // Only used for extra whitespace from resize
     let zLevel = 2;
     let mouseEnter = '';
 
@@ -217,7 +218,7 @@ function drawSvg(w, h, s, extra = '') {
  * @param {String} extra Extra attributes to be added to the rectangle tag.
  * @returns Returns a string containing a svg rectangle for the element that is drawn.
  */
-function drawRect(w, h, l, e, extra = `fill='${e.fill}'`) {
+function drawRect(w, h, l, e, extra = e.fill ? `fill='${e.fill}'` : `fill=#ffffff`) {
     return `<rect 
                 class='text' x='${l}' y='${l}' 
                 width='${w - l * 2}' height='${h - l * 2}' 
@@ -434,7 +435,7 @@ function drawElementSDEntity(element, boxw, boxh, linew, texth) {
                 z"
             stroke-width='${linew}'
             stroke='${element.stroke}'
-            fill='${element.fill}'
+            fill='${element.fill ? element.fill : "#ffffff"}'
         />`;
     let headText = drawText(boxw / 2, texth * lineHeight, 'middle', element.name);
     let headSvg = drawSvg(boxw, height, headPath + headText);
@@ -459,7 +460,7 @@ function drawElementSDEntity(element, boxw, boxh, linew, texth) {
                     z"
                 stroke-width='${linew}'
                 stroke='${element.stroke}'
-                fill='${element.fill}'
+                fill='${element.fill ? element.fill : "#ffffff"}'
             />`;
         let contentSvg = drawSvg(boxw, height, path + text);
         let style = `height:${height}px`;

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -60,7 +60,7 @@ function drawElement(element, ghosted = false) {
             cssClass = 'ie-element';
             style = element.name == "Inheritance" ?
              `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:2;` :
-             `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:1;`;
+             `left:0; top:0; width:auto; height:${boxh / 2}px; z-index:2;`;
             break;
         case elementTypesNames.UMLInitialState:
             let initVec = `
@@ -69,7 +69,7 @@ function drawElement(element, ghosted = false) {
                 </g>`;
             divContent = drawElementState(element, initVec);
             cssClass = 'uml-state';
-            style = `width:${boxw}px; height:${boxh}px; z-index:1;`;
+            style = `width:${boxw}px; height:${boxh}px; z-index:2;`;
             break;
         case elementTypesNames.UMLFinalState:
             let finalVec = `
@@ -92,7 +92,7 @@ function drawElement(element, ghosted = false) {
                 </g>`;
             divContent = drawElementState(element, finalVec);
             cssClass = 'uml-state';
-            style = `width:${boxw}px; height:${boxh}px; z-index:1;`;
+            style = `width:${boxw}px; height:${boxh}px; z-index:2;`;
             break;
         case elementTypesNames.UMLSuperState:
             divContent = drawElementSuperState(element, textWidth, boxw, boxh, linew);
@@ -102,12 +102,12 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.sequenceActor:
             divContent = drawElementSequenceActor(element, textWidth, boxw, boxh, linew, texth);
             mouseEnter = 'mouseEnterSeq(event);';
-            zLevel = 1;
+            zLevel = 2;
             break;
         case elementTypesNames.sequenceObject:
             divContent = drawElementSequenceObject(element, boxw, boxh, linew);
             mouseEnter = 'mouseEnterSeq(event);';
-            zLevel = 1;
+            zLevel = 2;
             break;
         case elementTypesNames.sequenceActivation:
             divContent = drawElementSequenceActivation(element, boxw, boxh, linew);

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -367,7 +367,7 @@ function drawRecursive(fx, fy, offset, line, lineColor) {
     const cornerX = fx + length;
     const cornerY = fy;
 
-    str += `<line id='${line.id}' x1='${startX + offset.x1 - 17 * zoomfact}' y1='${startY + offset.y1}' x2='${cornerX + offset.x1}' y2='${cornerY + offset.y1}'/>`;
+    str += `<line id='${line.id}' x1='${startX + offset.x1}' y1='${startY + offset.y1}' x2='${cornerX + offset.x1}' y2='${cornerY + offset.y1}'/>`;
     str += `<line id='${line.id}' x1='${startX + offset.x1}' y1='${startY + offset.y1}' x2='${cornerX + offset.x1}' y2='${startY + offset.y1}' stroke='${lineColor}' stroke-width='${strokewidth * zoomfact}'/>`;
     str += `<line id='${line.id}' x1='${cornerX + offset.x1}' y1='${startY + offset.y1}' x2='${cornerX + offset.x1}' y2='${cornerY + offset.y1}' stroke='${lineColor}' stroke-width='${strokewidth * zoomfact}'/>`;
     str += `<line id='${line.id}' x1='${cornerX + offset.x1}' y1='${cornerY + offset.y1}' x2='${endX + offset.x1}' y2='${cornerY + offset.y1}' stroke='${lineColor}' stroke-width='${strokewidth * zoomfact}'/>`;

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -12,15 +12,17 @@ function updateCSSForAllElements() {
             top -= deltaY;
         }
 
+        const includedElementTypes = Object.values(elementTypesNames);
+
         if (settings.grid.snapToGrid && useDelta) {
-            if (element.kind == elementTypesNames.EREntity) {
+            if (includedElementTypes.includes(element.kind)){
                 // The element coordinates with snap point
                 let objX = Math.round((elementData.x + elementData.width / 2 - (deltaX * (1.0 / zoomfact))) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
                 let objY = Math.round((elementData.y + elementData.height / 2 - (deltaY * (1.0 / zoomfact))) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
 
                 // Add the scroll values
                 left = Math.round(((objX - zoomOrigo.x) * zoomfact) + (scrollx * (1.0 / zoomfact)));
-                top = Math.round((((objY - zoomOrigo.y) - (settings.grid.gridSize / 2)) * zoomfact) + (scrolly * (1.0 / zoomfact)));
+                top  = Math.round(((objY - zoomOrigo.y) * zoomfact) + (scrolly * (1.0 / zoomfact)));
 
                 // Set the new snap point to center of element
                 left -= ((elementData.width * zoomfact) / 2);


### PR DESCRIPTION
An old check in stateChange.js was blocking IE-relations from saving changes to inheritance type. It was meant to avoid issues with a now-removed dropdown.

That check is no longer needed and has been removed. IE-relations can now switch between disjoint and overlapping as intended.

https://github.com/user-attachments/assets/47b89f6c-df14-4575-8cae-1f8f9538f80f

