### PR TITLE
G3 2025 v2 issue #16612 remove view buttons from mobile screens

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -73,15 +73,6 @@
   			margin-bottom: 1px;
 		}
 
-		/* Style for the "View" labe" */
-		.view-label {
-  			background-color: #5e4776;  
-  			color: white;               
-  			padding: 8px 16px;          
-  			border-radius: 1px;
-  			font-weight: normal;
-  			display: inline-block;      
-		}
 		/* Style for the item currently being dragged */
 		.dragging {
    			opacity: 0.9;
@@ -296,8 +287,8 @@
 		<div id='courseList'>
 
 		<!-- View mode toggle buttons -->
-		<div style="margin: 10px 0;">
-			<span class="view-label">View</span><br>
+		<div class="view-label">
+			<h2>View</h2>
   			<button class="submit-button" onclick="setViewMode('normal')">Normal</button>
   			<button class="submit-button" onclick="setViewMode('scroll')">Scroll</button>
  			<button class="submit-button" onclick="setViewMode('overview')">Overview</button>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -870,6 +870,10 @@ p {
 
 @media screen and (max-width : 570px) {
 
+  & .view-label {
+    display: none;
+  }
+
   .item {
     font-size: 10pt;
   }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -836,6 +836,17 @@ p {
   display: block;
   padding-top: 1px;
   border-radius: 5px;
+
+  & h2 {
+    text-align: center;
+    font-weight: normal;
+    background-color: #5e4776;  
+    color: white;               
+  }
+
+  & .view-label {
+    padding: 0.5rem;
+  }
 }
 
 #sectionList_arrowStatisticsClosed{


### PR DESCRIPTION
I have removed the three different view buttons from the DOM for screens smaller than or equal to 570px. I have also moved the related styling to the external stylesheet and improved the semantics of the elements.
# Before:
![image](https://github.com/user-attachments/assets/2d70a2ab-9019-42a8-b6f2-4b091b195002)
# After: 
![image](https://github.com/user-attachments/assets/ea87ffb5-91af-4d3b-a811-43a1c84c5b80)
