### PR TITLE
Documented inverse dependencies for getGithubURL and getIndexFile.

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -181,8 +181,10 @@ This is a list of all inverse dependencies of files in the gitFetchService folde
 ### downloadToWebServer
 
 ### getGithubURL
+No inverse dependencies
 
 ### getIndexFile
+No inverse dependencies
 
 ### insertToFileLink
 


### PR DESCRIPTION
Fixes #16752, no inverse dependencies found for either.