### PR TITLE
Solution to issue #16839, Text box in options no longer display text vertically

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -448,9 +448,19 @@ function toggleOptionsPane() {
  */
 function textboxFormatString(arr) {
     let content = '';
+    
+    /* (let i = 0; i < arr.length; i++) {
+        content += arr[i] + '\n';   
+    } */
+
     for (let i = 0; i < arr.length; i++) {
-        content += arr[i] + '\n';
-    }
+        content += arr[i];
+        if(arr[i+1] == "-" && arr[i] !== " "|| arr[i+1] == "+"  && arr[i] !== " " || arr[i+1] == "*" && arr[i] !== " "){ 
+            console.log(arr[i+1])
+            content += '\n';
+
+        } 
+    } 
     return content;
 }
 

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -449,6 +449,7 @@ function toggleOptionsPane() {
 function textboxFormatString(arr) {
     let content = '';
     
+    //Its an array when the textbox have more then one line
     if (!Array.isArray(arr)) {
         return arr;  
     }

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -449,18 +449,14 @@ function toggleOptionsPane() {
 function textboxFormatString(arr) {
     let content = '';
     
-    /* (let i = 0; i < arr.length; i++) {
+    if (!Array.isArray(arr)) {
+        return arr;  
+    }
+
+    for(let i = 0; i < arr.length; i++) {
         content += arr[i] + '\n';   
-    } */
+    }
 
-    for (let i = 0; i < arr.length; i++) {
-        content += arr[i];
-        if(arr[i+1] == "-" && arr[i] !== " "|| arr[i+1] == "+"  && arr[i] !== " " || arr[i+1] == "*" && arr[i] !== " "){ 
-            console.log(arr[i+1])
-            content += '\n';
-
-        } 
-    } 
     return content;
 }
 


### PR DESCRIPTION
The text inside the diagram entities should not be horizontal as previous.
Don't know what caused the problem, but the solution is small so it should not interfere if the original cause is also fixed.

Before and after:
<p align="center">
  <img
    src="https://github.com/user-attachments/assets/4a667dcd-8c16-4024-9730-e0ab3f14284e"
    alt="Before"
    width="400"
    style="margin-right: 10px;"
  />
  <img
    src="https://github.com/user-attachments/assets/68541fb3-1680-4f23-878e-57e26678dc3a"
    alt="After"
    width="400"
  />
</p>


