### PR TITLE
G3-2025-v3-#16336-delete-without-selection

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -654,9 +654,6 @@ function showSaveButton() {
 
 // Displaying and hiding the dynamic confirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
-
-  // it registrers both when clicking trashcan and selection trashcan - independent of selection or not.
-  // just displays popup.
   if (operation == "openConfirmBox") {
     active_lid = item ? $(item).parents('table').attr('value') : null;
     console.log('handling of one item?');
@@ -679,19 +676,20 @@ function confirmBox(operation, item = null) {
     $('#close-item-button').focus();
   } 
   else if (operation == "deleteItem") {
-    if(selectedItemList.length != 0){
-      console.log('selectedItemList: ' + selectedItemList);
-      console.log('activeLid (several): ' + active_lid);
-      deleteItem(selectedItemList);
-      document.getElementById("sectionConfirmBox").style.display = "none";
-    }
-    else{
-      console.log('selectedItemList: ' + selectedItemList);
+    //if done via trashcan (no selections)
+    if (selectedItemList == 0){
       console.log('activeLid (one): ' + active_lid);
-      selectedItemList.push(active_lid); // marks the "attached" item as selected
-      deleteItem(selectedItemList);
-      document.getElementById("sectionConfirmBox").style.display = "none";
+      selectedItemList.push(active_lid); // mark the "attached" item as selected
+      console.log('selectedItemList: ' + selectedItemList);
     }
+    // for debugging purposes (since selection already works)
+    else{
+      console.log('selectedItemList: ' + selectedItemList); 
+      console.log('activeLid (several): ' + active_lid);
+    }
+    
+    deleteItem(selectedItemList);
+    document.getElementById("sectionConfirmBox").style.display = "none";
   } 
   else if (operation == "hideItem" && !selectedItemList.length == 0) {
     hideMarkedItems(selectedItemList)

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -652,15 +652,17 @@ function showSaveButton() {
   $(".closeDugga").css("display", "block");
 }
 
-// Displaying and hidding the dynamic comfirmbox for the section edit dialog
+// Displaying and hiding the dynamic confirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
 
-  // it registrers both when clicking trashcan and selection trashcan
+  // it registrers both when clicking trashcan and selection trashcan - independent of selection or not.
+  // just displays popup.
   if (operation == "openConfirmBox") {
     active_lid = item ? $(item).parents('table').attr('value') : null;
-    selectedItemList.push(active_lid);
+    console.log('handling of one item?');
     console.log('active lid: ' + active_lid)
-    $("#sectionConfirmBox").css("display", "flex");
+    //$("#sectionConfirmBox").css("display", "flex");
+    document.getElementById("sectionConfirmBox").style.display = "flex";
   } 
   else if (operation == "openHideConfirmBox") {
     active_lid = item ? $(item).parents('table').attr('value') : null;
@@ -675,14 +677,21 @@ function confirmBox(operation, item = null) {
   else if (operation == "openItemsConfirmBox") {
     $("#sectionShowConfirmBox").css("display", "flex");
     $('#close-item-button').focus();
-
-    // something within this function is not working properly. When pressing the trash without selection,
-    // it doesn't have a selected item. So something that's calling this, doesn't include the items when calling
-    // from the trash.
-  } else if (operation == "deleteItem") {
-    console.log('selectedItemList: ' + selectedItemList)
-    deleteItem(selectedItemList);
-    document.getElementById("sectionConfirmBox").style.display = "none";
+  } 
+  else if (operation == "deleteItem") {
+    if(selectedItemList.length != 0){
+      console.log('selectedItemList: ' + selectedItemList);
+      console.log('activeLid (several): ' + active_lid);
+      deleteItem(selectedItemList);
+      document.getElementById("sectionConfirmBox").style.display = "none";
+    }
+    else{
+      console.log('selectedItemList: ' + selectedItemList);
+      console.log('activeLid (one): ' + active_lid);
+      selectedItemList.push(active_lid); // marks the "attached" item as selected
+      deleteItem(selectedItemList);
+      document.getElementById("sectionConfirmBox").style.display = "none";
+    }
   } 
   else if (operation == "hideItem" && !selectedItemList.length == 0) {
     hideMarkedItems(selectedItemList)
@@ -771,8 +780,8 @@ function markedItems(item = null) {
 
   }
 
-
-  console.log("Active lid: " + active_lid);
+  // handles selections
+  console.log("Active lid (SELECTION): " + active_lid);
   if (selectedItemList.length != 0) {
     for (let i = 0; i < selectedItemList.length; i++) {
       if (selectedItemList[i] === active_lid) {
@@ -799,7 +808,6 @@ function markedItems(item = null) {
     }
   } else {
     selectedItemList.push(active_lid);
-    console.log("Added");
     for (var j = 0; j < subItems.length; j++) {
       selectedItemList.push(subItems[j]);
     }
@@ -814,6 +822,7 @@ function markedItems(item = null) {
   }
   if (selectedItemList.length == 0) {
     // Disable ghost button when no checkboxes is checked
+    console.log('no element selected');
     document.querySelector('#hideElement').disabled = true;
     document.querySelector('#hideElement').style.opacity = 0.7;
     hideVisibilityIcons();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -765,32 +765,43 @@ function markedItems(item = null, typeInput) {
         }
       } else if (tempItem == active_lid) sectionStart = true;
     });
+    //console.log('subItems contains (0.1): ' + subItems);
 
   }
 
   // handles selections
-  console.log("Active lid (SELECTION): " + active_lid);
-  console.log('selectedItemList contains: ' + selectedItemList);
+  //console.log("Active lid (SELECTION): " + active_lid);
+  //console.log('selectedItemList contains: ' + selectedItemList);
 
   if (selectedItemList.length != 0) {
-    for (let i = 0; i < selectedItemList.length; i++) {
+    //console.log('subItems contains (1.1): ' + subItems);
+    let tempSelectedItemListLength = selectedItemList.length;
+    for (let i = 0; i < tempSelectedItemListLength; i++) {
+
       //removes items from selectedItemList, avoided if called via non-section trashcan.
-      console.log('typeinput: ' + typeInput);
+
       if (selectedItemList[i] === active_lid && typeInput != "trash") {
+        //document.getElementById(selectedItemList[i] + "-checkbox").setAttribute("checked", false);
+
+        console.log(selectedItemList[i] + " Removed from list (1)");
         $("#" + selectedItemList[i] + "-checkbox").prop("checked", false);
         selectedItemList.splice(i, 1);
-        i--;
         var removed = true;
-        console.log(selectedItemList[i] + " Removed from list (1)");
       }
       //unchecks children of section
       for (var j = 0; j < subItems.length; j++) {
-        if (selectedItemList[i] === subItems[j]) {
+        if (selectedItemList[i] == subItems[j]) {
+          //document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
+
           $("#" + selectedItemList[i] + "-checkbox").prop("checked", false);
+          //console.log('comparing: ' + selectedItemList[i] + ' and ' + subItems);
+          //console.log('Removes: ' + selectedItemList[i] + 'selected list: ' + selectedItemList);
           selectedItemList.splice(i, 1);
-          console.log(subItems[j]+" Removed from list (2)");
+          i--;
         }
       }
+      //console.log("selecteditem pos: " + i);
+      //console.log('subItems contains (1.2): ' + subItems);
     } 
     
     if (removed != true) {
@@ -799,30 +810,33 @@ function markedItems(item = null, typeInput) {
 
     for (var k = 0; k < selectedItemList.length; k++) {
       if(active_lid == selectedItemList[k]){
-        console.log('activeLid exist in list');
+        //console.log('activeLid exist in list');
         activeLidInList = true;
         break;
       }
     }
     
     if (activeLidInList == false){
-      console.log('activeLid does not exist within list');
+      //console.log('activeLid does not exist within list');
       selectedItemList.push(active_lid);
       $("#" + active_lid + "-checkbox").prop("checked", true);
-      console.log('selectedItemList contains (2.2): ' + selectedItemList);
+
+      //console.log('subItems contains (2.2): ' + subItems);
+      //console.log('selectedItemList contains (2.2): ' + selectedItemList);
     }
 
-      console.log("Adding !empty list");
+      //console.log("Adding !empty list");
 
       //handles checking within section
       for (var j = 0; j < subItems.length; j++) {
         selectedItemList.push(subItems[j]);
-        console.log('subitems item: ' + subItems[j]);
+        //console.log('subitems item: ' + subItems[j]);
 
         $("#" + subItems[j] + "-checkbox").prop("checked", true);
       }
     }
-      console.log('selectedItemList contains (2.3): ' + selectedItemList);
+      //console.log('subItems contains (2.3): ' + subItems);
+      //console.log('selectedItemList contains (2.3): ' + selectedItemList);
   } 
   // adds everything under section to selectedItems (if nothing selected beforehand)
   else {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2008,15 +2008,26 @@ function returnedSection(data) {
           str += `<img style='filter: invert(1);' class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
           src='../Shared/icons/Trashcan.svg' onclick='confirmBox(\"openConfirmBox\", this);'>`;
           str += "</td>";
+          // str += "onclick='console.log(\"RefreshButton Clicked!\");'"
         }
         
         // Trashcan -> opens poppup.
-        if (itemKind !== 0 && data['writeaccess'] || data['studentteacher']) {
+        if (itemKind !== 0 && itemKind !== 1 && data['writeaccess'] || data['studentteacher']) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick='confirmBox(\"openConfirmBox\", this);'>`;
+          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Trashcan Clicked!\");'>`;
+          str += "</td>";  
+          //onclick='confirmBox(\"openConfirmBox\", this);'>`
+        }
+
+        if (itemKind === 1 && data['writeaccess'] || data['studentteacher']){
+          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+          str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
+          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Trashcan Clicked from item kind 1!\");'>`;
           str += "</td>";
+
         }
 
         // Checkbox

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -742,22 +742,22 @@ function gitTemplatePopupOutsideClickHandler(){
 // Creates an array over all checked items
 function markedItems(item = null, typeInput) {
   var removed = false;
-  var kind = item ? $(item).parents('tr').attr('value') : null;
-  active_lid = item ? $(item).parents('table').attr('value') : null;
+  var kind = item ? item.closest('tr').getAttribute('value'): null;
+  active_lid = item ? item.closest('table').getAttribute('value'): null;
   var subItems = [];
-
-  console.log('typeinput: ' + typeInput);
-  console.log('item: ' + item);
 
   //if the checkbox belongs to one of these kinds then all elements below it should also be selected.
   if (kind == "section" || kind == "moment") {
     var itemInSection = true;
     var sectionStart = false;
     $("#Sectionlist").find(".item").each(function (i) {
-      var tempItem = $(this).attr('value');
+      var tempItem = this.getAttribute('value');
+
       if (itemInSection && sectionStart) {
         var tempDisplay = document.getElementById("lid" + tempItem).style.display;
-        var tempKind = $(this).parents('tr').attr('value');
+        var tempKind = this ? this.closest('tr').getAttribute('value'): null;
+
+
         if (tempDisplay != "none" && (tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
           itemInSection = false;
         } else {
@@ -765,79 +765,49 @@ function markedItems(item = null, typeInput) {
         }
       } else if (tempItem == active_lid) sectionStart = true;
     });
-    //console.log('subItems contains (0.1): ' + subItems);
-
   }
 
   // handles selections
-  //console.log("Active lid (SELECTION): " + active_lid);
-  //console.log('selectedItemList contains: ' + selectedItemList);
-
   if (selectedItemList.length != 0) {
-    //console.log('subItems contains (1.1): ' + subItems);
     let tempSelectedItemListLength = selectedItemList.length;
     for (let i = 0; i < tempSelectedItemListLength; i++) {
 
       //removes items from selectedItemList, avoided if called via non-section trashcan.
-
       if (selectedItemList[i] === active_lid && typeInput != "trash") {
-        //document.getElementById(selectedItemList[i] + "-checkbox").setAttribute("checked", false);
-
-        console.log(selectedItemList[i] + " Removed from list (1)");
-        $("#" + selectedItemList[i] + "-checkbox").prop("checked", false);
+        document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
         selectedItemList.splice(i, 1);
         var removed = true;
       }
       //unchecks children of section
       for (var j = 0; j < subItems.length; j++) {
         if (selectedItemList[i] == subItems[j]) {
-          //document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
-
-          $("#" + selectedItemList[i] + "-checkbox").prop("checked", false);
-          //console.log('comparing: ' + selectedItemList[i] + ' and ' + subItems);
-          //console.log('Removes: ' + selectedItemList[i] + 'selected list: ' + selectedItemList);
+          document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
           selectedItemList.splice(i, 1);
           i--;
         }
       }
-      //console.log("selecteditem pos: " + i);
-      //console.log('subItems contains (1.2): ' + subItems);
     } 
     
     if (removed != true) {
-    console.log('selectedItemList contains (2.1): ' + selectedItemList);
-    let activeLidInList = false;
-
-    for (var k = 0; k < selectedItemList.length; k++) {
-      if(active_lid == selectedItemList[k]){
-        //console.log('activeLid exist in list');
-        activeLidInList = true;
-        break;
+      let activeLidInList = false;
+      for (var k = 0; k < selectedItemList.length; k++) {
+        if(active_lid == selectedItemList[k]){
+          activeLidInList = true;
+          break;
+        }
       }
+      if (activeLidInList == false){
+        selectedItemList.push(active_lid);
+        document.getElementById(active_lid + "-checkbox").checked = true;
     }
-    
-    if (activeLidInList == false){
-      //console.log('activeLid does not exist within list');
-      selectedItemList.push(active_lid);
-      $("#" + active_lid + "-checkbox").prop("checked", true);
-
-      //console.log('subItems contains (2.2): ' + subItems);
-      //console.log('selectedItemList contains (2.2): ' + selectedItemList);
-    }
-
-      //console.log("Adding !empty list");
-
       //handles checking within section
       for (var j = 0; j < subItems.length; j++) {
         selectedItemList.push(subItems[j]);
-        //console.log('subitems item: ' + subItems[j]);
-
-        $("#" + subItems[j] + "-checkbox").prop("checked", true);
+        document.getElementById(subItems[j] + "-checkbox").checked = true;
       }
     }
-      //console.log('subItems contains (2.3): ' + subItems);
-      //console.log('selectedItemList contains (2.3): ' + selectedItemList);
   } 
+  
   // adds everything under section to selectedItems (if nothing selected beforehand)
   else {
     console.log('selectedItemList contains (3.1): ' + selectedItemList);
@@ -846,14 +816,13 @@ function markedItems(item = null, typeInput) {
       selectedItemList.push(subItems[j]);
     }
     for (i = 0; i < selectedItemList.length; i++) {
-      $("#" + selectedItemList[i] + "-checkbox").prop("checked", true);
+      document.getElementById(selectedItemList[i] + "-checkbox").checked = true;
       //console.log(hideItemList[i]+"-checkbox");
     }
     // Show ghost button when checkbox is checked
     document.querySelector('#hideElement').disabled = false;
     document.querySelector('#hideElement').style.opacity = 1;
     showVisibilityIcons();
-    console.log('selectedItemList contains (3.2): ' + selectedItemList);
   }
   if (selectedItemList.length == 0) {
     // Disable ghost button when no checkboxes is checked
@@ -861,7 +830,6 @@ function markedItems(item = null, typeInput) {
     document.querySelector('#hideElement').disabled = true;
     document.querySelector('#hideElement').style.opacity = 0.7;
     hideVisibilityIcons();
-
   }
 }
 
@@ -2045,7 +2013,6 @@ function returnedSection(data) {
           str += `<img style='filter: invert(1);' class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
           src='../Shared/icons/Trashcan.svg' onclick='confirmBox(\"openConfirmBox\", this);'>`;
           str += "</td>";
-          // str += "onclick='console.log(\"RefreshButton Clicked!\");'"
         }
         
         // Trashcan for items
@@ -2057,17 +2024,14 @@ function returnedSection(data) {
             str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
               "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
             str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-            src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Section trashcan clicked and lenght!\"  + this + selectedItemList.length); 
-            if(selectedItemList.length == 0){markedItems(this, "trash")}; 
-            confirmBox(\"openConfirmBox\", this); '>`;
+            src='../Shared/icons/Trashcan.svg' onclick='; if(selectedItemList.length == 0){markedItems(this, "trash")}; confirmBox(\"openConfirmBox\", this); '>`;
             str += "</td>";
           }
           else{
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"General trashcan clicked!\"  + this); 
-          markedItems(this, "trash"); confirmBox(\"openConfirmBox\", this); '>`;
+          src='../Shared/icons/Trashcan.svg' onclick=' markedItems(this, "trash"); confirmBox(\"openConfirmBox\", this); '>`;
           str += "</td>";  
           } 
         }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -31,6 +31,7 @@ var isLoggedIn = false;
 var inputColorTheme;
 let showHidden = true;
 let count = 0;
+let retrievedItemType;
 
 function initInputColorTheme() {
   if(localStorage.getItem('themeBlack').includes('blackTheme')){
@@ -654,11 +655,14 @@ function showSaveButton() {
 
 // Displaying and hiding the dynamic confirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
+
   if (operation == "openConfirmBox") {
+    retrievedItemType = item ? $(item).parents('tr').attr('value') : null;
+    console.log('(configuration box) itemType: ' + retrievedItemType );
+
     active_lid = item ? $(item).parents('table').attr('value') : null;
-    console.log('handling of one item?');
+
     console.log('active lid: ' + active_lid)
-    //$("#sectionConfirmBox").css("display", "flex");
     document.getElementById("sectionConfirmBox").style.display = "flex";
   } 
   else if (operation == "openHideConfirmBox") {
@@ -677,11 +681,19 @@ function confirmBox(operation, item = null) {
   } 
   else if (operation == "deleteItem") {
     //if done via trashcan (no selections)
+    
     if (selectedItemList == 0){
-      console.log('activeLid (one): ' + active_lid);
-      selectedItemList.push(active_lid); // mark the "attached" item as selected
-      console.log('selectedItemList: ' + selectedItemList);
+      console.log('gets here')
+      if (retrievedItemType == "section"){
+        console.log('registered section trash - not handled atm.')
+        // should then not delete yet, but select all.
+      }
+      else if (retrievedItemType != "section"){
+        console.log('registered general trash')
+        selectedItemList.push(active_lid); // mark the "attached" item as selected
+      }
     }
+
     // for debugging purposes (since selection already works)
     else{
       console.log('selectedItemList: ' + selectedItemList); 
@@ -2011,21 +2023,22 @@ function returnedSection(data) {
           // str += "onclick='console.log(\"RefreshButton Clicked!\");'"
         }
         
-        // Trashcan -> opens poppup.
+        // Trashcan for items
         if (itemKind !== 0 && itemKind !== 1 && data['writeaccess'] || data['studentteacher']) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Trashcan Clicked!\");'>`;
+          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"General trashcan clicked!\"  + this); confirmBox(\"openConfirmBox\", this); '>`;
           str += "</td>";  
           //onclick='confirmBox(\"openConfirmBox\", this);'>`
         }
-
+        
+        // Trashcan for sections
         if (itemKind === 1 && data['writeaccess'] || data['studentteacher']){
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Trashcan Clicked from item kind 1!\");'>`;
+          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Section trashcan clicked!\" + this); confirmBox(\"openConfirmBox\", this);'>`;
           str += "</td>";
 
         }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -654,27 +654,41 @@ function showSaveButton() {
 
 // Displaying and hidding the dynamic comfirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
+
+  // it registrers both when clicking trashcan and selection trashcan
   if (operation == "openConfirmBox") {
     active_lid = item ? $(item).parents('table').attr('value') : null;
+    selectedItemList.push(active_lid);
+    console.log('active lid: ' + active_lid)
     $("#sectionConfirmBox").css("display", "flex");
-  } else if (operation == "openHideConfirmBox") {
+  } 
+  else if (operation == "openHideConfirmBox") {
     active_lid = item ? $(item).parents('table').attr('value') : null;
     $("#sectionHideConfirmBox").css("display", "flex");
     $('#close-item-button').focus();
-  } else if (operation == "openTabConfirmBox") {
+  } 
+  else if (operation == "openTabConfirmBox") {
     active_lid = item ? $(item).parents('table').attr('value') : null;
     $("#tabConfirmBox").css("display", "flex");
     $("#tabs").val(0).change();
-  } else if (operation == "openItemsConfirmBox") {
+  } 
+  else if (operation == "openItemsConfirmBox") {
     $("#sectionShowConfirmBox").css("display", "flex");
     $('#close-item-button').focus();
+
+    // something within this function is not working properly. When pressing the trash without selection,
+    // it doesn't have a selected item. So something that's calling this, doesn't include the items when calling
+    // from the trash.
   } else if (operation == "deleteItem") {
+    console.log('selectedItemList: ' + selectedItemList)
     deleteItem(selectedItemList);
     document.getElementById("sectionConfirmBox").style.display = "none";
-  } else if (operation == "hideItem" && !selectedItemList.length == 0) {
+  } 
+  else if (operation == "hideItem" && !selectedItemList.length == 0) {
     hideMarkedItems(selectedItemList)
     $("#sectionHideConfirmBox").css("display", "none");
-  } else if (operation == "tabItem") {
+  } 
+  else if (operation == "tabItem") {
     tabMarkedItems(active_lid);
     $("#tabConfirmBox").css("display", "none");
   }
@@ -1988,8 +2002,8 @@ function returnedSection(data) {
           src='../Shared/icons/Trashcan.svg' onclick='confirmBox(\"openConfirmBox\", this);'>`;
           str += "</td>";
         }
-
-        // Trashcan
+        
+        // Trashcan -> opens poppup.
         if (itemKind !== 0 && data['writeaccess'] || data['studentteacher']) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -658,23 +658,12 @@ function confirmBox(operation, item = null) {
   let retrievedItemType;
 
   if (operation == "openConfirmBox") {
-    
-    retrievedItemType = item ? item.closest('tr').getAttribute('value'): null;
     active_lid = item ? item.closest('table').getAttribute('value') : null
-    
-    console.log('what is value of item parent?: ' + item.closest('tr').getAttribute('value'));
-    
-    if(retrievedItemType != "code" && selectedItemList.length == 0){
-      markedItems(item)
+   
+    if(selectedItemList.length == 0){
+      //markedItems(item);
+      //selectedItemList.push(active_lid);
     }
-    else if(selectedItemList.length == 0){
-      selectedItemList.push(active_lid);
-    }
-
-    console.log('(configuration box) itemType: ' + retrievedItemType );
-    console.log('selected item list: ' + selectedItemList)
-    console.log('active lid: ' + active_lid)
-
     document.getElementById("sectionConfirmBox").style.display = "flex";
   } 
   else if (operation == "openHideConfirmBox") {
@@ -2018,23 +2007,26 @@ function returnedSection(data) {
         
         // Trashcan for items
         if (itemKind !== 0  && data['writeaccess'] || data['studentteacher']) {
-          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"General trashcan clicked!\"  + this); confirmBox(\"openConfirmBox\", this); '>`;
-          str += "</td>";  
-          //onclick='confirmBox(\"openConfirmBox\", this);'>`
-        }
-        
-        /*// Trashcan for sections
-        if (itemKind === 1 && data['writeaccess'] || data['studentteacher']){
-          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Section trashcan clicked!\" + this); confirmBox(\"openConfirmBox\", this);'>`;
-          str += "</td>";
 
-        }*/
+          // Will run marked items independent of lenght
+          console.log('selectedItemList: ' + selectedItemList.length);
+          if (itemKind === 1 && selectedItemList.length == 0){
+            str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+              "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+            str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
+            src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Section trashcan clicked and lenght!\"  + this + selectedItemList.length); 
+            if(selectedItemList.length == 0){markedItems(this)}; 
+            confirmBox(\"openConfirmBox\", this); '>`;
+            str += "</td>";
+          }
+          else{
+          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+          str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
+          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"General trashcan clicked!\"  + this); markedItems(this); confirmBox(\"openConfirmBox\", this); '>`;
+          str += "</td>";  
+          } 
+        }
 
         // Checkbox
         if (data['writeaccess'] || data['studentteacher']) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -810,7 +810,6 @@ function markedItems(item = null, typeInput) {
   
   // adds everything under section to selectedItems (if nothing selected beforehand)
   else {
-    console.log('selectedItemList contains (3.1): ' + selectedItemList);
     selectedItemList.push(active_lid);
     for (var j = 0; j < subItems.length; j++) {
       selectedItemList.push(subItems[j]);

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -31,7 +31,7 @@ var isLoggedIn = false;
 var inputColorTheme;
 let showHidden = true;
 let count = 0;
-let retrievedItemType;
+//let retrievedItemType;
 
 function initInputColorTheme() {
   if(localStorage.getItem('themeBlack').includes('blackTheme')){
@@ -655,14 +655,26 @@ function showSaveButton() {
 
 // Displaying and hiding the dynamic confirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
+  let retrievedItemType;
 
   if (operation == "openConfirmBox") {
-    retrievedItemType = item ? $(item).parents('tr').attr('value') : null;
+    
+    retrievedItemType = item ? item.closest('tr').getAttribute('value'): null;
+    active_lid = item ? item.closest('table').getAttribute('value') : null
+    
+    console.log('what is value of item parent?: ' + item.closest('tr').getAttribute('value'));
+    
+    if(retrievedItemType != "code" && selectedItemList.length == 0){
+      markedItems(item)
+    }
+    else if(selectedItemList.length == 0){
+      selectedItemList.push(active_lid);
+    }
+
     console.log('(configuration box) itemType: ' + retrievedItemType );
-
-    active_lid = item ? $(item).parents('table').attr('value') : null;
-
+    console.log('selected item list: ' + selectedItemList)
     console.log('active lid: ' + active_lid)
+
     document.getElementById("sectionConfirmBox").style.display = "flex";
   } 
   else if (operation == "openHideConfirmBox") {
@@ -680,26 +692,6 @@ function confirmBox(operation, item = null) {
     $('#close-item-button').focus();
   } 
   else if (operation == "deleteItem") {
-    //if done via trashcan (no selections)
-    
-    if (selectedItemList == 0){
-      console.log('gets here')
-      if (retrievedItemType == "section"){
-        console.log('registered section trash - not handled atm.')
-        // should then not delete yet, but select all.
-      }
-      else if (retrievedItemType != "section"){
-        console.log('registered general trash')
-        selectedItemList.push(active_lid); // mark the "attached" item as selected
-      }
-    }
-
-    // for debugging purposes (since selection already works)
-    else{
-      console.log('selectedItemList: ' + selectedItemList); 
-      console.log('activeLid (several): ' + active_lid);
-    }
-    
     deleteItem(selectedItemList);
     document.getElementById("sectionConfirmBox").style.display = "none";
   } 
@@ -724,7 +716,8 @@ function confirmBox(operation, item = null) {
     $("#gitHubTemplate").css("display", "flex");
     gitTemplatePopupOutsideClickHandler();
     fetchCodeExampleHiddenLinkParam(item);
-  } else if (operation == "closeConfirmBox") {
+  } 
+  else if (operation == "closeConfirmBox") {
     $("#gitHubBox").css("display", "none");
     $("#gitHubTemplate").css("display", "none"); // ändra till githubtemplate
     $("#sectionConfirmBox").css("display", "none");
@@ -2024,7 +2017,7 @@ function returnedSection(data) {
         }
         
         // Trashcan for items
-        if (itemKind !== 0 && itemKind !== 1 && data['writeaccess'] || data['studentteacher']) {
+        if (itemKind !== 0  && data['writeaccess'] || data['studentteacher']) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
@@ -2033,7 +2026,7 @@ function returnedSection(data) {
           //onclick='confirmBox(\"openConfirmBox\", this);'>`
         }
         
-        // Trashcan for sections
+        /*// Trashcan for sections
         if (itemKind === 1 && data['writeaccess'] || data['studentteacher']){
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
@@ -2041,7 +2034,7 @@ function returnedSection(data) {
           src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Section trashcan clicked!\" + this); confirmBox(\"openConfirmBox\", this);'>`;
           str += "</td>";
 
-        }
+        }*/
 
         // Checkbox
         if (data['writeaccess'] || data['studentteacher']) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -655,15 +655,8 @@ function showSaveButton() {
 
 // Displaying and hiding the dynamic confirmbox for the section edit dialog
 function confirmBox(operation, item = null) {
-  let retrievedItemType;
-
   if (operation == "openConfirmBox") {
     active_lid = item ? item.closest('table').getAttribute('value') : null
-   
-    if(selectedItemList.length == 0){
-      //markedItems(item);
-      //selectedItemList.push(active_lid);
-    }
     document.getElementById("sectionConfirmBox").style.display = "flex";
   } 
   else if (operation == "openHideConfirmBox") {
@@ -747,11 +740,14 @@ function gitTemplatePopupOutsideClickHandler(){
   });
 }
 // Creates an array over all checked items
-function markedItems(item = null) {
+function markedItems(item = null, typeInput) {
   var removed = false;
   var kind = item ? $(item).parents('tr').attr('value') : null;
   active_lid = item ? $(item).parents('table').attr('value') : null;
   var subItems = [];
+
+  console.log('typeinput: ' + typeInput);
+  console.log('item: ' + item);
 
   //if the checkbox belongs to one of these kinds then all elements below it should also be selected.
   if (kind == "section" || kind == "moment") {
@@ -774,31 +770,63 @@ function markedItems(item = null) {
 
   // handles selections
   console.log("Active lid (SELECTION): " + active_lid);
+  console.log('selectedItemList contains: ' + selectedItemList);
+
   if (selectedItemList.length != 0) {
     for (let i = 0; i < selectedItemList.length; i++) {
-      if (selectedItemList[i] === active_lid) {
+      //removes items from selectedItemList, avoided if called via non-section trashcan.
+      console.log('typeinput: ' + typeInput);
+      if (selectedItemList[i] === active_lid && typeInput != "trash") {
+        $("#" + selectedItemList[i] + "-checkbox").prop("checked", false);
         selectedItemList.splice(i, 1);
         i--;
         var removed = true;
-        console.log("Removed from list");
+        console.log(selectedItemList[i] + " Removed from list (1)");
       }
+      //unchecks children of section
       for (var j = 0; j < subItems.length; j++) {
         if (selectedItemList[i] === subItems[j]) {
           $("#" + selectedItemList[i] + "-checkbox").prop("checked", false);
           selectedItemList.splice(i, 1);
-          //console.log(subItems[j]+" Removed from list");
+          console.log(subItems[j]+" Removed from list (2)");
         }
       }
-    } if (removed != true) {
+    } 
+    
+    if (removed != true) {
+    console.log('selectedItemList contains (2.1): ' + selectedItemList);
+    let activeLidInList = false;
+
+    for (var k = 0; k < selectedItemList.length; k++) {
+      if(active_lid == selectedItemList[k]){
+        console.log('activeLid exist in list');
+        activeLidInList = true;
+        break;
+      }
+    }
+    
+    if (activeLidInList == false){
+      console.log('activeLid does not exist within list');
       selectedItemList.push(active_lid);
+      $("#" + active_lid + "-checkbox").prop("checked", true);
+      console.log('selectedItemList contains (2.2): ' + selectedItemList);
+    }
+
       console.log("Adding !empty list");
+
+      //handles checking within section
       for (var j = 0; j < subItems.length; j++) {
         selectedItemList.push(subItems[j]);
-        console.log(subItems[j]);
+        console.log('subitems item: ' + subItems[j]);
+
         $("#" + subItems[j] + "-checkbox").prop("checked", true);
       }
     }
-  } else {
+      console.log('selectedItemList contains (2.3): ' + selectedItemList);
+  } 
+  // adds everything under section to selectedItems (if nothing selected beforehand)
+  else {
+    console.log('selectedItemList contains (3.1): ' + selectedItemList);
     selectedItemList.push(active_lid);
     for (var j = 0; j < subItems.length; j++) {
       selectedItemList.push(subItems[j]);
@@ -811,6 +839,7 @@ function markedItems(item = null) {
     document.querySelector('#hideElement').disabled = false;
     document.querySelector('#hideElement').style.opacity = 1;
     showVisibilityIcons();
+    console.log('selectedItemList contains (3.2): ' + selectedItemList);
   }
   if (selectedItemList.length == 0) {
     // Disable ghost button when no checkboxes is checked
@@ -2015,7 +2044,7 @@ function returnedSection(data) {
               "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
             str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
             src='../Shared/icons/Trashcan.svg' onclick='console.log(\"Section trashcan clicked and lenght!\"  + this + selectedItemList.length); 
-            if(selectedItemList.length == 0){markedItems(this)}; 
+            if(selectedItemList.length == 0){markedItems(this, "trash")}; 
             confirmBox(\"openConfirmBox\", this); '>`;
             str += "</td>";
           }
@@ -2023,7 +2052,8 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"General trashcan clicked!\"  + this); markedItems(this); confirmBox(\"openConfirmBox\", this); '>`;
+          src='../Shared/icons/Trashcan.svg' onclick='console.log(\"General trashcan clicked!\"  + this); 
+          markedItems(this, "trash"); confirmBox(\"openConfirmBox\", this); '>`;
           str += "</td>";  
           } 
         }

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -379,7 +379,7 @@
 
 				<!-- Error message, no duggas present-->
 				<div class="formFooter">
-					<input class='submit-button deleteDugga' type='button' value='Delete' onclick='deleteItem();' />
+					<!--<input class='submit-button deleteDugga' type='button' value='Delete' onclick='deleteItem();' />-->
 					<input class='submit-button closeDugga' type='button' value='Cancel' onclick='closeWindows(); closeSelect();' />
 					<input id="submitBtn" class='submit-button submitDugga' type='button' value='Submit' onclick='newItem(); showSaveButton();' />
 					<input id="saveBtn" onmouseover='quickValidateForm("editSection", "saveBtn");' class='submit-button updateDugga' type='button' value='Save' onclick='validateForm("editSection"); clearHideItemList();' />
@@ -403,6 +403,7 @@
 		</div>
 	</div>
 	
+	<!-- Handles the confirmation box popup from delete button -->
 	<script type="text/babel">
 		function ConfirmButtons() {
 			return (


### PR DESCRIPTION
Fixed trashcan by calling the markedItems function to select listItems before deletion. Also had to fix selection since it had some bugs when solo-trash was introduced as well as beforehand. You can now select several section-headers & only affect the right section - and solo-trash will not affect the selection. Section trashcan (marked with red) will now select everything in the section when pressed. Solo trashcan will only select the list item which it was pressed on.
![bild](https://github.com/user-attachments/assets/12b267ae-58ef-47b2-8133-fd654a0c8926)