### PR TITLE
Fixed the lines between objects when zooming in andor out

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -118,7 +118,7 @@
     width: 320px;
     bottom: 0px;
     z-index: 5000;
-    background-color: #eb4;
+    background-color: rgb(34, 33, 32);
     color: #FFF;
     border-top-left-radius: 15px;
     border-bottom-left-radius: 15px;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -118,8 +118,7 @@
     width: 320px;
     bottom: 0px;
     z-index: 5000;
-    background-color: rgb(243, 141, 39);
-    color: #FFF;
+    background-color: #eb4;    color: #FFF;
     border-top-left-radius: 15px;
     border-bottom-left-radius: 15px;
     box-shadow: 0px 6px 10px #888;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -118,7 +118,7 @@
     width: 320px;
     bottom: 0px;
     z-index: 5000;
-    background-color: rgb(34, 33, 32);
+    background-color: rgb(243, 141, 39);
     color: #FFF;
     border-top-left-radius: 15px;
     border-bottom-left-radius: 15px;

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -46,7 +46,7 @@ function drawLine(line, targetGhost = false) {
     }
 
 
-    const lineSpacing = 30; //Controlls spacing between lines
+    const lineSpacing = 30 * zoomfact; //Controlls spacing between lines
 
     //Checks if a line have gotten any properties from the checkAdjacentLines function 
     //fromOffsetIncrease, fromNumberOfLInes, toOffsetIncrease and toNumberOfLines
