### PR TITLE
G3 2025 v2 issue #16348 white space on mobile devices

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1512,10 +1512,10 @@ function returnedSection(data) {
         var valarr = ["header", "section", "code", "test", "moment", "link", "group", "message"];
         // New items added get the class glow to show they are new
         if ((Date.parse(item['ts']) - dateToday) > compareWeek) {
-          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " glow displayBlock'>";
+          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " glow courseRow'>";
         }
         else {
-          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " displayBlock'>";
+          str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " courseRow'>";
         }
 
         menuState.idCounter++;
@@ -1523,13 +1523,13 @@ function returnedSection(data) {
 
         // Content table
         str += `<table id='lid${item['lid']}' value='${item['lid']}'
-        style='width:100%;table-layout:fixed;'><tr value='${makeTextArray(item['kind'], valarr)}' style='height:32px;' `;
+        style='width:100%;table-layout:fixed;'><tr value='${makeTextArray(item['kind'], valarr)}'`;
 
-        if (kk % 2 == 0) {
-          str += " class='hi' ";
-        } else {
-          str += " class='lo' ";
-        }
+        //if (kk % 2 == 0) {
+        //  str += " class='hi' ";
+        //} else {
+        //  str += " class='lo' ";
+        //}
         str += " >";
 
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1523,7 +1523,7 @@ function returnedSection(data) {
 
         // Content table
         str += `<table id='lid${item['lid']}' value='${item['lid']}'
-        style='width:100%;table-layout:fixed;'><tr value='${makeTextArray(item['kind'], valarr)}'`;
+        ><tr value='${makeTextArray(item['kind'], valarr)}'`;
 
         //if (kk % 2 == 0) {
         //  str += " class='hi' ";

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -279,7 +279,7 @@ p {
 
 #content {
   background: var(--color-background);
-  margin: 5px 10px 15px 10px;
+  margin: 5px 0px 15px 0px;
 }
 
 #accessedcontent {
@@ -872,6 +872,8 @@ p {
 
   & .view-label {
     display: none;
+  #SectionList {
+    margin: 10px 0px 10px 0px;
   }
 
   .item {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -860,7 +860,6 @@ p {
   cursor: pointer;
 }
 
-
 .item {
   /*padding-top: 4px;*/
   min-height: 30px;
@@ -875,7 +874,7 @@ p {
   #SectionList {
     margin: 10px 0px 10px 0px;
   }
-
+  
   .item {
     font-size: 10pt;
   }
@@ -1350,8 +1349,34 @@ p {
 #Sectionlistc {
   /* Move up later*/
   display: block;
+
+  & .courseRow {
+    background-color: var(--color-sectioned-table-hi);
+    height: fit-content;
+    display: block;
+    
+    & tr {
+      height: 100%;
+      font-size: 1.5rem;
+      padding: 0.25rem;
+    }
+
+    &:first-child {
+      height: fit-content;
+    }
+    
+    &:nth-child(odd) {
+      background-color: var(--color-sectioned-table-lo);
+    }
+  }
+
+  & .courseRow:hover {
+    background-color: var(--color-background-2);
+    cursor: pointer;
+  }
 }
 
+/*TODO: Clean up section classes? */
 /* Sectionlistc */
 .sectionlistCMargin {
   margin-top: 30px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -872,7 +872,7 @@ p {
   & .view-label {
     display: none;
   #SectionList {
-    margin: 10px 0px 10px 0px;
+    margin: 10px 0;
   }
   
   .item {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -871,6 +871,8 @@ p {
 
   & .view-label {
     display: none;
+  }
+  
   #SectionList {
     margin: 10px 0;
   }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1350,15 +1350,20 @@ p {
   /* Move up later*/
   display: block;
 
+  --rowHeight: 3rem;
+
+  & table {
+    table-layout: fixed;
+    width: 100%;
+  }
+
   & .courseRow {
     background-color: var(--color-sectioned-table-hi);
-    height: fit-content;
-    display: block;
+    height: var(--rowHeight);
     
-    & tr {
-      height: 100%;
+    & td {
       font-size: 1.5rem;
-      padding: 0.25rem;
+      line-height: var(--rowHeight); /*Suboptimal solution because display:flex breaks the site*/
     }
 
     &:first-child {
@@ -1373,6 +1378,25 @@ p {
   & .courseRow:hover {
     background-color: var(--color-background-2);
     cursor: pointer;
+  }
+
+  @media screen and (max-width : 570px) {
+    --adjustedRowHeight: calc(var(--rowHeight) - 1.5rem)
+
+    display: block;
+
+    & div {
+      margin: 0;
+    }
+    
+    & .courseRow {   
+      height: var(--adjustedRowHeight);
+
+      & td {
+        font-size: 1rem;
+        line-height: var(--adjustedRowHeight);
+      }
+    }
   }
 }
 
@@ -1400,9 +1424,9 @@ p {
  }
 
  .sectionlistCWidth {
-  width: calc(100% - 30px);
-  margin-left: auto;
-  margin-right: auto;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0;
  }
 
 


### PR DESCRIPTION
This is a retread of a previous PR that did not get implemented before the weekly merge. 

## What's changed:
Unnecessary white space have now been removed. I have left the white space between the header, course title and load dugga heading. I have only changed styling for mobile screens (width <= 570px). A separate issue for white screen on desktop will need to be created. I have also changed some HTML and moved inline styling to the external stylesheet. More courses is also visible on mobile devices now per the request, although this feels a tad bit excessive for mobile platforms. 

## Future issues:
Future issues include reviewing the different SectionList ID's, small course names and egregious use of inline styling as well as creating tables correctly.

# Before:
![image](https://github.com/user-attachments/assets/562f49d9-1ea2-4b67-8b4d-be457b9280a7)

# After: 
![image](https://github.com/user-attachments/assets/c9957c2c-bfd6-4423-874d-82b8315db700)
