### PR TITLE
Fixed: You can't toggle the error check using its keybind

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -857,7 +857,7 @@ document.addEventListener('keyup', function (e) {
     if (isKeybindValid(e, keybinds.RESET_DIAGRAM)) resetDiagramAlert();
     if (isKeybindValid(e, keybinds.TOGGLE_TEST_CASE)) toggleTestCase();
 
-    //if(isKeybindValid(e, keybinds.TOGGLE_ERROR_CHECK)) toggleErrorCheck(); Note that this functionality has been moved to hideErrorCheck(); because special conditions apply.
+    if (isKeybindValid(e, keybinds.TOGGLE_ERROR_CHECK)) toggleErrorCheck();
 
     if (isKeybindValid(e, keybinds.COPY)) {
         // Remove the preivous copy-paste data from localstorage.


### PR DESCRIPTION
The solution was to place back the if-statement that sends the keybinds of toggle_error_check and if it is true then it executes the toggleErrorCheck() function. 

Fixed the issue: #16818