### PR TITLE
refactor(gitCommitService): replace legacy includes with cURL-based

### DIFF
--- a/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php
+++ b/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php
@@ -1,40 +1,31 @@
 <?php
-
-// Remove includes
-// Include basic application services!
-// include_once "../../../Shared/basic.php";
-// include_once "../../../Shared/sessions.php";
-
-//--------------------------------------------------------------------------------------------------
-// clearGitFiles: Clear the gitFiles table in SQLite db when a course has been updated with a new github repo. This function is used by other github microservices.
-//--------------------------------------------------------------------------------------------------
-
-// Check if it's a POST request and get cid
-$cid = null;
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (isset($_POST['cid'])) {
-        $cid = $_POST['cid'];
-        
-        $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-        $query = $pdolite->prepare("DELETE FROM gitFiles WHERE cid = :cid"); 
-        $query->bindParam(':cid', $cid);
-        if (!$query->execute()) {
-            $error = $query->errorInfo();
-            $errorvar = $error[2];
-            
-            // Return error as JSON
-            header('Content-Type: application/json');
-            echo json_encode(['status' => 'error', 'message' => "Error updating file entries: " . $errorvar]);
-        } else {
-            // Return success as JSON
-            header('Content-Type: application/json');
-            echo json_encode(['status' => 'success']);
-        }
-    } else {
-        header('Content-Type: application/json');
-        echo json_encode(['status' => 'error', 'message' => 'Missing cid parameter']);
-    }
-} else {
-    header('Content-Type: application/json');
-    echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
+header('Content-Type: application/json');
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['status'=>'error','message'=>'Only POST allowed']);
+    exit;
 }
+
+if (!isset($_POST['cid'])) {
+    echo json_encode(['status'=>'error','message'=>'Missing cid']);
+    exit;
+}
+$cid = $_POST['cid'];
+
+try {
+    $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+    $query = $pdolite->prepare("DELETE FROM gitFiles WHERE cid = :cid");
+    $query->bindParam(':cid', $cid);
+    if (!$query->execute()) {
+        $e = $query->errorInfo();
+        throw new Exception($e[2] ?? 'Unknown error');
+    }
+} catch (Exception $ex) {
+    echo json_encode(['status'=>'error','message'=>$ex->getMessage()]);
+    exit;
+}
+
+echo json_encode([
+    'status'  => 'success',
+    'message' => "Cleared gitFiles for cid {$cid}"
+]);
+exit;

--- a/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php
+++ b/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php
@@ -1,24 +1,40 @@
 <?php
 
+// Remove includes
 // Include basic application services!
-include_once "../../../Shared/basic.php";
-include_once "../../../Shared/sessions.php";
-
-global $pdo;
+// include_once "../../../Shared/basic.php";
+// include_once "../../../Shared/sessions.php";
 
 //--------------------------------------------------------------------------------------------------
 // clearGitFiles: Clear the gitFiles table in SQLite db when a course has been updated with a new github repo. This function is used by other github microservices.
 //--------------------------------------------------------------------------------------------------
 
-function clearGitFiles($cid) {
-    $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-    $query = $pdolite->prepare("DELETE FROM gitFiles WHERE cid = :cid"); 
-    $query->bindParam(':cid', $cid);
-    if (!$query->execute()) {
-        $error = $query->errorInfo();
-        echo "Error updating file entries" . $error[2];
-        $errorvar = $error[2];
-        print_r($error);
-        echo $errorvar;
+// Check if it's a POST request and get cid
+$cid = null;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['cid'])) {
+        $cid = $_POST['cid'];
+        
+        $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+        $query = $pdolite->prepare("DELETE FROM gitFiles WHERE cid = :cid"); 
+        $query->bindParam(':cid', $cid);
+        if (!$query->execute()) {
+            $error = $query->errorInfo();
+            $errorvar = $error[2];
+            
+            // Return error as JSON
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'error', 'message' => "Error updating file entries: " . $errorvar]);
+        } else {
+            // Return success as JSON
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'success']);
+        }
+    } else {
+        header('Content-Type: application/json');
+        echo json_encode(['status' => 'error', 'message' => 'Missing cid parameter']);
     }
+} else {
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }

--- a/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php
+++ b/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php
@@ -1,4 +1,5 @@
 <?php
+// test from code space
 header('Content-Type: application/json');
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     echo json_encode(['status'=>'error','message'=>'Only POST allowed']);

