### PR TITLE
Options table fix

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -6,8 +6,16 @@ function generateContextProperties() {
     let str = '';
     const element = context[0];
     const line = contextLine[0];
+
+    if ((context.length > 0 || contextLine.length > 0) && (erTableToggle || testCaseToggle)) {
+        erTableToggle = false;
+        testCaseToggle = false;
+    }
+
     let propSet = document.getElementById("propertyFieldset");
     let menuSet = document.getElementsByClassName('options-section');
+
+    propSet.innerHTML = ""; 
 
     str += "<legend>Properties</legend>";
     if (context.length == 0 && contextLine.length == 0 && !erTableToggle && !testCaseToggle) {


### PR DESCRIPTION
Issue is now fixed, refreshing is not needed anymore, the ER or test case toggle does no longer get stuck once clicked, when they are clicked and an element afterwards is placed, selecting the pointer and clicking on the element will show **that** elements properties in the right options panel, and when deselected the regular options panel is shown. See Fixed version video below.


**Master:**


https://github.com/user-attachments/assets/9bc05afe-93cd-49a5-9d95-14e6991a0c82





**Fixed version**:


https://github.com/user-attachments/assets/bfa8f9c7-44c4-4def-a53d-d112718c5582



