### PR TITLE
[#16669] Fixed issues with lines not updating when moving to left side

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -399,16 +399,9 @@ function getLineAttrubutes(f, t, ctype) {
             return [f.cx, f.y2, t.cx, t.y1, offset];
 
         case lineDirection.LEFT:
-
-            offset.x1 = px;
-            offset.x2 = px * 4;
-            result = [f.x1, f.cy, t.x2, t.cy, offset];
-            break;
-
             offset.x1 = -px;          
             offset.x2 = px * 2;       
             return [f.x1, f.cy, t.x2, t.cy, offset];
-
 
         case lineDirection.RIGHT:
             offset.x1 = px;           


### PR DESCRIPTION
This issue seems to have stemmed from duplicate code being added during the merge to the weekly branch. The function getLineAttribute had been updated in between the opening of the merged branch and the merging of the branch, which caused duplicate code to get added that didn't align with how the updated function worked, breaking before it could return the correct values for the left side, causing all lines to stop updating if lineDirection.LEFT was true. 

That issue may mostly have been my fault, since it was my code that got added that messed up the function and was outdated - most likely due to not fetching origin or something of the sort, so apologies for that.

The lines should now work as intended again.

![fixedlines demo](https://github.com/user-attachments/assets/42a90e32-ad19-4a37-9402-fa1a8d6f3de0)