--- a/DuggaSys/microservices/gitCommitService/fetchOldToken_ms.php
+++ b/DuggaSys/microservices/gitCommitService/fetchOldToken_ms.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 
 // Check if it's a POST request and get parameters
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -16,17 +17,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $old_token = $row['gitToken'];
         }
 
-        header('Content-Type: application/json');
-        if(strlen($old_token) > 1) {
+                if(strlen($old_token) > 1) {
             echo json_encode(['status' => 'success', 'token' => $old_token]);
         } else {
             echo json_encode(['status' => 'error', 'message' => 'No token found']);
         }
     } else {
-        header('Content-Type: application/json');
-        echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
+                echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
 } else {
-    header('Content-Type: application/json');
-    echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
+        echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }

--- a/DuggaSys/microservices/gitCommitService/fetchOldToken_ms.php
+++ b/DuggaSys/microservices/gitCommitService/fetchOldToken_ms.php
@@ -1,23 +1,32 @@
 <?php
 
-function fetchOldToken($pdolite, $cid) {
+// Check if it's a POST request and get parameters
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['cid'])) {
+        $cid = $_POST['cid'];
+        
+        $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+        
+        $query = $pdolite->prepare('SELECT gitToken FROM gitRepos WHERE cid=:cid');
+        $query->bindParam(':cid', $cid);
+        $query->execute();
 
-    $query = $pdolite->prepare('SELECT gitToken FROM gitRepos WHERE cid=:cid');
-    $query->bindParam(':cid', $cid);
-    $query->execute();
+        $old_token = "";
+        foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
+            $old_token = $row['gitToken'];
+        }
 
-    $old_token="";
-    foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-        $old_token = $row['gitToken'];
+        header('Content-Type: application/json');
+        if(strlen($old_token) > 1) {
+            echo json_encode(['status' => 'success', 'token' => $old_token]);
+        } else {
+            echo json_encode(['status' => 'error', 'message' => 'No token found']);
+        }
+    } else {
+        header('Content-Type: application/json');
+        echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
-
-    if(strlen($old_token)>1)
-    {
-        return $old_token;
-    }
-    else
-    {
-        return null;
-    }
+} else {
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }
-?>

--- a/DuggaSys/microservices/gitCommitService/getCourseID_ms.php
+++ b/DuggaSys/microservices/gitCommitService/getCourseID_ms.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 
 // Remove includes
 // include_once "../../../Shared/sessions.php";
@@ -48,17 +49,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             curl_exec($ch);
             curl_close($ch);
             
-            header('Content-Type: application/json');
             echo json_encode(['status' => 'success', 'cid' => $cid]);
         } else {
-            header('Content-Type: application/json');
             echo json_encode(['status' => 'error', 'message' => 'No matches in database!']);
         }
     } else {
-        header('Content-Type: application/json');
         echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
 } else {
-    header('Content-Type: application/json');
     echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }

--- a/DuggaSys/microservices/gitCommitService/getCourseID_ms.php
+++ b/DuggaSys/microservices/gitCommitService/getCourseID_ms.php
@@ -1,36 +1,64 @@
 <?php
 
-include_once "../../../Shared/sessions.php";
-include_once "../../../Shared/basic.php";
-include_once "./insertIntoSQLite_ms.php";
+// Remove includes
+// include_once "../../../Shared/sessions.php";
+// include_once "../../../Shared/basic.php";
+// include_once "./insertIntoSQLite_ms.php";
 
