### PR TITLE
Re-engineered microservice deleteCourseMaterial

### DIFF
--- a/DuggaSys/microservices/courseedService/deleteCourseMaterial_ms.php
+++ b/DuggaSys/microservices/courseedService/deleteCourseMaterial_ms.php
@@ -6,7 +6,36 @@ date_default_timezone_set("Europe/Stockholm");
 // Include basic application services
 include_once "../../../Shared/basic.php";
 include_once "../../../Shared/sessions.php";
-include_once "./retrieveCourseedService_ms.php";
+//include_once "./retrieveCourseedService_ms.php";
+
+header("Content-Type: application/json");
+
+$baseURL = "https://" . $_SERVER['HTTP_HOST'];
+$url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/retrieveCourseedService_ms.php";
+$ch = curl_init($url);
+
+    //options for curl
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, false);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+        'cid' => $cid, 'versid' => $versid
+    ]));
+
+    curl_exec($ch);
+    curl_close($ch);
+
+    //get values from post
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if (isset($_POST['cid'], $_POST['versid'])) {
+            $cid = $_POST['cid'];
+            $versid = $_POST['versid'];
+        }
+    }
+
+    //set active course in database
+    $query = $pdo->prepare("UPDATE course SET activeversion=:vers WHERE cid=:cid");
+    $query->bindParam(':cid', $cid);
+    $query->bindParam(':vers', $versid);
 
 function deleteCourseMaterial($pdo){
 

--- a/DuggaSys/microservices/courseedService/retrieveCourseedService_ms.php
+++ b/DuggaSys/microservices/courseedService/retrieveCourseedService_ms.php
@@ -8,7 +8,23 @@ date_default_timezone_set("Europe/Stockholm");
 include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
 include_once "../sharedMicroservices/getUid_ms.php";
-include_once "./deleteCourseMaterial_ms.php";
+//include_once "./deleteCourseMaterial_ms.php";
+
+// Retrieve Course Versions from microservice 'readCourseVersions_ms.php'
+$baseURL = "https://" . $_SERVER['HTTP_HOST'];
+
+$url = $baseURL . "/LenaSYS/duggaSys/microservices/sectionedService/deleteCourseMaterial_ms.php";
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+$response = curl_exec($ch);
+curl_close($ch);
+
+$data = json_decode($response, true);
+
+$versions = $data;
+
+header('Content-Type: application/json');
+echo json_encode($data);
 
 function retrieveCourseedService($pdo, $ha, $debug, $LastCourseCreated, $isSuperUserVar){ 
 

--- a/DuggaSys/microservices/courseedService/retrieveCourseedService_ms.php
+++ b/DuggaSys/microservices/courseedService/retrieveCourseedService_ms.php
@@ -10,7 +10,6 @@ include_once "../../../Shared/basic.php";
 include_once "../sharedMicroservices/getUid_ms.php";
 //include_once "./deleteCourseMaterial_ms.php";
 
-// Retrieve Course Versions from microservice 'readCourseVersions_ms.php'
 $baseURL = "https://" . $_SERVER['HTTP_HOST'];
 
 $url = $baseURL . "/LenaSYS/duggaSys/microservices/sectionedService/deleteCourseMaterial_ms.php";


### PR DESCRIPTION
Re-engineered microservice deleteCourseMaterial according to the documentation in `microserviceCodingStandard.md`.
Just commented the includes as I am a little unsure if its 100% correct.

POST (the file i got assigned): deleteCourseMaterial_ms
GET (the file my assigned file was included in): retrieveCourseedService_ms

Fixes issue  #16858.