### PR TITLE
Sanitized inputs #16782

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -229,6 +229,18 @@ function drawRect(w, h, l, e, extra = e.fill ? `fill='${e.fill}'` : `fill=#fffff
 }
 
 /**
+ * @description Strips everything from a string that could be html.
+ * @param {String} s String to be stripped of html.
+ * @returns Returns a html-free string.
+ */
+function stripHtml(str) {
+    if (typeof str !== 'string') return '';
+    const tmp = document.createElement('div');
+    tmp.innerHTML = str;
+    return tmp.textContent || tmp.innerText || '';
+}
+
+/**
  * @description Draw the text for the element.
  * @param {Number} x The X coordinate for the drawn text.
  * @param {Number} y The Y coordinate for the drawn text.
@@ -238,10 +250,11 @@ function drawRect(w, h, l, e, extra = e.fill ? `fill='${e.fill}'` : `fill=#fffff
  * @returns Returns a string containing a svg text for the element that is drawn.
  */
 function drawText(x, y, a, t, extra = '') {
+    const safeText = stripHtml(t);
     return `<text
                 class='text' x='${x}' y='${y}' 
                 dominant-baseline='auto' text-anchor='${a}' ${extra}
-            > ${t} </text>`;
+            > ${safeText} </text>`;
 }
 
 /**

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -229,17 +229,19 @@ function drawRect(w, h, l, e, extra = e.fill ? `fill='${e.fill}'` : `fill=#fffff
 }
 
 /**
- * @description Strips everything from a string that could be html.
- * @param {String} s String to be stripped of html.
+ * @description Escapes the html which removes problematic characters and replaces them with string-character.
+ * @param {String} str String to be escaped.
  * @returns Returns a html-free string.
  */
-function stripHtml(str) {
+function escapeHtml(str) {
     if (typeof str !== 'string') return '';
-    const tmp = document.createElement('div');
-    tmp.innerHTML = str;
-    return tmp.textContent || tmp.innerText || '';
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
 }
-
 /**
  * @description Draw the text for the element.
  * @param {Number} x The X coordinate for the drawn text.
@@ -250,7 +252,7 @@ function stripHtml(str) {
  * @returns Returns a string containing a svg text for the element that is drawn.
  */
 function drawText(x, y, a, t, extra = '') {
-    const safeText = stripHtml(t);
+    const safeText = escapeHtml(t);
     return `<text
                 class='text' x='${x}' y='${y}' 
                 dominant-baseline='auto' text-anchor='${a}' ${extra}

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -77,6 +77,18 @@ function showProperties(show, propSet, menuSet) {
 }
 
 /**
+ * @description Strips everything from a string that could be html.
+ * @param {String} s String to be stripped of html.
+ * @returns Returns a html-free string.
+ */
+function stripHtml(str) {
+    if (typeof str !== 'string') return '';
+    const tmp = document.createElement('div');
+    tmp.innerHTML = str;
+    return tmp.textContent || tmp.innerText || '';
+}
+
+/**
  * @description Makes a textarea to be able for example add new classes for UML.
  * @param {String} name Name for the header for the textarea.
  * @param {String} property What type of property the textarea is.
@@ -84,11 +96,12 @@ function showProperties(show, propSet, menuSet) {
  * @return Returns the div that is the header and the textarea for the specific element.
  */
 function textarea(name, property, element) {
+    const safeText = stripHtml(textboxFormatString(element[property]));
     return `<div style='color:${color.WHITE};'>${name}</div>
             <textarea 
                 id='elementProperty_${property}' 
                 rows='4' style='width:98%;resize:none;'
-            >${textboxFormatString(element[property])}</textarea>`;
+            >${textboxFormatString(safeText)}</textarea>`;
 }
 
 /**
@@ -97,11 +110,12 @@ function textarea(name, property, element) {
  * @return Returns the div that is the header and the text input.
  */
 function nameInput(element) {
+    const safeName = stripHtml(element.name);
     return `<div style='color:${color.WHITE};'>Name</div>
             <input 
                 id='elementProperty_name' 
                 type='text' 
-                value='${element.name}' 
+                value='${safeName}' 
             >`;
 }
 

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -77,17 +77,19 @@ function showProperties(show, propSet, menuSet) {
 }
 
 /**
- * @description Strips everything from a string that could be html.
- * @param {String} s String to be stripped of html.
+ * @description Escapes the html which removes problematic characters and replaces them with string-character.
+ * @param {String} str String to be escaped.
  * @returns Returns a html-free string.
  */
-function stripHtml(str) {
+function escapeHtml(str) {
     if (typeof str !== 'string') return '';
-    const tmp = document.createElement('div');
-    tmp.innerHTML = str;
-    return tmp.textContent || tmp.innerText || '';
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
 }
-
 /**
  * @description Makes a textarea to be able for example add new classes for UML.
  * @param {String} name Name for the header for the textarea.
@@ -96,7 +98,7 @@ function stripHtml(str) {
  * @return Returns the div that is the header and the textarea for the specific element.
  */
 function textarea(name, property, element) {
-    const safeText = stripHtml(textboxFormatString(element[property]));
+    const safeText = escapeHtml(textboxFormatString(element[property]));
     return `<div style='color:${color.WHITE};'>${name}</div>
             <textarea 
                 id='elementProperty_${property}' 
@@ -110,7 +112,7 @@ function textarea(name, property, element) {
  * @return Returns the div that is the header and the text input.
  */
 function nameInput(element) {
-    const safeName = stripHtml(element.name);
+    const safeName = escapeHtml(element.name);
     return `<div style='color:${color.WHITE};'>Name</div>
             <input 
                 id='elementProperty_name' 


### PR DESCRIPTION
Added a function that escapes strings with html-characters to normal string characters. Attempts to insert html code now simply inserts that code as strings instead. 

_The tag <script...> that would have previously be handled as code is now simply displayed as a string. This can also be seen in the console_
![image](https://github.com/user-attachments/assets/08bce03c-20e7-4827-b00b-b83c0939033c)
