### PR TITLE
Fixed microservice endpoint output format

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/directoryRendering.php
+++ b/DuggaSys/microservices/endpointDirectory/directoryRendering.php
@@ -1,0 +1,36 @@
+<?php
+header('Content-Type: text/plain');
+
+$search = $_GET['name'] ?? $_GET['description'] ?? $_GET['parameter'] ?? '';
+if (empty($search)) {
+    die("Please use existing parameter");
+}
+
+$db = new PDO('sqlite:endpointDirectory_db.sqlite');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+// Determine search type and prepare query
+if (isset($_GET['name'])) {
+    $query = $db->prepare("SELECT * FROM microservices WHERE ms_name = ?");
+} elseif (isset($_GET['description'])) {
+    $query = $db->prepare("SELECT * FROM microservices WHERE description LIKE ?");
+    $search = "%$search%";
+} elseif (isset($_GET['parameter'])) {
+    $query = $db->prepare("SELECT * FROM microservices WHERE parameters LIKE ?");
+    $search = "%$search%";
+}
+
+$query->execute([$search]);
+$service = $query->fetch(PDO::FETCH_ASSOC);
+
+if (!$service) {
+    die("Service not found");
+}
+
+// Convert to md
+echo "### MICROSERVICE DOCUMENTATION ###\n\n";
+foreach ($service as $key => $value) {
+    echo "# " . strtoupper($key) . " #\n";
+    echo $value . "\n\n";
+}
+?>

--- a/DuggaSys/microservices/endpointDirectory/endpointDirectory.php
+++ b/DuggaSys/microservices/endpointDirectory/endpointDirectory.php
@@ -5,8 +5,9 @@ include_once "./parameterQuery.php";
 include_once "./descriptionSearch.php";
 include_once "./directoryRendering.php";
 
+// Not needed anymore
+/*
 $results = null;
-
 if(isset($_GET['name'])){
     $name = $_GET['name'];
     //get list of courses with matching name
@@ -37,7 +38,7 @@ else{
 if($results != null){
     render($results);
 }
-
+*/
 
 
 


### PR DESCRIPTION
Fixes #16522, now you get a markdown/html (html conversion can be added later) output of the relevant microservice documentation (from the database). Also removed debug outputs for less clutter and easier testing. The searchable parameters include: name, description and parameter, these are the ones that should be used when testing. More parameters can be added later if requested.