### PR TITLE
Documented inverse dependencies for clearGitFiles and fetchOldToken.

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -154,8 +154,10 @@ This is a list of all inverse dependencies of files in the fileedService folder.
 This is a list of all inverse dependencies of files in the gitCommitService folder.
 
 ### clearGitFiles
+[refreshGithubRepo_ms.php](GitCommitService/refreshGithubRepo_ms.php)
 
 ### fetchOldToken
+No inverse dependencies
 
 ### getCourseID
 


### PR DESCRIPTION
Fixes #16729, no found for fetchOldToken, one for clearGitFiles.