+// Check if it's a POST request and get parameters
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['githubURL'])) {
+        $githubURL = $_POST['githubURL'];
+        
+        // Connect to database
+        $pdo = new PDO('mysql:host=localhost;dbname=LenaSYS', 'lena', 'password');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        
+        // Start session
+        session_start();
 
-function getCourseID($githubURL) {
+        // Translates the url to the same structure as in mysql
+        // The "/" needs to be "&#47;" for the query to work
+        $newURL = str_replace("/", "&#47;", $githubURL);
 
-    global $pdo;
-    // Connect to database and start session
-    pdoConnect();
-    session_start();
+        // Fetching from the database
+        $query = $pdo->prepare('SELECT cid FROM course WHERE courseGitURL = :githubURL;');
+        $query->bindParam(':githubURL', $newURL);
+        $query->execute();
 
-    // Translates the url to the same structure as in mysql
-    // The "/" needs to be "&#47;" for the query to work
-    $newURL = str_replace("/", "&#47;", $githubURL);
+        $cid = "";
+        foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
+            $cid = $row['cid'];
+            // TODO: Limit this to only one result
+        }
 
-    // Fetching from the database
-    $query = $pdo->prepare('SELECT cid FROM course WHERE courseGitURL = :githubURL;');
-    $query->bindParam(':githubURL', $newURL);
-    $query->execute();
-
-    $cid = "";
-    foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-        $cid = $row['cid'];
-        // TODO: Limit this to only one result
-    }
-
-    // Check if not null, else add it to Sqlite db
-    if($cid != null) {
-        insertIntoSQLite($githubURL, $cid, "");
+        // Check if not null, else add it to Sqlite db
+        if($cid != null) {
+            // Call insertIntoSQLite microservice
+            $baseURL = "https://" . $_SERVER['HTTP_HOST'];
+            $insertURL = $baseURL . "/LenaSYS/DuggaSys/microservices/gitCommitService/insertIntoSQLite_ms.php";
+            $ch = curl_init($insertURL);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+                'githubURL' => $githubURL,
+                'cid' => $cid,
+                'commit' => ''
+            ]));
+            curl_exec($ch);
+            curl_close($ch);
+            
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'success', 'cid' => $cid]);
+        } else {
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'error', 'message' => 'No matches in database!']);
+        }
     } else {
-        print_r("No matches in database!");
+        header('Content-Type: application/json');
+        echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
+} else {
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }

--- a/DuggaSys/microservices/gitCommitService/insertIntoSQLite_ms.php
+++ b/DuggaSys/microservices/gitCommitService/insertIntoSQLite_ms.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 
 // Remove includes
 // include_once "../../../Shared/basic.php";
@@ -65,8 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (!$query->execute()) {
             $error = $query->errorInfo();
             $errorvar = $error[2];
-            header('Content-Type: application/json');
-            echo json_encode(['status' => 'error', 'message' => "Error updating file entries: " . $errorvar]);
+                        echo json_encode(['status' => 'error', 'message' => "Error updating file entries: " . $errorvar]);
         } else {
             // Call BFS function for REFRESH
             $ch = curl_init($bfsURL);
@@ -80,15 +80,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             curl_exec($ch);
             curl_close($ch);
             
-            header('Content-Type: application/json');
             echo json_encode(['status' => 'success']);
         }
     } else {
-        header('Content-Type: application/json');
-        echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
+         echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
 } else {
-    header('Content-Type: application/json');
     echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }
 ?>

--- a/DuggaSys/microservices/gitCommitService/insertIntoSQLite_ms.php
+++ b/DuggaSys/microservices/gitCommitService/insertIntoSQLite_ms.php
@@ -1,37 +1,94 @@
 <?php
 
-// Include basic application services!
-include_once "../../../Shared/basic.php";
-include_once "../../../Shared/sessions.php";
-include_once "../../gitfetchService.php";
+// Remove includes
+// include_once "../../../Shared/basic.php";
+// include_once "../../../Shared/sessions.php";
+// include_once "../../gitfetchService.php";
 
