### PR TITLE
Updated stateChange.js

### DIFF
--- a/DuggaSys/diagram/classes/stateChange.js
+++ b/DuggaSys/diagram/classes/stateChange.js
@@ -184,7 +184,7 @@ class StateChange {
         const newRelation = document.getElementById("propertySelect")?.value || undefined;
         if (newRelation && oldRelation != newRelation) {
             if (element.type == entityType.ER || element.type == entityType.UML || element.type == entityType.IE) {
-                if (element.kind != elementTypesNames.UMLEntity && element.kind != elementTypesNames.IERelation) {
+                if (element.kind != elementTypesNames.UMLEntity) {
                     let property = document.getElementById("propertySelect").value;
                     element.state = property;
                     return element.state;


### PR DESCRIPTION
An old check in stateChange.js was blocking IE-relations from saving changes to inheritance type. It was meant to avoid issues with a now-removed dropdown.

That check is no longer needed and has been removed. IE-relations can now switch between disjoint and overlapping as intended.

https://github.com/user-attachments/assets/2e40ac96-d32f-4bf3-87f5-02aca0b46563

