### PR TITLE
Inverse dependencies: getShowDugga_ms.php & loadDugga_ms.php

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -476,8 +476,15 @@ There is no list of all inverse dependencies
 This is a list of all inverse dependencies of files in the showDuggaServices folder.
 
 ### getShowDugga
+No inverse dependencies.
 
 ### loadDugga
+[retrieveShowDuggaService_ms](showDuggaService/retrieveShowDuggaService_ms.php)
+Row 60:
+```
+if($hash!="UNK"){
+	include_once("loadDugga_ms.php");
+```
 
 ### processDuggaFile
 


### PR DESCRIPTION
Updated document with found inverse dependencies.

loadDugga had an inverse dependency inside of an if-statement in retrieveShowDuggaService_ms.php.  

Fixes issue #16793