### PR TITLE
fixed so weeks are 'taller' in sectioned.js

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2382,7 +2382,7 @@ function returnedHighscore(data) {
 }
 
 //----------------------------------------------------------------------------------
-// drawSwimlanes: Draws schedule for deaadlines on all assignments is course
+// drawSwimlanes: Draws schedule for deadlines on all assignments is course
 //----------------------------------------------------------------------------------
 
 function drawSwimlanes() {
@@ -2455,7 +2455,7 @@ function drawSwimlanes() {
   var weekwidth = daywidth * 7; 
   
   var colwidth = 60;
-  var weekheight = 25;
+  var weekheight = 50;
 
   var str = "";
   // Fades a long text. Gradients on swimlane text depending on if dugga is submitted or not.

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -84,8 +84,6 @@
     		position: relative;
   		}
 
-</style>
-
 	</style>
 
 	<!-- <link type="text/css" href="../Shared/css/blackTheme.css" rel="stylesheet"> -->

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -944,7 +944,7 @@ p {
 }
 
 #swimlaneSVG text {
-  font-size: 10px;
+  font-size: 1em;
 }
 
 #swimlaneSVG rect:nth-child(n of .progressBar){


### PR DESCRIPTION
And changed so the text in css for #svimlaneSVG is 1em, which will make the font change size dynamicly based on parent element. 
(Also removed an unnecessary <style>-tag in style.css since it gave me an ulser)

- Need to make a new issue for fixing on mobile! 

Old swimlanes
![image](https://github.com/user-attachments/assets/af93d5d5-d31c-4470-9ea5-b53eb9ea54b4)

New swimlanes
![image](https://github.com/user-attachments/assets/134e7157-99aa-41c8-95d6-434935a94546)
