### PR TITLE
Documented inverse dependencies: refreshGithubRepo_ms.php AND retrieveGitCommitService_ms.php #16734

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -169,8 +169,10 @@ This is a list of all inverse dependencies of files in the gitCommitService fold
 ### refreshCheck
 
 ### refreshGithubRepo
+No inverse dependencies.
 
 ### retrieveGitCommitService
+No inverse dependencies.
 
 ## gitFetchService
 


### PR DESCRIPTION
Documented inverse dependencies: refreshGithubRepo_ms.php and retrieveGitCommitService_ms.php, found no inverse dependencies for neither of them. 

Fixes issue #16734.