### PR TITLE
Pre-filled root username with 'root' in new installer

### DIFF
--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -57,7 +57,7 @@
 				<div class="content">
 					<?php
 						header2("Select installation options");
-					  bodyText("If this is your first time installing LenaSYS, you <u><b>must</b></u> select both options.", 
+						bodyText("If this is your first time installing LenaSYS, you <u><b>must</b></u> select both options.", 
 						"https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#step-2");
 					?>
 					<div class="inner-wrapper">
@@ -125,7 +125,7 @@
 				<div class="content">
 					<?php
 						header2("Enter root user credentials");
-					  bodyText("Provide the credentials for the database root user", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#step-4");
+						bodyText("Provide the credentials for the database root user", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#step-4");
 					?>
 					<div class="inner-wrapper">
 						<div class="input-flex">
@@ -153,7 +153,7 @@
 				<div class="content">
 					<?php
 						header2("Prepopulate with sample data");
-					  bodyText("Select the sample data you want to prepopulate LenaSYS with.", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#step-5");
+						bodyText("Select the sample data you want to prepopulate LenaSYS with.", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#step-5");
 					?>
 					<div class="inner-wrapper">
 						<div class="input-flex">
@@ -166,12 +166,12 @@
 									'language_support' => 'Include language-support'
 								];
 								$active = ['add_test_data', 'add_demo_course', 'add_test_course_data', 'add_test_files', 'language_support'];
-                $helpLinks = [
-								  'test-course' => "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#include-test-course",
-								  'demo-course' => "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#include-demo-course",
-								  'test-files' => "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#include-test-files",
-								  'language-support' => "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#include-test-files"
-                ];
+								$helpLinks = [
+									'test-course' => "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#include-test-course",
+									'demo-course' => "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#include-demo-course",
+									'test-files' => "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#include-test-files",
+									'language-support' => "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#include-test-files"
+								];
 
 								checkBoxes("creation_settings", $buttons, $active, $helpLinks);
 

--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -130,7 +130,7 @@
 					<div class="inner-wrapper">
 						<div class="input-flex">
 							<?php
-								inputField("root_username", "Root username:", "text");
+								inputField("root_username", "Root username:", "text", "root");
 								inputField("root_password", "Root password:", "password");
 							?>
 						</div>

--- a/newinstaller/tools/components.php
+++ b/newinstaller/tools/components.php
@@ -96,7 +96,7 @@
 			echo "<div class='radiobutton'>
 					<input id='$id' type='radio' name='$radioGroupName' value='$id' $checked>
 					<label for='$id'>$label</label>
-				  </div>";
+				</div>";
 		}
 		echo "</div>";
 	}

--- a/newinstaller/tools/components.php
+++ b/newinstaller/tools/components.php
@@ -66,10 +66,10 @@
 			</div>";
 	}
 
-	function inputField($inputId, $inputLabel, $inputType) {
+	function inputField($inputId, $inputLabel, $inputType, $inputValue='') {
 		echo "<div class='input-field'>
 					<label for='$inputId'>$inputLabel</label>
-					<input id='$inputId' type='$inputType'>
+					<input id='$inputId' name='$inputId' type='$inputType' value='". htmlspecialchars($inputValue) ."'>
 			</div>";
 	}
 


### PR DESCRIPTION
Added 'root' as the default pre-filled username in the new installer. The `$inputValue` parameter is set to an empty string by default, ensuring no impact on other input fields. 

`htmlspecialchars()` is used to prevent XSS vulnerabilities.

Also fixed som faulty indentation I came across in the files.

Fixes issue #16634

<img width="729" alt="Skärmavbild 2025-04-16 kl  13 28 26" src="https://github.com/user-attachments/assets/df044d96-6e07-4569-9564-1727b3f05d00" />