### PR TITLE
Documented inverse dependencies: highscoreservice_ms.php AND retrieveHighscoreService_ms.php #16754

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -195,8 +195,10 @@ This is a list of all inverse dependencies of files in the gitFetchService folde
 This is a list of all inverse dependencies of files in the highscoreService folder.
 
 ### highscoreservice
+No inverse dependencies. (Not in use)
 
 ### retrieveHighscoreService
+- ..\highscoreService\highscoreservice_ms.php
 
 ## profileService
 


### PR DESCRIPTION
Document inverse dependencies: highscoreservice_ms.php and retrieveHighscoreService_ms.php, found one inverse dependency for retrieveHighscoreService_ms.php. 

Also discovered that highscoreservice_ms.php is not in use anymore. It's commented out in the code in dugga.js.(highscoreservice.php is used instead).

Fixes issue #16754