### PR TITLE
A4 template title text size is now static

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1090,7 +1090,7 @@
     <!-- A4 template -->
     <div id="a4Template">
         <svg id="svgA4Template">
-            <rect id="a4Rect" x="100" y="100" />
+            <rect id="a4Rect" x="100" y="100"/>
             <rect id="vRect" x="100" y="100"/>
             <text id="a4Text" x="880" y="90">A4</text>
         </svg>  

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1091,7 +1091,7 @@
     <div id="a4Template">
         <svg id="svgA4Template">
             <rect id="a4Rect" x="100" y="100" />
-            <rect id="vRect" x="100" y="100"/>
+            <rect id="vRect" x="100" y="100"/>            
             <text id="a4Text" x="880" y="90">A4</text>
         </svg>  
     </div>  

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1091,7 +1091,7 @@
     <div id="a4Template">
         <svg id="svgA4Template">
             <rect id="a4Rect" x="100" y="100" />
-            <rect id="vRect" x="100" y="100"/>            
+            <rect id="vRect" x="100" y="100"/>
             <text id="a4Text" x="880" y="90">A4</text>
         </svg>  
     </div>  

--- a/DuggaSys/diagram/draw/update.js
+++ b/DuggaSys/diagram/draw/update.js
@@ -254,7 +254,7 @@ function updateA4Size() {
     const scaleFactor = a4Width * zoomfact * settings.grid.a4SizeFactor / 210; 
     
     // Apply the scale factor to the font size of the text
-    const fontSize = 32; 
+    const fontSize = 14; 
     const newFontSize = fontSize * scaleFactor; 
 
     // Apply the new font size to the text

--- a/DuggaSys/diagram/draw/update.js
+++ b/DuggaSys/diagram/draw/update.js
@@ -236,6 +236,8 @@ function updateGridPos() {
 function updateA4Size() {
     const rect = document.getElementById("a4Rect");
     const vRect = document.getElementById("vRect");
+    const text = document.getElementById("a4Text");
+
     const pxlength = (pixellength.offsetWidth / 1000) * window.devicePixelRatio;
     const a4Width = 210 * pxlength;   // Width for A4 paper in portrait mode
     const a4Height = 297 * pxlength;  // Height for A4 paper in portrait mode
@@ -248,6 +250,17 @@ function updateA4Size() {
     vRect.setAttribute("width", a4Height * zoomfact * settings.grid.a4SizeFactor + "px");
     vRect.setAttribute("height", a4Width * zoomfact * settings.grid.a4SizeFactor + "px");
 
+    // Calculate the scale factor for text size 
+    const scaleFactor = a4Width * zoomfact * settings.grid.a4SizeFactor / 210; 
+    
+    // Apply the scale factor to the font size of the text
+    const fontSize = 32; 
+    const newFontSize = fontSize * scaleFactor; 
+
+    // Apply the new font size to the text
+    text.setAttribute('font-size', newFontSize + "px");
+
+    // Update the position of the A4 elements 
     updateA4Pos();
 }
 


### PR DESCRIPTION
The A4 template title text scaled with zoom before. This added patch makes the title text static, which effectively solves the target issue. The aim for the issue was to make the title text static, since the A4 template size was static, the fix involved copying the code that scales the A4 accordingly with the current zoom-factor, and applying it in a similar manner to the text element.

0.5x zoom:
![image](https://github.com/user-attachments/assets/93bebb9f-f320-4939-ab4d-f69aa9246f11)

2x zoom: 
![image](https://github.com/user-attachments/assets/50fe03c6-2a30-4bdb-a767-554804efc85f)
