### PR TITLE
Fixed: Copy pasting is no longer working in the diagram site.

### DIFF
--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -31,8 +31,8 @@ const keybinds = {
     CENTER_CAMERA: { key: "home", ctrl: false },
     OPTIONS: { key: "o", ctrl: false },
     ENTER: { key: "enter", ctrl: false },
-    COPY: { key: "c", ctrl: true, meta: true },
-    PASTE: { key: "v", ctrl: true, meta: true },
+    COPY: { key: "c", ctrl: true, meta: false },
+    PASTE: { key: "v", ctrl: true, meta: false },
     SELECT_ALL: { key: "a", ctrl: true },
     DELETE_B: { key: "backspace", ctrl: false },
     MOVING_OBJECT_UP: { key: "ArrowUp", ctrl: false },
@@ -44,7 +44,7 @@ const keybinds = {
     TOGGLE_ER_TABLE: { key: "e", ctrl: false },
     TOGGLE_TEST_CASE: { key: "u", ctrl: false },
     TOGGLE_ERROR_CHECK: { key: "h", ctrl: false },
-    SAVE_DIAGRAM: { key: "s", ctrl: true },
+    SAVE_DIAGRAM: { key: "s", ctrl: true, meta: false, shift: false, alt: false },
     LOAD_DIAGRAM: { key: "l", ctrl: true },
     RESET_DIAGRAM: { key: "i", ctrl: false }
 };

--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -4,15 +4,15 @@
  * @param {{key:string, ctrl:boolean}} keybind
  * @returns {boolean}
  */
+
 function isKeybindValid(e, keybind) {
     const keyMatches = e.key.toLowerCase() === keybind.key.toLowerCase();
-
-    //Checks and compares if the pressed key is correct based on the keybind (true or false)
     const ctrlMatches = e.ctrlKey === !!keybind.ctrl;
+    const altMatches = e.altKey === !!keybind.alt;
     const metaMatches = e.metaKey === !!keybind.meta;
     const shiftMatches = e.shiftKey === !!keybind.shift;
 
-    return keyMatches && ctrlMatches && metaMatches && shiftMatches;
+    return keyMatches && ctrlMatches && altMatches && metaMatches && shiftMatches;
 }
 
 /**


### PR DESCRIPTION
The problem was fixed by explicitly ensuring that the COPY and PASTE events do not have meta as true but false.
Fixed this issue #16658