### PR TITLE
Fixed: The keybinding for toggling the keybind list is not working

### DIFF
--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -39,7 +39,7 @@ const keybinds = {
     MOVING_OBJECT_DOWN: { key: "ArrowDown", ctrl: false },
     MOVING_OBJECT_LEFT: { key: "ArrowLeft", ctrl: false },
     MOVING_OBJECT_RIGHT: { key: "ArrowRight", ctrl: false },
-    TOGGLE_KEYBINDLIST: { key: "F1", ctrl: false },
+    TOGGLE_KEYBINDLIST: { key: "F1", ctrl: true },
     TOGGLE_REPLAY_MODE: { key: "r", ctrl: false },
     TOGGLE_ER_TABLE: { key: "e", ctrl: false },
     TOGGLE_TEST_CASE: { key: "u", ctrl: false },

--- a/DuggaSys/diagramkeybinds.md
+++ b/DuggaSys/diagramkeybinds.md
@@ -42,7 +42,7 @@
 - Copy elements or lines = CTRL + ”C”
 - Paste elements or lines = CTRL + ”V”
 - Mark all elements and lines = CTRL + ”A”
-- Toggle keybindlist - ”F1”
+- Toggle keybindlist - ”F1 + CTRL”
 
 
 ## ER-Table


### PR DESCRIPTION
The solution was to alter the keybind for toggling the keybind list by changing ctrl from false to true. So, when you press f1 + ctrl, then the keybind list should toggle. Also changed the instruction on keybind list document so the keybind matches with the list. I have also tested the remainder of the keybind. 

Fixed the issue: #16848 