### PR TITLE
List inverse dependencies for updateListEntriesTabs_ms.php AND updateListEntries_ms.php

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -277,10 +277,14 @@ No inverse dependencies.
 ### updateCourseVersion_sectioned
 
 ### updateListEntries
+No inverse dependencies.
+
 
 ### updateListEntriesGradesystem
 
 ### updateListEntriesTabs
+No inverse dependencies.
+
 
 ### updateListEntryOrder
 


### PR DESCRIPTION
Updated Microservices_inverse_dependencies.md with inverse dependencies for updateListEntriesTabs_ms.php AND updateListEntries_ms.php. None found. Fixes issue #16664 .