### PR TITLE
Hopefully solution for disappearance of object elements when deleting attached lines

### DIFF
--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -177,6 +177,7 @@ function mdown(event) {
 function ddown(event) {
     // Mouse pressed over delete button for a single line over a element
     if (event.button == 0 && (contextLine.length > 0 || context.length > 0)) {
+        canPressDeleteBtn = true;
         hasPressedDelete = checkDeleteBtn();
     }
 
@@ -393,8 +394,14 @@ function checkDeleteBtn() {
         lastMousePos.y > deleteBtnY && lastMousePos.y < (deleteBtnY + deleteBtnSize)
     ) {
         if (canPressDeleteBtn) {
-            if (context.length > 0) removeElements(context);
-            if (contextLine.length > 0) removeLines(contextLine);
+            // Checks number of selected elements/objects and removes them
+            if (context.length > 0) {
+                removeElements(context);
+            }
+            // Checks number of selected lines and removes them
+            if (contextLine.length > 0) {
+                removeLines(contextLine);
+            }
             updateSelection(null);
             canPressDeleteBtn = false;
             return true;


### PR DESCRIPTION
There are two different mouseDown events that both check for clicks on the delete button but according to documentation one is for sole elements and the other is for deletions of multiple selected elements. Both called the _checkDeleteBtn()_ function that has a flag which is toggled between true and false if the conditions for a deletion are appeased. The problem seemed to be that one of the calls never toggled the boolean flag back to true and thus creating problems on every deletion except the first where the flag was initially true. The inconsistency of whether the class element was erased alongside the line might have been some kind of race condition, where the function with the actual flag toggle accidentally got through, that stemmed from the defective code. Hopefully this is now fixed by allowing both events to toggle the flag back to true when pressing the delete button. This would also explain why the problem never arose while using the keyboard's delete key but only while utilizing mouse click deletion.

https://github.com/user-attachments/assets/a37437e3-875a-4d29-b676-6dafe850539f


https://github.com/user-attachments/assets/1de58f33-f9a6-42d0-adf3-5d6fec2ad117

