### PR TITLE
#16467 fix darkmode by using colour variables on even & odd table rows

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4066,9 +4066,12 @@ div.submit-button:disabled {
 }
 
 .list tbody tr:nth-child(odd) {
-  background-color: var(--color-background-2);
+  background-color: var(--color-sectioned-table-hi);
 }
 
+.list tbody tr:nth-child(even) {
+  background-color: var(--color-sectioned-table-lo);
+}
 
 .list#testTable tr:nth-child(odd),
 .list#testTable tr:nth-child(even) {


### PR DESCRIPTION
Issue has been fixed by simply using the table row colour variables rather than the high constrast on only odd rows.
See results
![image](https://github.com/user-attachments/assets/43313112-e15a-4ba3-ba6a-4f732e23ebcc)
