### PR TITLE
Fixed the tooltip for options panel

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -484,7 +484,7 @@
 }
 
 #options-pane-button .toolTipText{
-    transform: translate(-150px,100px) rotate(-90deg);
+    transform: translate(-100px,170px) rotate(-90deg);
 }
 #options-pane-button:hover .toolTipText{
     visibility: visible;


### PR DESCRIPTION
Update diagram.css
Changed the position of options tooltip.


Before:
![image](https://github.com/user-attachments/assets/0e43a021-bead-4891-a2b2-8ce45daa6ff2)

After:
![image](https://github.com/user-attachments/assets/7c1bdb3a-3d7c-477e-81c0-cba3f26e3812)
