### PR TITLE
Corrected IE relation line anchoring points

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -60,7 +60,7 @@ function drawElement(element, ghosted = false) {
             divContent = drawElementIERelation(element, boxw, boxh, linew);
             cssClass = 'ie-element';
             style = element.name == "Inheritance" ?
-             `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:2;` :
+             `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:;` :
              `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:1;`;
             break;
         case elementTypesNames.UMLInitialState:

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -35,7 +35,7 @@ function drawLine(line, targetGhost = false) {
         tx = fx;
         ty = fy;
     } else {
-        [fx, fy, tx, ty, offset] = getLineAttrubutes(felem, telem, line.ctype);
+        [fx, fy, tx, ty, offset] = getLineAttributes(felem, telem, line.ctype);
     }
 
     // Follows the cursor while drawing the line
@@ -411,7 +411,7 @@ function recursiveERRelation(felem, telem, line) {
     return [fx, fy, tx ?? telem.cx, ty ?? telem.cy];
 }
 
-function getLineAttrubutes(f, t, ctype) {
+function getLineAttributes(f, t, ctype) {
     let px = -1; // Don't touch
 
     let fWidth = f.width;
@@ -420,19 +420,27 @@ function getLineAttrubutes(f, t, ctype) {
     let tHeight = t.height;
 
     if (f.kind === elementTypesNames.IERelation) {
-      fWidth = f.width * 0.8 * zoomfact;
-      tWidth *= zoomfact;
+        fWidth = f.width * 0.8 * zoomfact;
+        fHeight = f.height * 0.8 * zoomfact;
+        tWidth *= zoomfact;
+        tHeight *= zoomfact;
     }
-    
+
     if (t.kind === elementTypesNames.IERelation) {
-      tWidth = t.width * 0.8 * zoomfact;
-      fWidth *= zoomfact;
+        tWidth = t.width * 0.8 * zoomfact;
+        tHeight = t.height * 0.8 * zoomfact;
+        fWidth *= zoomfact;
+        fHeight *= zoomfact;
     }
 
     const fx1 = f.cx - fWidth / 2;
     const fx2 = f.cx + fWidth / 2;
     const tx1 = t.cx - tWidth / 2;
     const tx2 = t.cx + tWidth / 2;
+    const fy1 = f.cy - fHeight / 2;
+    const fy2 = f.cy + fHeight / 2;
+    const ty1 = t.cy - tHeight / 2;
+    const ty2 = t.cy + tHeight / 2;
 
     const offset = { x1: 0, x2: 0, y1: 0, y2: 0 };
 
@@ -440,12 +448,12 @@ function getLineAttrubutes(f, t, ctype) {
         case lineDirection.UP:
             offset.y1 = px;
             offset.y2 = -px * 2;
-            return [f.cx, f.y1, t.cx, t.y2, offset];
+            return [f.cx, fy1, t.cx, ty2, offset];
 
         case lineDirection.DOWN:
             offset.y1 = -px * 2;
             offset.y2 = px;
-            return [f.cx, f.y2, t.cx, t.y1, offset];
+            return [f.cx, fy2, t.cx, ty1, offset];
 
         case lineDirection.LEFT:
             offset.x1 = -px;
@@ -458,6 +466,7 @@ function getLineAttrubutes(f, t, ctype) {
             return [fx2, f.cy, tx1, t.cy, offset];
     }
 }
+
 
 /**
  * @description Draw the label for the line.

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -26,7 +26,7 @@ function drawLine(line, targetGhost = false) {
     // Sets the to-coordinates to the same as the from-coordinates after getting line attributes
     // if the line is recursive
     if (line.kind === lineKind.RECURSIVE) {
-        [fx, fy, tx, ty, offset] = getLineAttrubutes(felem, felem, line.ctype);
+        [fx, fy, tx, ty, offset] = getLineAttributes(felem, felem, line.ctype);
         //Setting start position for the recursive line, to originate from the top.
         fx = felem.cx;
         fy = felem.y1;
@@ -419,16 +419,18 @@ function getLineAttributes(f, t, ctype) {
     let fHeight = f.height;
     let tHeight = t.height;
 
+    // Special case if line connection involves connecting from IERelation
     if (f.kind === elementTypesNames.IERelation) {
-        fWidth = f.width * 0.8 * zoomfact;
-        fHeight = f.height * 0.8 * zoomfact;
+        fWidth = f.width * 0.3 * zoomfact;
+        fHeight = f.height * 0 * zoomfact;
         tWidth *= zoomfact;
         tHeight *= zoomfact;
     }
 
+    // Special case if line connection involves connecting to IERelation
     if (t.kind === elementTypesNames.IERelation) {
-        tWidth = t.width * 0.8 * zoomfact;
-        tHeight = t.height * 0.8 * zoomfact;
+        tWidth = t.width * 0.3 * zoomfact;
+        tHeight = t.height * 0 * zoomfact;
         fWidth *= zoomfact;
         fHeight *= zoomfact;
     }

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -413,10 +413,14 @@ function recursiveERRelation(felem, telem, line) {
 }
 
 function getLineAttrubutes(f, t, ctype) {
-    const px = -1; // Don't touch
+    let px = -1; // Don't touch
+    if (t.kind || f.kind === elementTypesNames.IERelation){        
+        console.log("To/from");
+        px += - 5 * zoomfact;
+    }
     const offset = { x1: 0, x2: 0, y1: 0, y2: 0 };
 
-    switch (ctype) {
+    switch (ctype) { 
         case lineDirection.UP:
             offset.y1 = px;
             offset.y2 = -px * 2;
@@ -428,15 +432,13 @@ function getLineAttrubutes(f, t, ctype) {
             return [f.cx, f.y2, t.cx, t.y1, offset];
 
         case lineDirection.LEFT:
-
             offset.x1 = -px;          
             offset.x2 = px * 2;       
-
             return [f.x1, f.cy, t.x2, t.cy, offset];
 
         case lineDirection.RIGHT:
-            offset.x1 = px;
-            offset.x2 = -px * 2;
+            offset.x1 = px;           
+            offset.x2 = -px * 2;      
             return [f.x2, f.cy, t.x1, t.cy, offset];
     }
 }

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -34,8 +34,7 @@ function drawLine(line, targetGhost = false) {
         offset.y1 = 0;
         tx = fx;
         ty = fy;
-    }
-    else {
+    } else {
         [fx, fy, tx, ty, offset] = getLineAttrubutes(felem, telem, line.ctype);
     }
 
@@ -414,13 +413,30 @@ function recursiveERRelation(felem, telem, line) {
 
 function getLineAttrubutes(f, t, ctype) {
     let px = -1; // Don't touch
-    if (t.kind || f.kind === elementTypesNames.IERelation){        
-        console.log("To/from");
-        px += - 5 * zoomfact;
+
+    let fWidth = f.width;
+    let tWidth = t.width;
+    let fHeight = f.height;
+    let tHeight = t.height;
+
+    if (f.kind === elementTypesNames.IERelation) {
+      fWidth = f.width * 0.8 * zoomfact;
+      tWidth *= zoomfact;
     }
+    
+    if (t.kind === elementTypesNames.IERelation) {
+      tWidth = t.width * 0.8 * zoomfact;
+      fWidth *= zoomfact;
+    }
+
+    const fx1 = f.cx - fWidth / 2;
+    const fx2 = f.cx + fWidth / 2;
+    const tx1 = t.cx - tWidth / 2;
+    const tx2 = t.cx + tWidth / 2;
+
     const offset = { x1: 0, x2: 0, y1: 0, y2: 0 };
 
-    switch (ctype) { 
+    switch (ctype) {
         case lineDirection.UP:
             offset.y1 = px;
             offset.y2 = -px * 2;
@@ -432,17 +448,16 @@ function getLineAttrubutes(f, t, ctype) {
             return [f.cx, f.y2, t.cx, t.y1, offset];
 
         case lineDirection.LEFT:
-            offset.x1 = -px;          
-            offset.x2 = px * 2;       
-            return [f.x1, f.cy, t.x2, t.cy, offset];
+            offset.x1 = -px;
+            offset.x2 = px * 2;
+            return [fx1, f.cy, tx2, t.cy, offset];
 
         case lineDirection.RIGHT:
-            offset.x1 = px;           
-            offset.x2 = -px * 2;      
-            return [f.x2, f.cy, t.x1, t.cy, offset];
+            offset.x1 = px;
+            offset.x2 = -px * 2;
+            return [fx2, f.cy, tx1, t.cy, offset];
     }
 }
-
 
 /**
  * @description Draw the label for the line.


### PR DESCRIPTION
The line anchoring points for the IE-relations were previously calculated by the height and width of the element. Due to the curvature and smaller size of the element inside, it appeared as if the lines didn't connect to the actual element, but instead floated mid-air. This has been corrected so that the lines now connect to a set of adjusted coordinates within the IE relation shape, which makes the lines visually connect to the IE-relation. 

Before. Line endings floating mid-air:
![image](https://github.com/user-attachments/assets/dea775b8-467f-4271-b643-099283f876cb)

After. Corrected anchoring points and lines connect to the element:
![image](https://github.com/user-attachments/assets/cc32074a-eae3-42c5-ac4e-bb800c75764c)