-function insertIntoSQLite($url, $cid, $token) { 
-    if(strlen($token)<1)
-    {
-        $token=fetchOldToken($cid);
-    }
-    $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
-    $lastCommit = bfs($url, $cid, "GETCOMMIT");
-    print_r($lastCommit);
-    // Splits the url into different parts for every "/" there is
-    $urlParting = explode('/', $url);
-    // The 4th part contains the name of the repo, which is accessed by [4]
-    $repoName = $urlParting[4];
-    $query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid,repoName, repoURL, lastCommit, gitToken) VALUES (:cid, :repoName, :repoURL, :lastCommit, :gitToken )"); 
-    $query->bindParam(':cid', $cid);
-    $query->bindParam(':repoName', $repoName);
-    $query->bindParam(':repoURL', $url);
-    $query->bindParam(':lastCommit', $lastCommit);
-    $query->bindParam(':gitToken', $token);
+// Check if it's a POST request and get parameters
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['githubURL']) && isset($_POST['cid'])) {
+        $url = $_POST['githubURL'];
+        $cid = $_POST['cid'];
+        $token = isset($_POST['token']) ? $_POST['token'] : '';
+        
+        if (strlen($token) < 1) {
+            // Call fetchOldToken microservice
+            $baseURL = "https://" . $_SERVER['HTTP_HOST'];
+            $tokenURL = $baseURL . "/LenaSYS/DuggaSys/microservices/gitCommitService/fetchOldToken_ms.php";
+            $ch = curl_init($tokenURL);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+                'cid' => $cid
+            ]));
+            $tokenResponse = curl_exec($ch);
+            curl_close($ch);
+            
+            $tokenResult = json_decode($tokenResponse, true);
+            if ($tokenResult && isset($tokenResult['token'])) {
+                $token = $tokenResult['token'];
+            }
+        }
+        
+        $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
+        
+        // Call BFS function from gitFetchService to get commit
+        $baseURL = "https://" . $_SERVER['HTTP_HOST'];
+        $bfsURL = $baseURL . "/LenaSYS/DuggaSys/microservices/gitFetchService/bfs_ms.php";
+        $ch = curl_init($bfsURL);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+            'url' => $url,
+            'cid' => $cid,
+            'action' => 'GETCOMMIT'
+        ]));
+        $lastCommitResponse = curl_exec($ch);
+        curl_close($ch);
+        
+        $lastCommitResult = json_decode($lastCommitResponse, true);
+        $lastCommit = $lastCommitResult['commit'];
+        
+        // Splits the url into different parts for every "/" there is
+        $urlParting = explode('/', $url);
+        // The 4th part contains the name of the repo, which is accessed by [4]
+        $repoName = $urlParting[4];
+        
+        $query = $pdolite->prepare("INSERT OR REPLACE INTO gitRepos (cid,repoName, repoURL, lastCommit, gitToken) VALUES (:cid, :repoName, :repoURL, :lastCommit, :gitToken )"); 
+        $query->bindParam(':cid', $cid);
+        $query->bindParam(':repoName', $repoName);
+        $query->bindParam(':repoURL', $url);
+        $query->bindParam(':lastCommit', $lastCommit);
+        $query->bindParam(':gitToken', $token);
 
-    if (!$query->execute()) {
-        $error = $query->errorInfo();
-        echo "Error updating file entries" . $error[2];
-        $errorvar = $error[2];
-        print_r($error);
-        echo $errorvar;
+        if (!$query->execute()) {
+            $error = $query->errorInfo();
+            $errorvar = $error[2];
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'error', 'message' => "Error updating file entries: " . $errorvar]);
+        } else {
+            // Call BFS function for REFRESH
+            $ch = curl_init($bfsURL);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+                'url' => $url,
+                'cid' => $cid,
+                'action' => 'REFRESH'
+            ]));
+            curl_exec($ch);
+            curl_close($ch);
+            
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'success']);
+        }
     } else {
-        bfs($url, $cid, "REFRESH");
+        header('Content-Type: application/json');
+        echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
+} else {
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }
 ?>

--- a/DuggaSys/microservices/gitCommitService/newUpdateTime_ms.php
+++ b/DuggaSys/microservices/gitCommitService/newUpdateTime_ms.php
@@ -1,17 +1,39 @@
 <?php
 
-
 //--------------------------------------------------------------------------------------------------
 // newUpdateTime: Updates the MySQL database to save the latest update time
 //--------------------------------------------------------------------------------------------------
-function newUpdateTime ($pdo, $currentTime, $cid) {
 
-    // Formats the UNIX timestamp into datetime
-    $parsedTime = date("Y-m-d H:i:s", $currentTime); 
+// Check if it's a POST request and get parameters
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['currentTime']) && isset($_POST['cid'])) {
+        $currentTime = $_POST['currentTime'];
+        $cid = $_POST['cid'];
+        
+        // Connect to database
+        $pdo = new PDO('mysql:host=localhost;dbname=LenaSYS', 'lena', 'password');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        
+        // Formats the UNIX timestamp into datetime
+        $parsedTime = date("Y-m-d H:i:s", $currentTime); 
 
-    // update the latest update timestamp of the course from the MySQL database
-    $query = $pdo->prepare('UPDATE course SET updated = :parsedTime WHERE cid = :cid;');
-    $query->bindParam(':cid', $cid);
-    $query->bindParam(':parsedTime', $parsedTime);
-    $query->execute();
+        // Update the latest update timestamp of the course from the MySQL database
+        $query = $pdo->prepare('UPDATE course SET updated = :parsedTime WHERE cid = :cid;');
+        $query->bindParam(':cid', $cid);
+        $query->bindParam(':parsedTime', $parsedTime);
+        
+        if ($query->execute()) {
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'success']);
+        } else {
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'error', 'message' => 'Failed to update time']);
+        }
+    } else {
+        header('Content-Type: application/json');
+        echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
+    }
+} else {
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }

