### PR TITLE
Document inverse dependencies for bfs_ms.php and downloadToWebServer_ms.php

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -177,8 +177,10 @@ This is a list of all inverse dependencies of files in the gitCommitService fold
 This is a list of all inverse dependencies of files in the gitFetchService folder.
 
 ### bfs
+No inverse dependencies.
 
 ### downloadToWebServer
+No inverse dependencies.
 
 ### getGithubURL
 


### PR DESCRIPTION
Updated documentation for inverse dependencies for bfs_ms.php and downloadToWebServer_ms.php, none found. Fixes issue #16751 .