### PR TITLE
Added microservice documentation viewer

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/directoryRendering.php
+++ b/DuggaSys/microservices/endpointDirectory/directoryRendering.php
@@ -1,0 +1,26 @@
+<?php
+header('Content-Type: text/plain');
+
+// Get parameters
+$serviceName = $_GET['name'] ?? '';
+$renderMode = $_GET['render'] ?? 'md';
+
+// Check if service name was entered
+if (empty($serviceName)) {
+    die("Please specify a service name with ?name=service_name");
+}
+
+$db = new PDO('sqlite:endpointDirectory_db.sqlite');
+$query = $db->prepare("SELECT * FROM microservices WHERE ms_name = ?");
+$query->execute([$serviceName]);
+$service = $query->fetch();
+
+// Invalid service
+if (!$service) {
+    die("Service not found");
+}
+
+// Load file
+$markdown = file_get_contents('testMarkDownFile.md');
+echo $markdown;  // Returns raw md
+?>

--- a/DuggaSys/microservices/endpointDirectory/directoryRendering.php
+++ b/DuggaSys/microservices/endpointDirectory/directoryRendering.php
@@ -22,5 +22,17 @@ if (!$service) {
 
 // Load file
 $markdown = file_get_contents('testMarkDownFile.md');
-echo $markdown;  // Returns raw md
+echo $markdown;  // Remove if you uncomment the HTML conversion below
+
+// Uncomment IF HTML rendering support (with parsedown) is needed
+/*
+if ($renderMode == 'html') {
+    header('Content-Type: text/html');
+    require_once 'Parsedown.php';
+    $converter = new Parsedown();
+    echo $converter->text($markdown);  // Converts md to HTML
+} else {
+    echo $markdown;  // Returns raw md
+}
+*/
 ?>


### PR DESCRIPTION
This fixes #16522 and serves as a simple documentation viewer in MD (with the possibility of viewing in HTML). For expansion more files will need to be added not just 'testMarkDownFile.md' and for the HTML rendering support to work you would need to uncomment the segment mentioned in the code.
 