--- a/DuggaSys/microservices/gitCommitService/newUpdateTime_ms.php
+++ b/DuggaSys/microservices/gitCommitService/newUpdateTime_ms.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 
 //--------------------------------------------------------------------------------------------------
 // newUpdateTime: Updates the MySQL database to save the latest update time
@@ -23,17 +24,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $query->bindParam(':parsedTime', $parsedTime);
         
         if ($query->execute()) {
-            header('Content-Type: application/json');
             echo json_encode(['status' => 'success']);
         } else {
-            header('Content-Type: application/json');
             echo json_encode(['status' => 'error', 'message' => 'Failed to update time']);
         }
     } else {
-        header('Content-Type: application/json');
         echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
 } else {
-    header('Content-Type: application/json');
     echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }

--- a/DuggaSys/microservices/gitCommitService/refreshCheck_ms.php
+++ b/DuggaSys/microservices/gitCommitService/refreshCheck_ms.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 
 // Remove includes
 // include_once "../../../Shared/sessions.php";
@@ -49,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Check if the user has superuser privileges
         if($user == 1) { // 1 = superuser
             if(($currentTime - $_SESSION["updatetGitReposCooldown"][$cid]) < $shortdeadline) { // If they to, use the short deadline
-                header('Content-Type: application/json');
+                
                 echo json_encode(['status' => 'error', 'message' => 'Too soon since last update, please wait.']);
             } else {
                 // Call newUpdateTime microservice
@@ -65,7 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 curl_exec($ch);
                 curl_close($ch);
                 
-                header('Content-Type: application/json');
+                
                 echo json_encode(['status' => 'success']);
             }
         } else { 
@@ -83,18 +84,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 curl_exec($ch);
                 curl_close($ch);
                 
-                header('Content-Type: application/json');
+                
                 echo json_encode(['status' => 'success']);
             } else {
-                header('Content-Type: application/json');
+                
                 echo json_encode(['status' => 'error', 'message' => 'Too soon since last update, please wait.']);
             }
         }
     } else {
-        header('Content-Type: application/json');
+        
         echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
 } else {
-    header('Content-Type: application/json');
     echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }

--- a/DuggaSys/microservices/gitCommitService/refreshCheck_ms.php
+++ b/DuggaSys/microservices/gitCommitService/refreshCheck_ms.php
@@ -1,58 +1,100 @@
 <?php
 
-include_once "../../../Shared/sessions.php";
-include_once "../../../Shared/basic.php";
-include_once "./newUpdateTime_ms.php";
+// Remove includes
+// include_once "../../../Shared/sessions.php";
+// include_once "../../../Shared/basic.php";
+// include_once "./newUpdateTime_ms.php";
 
-function refreshCheck($cid, $user) {
-    global $shortdeadline, $longdeadline;
-    // Connect to database and start session
-    pdoConnect();
-    session_start();
+// Variables for the refresh button, deadlines specified in seconds
+$shortdeadline = 300; // 300 = 5 minutes
+$longdeadline = 600; // 600 = 10 minutes
 
-    // Fetching the latest update of the course from the MySQL database
-    global $pdo;
-    $query = $pdo->prepare('SELECT updated FROM course WHERE cid = :cid;');
-    $query->bindParam(':cid', $cid);
-    $query->execute();
+// Check if it's a POST request and get parameters
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['cid']) && isset($_POST['user'])) {
+        $cid = $_POST['cid'];
+        $user = $_POST['user'];
+        
+        // Connect to database
+        $pdo = new PDO('mysql:host=localhost;dbname=LenaSYS', 'lena', 'password');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        
+        // Start session
+        session_start();
 
-    // Save the result in a variable
-    $updated = "";
-    foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
-        $updated = $row['updated'];
-    }
+        // Fetching the latest update of the course from the MySQL database
+        $query = $pdo->prepare('SELECT updated FROM course WHERE cid = :cid;');
+        $query->bindParam(':cid', $cid);
+        $query->execute();
 