@@ -496,9 +496,9 @@ function drawLineLabel(line, label, lineColor, labelStr, x, y, isStart, felem) {
                 class='text cardinalityLabel' 
                 id='${line.id + labelStr}' 
                 x='${x - textWidth / 2}' 
-                y='${y - (textheight * zoomfact + zoomfact * 3) / 2}' 
+                y='${y - (textheight + 6) / 2}' 
                 width='${textWidth + 2}' 
-                height='${(textheight - 4) * zoomfact + zoomfact * 3}'/> 
+                height='${textheight + 6}'/> 
             <text 
                 class='text cardinalityLabelText' 
                 dominant-baseline='middle' 
@@ -932,8 +932,8 @@ function clearLinesForElement(element) {
     element.y1 = domelementpos.top;
     element.x2 = domelementpos.left + domelementpos.width - 2;
     element.y2 = domelementpos.top + domelementpos.height - 2;
-    element.cx = element.x1 + (domelementpos.width * 0.5);
-    element.cy = element.y1 + (domelementpos.height * 0.5);
+    element.cx = element.x1 + element.x2;
+    element.cy = element.y1 + element.y2;
 }
 
 /**

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -44,7 +44,7 @@ function drawLine(line, targetGhost = false) {
 //Looks if the lines have gotta an index value from the function getLineAttrubutes
 //If so then there are multiple lines on the same row and the offset is changed
 if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'number') {
-    const lineSpacing = 15; //Can be changed to change the spacing between lines
+    const lineSpacing = 30 * zoomfact; //Can be changed to change the spacing between lines
     const offsetIncrease = (line.multiLineOffset- (line.numberOfLines - 1) / 2) * lineSpacing;
     if (line.ctype === lineDirection.UP || line.ctype === lineDirection.DOWN) {
         offset.x1 += offsetIncrease;

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -22,38 +22,51 @@ function drawLine(line, targetGhost = false) {
     let isSelected = contextLine.includes(line);
     if (isSelected) lineColor = color.SELECTED;
     let fx, fy, tx, ty, offset;
-    
+
     // Sets the to-coordinates to the same as the from-coordinates after getting line attributes
     // if the line is recursive
-    if (line.kind === lineKind.RECURSIVE){
-
+    if (line.kind === lineKind.RECURSIVE) {
         [fx, fy, tx, ty, offset] = getLineAttrubutes(felem, felem, line.ctype);
-        [fx, fy, tx, ty, offset] = [fx, fy, fx, fy, offset];
+        //Setting start position for the recursive line, to originate from the top.
+        fx = felem.cx;
+        fy = felem.y1;
+        offset.x1 = 0;
+        offset.y1 = 0;
+        tx = fx;
+        ty = fy;
     }
-    else{
+    else {
         [fx, fy, tx, ty, offset] = getLineAttrubutes(felem, telem, line.ctype);
     }
-    
+
     // Follows the cursor while drawing the line
-    if (isCurrentlyDrawing){
+    if (isCurrentlyDrawing) {
         tx = event.clientX;
         ty = event.clientY;
     }
 
 
-//Looks if the lines have gotta an index value from the function getLineAttrubutes
-//If so then there are multiple lines on the same row and the offset is changed
-if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'number') {
-    const lineSpacing = 30 * zoomfact; //Can be changed to change the spacing between lines
-    const offsetIncrease = (line.multiLineOffset- (line.numberOfLines - 1) / 2) * lineSpacing;
-    if (line.ctype === lineDirection.UP || line.ctype === lineDirection.DOWN) {
-        offset.x1 += offsetIncrease;
-        offset.x2 += offsetIncrease;
-    } else if (line.ctype === lineDirection.LEFT || line.ctype === lineDirection.RIGHT) {
-        offset.y1 += offsetIncrease;
-        offset.y2 += offsetIncrease;
+    const lineSpacing = 30 * zoomfact; //Controlls spacing between lines
+
+    //Checks if a line have gotten any properties from the checkAdjacentLines function 
+    //fromOffsetIncrease, fromNumberOfLInes, toOffsetIncrease and toNumberOfLines
+    //Different offset for the side they go to and come from
+    if ("fromOffsetIndex" in line && "fromNumberOfLines" in line) {
+        const fromOffsetIncrease = (line.fromOffsetIndex - (line.fromNumberOfLines - 1) / 2) * lineSpacing;
+        if (line.ctype === lineDirection.UP || line.ctype === lineDirection.DOWN) {
+            offset.x1 += fromOffsetIncrease;
+        } else if (line.ctype === lineDirection.LEFT || line.ctype === lineDirection.RIGHT) {
+            offset.y1 += fromOffsetIncrease;
+        }
     }
-}
+    if ("toOffsetIndex" in line && "toNumberOfLines" in line) {
+        const toOffsetIncrease = (line.toOffsetIndex - (line.toNumberOfLines - 1) / 2) * lineSpacing;
+        if (line.ctype === lineDirection.UP || line.ctype === lineDirection.DOWN) {
+            offset.x2 += toOffsetIncrease;
+        } else if (line.ctype === lineDirection.LEFT || line.ctype === lineDirection.RIGHT) {
+            offset.y2 += toOffsetIncrease;
+        }
+    }
 
     if (targetGhost && line.type == entityType.SD) line.endIcon = SDLineIcons.ARROW;
     if (line.type == entityType.ER) {
@@ -71,7 +84,7 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
             let len = Math.sqrt((dx * dx) + (dy * dy));
             dy /= len;
             dx /= len;
-            
+
             const double = (a, b) => {
                 return `<line 
                 id='${line.id}-${b}' 
@@ -88,14 +101,50 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
         }
     } else if ((line.type == entityType.SD && line.innerType != SDLineType.SEGMENT)) {
         if (line.kind == lineKind.RECURSIVE) {
-            str += drawRecursive(fx, fy, offset, line, lineColor);
+            str += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
+
         } else if ((fy > ty) && (line.ctype == lineDirection.UP)) {
-            offset.y1 = 1;
-            offset.y2 = -7 + 3 / zoomfact;
+            //UMLFinalState seems to always end up as telem after line has been drawn even if drawn line originated from it
+            if (telem.kind === elementTypesNames.UMLFinalState) {
+                offset.y2 = -4 + 3 / zoomfact;
+                offset.x2 = 0;
+                //Special offset for SD entity telem, since it can be both felem and telem. UMLInitialState can only be felem and doesn't utilize x2 or y2
+            } else if (telem.kind === elementTypesNames.SDEntity) {
+                offset.y2 = -15;
+            } else { offset.y2 = 0; } //Aligning line with mouse coordinate before telem has been set
+            offset.y1 = 15;
+
         } else if ((fy < ty) && (line.ctype == lineDirection.DOWN)) {
-            offset.y1 = -7 + 3 / zoomfact;
-            offset.y2 = 1;
+            if (telem.kind === elementTypesNames.UMLFinalState) {
+                offset.y2 = 3;
+                offset.x2 = 0;
+            } else if (telem.kind === elementTypesNames.SDEntity) {
+                offset.y2 = 15;
+            } else { offset.y2 = 0; }
+            offset.y1 = -15;
+
+
+        } else if ((fx > tx) && (line.ctype == lineDirection.LEFT)) {
+            if (telem.kind === elementTypesNames.UMLFinalState) {
+                offset.x2 = 1 / zoomfact;
+                offset.y2 = 0;
+            } else if (telem.kind === elementTypesNames.SDEntity) {
+                offset.x2 = -15;
+            } else { offset.x2 = 0; }
+            offset.x1 = 15;
+
+
+        } else if ((fx < tx) && (line.ctype == lineDirection.RIGHT)) {
+            if (telem.kind === elementTypesNames.UMLFinalState) {
+                offset.x2 = 1 / zoomfact;
+                offset.y2 = 0;
+            } else if (telem.kind === elementTypesNames.SDEntity) {
+                offset.x2 = 15;
+            } else { offset.x2 = 0; }
+            offset.x1 = -15;
+
         }
+
         str += `<line 
                     id='${line.id}' 
                     x1='${fx + offset.x1 * zoomfact}' 
@@ -106,45 +155,80 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
                 />`;
     } else { // UML, IE or SD
         if (line.kind == lineKind.RECURSIVE) {
-            str += drawRecursive(fx, fy, offset, line, lineColor, strokewidth, strokeDash);
+            str += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
             str += drawRecursiveLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
-            
         }
-        else{
+        else {
             str += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
         }
+
+    }
+
+    //Drawing Arrow and other line icons for UML abnd IE lines
+    if (line.kind === lineKind.RECURSIVE) {
+        //Arrow/icon location dependant on element length, so its always in the top right corner of the element.
+        const length = 40 * zoomfact;
+        const elementLength = felem.x2 - felem.x1;
+        let startX = felem.x1 + elementLength - length;
+        let startY = felem.y1;
         
-    }
-    str += drawLineIcon(line.startIcon, line.ctype, fx + offset.x1, fy + offset.y1, lineColor, line);
-    if (line.kind === lineKind.RECURSIVE){
-        str += drawLineIcon(line.endIcon, line.ctype, tx, ty + 40 * zoomfact, lineColor, line);
-    }
-    else{
+        //Same values for UML and IE as they use the same icons, just different element values.
+        if(line.type !== entityType.SD || line.type !== entityType.SE){
+            line.ctype = lineDirection.UP;  //So arrows point down
+            str += drawLineIcon(line.startIcon, line.ctype, startX, startY, lineColor, line);
+            str += drawLineIcon(line.endIcon, line.ctype, (startX + length), startY, lineColor, line);
+        }
+    }else {
+        str += drawLineIcon(line.startIcon, line.ctype, fx + offset.x1, fy + offset.y1, lineColor, line);
         str += drawLineIcon(line.endIcon, line.ctype.split('').reverse().join(''), tx + offset.x2, ty + offset.y2, lineColor, line);
     }
-  
-    if ((line.type == entityType.SD && line.innerType != SDLineType.SEGMENT) || (line.type == entityType.SE && line.innerType != SELineType.SEGMENT)) {
+    // Always allow arrowheads to render if icon is ARROW
+    // If the line is SEGMENTED (has 90-degree bends), draw a fixed arrowhead with iconPoly.
+    // Otherwise, draw a rotated arrowhead using drawArrowPoint based on the line direction.
+    if (line.type == entityType.SD || line.type == entityType.SE) {
         let to = new Point(tx + offset.x2 * zoomfact, ty + offset.y2 * zoomfact);
         let from = new Point(fx + offset.x1 * zoomfact, fy + offset.y1 * zoomfact);
-        if (line.startIcon == SDLineIcons.ARROW) {
-            
-            str += drawArrowPoint(calculateArrowBase(to, from, 10 * zoomfact), from, fx, fy, lineColor, line, line.ctype);
+
+        // Handle start arrow
+        if (line.startIcon === SDLineIcons.ARROW) {
+            if (line.innerType === SDLineType.SEGMENT) {
+                str += iconPoly(SD_ARROW[line.ctype], from.x, from.y, lineColor, color.BLACK);
+            } else {
+                str += drawArrowPoint(
+                    calculateArrowBase(to, from, 10 * zoomfact),
+                    from,
+                    lineColor,
+                    strokewidth
+                );
+            }
         }
-        if (line.endIcon == SDLineIcons.ARROW) {
-            
-            str += drawArrowPoint(calculateArrowBase(from, to, 10 * zoomfact), to, tx, ty, lineColor, line, line.ctype.split('').reverse().join(''));
+
+        // Handle end arrow
+        if (line.endIcon === SDLineIcons.ARROW) {
+            const reverseCtype = line.ctype.split('').reverse().join('');
+            if (line.innerType === SDLineType.SEGMENT) {
+                str += iconPoly(SD_ARROW[reverseCtype], to.x, to.y, lineColor, color.BLACK);
+            } else {
+                str += drawArrowPoint(
+                    calculateArrowBase(from, to, 10 * zoomfact),
+                    to,
+                    lineColor,
+                    strokewidth
+                );
+            }
         }
     }
+
     if (felem.type != entityType.ER || telem.type != entityType.ER) {
         if (line.startLabel && line.startLabel != '') {
-                fx += offset.x1;
-                fy += offset.y1;
-            str += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fx, fy, true);
+            fx += offset.x1;
+            fy += offset.y1;
+            str += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fx, fy, true, felem);
         }
         if (line.endLabel && line.endLabel != '') {
             tx += offset.x1;
             ty += offset.y2;
-            str += drawLineLabel(line, line.endLabel, lineColor, 'endLabel', tx, ty, false);
+            str += drawLineLabel(line, line.endLabel, lineColor, 'endLabel', tx, ty, false, felem);
         }
     } else {
         if (line.cardinality) {
@@ -171,23 +255,23 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
         const label = {
             id: line.id + "Label",
             labelLineID: line.id,
-            centerX: (tx + fx) / 2,
-            centerY: (ty + fy) / 2,
+            centerX: (tx + offset.x2 + fx + offset.x1) / 2,
+            centerY: (ty + offset.y2 + fy + offset.y1) / 2,
             width: textWidth + zoomfact * 4,
             height: textheight * zoomfact + zoomfact * 3,
             labelMovedX: 0,
             labelMovedY: 0,
-            lowY: Math.min(ty, fy),
-            highY: Math.max(ty, fy),
-            lowX: Math.min(tx, fx),
-            highX: Math.max(ty, fy),
+            lowY: Math.min(ty + offset.y2, fy + offset.y1),
+            highY: Math.max(ty + offset.y2, fy + offset.y1),
+            lowX: Math.min(tx + offset.x2, fx + offset.x1),
+            highX: Math.max(tx + offset.x2, fx + offset.x1),
             percentOfLine: 0,
             displacementX: 0,
             displacementY: 0,
-            fromX: fx,
-            toX: tx,
-            fromY: fy,
-            toY: ty,
+            fromX: fx + offset.x1,
+            toX: tx + offset.x2,
+            fromY: fy + offset.y1,
+            toY: ty + offset.y2,
             lineGroup: 0,
             labelMoved: false
         };
@@ -215,18 +299,32 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
         if (rememberTargetLabelID) {
             targetLabel = lineLabelList[findIndex(lineLabelList, rememberTargetLabelID)];
         }
-        // Label position for recursive edges
-        const labelPosX = (tx + fx) / 2 - ((textWidth) + zoomfact * 8) / 2;
+        // Label positioning for recursive lines
         const labelPosY = (ty + fy) / 2 - ((textheight / 2) * zoomfact + 4 * zoomfact);
-        const labelPositionX = labelPosX + zoomfact;
         const labelPositionY = labelPosY - zoomfact;
+
+        // Label positioning for regual (non-recursive) lines
+        const labelCenterX = label.centerX - (2 * zoomfact);
+        const labelCenterY = label.centerY;
+
+        // Centers the background rectangle around the text
+        const rectPosX = labelCenterX - textWidth / 2 - zoomfact * 2;
+        const rectPosY = labelCenterY - (textheight * zoomfact + zoomfact * 3) / 2;
+
         //Add label with styling based on selection.
         if (line.kind === lineKind.RECURSIVE) {
+            //Calculatin the lable possition based on element size, so it follows when resized.
+            const length = 20 * zoomfact;
+            const lift   = 80 * zoomfact; 
+            const elementLength = felem.x2 - felem.x1;
+            let startX = felem.x1 + elementLength - length;
+            let startY = felem.y1  - lift;
+
             str += `<rect
                         class='text cardinalityLabel'
                         id='${line.id + 'Label'}'
-                        x='${((fx + length + (30 * zoomfact))) - textWidth / 2}'
-                        y='${(labelPositionY - 70 * zoomfact) - ((textheight / 4) * zoomfact)}'
+                        x='${((startX)) - textWidth / 2}'
+                        y='${((startY)) - ((textheight / 4))}'
                         width='${(textWidth + zoomfact * 4)}'
                         height='${textheight * zoomfact}'
                     />`;
@@ -234,17 +332,18 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
                         class='cardinalityLabelText'
                         dominant-baseline='middle'
                         text-anchor='middle'
-                        x='${(fx + length + (30 * zoomfact))}'
-                        y='${(labelPositionY - 70 * zoomfact) + ((textheight / 4) * zoomfact)}'
+                        x='${((startX))}'
+                        y='${((startY)) + ((textheight / 4))}'
                         style='fill:${lineColor}; font-size:${Math.round(zoomfact * textheight)}px;'>
                         ${labelValue}
                     </text>`;
         } else {
+            // For non-recursive lines
             str += `<rect
                         class='text cardinalityLabel'
-                        id=${line.id + 'Label'}
-                        x='${labelPositionX}'
-                        y='${labelPositionY}'
+                        id='${line.id + 'Label'}'
+                        x='${rectPosX}'
+                        y='${rectPosY}'
                         width='${(textWidth + zoomfact * 4)}'
                         height='${textheight * zoomfact + zoomfact * 3}'
                     />`;
@@ -253,8 +352,8 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
                         dominant-baseline='middle'
                         text-anchor='middle'
                         style='font-size:${Math.round(zoomfact * textheight)}px;'
-                        x='${label.centerX - (2 * zoomfact)}'
-                        y='${label.centerY - (2 * zoomfact)}'>
+                        x='${labelCenterX}'
+                        y='${labelCenterY}'>
                         ${labelValue}
                     </text>`;
         }
@@ -276,10 +375,10 @@ if (typeof line.multiLineOffset=== 'number' && typeof line.numberOfLines === 'nu
 function recursiveERCalc(ax, ay, bx, by, elem, isFirst, line) {
     if (line.ctype == lineDirection.UP || line.ctype == lineDirection.DOWN) {
         ay = elem.cy;
-        ax = isFirst? elem.x1 : elem.x2;
+        ax = isFirst ? elem.x1 : elem.x2;
     } else if (line.ctype == lineDirection.LEFT || line.ctype == lineDirection.RIGHT) {
         ax = elem.cx;
-        ay = isFirst? elem.y1 : elem.y2;
+        ay = isFirst ? elem.y1 : elem.y2;
     }
     if (isFirst) {
         elem.recursivePos = 0;
@@ -314,38 +413,35 @@ function recursiveERRelation(felem, telem, line) {
 }
 
 function getLineAttrubutes(f, t, ctype) {
-    let result;
-    let px = 3;
-    let offset = {
-        x1: 0,
-        x2: 0,
-        y1: 0,
-        y2: 0,
-    };
+    const px = -1; // Don't touch
+    const offset = { x1: 0, x2: 0, y1: 0, y2: 0 };
+
     switch (ctype) {
         case lineDirection.UP:
             offset.y1 = px;
             offset.y2 = -px * 2;
-            result = [f.cx, f.y1, t.cx, t.y2, offset];
-            break;
+            return [f.cx, f.y1, t.cx, t.y2, offset];
+
         case lineDirection.DOWN:
             offset.y1 = -px * 2;
             offset.y2 = px;
-            result = [f.cx, f.y2, t.cx, t.y1, offset];
-            break;
+            return [f.cx, f.y2, t.cx, t.y1, offset];
+
         case lineDirection.LEFT:
-            offset.x1 = px;
-            offset.x2 = px * 4;
-            result = [f.x1, f.cy, t.x1, t.cy, offset];
-            break;
+
+            offset.x1 = -px;          
+            offset.x2 = px * 2;       
+
+            return [f.x1, f.cy, t.x2, t.cy, offset];
+
         case lineDirection.RIGHT:
-            offset.x1 = 0;
-            offset.x2 = px;
-            result = [f.x2, f.cy, t.x1, t.cy, offset];
+            offset.x1 = px;
+            offset.x2 = -px * 2;
+            return [f.x2, f.cy, t.x1, t.cy, offset];
     }
-    return result;
 }
- 
+
+
 /**
  * @description Draw the label for the line.
  * @param {Object} line The line object for the label to be drawn.
@@ -355,26 +451,45 @@ function getLineAttrubutes(f, t, ctype) {
  * @param {Number} x The X coodinates on the line for draw the label.
  * @param {Number} y The Y coodinates on the line for draw the label.
  * @param {boolean} isStart Where the start and end label should be.
+ * @param {Object} felem The element object that is drawn, for recursive.
  * @returns Returns the label for the line
  */
-function drawLineLabel(line, label, lineColor, labelStr, x, y, isStart) {
+function drawLineLabel(line, label, lineColor, labelStr, x, y, isStart, felem) {
     const offsetOnLine = 20 * zoomfact;
     let canvas = document.getElementById('canvasOverlay');
     let canvasContext = canvas.getContext('2d');
     let textWidth = canvasContext.measureText(label).width;
 
-    if (line.ctype == lineDirection.UP) {
-        x -= offsetOnLine / 2;
-        y += (isStart) ? -offsetOnLine : offsetOnLine;
-    } else if (line.ctype == lineDirection.DOWN) {
-        x -= offsetOnLine / 2;
-        y += (isStart) ? offsetOnLine : -offsetOnLine;
-    } else if (line.ctype == lineDirection.LEFT) {
-        x += (isStart) ? -offsetOnLine : offsetOnLine;
-        y -= offsetOnLine / 2;
-    } else if (line.ctype == lineDirection.RIGHT) {
-        x += (isStart) ? offsetOnLine : -offsetOnLine;
-        y -= offsetOnLine / 2;
+
+    if(line.kind === lineKind.RECURSIVE){
+        //Calculatin the cardinality possition based on element size, so it follows when resized.
+        const length = 50 * zoomfact;
+        const lift   = 55 * zoomfact; 
+        const elementLength = felem.x2 - felem.x1;
+        x = felem.x1 + elementLength - length;
+        y = felem.y1  - lift;
+
+        if(labelStr == "startLabel"){
+            x -= 0;
+            y -= 0;
+        }else if(labelStr == "endLabel"){
+            x += length + 10;
+            y -= 0;
+        } 
+    }else {
+        if (line.ctype == lineDirection.UP) {
+            x -= offsetOnLine / 2;
+            y += (isStart) ? -offsetOnLine : offsetOnLine;
+        } else if (line.ctype == lineDirection.DOWN) {
+            x -= offsetOnLine / 2;
+            y += (isStart) ? offsetOnLine : -offsetOnLine;
+        } else if (line.ctype == lineDirection.LEFT) {
+            x += (isStart) ? -offsetOnLine : offsetOnLine;
+            y -= offsetOnLine / 2;
+        } else if (line.ctype == lineDirection.RIGHT) {
+            x += (isStart) ? offsetOnLine : -offsetOnLine;
+            y -= offsetOnLine / 2;
+        }
     }
 
     return `<rect 
@@ -396,27 +511,57 @@ function drawLineLabel(line, label, lineColor, labelStr, x, y, isStart) {
 
 /**
  * @description Draw a recursive line for the elements.
- * @param {Number} fx The X coordinate on start and end for the recursive line.
- * @param {Number} fy The Y coordinate on start and end for the recursive line.
  * @param {Number} offset It's a offset for the coodinate when draw a recursive line. 
  * @param {Object} line The line object that is drawn.
- * @param {Object} lineColor Where the start and end label should be.
+ * @param {Object} lineColor Where the start and end label should be.  
+ * @param {Number} strokewidth The width of the line.
+ * @param {Number} strokeDash A number for patterns of dashes and gaps.
+ * @param {Object} felem The element object that is drawn.
  * @returns Returns the different lines for the recursive line and the Array on the line.
  */
-function drawRecursive(fx, fy, offset, line, lineColor, strokewidth, strokeDash) {
+function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) {
     let str = '';
-    const length = 40 * zoomfact;
-    const startX = fx;
-    str += `<polyline id="${line.id}"
-    points="${startX + offset.x1 * zoomfact},${fy + offset.y1 * zoomfact} 
-            ${startX + offset.x1 + length},${fy + offset.y1 * zoomfact} 
-            ${startX + offset.x1 + length},${fy + offset.y1 + length} 
-            ${startX + offset.x1 * zoomfact},${fy + offset.y1 + length}"
-    fill="none" 
-    stroke="${lineColor}" 
-    stroke-width="${strokewidth}" 
-    stroke-dasharray="${strokeDash}" 
-/>`;
+    let points= "";
+
+    //Draw the recursive line top right of the element.
+    //Using the elemtns length to dynamicly change when re-sized.
+    const lineHeight = 60 * zoomfact; 
+    const lineLength = 40 * zoomfact; 
+    const lift   = 55 * zoomfact; 
+    const elementLength = felem.x2 - felem.x1;
+    const startX = felem.x1 + elementLength - lineLength + offset.x1 * zoomfact;
+    const startY = felem.y1  - lift + offset.y1 * zoomfact;
+    
+
+    if(line.type === entityType.IE) {
+        points =
+            `${startX},${startY + lineHeight } ` +
+            `${startX},${startY} ` +
+            `${startX + lineLength},${startY} ` +
+            `${startX + lineLength},${startY+lineHeight }`;
+    }else if(line.type === entityType.SD){
+        points =
+            `${startX},${startY + lineHeight} ` +
+            `${startX},${startY} ` +
+            `${startX + lineLength},${startY} ` +
+            `${startX + lineLength},${startY + lineHeight + 15}`;
+    }else if(line.type !== entityType.IE && line.type !== entityType.SD){
+        points =
+            `${startX},${startY + lineHeight  } ` +
+            `${startX},${startY} ` +
+            `${startX + lineLength},${startY} ` +
+            `${startX + lineLength},${startY+lineHeight  }`;
+    }
+    str += `
+            <polyline
+              id="${line.id}"
+              points="${points}"
+              fill="none"
+              stroke="${lineColor}"
+              stroke-width="${strokewidth}"
+              stroke-dasharray="${strokeDash}"
+            />
+          `;
     return str;
 }
 
@@ -527,10 +672,10 @@ function drawRecursiveLineSegmented(fx, fy, tx, ty, offset, line, lineColor, str
     let dx = (line.ctype == lineDirection.LEFT || line.ctype == lineDirection.RIGHT) ? (((fx + offset.x1) - (tx + offset.x2)) / 2) : 0;
     return `<polyline id="${line.id}"
     points='${fx + offset.x1},${fy + offset.y1} ${fx + offset.x1 - dx},${fy + offset.y1 - dy} ${tx + offset.x2 + dx},${ty + offset.y2 + dy} ${tx + offset.x2},${ty + offset.y2}' 
-                points="${fx + offset.x1 },${fy + offset.y1 } 
-                        ${fx + offset.x1 + 40 },${fy + offset.y1} 
-                        ${fx + offset.x1 + 40 },${fy + offset.y1 + 40 } 
-                        ${fx + offset.x1 },${fy + offset.y1 + 40 }"
+                points="${fx + offset.x1},${fy + offset.y1} 
+                        ${fx + offset.x1 + 40},${fy + offset.y1} 
+                        ${fx + offset.x1 + 40},${fy + offset.y1 + 40} 
+                        ${fx + offset.x1},${fy + offset.y1 + 40}"
                 fill="none" 
                 stroke="${lineColor}" stroke-width="${strokewidth}" stroke-dasharray="${strokeDash}" 
             />`;
@@ -590,15 +735,9 @@ function drawLineIcon(icon, ctype, x, y, lineColor, line) {
             break;
         case UMLLineIcons.BLACKDIAMOND:
             str += iconPoly(DIAMOND[ctype], x, y, lineColor, color.BLACK);
-            break;
-        case SDLineIcons.ARROW:
-            if (line.innerType == SDLineType.SEGMENT) {
-                // class should be diagram-umlicon-darkmode-sd and not diagram-umlicon-darkmode?
-                str += iconPoly(SD_ARROW[ctype], x, y, lineColor, color.BLACK);
-            } else if (line.type == entityType.SE) {
-                str += iconPoly(SD_ARROW[ctype], x, y, lineColor, color.BLACK);
-            }
-            break;
+            break
+
+
     }
     return str;
 }
@@ -649,7 +788,7 @@ function iconPoly(arr, x, y, lineColor, fill) {
     let s = "";
     for (let i = 0; i < arr.length; i++) {
         const [a, b] = arr[i];
-        s += `${x + a * zoomfact} ${y + b * zoomfact}, `;
+        s += `${x + a * zoomfact} ${y + b * zoomfact} `;
     }
     return `<polyline 
                 points='${s}' 
@@ -681,23 +820,29 @@ function calculateArrowBase(from, to, size) {
 }
 
 /**
- * @description Calculates the coordiates of the point representing one of the arrows corners
- * @param {Point} base The coordinates/Point where the arrow base is placed on the line, this Point is the pivot that the corners are "rotated" around.
- * @param {Point} to The coordinates/Point where the line between @param base and the element end
- * @param {boolean} clockwise Should the rotation be clockwise (true) or counter-clockwise (false).
- * @returns Returns the calculated coordinate for rotate the arrow point.
+ * @description* Rotates a point around another point (the base) by 45 degrees.
+ * This is mainly used to create the angled corners of an arrowhead.
+ * 
+ * @param {Point} base - The pivot point which is usually the base of the arrow.
+ * @param {Point} point - The point to rotate around the base which is usually the tip of arrow
+ * @param {boolean} clockwise - If true, it rotates the point 45° clockwise; otherwise, counter-clockwise.
+ * @returns {Point} A new point that has been rotated around the base.
  */
 function rotateArrowPoint(base, point, clockwise) {
-    const angle = Math.PI / 4; 
-    const direction = clockwise ? 1 : -1; 
+    const angle = Math.PI / 4; // 45 degrees in radians
+    const direction = clockwise ? 1 : -1; // Decides rotation direction
+
+    // Calculate how far the point is from the base
     const dx = point.x - base.x;
     const dy = point.y - base.y;
-        return {
-            x: base.x + (dx * Math.cos(direction * angle) - dy * Math.sin(direction * angle)),
-            y: base.y + (dx * Math.sin(direction * angle) + dy * Math.cos(direction * angle))
-        };
+
+    // Rotate the point around the base
+    return {
+        x: base.x + (dx * Math.cos(direction * angle) - dy * Math.sin(direction * angle)),
+        y: base.y + (dx * Math.sin(direction * angle) + dy * Math.cos(direction * angle))
+    };
 }
-     
+
 /**
  * @description Draw the arraow head for the line.
  * @param {Point} base The start x and y coordinate.
@@ -707,14 +852,27 @@ function rotateArrowPoint(base, point, clockwise) {
  * @returns Returns a polygon for the arrow head.
  */
 function drawArrowPoint(base, point, lineColor, strokeWidth) {
-    let right = rotateArrowPoint(base, point, true);
-    let left = rotateArrowPoint(base, point, false);
-    return ` 
-    <svg width="100" height="100">
-        <polygon points='${base.x},${base.y} ${right.x},${right.y} ${left.x},${left.y}'
-            stroke='${lineColor}' fill='none' stroke-width='${strokeWidth}' />
-    </svg>`;
- }
+
+    const size = 10 * zoomfact; // arrow size
+    const angle = Math.atan2(point.y - base.y, point.x - base.x);
+
+    const p1 = point;
+    const p2 = {
+        x: point.x - size * Math.cos(angle - Math.PI / 6),
+        y: point.y - size * Math.sin(angle - Math.PI / 6)
+    };
+    const p3 = {
+        x: point.x - size * Math.cos(angle + Math.PI / 6),
+        y: point.y - size * Math.sin(angle + Math.PI / 6)
+    };
+
+    return `
+        <polygon points='${p1.x},${p1.y} ${p2.x},${p2.y} ${p3.x},${p3.y}'
+            stroke='${lineColor}' fill='${lineColor}' stroke-width='${strokeWidth}' />
+    `;
+}
+
+
 
 
 /**
@@ -738,6 +896,10 @@ function redrawArrows() {
     // Sort all association ends that number above 0 according to direction of line
     for (let i = 0; i < data.length; i++) {
         sortElementAssociations(data[i]);
+    }
+    //Going through all elements and checking for adjacent lines
+    for (let i = 0; i < data.length; i++) {
+        checkAdjacentLines(data[i]);
     }
     // Draw each line using sorted line ends when applicable
     for (let i = 0; i < lines.length; i++) {
@@ -841,51 +1003,72 @@ function sortElementAssociations(element) {
     if (element.right.length > 1) element.right.sort(function (currentElementID, compareElementID) {
         return sortvectors(currentElementID, compareElementID, element.right, element.id, 1)
     });
+}
 
-    //Goes through all directions, if the function "determineLine" have added multiple lines to the same side
-    //it will then sort them and give them an index and number of lines.
-    //This is used to draw the lines in the right order and to give them a offset if they are on the same side.
-    //the offset is done is done in the function drawLine.
-    try{
+/**
+ * @description Gets a element as parameter and analyses each of its side for multiple lines adjacent
+ *  The line will then get properties dependant on their direction
+ *  These properties are used in drawLine do give them a offset. 
+ * @param {Object} element diagram entity 
+ */
+function checkAdjacentLines(element) {
+
+    try {
         ['top', 'bottom', 'right', 'left'].forEach(side => {
-
-            //First we got to sort out recusive lines, dont want them to move about
             const linesOfTargetSide = element[side];
+
+            //Dont want to effect recusive lines, so they are sorted out of the offset calculation.
             const filteredLines = linesOfTargetSide.filter(lineID => {
-            const lineIdIndex = findIndex(lines, lineID);
-            // Check if the line exists in the lines array.
-            if (lineIdIndex === -1) {
-                return false; }
-            const lineObject = lines[lineIdIndex]; 
-            if (lineObject.ghostLine || lineObject.targetGhost) {
-                return lineObject.kind === lineKind.NORMAL;
-            }
-            return lineObject.kind !== lineKind.RECURSIVE;
+                const lineIdIndex = findIndex(lines, lineID);
+                if (lineIdIndex === -1) { // Check if the line exists in the lines array.
+                    return false;
+                }
+                    const lineObject = lines[lineIdIndex];
+                if (lineObject.ghostLine || lineObject.targetGhost) { //To keep ghostlines active
+                    return lineObject.kind === lineKind.NORMAL;
+                }
+                    return lineObject.kind !== lineKind.RECURSIVE;
             });
-        
-            //If there are more then one line at one side
-            //sort them and give them an index and numberOfLines values
+
             if (filteredLines.length > 1) {
-                filteredLines.sort((line_1, line_2) =>
-                sortvectors(line_1, line_2, filteredLines, element.id, 2)
-                );
                 filteredLines.forEach((lineID, index) => {
-                const lineIdIndex = findIndex(lines, lineID); 
-                if (lineIdIndex === -1){
-                    return;   //Checks if enmpty
-                } 
-                //Give lineObject the variables of multiLineOffset and numberOfLines
-                //To be used in the function drawLine
-                const lineObject = lines[lineIdIndex]; 
-                lineObject.multiLineOffset = index;
-                lineObject.numberOfLines = filteredLines.length;
-            });
+                    const lineIndex = findIndex(lines, lineID);
+                    if (lineIndex === -1) {
+                        return;
+                    }
+                    const lineObject = lines[lineIndex];
+
+                    //Different offset dependant on if the line is going to or coming from a element.
+                    //This file is triggered multiple times, as such both if and else if will get done fast.
+                    if (lineObject.fromID === element.id) {
+                        lineObject.fromOffsetIndex = index;
+                        lineObject.fromNumberOfLines = filteredLines.length;
+
+                    } else if (lineObject.toID === element.id) {
+                        lineObject.toOffsetIndex = index;
+                        lineObject.toNumberOfLines = filteredLines.length;
+                    }
+                });
+                //Reverts the offset if lines are removed
+            } else if (filteredLines.length == 1) {
+                const lineIdIndex = findIndex(lines, filteredLines[0]);
+                const lineObject = lines[lineIdIndex];
+
+                if (lineObject.fromID === element.id) {
+                    lineObject.fromOffsetIndex = 0
+                    lineObject.fromNumberOfLines = 1
+                } else if (lineObject.toID === element.id) {
+                    lineObject.toOffsetIndex = 0
+                    lineObject.toNumberOfLines = 1;
+                }
+
             }
         });
-    }catch (error) {
+    } catch (error) {
         console.error("Error in sortElementAssociations, Multi-line sorting:", error);
     }
 }
+
 
 /**
  * @description calculates how the label should be displacesed.


### PR DESCRIPTION
By changing the line spacing between the lines, you are now able to zoom out and in without the it looking too messy. Especially when zooming out, the lines no longer deattaach from the source and target object. 