### PR TITLE
Fix for overlapping elements

### DIFF
--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -146,32 +146,18 @@ function entityIsOverlapping(id, x, y) {
             });
         });
 
-        // Collision detection for the ER and UML Relation elements
         if (element.kind === "ERRelation" || element.kind === "UMLRelation") {
-            // Calculate centre of first element
-            const centerAX = x + element.width / 2;
-            const centerAY = y + element.height / 2;
-
-            // Calculate centre of second element
-            const centerBX = data[i].x + data[i].width / 2;
-            const centerBY = data[i].y + data[i].height / 2;
-
-            // Calculate difference of the two elements on x-axis and y-axis
-            const dx = Math.abs(centerAX - centerBX);
-            const dy = Math.abs(centerAY - centerBY);
-
-            // Calculate maximum half width and height where the elements are still overlapping
-            const sumHalfWidth = (element.width / 2) + (data[i].width / 2);
-            const sumHalfHeight = (element.height / 2) + (data[i].height / 2);
-
-            // Detects if there is an actual collision
-            if ((dx / sumHalfWidth + dy / sumHalfHeight) <= 1) {
-                return true;
-            }
-            else {
-                continue;
+            // Use default rectangle collision detection
+            if (x < x2 &&
+                x + element.width > data[i].x &&
+                y < y2 &&
+                y + eHeight > data[i].y
+            ) {
+                isOverlapping = true;
+                break;
             }
         }
+
 
         // Default collision detection where overlapping is derived from height and width of element in a rectangle shape
         // Some elements doesnt have a height so the second parameter gets the height manually


### PR DESCRIPTION
The issue where ER and UML elements could overlap is now fixed by updating helper.js file. The issue was that ER relations and UML inheritance was using a custom center-point overlap check inside the function entityIsOverlapping(), which wasn't reliable when detecting collisions with other elements. This caused them to be placeable on top of UML classes, IE entities, and SD states unlike other elements which correctly triggered an overlap error.

The issue was fixed by removing the custom center-based logic and applying the same collision detection method used by all other elements. So the elements stated in the issue that could overlap, can't anymore either. .