-
-    $currentTime = time(); // Get the current time as a Unix timestamp
-    $updateTime = strtotime($updated); // Format the update-time as Unix timestamp
-
-    $_SESSION["updatetGitReposCooldown"][$cid]=$updateTime;
-
-
-    $_SESSION["lastFetchTime"] = date("Y-m-d H:i:s", $currentTime);
-    $fetchCooldown = $longdeadline - (time() - $updateTime);
-    if($fetchCooldown<0){
-        $_SESSION["fetchCooldown"]=0;
-    }else{
-        $_SESSION["fetchCooldown"]=$fetchCooldown;
-    }
-    // Check if the user has superuser priviliges
-    if($user == 1) { // 1 = superuser
-        if(($currentTime - $_SESSION["updatetGitReposCooldown"][$cid]) < $shortdeadline) { // If they to, use the short deadline
-
-            print "Too soon since last update, please wait.";
-            return false;
-        } else {
-            newUpdateTime($pdo, $currentTime, $cid);
-            return true;
+        // Save the result in a variable
+        $updated = "";
+        foreach($query->fetchAll(PDO::FETCH_ASSOC) as $row){
+            $updated = $row['updated'];
         }
-    } else { 
-        if(($currentTime - $_SESSION["updatetGitReposCooldown"][$cid]) > $longdeadline) { // Else use the long deadline
-            newUpdateTime($pdo, $currentTime, $cid);
-            return true;
+
+        $currentTime = time(); // Get the current time as a Unix timestamp
+        $updateTime = strtotime($updated); // Format the update-time as Unix timestamp
+
+        $_SESSION["updatetGitReposCooldown"][$cid] = $updateTime;
+
+        $_SESSION["lastFetchTime"] = date("Y-m-d H:i:s", $currentTime);
+        $fetchCooldown = $longdeadline - (time() - $updateTime);
+        if($fetchCooldown < 0) {
+            $_SESSION["fetchCooldown"] = 0;
         } else {
-            print "Too soon since last update, please wait.";
-            return false;
+            $_SESSION["fetchCooldown"] = $fetchCooldown;
         }
+        
+        // Check if the user has superuser privileges
+        if($user == 1) { // 1 = superuser
+            if(($currentTime - $_SESSION["updatetGitReposCooldown"][$cid]) < $shortdeadline) { // If they to, use the short deadline
+                header('Content-Type: application/json');
+                echo json_encode(['status' => 'error', 'message' => 'Too soon since last update, please wait.']);
+            } else {
+                // Call newUpdateTime microservice
+                $baseURL = "https://" . $_SERVER['HTTP_HOST'];
+                $updateURL = $baseURL . "/LenaSYS/DuggaSys/microservices/gitCommitService/newUpdateTime_ms.php";
+                $ch = curl_init($updateURL);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($ch, CURLOPT_POST, true);
+                curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+                    'currentTime' => $currentTime,
+                    'cid' => $cid
+                ]));
+                curl_exec($ch);
+                curl_close($ch);
+                
+                header('Content-Type: application/json');
+                echo json_encode(['status' => 'success']);
+            }
+        } else { 
+            if(($currentTime - $_SESSION["updatetGitReposCooldown"][$cid]) > $longdeadline) { // Else use the long deadline
+                // Call newUpdateTime microservice
+                $baseURL = "https://" . $_SERVER['HTTP_HOST'];
+                $updateURL = $baseURL . "/LenaSYS/DuggaSys/microservices/gitCommitService/newUpdateTime_ms.php";
+                $ch = curl_init($updateURL);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($ch, CURLOPT_POST, true);
+                curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+                    'currentTime' => $currentTime,
+                    'cid' => $cid
+                ]));
+                curl_exec($ch);
+                curl_close($ch);
+                
+                header('Content-Type: application/json');
+                echo json_encode(['status' => 'success']);
+            } else {
+                header('Content-Type: application/json');
+                echo json_encode(['status' => 'error', 'message' => 'Too soon since last update, please wait.']);
+            }
+        }
+    } else {
+        header('Content-Type: application/json');
+        echo json_encode(['status' => 'error', 'message' => 'Missing required parameters']);
     }
+} else {
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method. Use POST.']);
 }

--- a/DuggaSys/microservices/gitCommitService/refreshGithubRepo_ms.php
+++ b/DuggaSys/microservices/gitCommitService/refreshGithubRepo_ms.php
@@ -1,39 +1,46 @@
 <?php
-// -------------==============######## Setup ###########==============-------------
+header('Content-Type: application/json');
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['status'=>'error','message'=>'Only POST allowed']);
+    exit;
+}
 
 // Variables for the refresh button, deadlines specified in seconds
 $shortdeadline = 300; // 300 = 5 minutes
 $longdeadline = 600; // 600 = 10 minutes
 
-// Used to display errors on screen since PHP doesn't do that automatically.
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+foreach (['action','cid','user'] as $field) {
+    if (!isset($_POST[$field])) {
+        echo json_encode(['status'=>'error','message'=>"Missing {$field}"]);
+        exit;
+    }
+}
+$action = $_POST['action'];
+$cid = $_POST['cid'];
+$user = $_POST['user'];
 
