### PR TITLE
Documentation inverse dependencies for insertToFileLink_ms.php and insertToMetadata_ms.php

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -185,8 +185,10 @@ This is a list of all inverse dependencies of files in the gitFetchService folde
 ### getIndexFile
 
 ### insertToFileLink
+No inverse dependencies.
 
 ### insertToMetadata
+No inverse dependencies.
 
 ## highscoreService
 


### PR DESCRIPTION
Documented inverse dependencies for insertToFileLink_ms.php and insertToMetadata_ms.php. None found. Fixes issue #16753.