### PR TITLE
Corrected the documentation of reorderListEntries/updateListEntryOrder

### DIFF
--- a/backend-models/microservices/duggaSys services/Microservices.md
+++ b/backend-models/microservices/duggaSys services/Microservices.md
@@ -237,7 +237,7 @@ __Sectioned Service:__
 - deleteListentries_ms.php __==finished==__ Should keep existing name according to new nameconvention based on CRUD.
 - removeListentries_ms.php __==finished==__ Should keep existing name according to new nameconvention based on CRUD and the actual function of the ms.
 - createListentry_ms.php __==finished==__ Should keep existing name according to new nameconvention based on CRUD.
-- reorderListentries_ms.php __==finished==__ New filename: "updateOrder_ms.php" according to new nameconvention based on CRUD and the actual function of the ms.
+- reorderListentries_ms.php __==finished==__ New filename: "updateListEntryOrder_ms.php" according to new nameconvention based on CRUD and the actual function of the ms.
 - updateListentries_ms.php __==finished==__ Should keep existing name according to new nameconvention based on CRUD and the actual function of the ms.
 - updateListentriesTabs_ms.php __==finished==__ Should keep existing name according to new nameconvention based on CRUD and the actual function of the ms.
 - updateListentriesGradesystem_ms.php __==finished==__ Should keep existing name according to new nameconvention based on CRUD.
@@ -3085,8 +3085,8 @@ INSERT INTO listentries (cid,vers, entryname, link, kind, pos, visible,creator,c
 
 <br>
 
-### updateOrder_ms.php
-Updates the order of the listentries of a course. Not to be confused with __updateListentrie_ms.php__.
+### updateListEntryOrder_ms.php
+Updates the order of the listentries of a course. Not to be confused with __updateListEntries_ms.php__.
 
 __Include original service files:__ sessions.php, basic.php
 __Include microservice:__ getUid_ms.php, retrieveSectionedService_ms.php


### PR DESCRIPTION
Previous documentation said updateOrder should replace reorderListEntries, but it is supposed to be updateListEntryOrder. Changed the documentation from updateOrder to updateListEntryOrder, since updateOrder was incorrect.

Also, reorderListEntries and updateListEntryOrder contain the exact same code, reorderListEntries should be completely replaced with updateListEntryOrder and then removed (?).