-// Remove includes
-// include_once "../../../Shared/basic.php";
-// include_once "../../../Shared/sessions.php";
-// include_once "../../gitfetchService.php";
-// include_once "./refreshCheck_ms.php";
-// include_once "./clearGitFiles_ms.php";
+if ($action != 'refreshGithubRepo') {
+    echo json_encode(['status'=>'error','message'=>'Invalid action']);
+    exit;
+}
 
-//Get data from AJAX call in courseed.js and then runs the function getCourseID, refreshGithubRepo or updateGithubRepo depending on the action
-if (isset($_POST['action']) && $_POST['action'] == 'refreshGithubRepo' && isset($_POST['cid']) && isset($_POST['user'])) {
-    $cid = $_POST['cid'];
+// POST to clearGitFiles_ms.php
+$baseURL = "https://".$_SERVER['HTTP_HOST'];
+$url = "{$baseURL}/LenaSYS/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php";
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(['cid'=>$cid]));
+$resp = curl_exec($ch);
+curl_close($ch);
+$res = json_decode($resp, true);
+if (!$res || $res['status']!=='success') {
+    echo json_encode($res ?: ['status'=>'error','message'=>'clearGitFiles failed']);
+    exit;
+}
 
-    // Call clearGitFiles microservice
-    $baseURL = "https://" . $_SERVER['HTTP_HOST'];
-    $clearURL = $baseURL . "/LenaSYS/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php";
-    $ch = curl_init($clearURL);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_POST, true);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-        'cid' => $cid
-    ]));
-    curl_exec($ch);
-    curl_close($ch);
-
-    // Get old commit and URL from Sqlite 
+// Get old commit and URL from Sqlite
+try {
     $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
     $query = $pdolite->prepare('SELECT lastCommit, repoURL FROM gitRepos WHERE cid = :cid');
     $query->bindParam(':cid', $cid);
@@ -41,80 +48,97 @@ if (isset($_POST['action']) && $_POST['action'] == 'refreshGithubRepo' && isset(
 
     $commit = "";
     $url = "";
-
     foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
         $commit = $row['lastCommit'];
         $url = $row['repoURL'];
     }
 
-    //If both values are valid
+    // If both values are invalid
     if ($commit == "" && $url == "") {
-        header('Content-Type: application/json');
         echo json_encode(['status' => 'error', 'message' => 'No repo']);
-    } else {
-        // Call refreshCheck microservice
-        $refreshURL = $baseURL . "/LenaSYS/DuggaSys/microservices/gitCommitService/refreshCheck_ms.php";
-        $ch = curl_init($refreshURL);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-            'cid' => $cid,
-            'user' => $_POST['user']
-        ]));
-        $refreshResponse = curl_exec($ch);
-        curl_close($ch);
-        
-        $refreshResult = json_decode($refreshResponse, true);
-        
-        if ($refreshResult && isset($refreshResult['status']) && $refreshResult['status'] == 'success') {
-            // Call BFS function from gitFetchService
-            $bfsURL = $baseURL . "/LenaSYS/DuggaSys/microservices/gitFetchService/bfs_ms.php";
-            $ch = curl_init($bfsURL);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_POST, true);
-            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-                'url' => $url,
-                'cid' => $cid,
-                'action' => 'GETCOMMIT'
-            ]));
-            $latestCommitResponse = curl_exec($ch);
-            curl_close($ch);
-            
-            $latestCommitResult = json_decode($latestCommitResponse, true);
-            $latestCommit = $latestCommitResult['commit'];
-            
-            // Compare old commit in db with the new one from the url
-            if ($latestCommit != $commit) {
-                // Update the SQLite db with the new commit
-                $query = $pdolite->prepare('UPDATE gitRepos SET lastCommit = :latestCommit WHERE cid = :cid');
-                $query->bindParam(':cid', $cid);
-                $query->bindParam(':latestCommit', $latestCommit);
-                $query->execute();
-
-                // Download files and metadata via BFS
-                $ch = curl_init($bfsURL);
-                curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                curl_setopt($ch, CURLOPT_POST, true);
-                curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-                    'url' => $url,
-                    'cid' => $cid,
-                    'action' => 'DOWNLOAD'
-                ]));
-                curl_exec($ch);
-                curl_close($ch);
-                
-                header('Content-Type: application/json');
-                echo json_encode(['status' => 'success', 'message' => 'The course has been updated, files have been downloaded!']);
-            } else if (http_response_code() == 200) {
-                header('Content-Type: application/json');
-                echo json_encode(['status' => 'success', 'message' => 'The course is already up to date!']);
-            }
-        } else {
-            header('Content-Type: application/json');
-            echo json_encode(['status' => 'error', 'message' => 'Refresh check failed']);
-        }
+        exit;
     }
