### PR TITLE
16617 fix the tooltip for scaling panel

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -784,7 +784,7 @@
     padding: 5px 0;
     pointer-events: none;
     position: absolute;
-    z-index:1;
+    z-index:20;
 }
 
 

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -774,7 +774,7 @@
 }
 .zoomToolTipText {
     bottom: 40px;
-    right: 0%;
+    left:1px;
     visibility: hidden;
     width: 250px;
     background: rgba(0, 0, 0, 0.8);
@@ -784,7 +784,7 @@
     padding: 5px 0;
     pointer-events: none;
     position: absolute;
-    z-index: 20;
+    z-index:1;
 }
 
 

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -774,7 +774,7 @@
 }
 .zoomToolTipText {
     bottom: 40px;
-    left:1px;
+    left:0%;
     visibility: hidden;
     width: 250px;
     background: rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
he task bestowed upon me is now complete.
I have removed right: 0; from the tooltip, as it caused the text to hide behind the toolbar. In its place, I added left: 0;, which ensures the tooltip appears correctly—spaced out and visually distinct from surrounding elements. If change is demanded for better UI then i shall make it so.

before:
![Skärmbild 2025-04-16 142852](https://github.com/user-attachments/assets/01e6121a-99eb-4b21-ad13-6333301419f9)

after:
![image](https://github.com/user-attachments/assets/2daed172-c866-47e8-bf07-35fa6ffe005d)

The code awaits your judgment.