-} else {
-    header('Content-Type: application/json');
-    echo json_encode(['status' => 'error', 'message' => 'Invalid request parameters']);
+} catch (Exception $ex) {
+    echo json_encode(['status'=>'error','message'=>$ex->getMessage()]);
+    exit;
 }
+
+// POST to refreshCheck_ms.php
+$refreshURL = "{$baseURL}/LenaSYS/DuggaSys/microservices/gitCommitService/refreshCheck_ms.php";
+$ch = curl_init($refreshURL);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+    'cid' => $cid,
+    'user' => $user
+]));
+$refreshResponse = curl_exec($ch);
+curl_close($ch);
+
+$refreshResult = json_decode($refreshResponse, true);
+
+if (!$refreshResult || $refreshResult['status'] !== 'success') {
+    echo json_encode($refreshResult ?: ['status' => 'error', 'message' => 'refreshCheck failed']);
+    exit;
+}
+
+// Call BFS function from gitFetchService
+$bfsURL = "{$baseURL}/LenaSYS/DuggaSys/microservices/gitFetchService/bfs_ms.php";
+$ch = curl_init($bfsURL);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+    'url' => $url,
+    'cid' => $cid,
+    'action' => 'GETCOMMIT'
+]));
+$latestCommitResponse = curl_exec($ch);
+curl_close($ch);
+
+$latestCommitResult = json_decode($latestCommitResponse, true);
+if (!$latestCommitResult || !isset($latestCommitResult['commit'])) {
+    echo json_encode(['status' => 'error', 'message' => 'Failed to fetch latest commit']);
+    exit;
+}
+$latestCommit = $latestCommitResult['commit'];
+
+// Compare old commit in db with the new one from the url
+if ($latestCommit != $commit) {
+    // Update the SQLite db with the new commit
+    try {
+        $query = $pdolite->prepare('UPDATE gitRepos SET lastCommit = :latestCommit WHERE cid = :cid');
+        $query->bindParam(':cid', $cid);
+        $query->bindParam(':latestCommit', $latestCommit);
+        if (!$query->execute()) {
+            $e = $query->errorInfo();
+            throw new Exception($e[2] ?? 'Unknown error');
+        }
+    } catch (Exception $ex) {
+        echo json_encode(['status'=>'error','message'=>$ex->getMessage()]);
+        exit;
+    }
+
+    // Download files and metadata via BFS
+    $ch = curl_init($bfsURL);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+        'url' => $url,
+        'cid' => $cid,
+        'action' => 'DOWNLOAD'
+    ]));
+    curl_exec($ch);
+    curl_close($ch);
+    
+    echo json_encode([
+        'status' => 'success', 
+        'message' => 'The course has been updated, files have been downloaded!',
+        'newCommit' => $latestCommit
+    ]);
+} else {
+    echo json_encode([
+        'status' => 'success', 
+        'message' => 'The course is already up to date!'
+    ]);
+}
+exit;

--- a/DuggaSys/microservices/gitCommitService/refreshGithubRepo_ms.php
+++ b/DuggaSys/microservices/gitCommitService/refreshGithubRepo_ms.php
@@ -1,5 +1,6 @@
 <?php
 header('Content-Type: application/json');
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     echo json_encode(['status'=>'error','message'=>'Only POST allowed']);
     exit;


### PR DESCRIPTION
Removed every include_once statement from the seven *_ms.php files. Re-implemented data exchange with cURL:
  - GET requests now use CURLOPT_RETURNTRANSFER true and json_decode the response.
  - Fire-and-forget POST requests set CURLOPT_POST true and CURLOPT_RETURNTRANSFER false. Added `header('Content-Type: application/json'); echo json_encode(...);` to all receiving endpoints. Normalized `$baseURL = "https://" . $_SERVER['HTTP_HOST'];` path handling to keep dev/prod parity. Consolidated error reporting into consistent `{ status, message }` JSON objects. Deleted dead wrapper functions and ensured every script exits immediately after echoing JSON to prevent accidental output.

fixes #16861