### PR TITLE
Re-engineer microservice createNewCodeExample

### DIFF
--- a/DuggaSys/microservices/courseedService/copyCourseVersion_ms.php
+++ b/DuggaSys/microservices/courseedService/copyCourseVersion_ms.php
@@ -10,7 +10,7 @@ include_once "../sharedMicroservices/getUid_ms.php";
 include_once "../sharedMicroservices/retrieveUsername_ms.php";
 include_once "./retrieveCourseedService_ms.php";
 include_once "../sharedMicroservices/createNewListEntry_ms.php";
-include_once "../sharedMicroservices/createNewCodeExample_ms.php";
+
 
 // Connect to the database and start the session
 pdoConnect();

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -131,7 +131,6 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     //create codeexample
     //$link = createNewCodeExample($pdo, null, $courseid, $coursevers, $sectionname, $link, $log_uuid, $templateNumber);
 
-    header("Content-Type: application/json");
     //set url for createNewCodeExample.php path
     $baseURL = "https://" . $_SERVER['HTTP_HOST'];
     $url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php";

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -127,7 +127,27 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     $sectionname = $exampleName;
 
     //create codeexample
-    $link = createNewCodeExample($pdo, null, $courseid, $coursevers, $sectionname, $link, $log_uuid, $templateNumber);
+    //$link = createNewCodeExample($pdo, null, $courseid, $coursevers, $sectionname, $link, $log_uuid, $templateNumber);
+
+    header("Content-Type: application/json");
+    //set url for createNewCodeExample.php path
+    $baseURL = "https://" . $_SERVER['HTTP_HOST'];
+    $url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php";
+    $ch = curl_init($url);
+
+    //options for curl
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+        'courseid'       => $courseid, 'coursevers'     => $coursevers, 'sectionname'    => $sectionname, 'link'           => $link,
+        'log_uuid'       => $log_uuid, 'templateNumber' => $templateNumber
+    ]));
+       
+    $response = curl_exec($ch);
+    curl_close($ch);
+    
+    $data = json_decode($response, true);
+    $link = $data['link'] ?? null;
 
     //select the latest codeexample created to link boxes to this codeexample
     $query = $pdo->prepare("SELECT MAX(exampleid) as LatestExID FROM codeexample;");

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -143,16 +143,15 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
         'exampleid'=> $exampleid,
         'courseid'=> $courseid,
         'coursevers'=> $coursevers, 
-        'sectionname'=> $sectionname,
+        'sectname'=> $sectionname,
         'link'=> $link,
         'log_uuid'=> $log_uuid, 
-        'templateNumber'=> $templateNumber
+        'templatenumber'=> $templateNumber
     ]));
        
     $response = curl_exec($ch);
-    $data = json_decode($response, true);
-    $link = $data;
-    curl_close($ch);
+    $link = json_decode($response, true);
+
 
     //select the latest codeexample created to link boxes to this codeexample
     $query = $pdo->prepare("SELECT MAX(exampleid) as LatestExID FROM codeexample;");
@@ -461,5 +460,5 @@ function NoCodeExampleNoFiles($exampleName)
 }
 
 $data = retrieveSectionedService($debug, $opt, $pdo, $userid, $courseid, $coursevers, $log_uuid);
-header('Content-Type: application/json')
+header('Content-Type: application/json');
 echo json_encode($data);

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -132,6 +132,7 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     //$link = createNewCodeExample($pdo, null, $courseid, $coursevers, $sectionname, $link, $log_uuid, $templateNumber);
 
     //set url for createNewCodeExample.php path
+    header("Content-Type: application/json");
     $baseURL = "https://" . $_SERVER['HTTP_HOST'];
     $url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php";
     $ch = curl_init($url);

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -151,6 +151,7 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     $response = curl_exec($ch);
     $data = json_decode($response, true);
     $link = $data;
+    curl_close($ch);
 
     //select the latest codeexample created to link boxes to this codeexample
     $query = $pdo->prepare("SELECT MAX(exampleid) as LatestExID FROM codeexample;");

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -17,6 +17,8 @@ $highscoremode = getOP('highscoremode');
 $pos = getOP('pos');
 $lid = getOP('lid');
 $log_uuid = getOP('log_uuid');
+$sectionname = getOP('sectionname');//Not used but needed since post sends them along
+$templateNumber = getOP('templateNumber');//Not used but needed since post sends them along
 $debug = "NONE!";
 
 pdoConnect();

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -19,6 +19,7 @@ $lid = getOP('lid');
 $log_uuid = getOP('log_uuid');
 $sectionname = getOP('sectionname');//Not used but needed since post sends them along
 $templateNumber = getOP('templateNumber');//Not used but needed since post sends them along
+$exampleid = getOP('exampleid');// Not used but needed since post sends them along
 $debug = "NONE!";
 
 pdoConnect();
@@ -140,6 +141,7 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+        'exampleid'=> $exampleid,
         'courseid'=> $courseid,
         'coursevers'=> $coursevers, 
         'sectionname'=> $sectionname,

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -1,7 +1,6 @@
 <?php
 
 include_once "../sharedMicroservices/getUid_ms.php";
-//include_once "../sharedMicroservices/createNewCodeExample_ms.php";
 include_once "../sharedMicroservices/createNewListEntry_ms.php";
 include_once "./retrieveSectionedService_ms.php";
 include_once "../../../Shared/sessions.php";

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -468,4 +468,5 @@ function NoCodeExampleNoFiles($exampleName)
 }
 
 $data = retrieveSectionedService($debug, $opt, $pdo, $userid, $courseid, $coursevers, $log_uuid);
+header('Content-Type: application/json')
 echo json_encode($data);

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -1,7 +1,7 @@
 <?php
 
 include_once "../sharedMicroservices/getUid_ms.php";
-include_once "../sharedMicroservices/createNewCodeExample_ms.php";
+//include_once "../sharedMicroservices/createNewCodeExample_ms.php";
 include_once "../sharedMicroservices/createNewListEntry_ms.php";
 include_once "./retrieveSectionedService_ms.php";
 include_once "../../../Shared/sessions.php";

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -135,7 +135,6 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     $baseURL = "https://" . $_SERVER['HTTP_HOST'];
     $url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php";
     $ch = curl_init($url);
-
     //options for curl
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_POST, true);
@@ -150,18 +149,8 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     ]));
        
     $response = curl_exec($ch);
-    if ($response === false) {
-        throw new RuntimeException('cURL error: '.curl_error($ch));
-    }
-    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
-
-    if ($httpCode !== 200) {
-        throw new RuntimeException("Microservice returned HTTP $httpCode: $response");
-    }
-    
     $data = json_decode($response, true);
-    $link = $data['link'] ?? null;
+    $link = $data;
 
     //select the latest codeexample created to link boxes to this codeexample
     $query = $pdo->prepare("SELECT MAX(exampleid) as LatestExID FROM codeexample;");

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -139,12 +139,24 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-        'courseid'       => $courseid, 'coursevers'     => $coursevers, 'sectionname'    => $sectionname, 'link'           => $link,
-        'log_uuid'       => $log_uuid, 'templateNumber' => $templateNumber
+        'courseid'=> $courseid,
+        'coursevers'=> $coursevers, 
+        'sectionname'=> $sectionname,
+        'link'=> $link,
+        'log_uuid'=> $log_uuid, 
+        'templateNumber'=> $templateNumber
     ]));
        
     $response = curl_exec($ch);
+    if ($response === false) {
+        throw new RuntimeException('cURL error: '.curl_error($ch));
+    }
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
+
+    if ($httpCode !== 200) {
+        throw new RuntimeException("Microservice returned HTTP $httpCode: $response");
+    }
     
     $data = json_decode($response, true);
     $link = $data['link'] ?? null;

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -27,6 +27,7 @@ $pos=getOP('pos');
 $tabs=getOP('tabs');
 $userid=getUid();
 $log_uuid=getOP('log_uuid');
+$templateNumber=getOP('templateNumber');
 $debug = "NONE!";
 
 global $pdo;
@@ -55,7 +56,7 @@ if($link==-1) {
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
         'courseid'=> $courseid,
         'coursevers'=> $coursevers, 
-        'sectionname'=> $sectionname,
+        'sectionname'=> $sectname,
         'link'=> $link,
         'log_uuid'=> $log_uuid, 
         'templateNumber'=> $templateNumber

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -96,6 +96,7 @@ $debug = createNewListEntry($pdo,
 
 
 $data = retrieveSectionedService($debug, $opt, $pdo, $userid, $courseid, $coursevers, $log_uuid);
+header('Content-Type: application/json')
 echo json_encode($data);
 return;
 ?>

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -58,16 +58,16 @@ if($link==-1) {
         'exampleid'=> $exampleid,
         'courseid'=> $courseid,
         'coursevers'=> $coursevers, 
-        'sectionname'=> $sectionname,
+        'sectname'=> $sectname,
         'link'=> $link,
-        'log_uuid'=> $log_uuid, 
-        'templateNumber'=> $templateNumber
+        'log_uuid'=> $log_uuid,
+        'templatenumber'=> $templateNumber 
     ]));
        
     $response = curl_exec($ch);
     $data = json_decode($response, true);
-    $link = $data;
-    curl_close($ch);
+    $link=$data['link'];
+
 }
 
 $debug = createNewListEntry($pdo,
@@ -87,7 +87,7 @@ $debug = createNewListEntry($pdo,
 
 
 $data = retrieveSectionedService($debug, $opt, $pdo, $userid, $courseid, $coursevers, $log_uuid);
-header('Content-Type: application/json')
+header('Content-Type: application/json');
 echo json_encode($data);
 return;
 ?>

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -42,8 +42,40 @@ if($link==-1) {
     foreach($queryz2->fetchAll() as $row) {
         $exampleid=$row['exampleid'];
     }
-    $data = createNewCodeExample($pdo,$exampleid, $courseid, $coursevers, $sectname,$link,$log_uuid);
-    $link=$data['link'];
+    //$data = createNewCodeExample($pdo,$exampleid, $courseid, $coursevers, $sectname,$link,$log_uuid);
+    //$link=$data['link'];
+
+    $baseURL = "https://" . $_SERVER['HTTP_HOST'];
+    $url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php";
+    $ch = curl_init($url);
+
+    //options for curl
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+        'courseid'=> $courseid,
+        'coursevers'=> $coursevers, 
+        'sectionname'=> $sectionname,
+        'link'=> $link,
+        'log_uuid'=> $log_uuid, 
+        'templateNumber'=> $templateNumber
+    ]));
+       
+    $response = curl_exec($ch);
+    if ($response === false) {
+        throw new RuntimeException('cURL error: '.curl_error($ch));
+    }
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($httpCode !== 200) {
+        throw new RuntimeException("Microservice returned HTTP $httpCode: $response");
+    }
+    
+    $data = json_decode($response, true);
+    $link = $data['link'] ?? null;
+
+
     $debug=$data['debug'];
 }
 

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -47,6 +47,7 @@ if($link==-1) {
     //$link=$data['link'];
 
     //set url for createNewCodeExample.php path
+    header("Content-Type: application/json");
     $baseURL = "https://" . $_SERVER['HTTP_HOST'];
     $url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php";
     $ch = curl_init($url);

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -6,7 +6,7 @@ include_once "../../../Shared/basic.php";
 include_once "../sharedMicroservices/getUid_ms.php";
 include_once "../sharedMicroservices/retrieveUsername_ms.php";
 include_once "../sharedMicroservices/createNewListEntry_ms.php";
-include_once "../sharedMicroservices/createNewCodeExample_ms.php";
+//include_once "../sharedMicroservices/createNewCodeExample_ms.php";
 include_once "./retrieveSectionedService_ms.php";
 
 pdoConnect();

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -46,39 +46,27 @@ if($link==-1) {
     //$data = createNewCodeExample($pdo,$exampleid, $courseid, $coursevers, $sectname,$link,$log_uuid);
     //$link=$data['link'];
 
+    //set url for createNewCodeExample.php path
     $baseURL = "https://" . $_SERVER['HTTP_HOST'];
     $url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php";
     $ch = curl_init($url);
-
     //options for curl
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-        'exampleid'=>$exampleid,
+        'exampleid'=> $exampleid,
         'courseid'=> $courseid,
         'coursevers'=> $coursevers, 
-        'sectionname'=> $sectname,
+        'sectionname'=> $sectionname,
         'link'=> $link,
         'log_uuid'=> $log_uuid, 
         'templateNumber'=> $templateNumber
     ]));
        
     $response = curl_exec($ch);
-    if ($response === false) {
-        throw new RuntimeException('cURL error: '.curl_error($ch));
-    }
-    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
-
-    if ($httpCode !== 200) {
-        throw new RuntimeException("Microservice returned HTTP $httpCode: $response");
-    }
-    
     $data = json_decode($response, true);
-    $link = $data['link'] ?? null;
-
-
-    $debug=$data['debug'];
+    $link = $data;
+    curl_close($ch);
 }
 
 $debug = createNewListEntry($pdo,

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -28,6 +28,7 @@ $tabs=getOP('tabs');
 $userid=getUid();
 $log_uuid=getOP('log_uuid');
 $templateNumber=getOP('templateNumber');
+$exampleid=getOP('exampleid');
 $debug = "NONE!";
 
 global $pdo;
@@ -54,6 +55,7 @@ if($link==-1) {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+        'exampleid'=>$exampleid,
         'courseid'=> $courseid,
         'coursevers'=> $coursevers, 
         'sectionname'=> $sectname,

--- a/DuggaSys/microservices/sectionedService/createListEntry_ms.php
+++ b/DuggaSys/microservices/sectionedService/createListEntry_ms.php
@@ -6,7 +6,6 @@ include_once "../../../Shared/basic.php";
 include_once "../sharedMicroservices/getUid_ms.php";
 include_once "../sharedMicroservices/retrieveUsername_ms.php";
 include_once "../sharedMicroservices/createNewListEntry_ms.php";
-//include_once "../sharedMicroservices/createNewCodeExample_ms.php";
 include_once "./retrieveSectionedService_ms.php";
 
 pdoConnect();

--- a/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
@@ -7,9 +7,6 @@ pdoConnect();
 session_start();
 
 
-header('Content-Type: application/json');
-
-
 //get values from post
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['exampleid'], $_POST['courseid'], $_POST['coursevers'], $_POST['sectname'], $_POST['link'], $_POST['log_uuid'], $_POST['templatenumber'])) {
@@ -45,6 +42,7 @@ $userid = getUid();
 $username = retrieveUsername($pdo);
 logUserEvent($userid, $username, EventTypes::SectionItems, $sectname);
 
-$response = ['debug'=>$debug, 'link'=>$link];
-echo json_encode($response);
-exit;
+$result = array('debug'=>$debug,'link'=>$link);
+header('Content-Type: application/json');
+echo json_encode($result);
+

--- a/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
@@ -11,7 +11,22 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     echo json_encode(['error' => 'Only POST allowed']);
     exit;
 }
-
+// Error handling regarding the six values needed
+// These are required for the post call to work
+$required = [
+    'courseid', 'coursevers', 'sectionname',
+    'link', 'log_uuid', 'templateNumber'
+];
+//If any value is missing the function will return error code 400 and a error message
+foreach ($required as $f) {
+    if (! isset($_POST[$f])) {
+        http_response_code(400);
+        echo json_encode([
+            'error' => "Missing parameter: $f"
+        ]);
+        exit;
+    }
+}
 // Turn post values into locals
 $courseid = $_POST['courseid'];
 $coursevers = $_POST['coursevers'];

--- a/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
@@ -14,7 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 // Error handling regarding the six values needed
 // These are required for the post call to work
 $required = [
-    'courseid', 'coursevers', 'sectionname',
+    'exampleid','courseid', 'coursevers', 'sectionname',
     'link', 'log_uuid', 'templateNumber'
 ];
 //If any value is missing the function will return error code 400 and a error message
@@ -28,6 +28,7 @@ foreach ($required as $f) {
     }
 }
 // Turn post values into locals
+$exampleid = $_POST['exampleid'];
 $courseid = $_POST['courseid'];
 $coursevers = $_POST['coursevers'];
 $sectionname = $_POST['sectionname'];
@@ -38,7 +39,7 @@ $templateNumber = $_POST['templateNumber'];
 // Here we call the original function
 $result = createNewCodeExample(
     $pdo,
-    null,
+    $exampleid,
     $courseid,
     $coursevers,
     $sectionname,

--- a/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
@@ -2,79 +2,48 @@
 include_once "./getUid_ms.php";
 include_once "./retrieveUsername_ms.php";
 
-//Here we add a http call for post requests
+// Connect to database and start session
+pdoConnect();
+session_start();
+
+
 header('Content-Type: application/json');
 
-// This makes the function only accept POST
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(405);
-    echo json_encode(['error' => 'Only POST allowed']);
-    exit;
-}
-// Error handling regarding the six values needed
-// These are required for the post call to work
-$required = [
-    'exampleid','courseid', 'coursevers', 'sectionname',
-    'link', 'log_uuid', 'templateNumber'
-];
-//If any value is missing the function will return error code 400 and a error message
-foreach ($required as $f) {
-    if (! isset($_POST[$f])) {
-        http_response_code(400);
-        echo json_encode([
-            'error' => "Missing parameter: $f"
-        ]);
-        exit;
+
+//get values from post
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['exampleid'], $_POST['courseid'], $_POST['coursevers'], $_POST['sectname'], $_POST['link'], $_POST['log_uuid'], $_POST['templatenumber'])) {
+		$exampleid = $_POST['exampleid'];
+		$courseid = $_POST['courseid'];
+		$coursevers = $_POST['coursevers'];
+		$sectname = $_POST['sectname'];
+		$link = $_POST['link'];
+		$log_uuid  = $_POST['log_uuid'];
+		$templateNumber = $_POST['templatenumber'];
     }
 }
-// Turn post values into locals
-$exampleid = $_POST['exampleid'];
-$courseid = $_POST['courseid'];
-$coursevers = $_POST['coursevers'];
-$sectionname = $_POST['sectionname'];
-$link = $_POST['link'];
-$log_uuid = $_POST['log_uuid'];
-$templateNumber = $_POST['templateNumber'];
 
-// Here we call the original function
-$result = createNewCodeExample(
-    $pdo,
-    $exampleid,
-    $courseid,
-    $coursevers,
-    $sectionname,
-    $link,
-    $log_uuid,
-    $templateNumber
-);
-
-// Return the result as JSON
-echo json_encode($result);
-exit;
-
-//Here is where the microservice function starts
-function createNewCodeExample($pdo, $exampleid, $courseid, $coursevers, $sectname, $link, $log_uuid, $templateNumber=0){
-	if (!is_null($exampleid)){
-		$sname = $sectname . ($exampleid + 1);
-	}else{
-		$sname= $sectname;
-	}
-	$debug="NONE!";
-	$query2 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (:cid,:ename,:sname,1,:cversion, :templateid);");
-	$query2->bindParam(':cid', $courseid);
-	$query2->bindParam(':cversion', $coursevers);
-	$query2->bindParam(':ename', $sectname);
-	$query2->bindParam(':sname', $sname);
-	$query2->bindParam(":templateid", $templateNumber);
-	if (!$query2->execute()) {
-		$error = $query2->errorInfo();
-		$debug = "Error updating entries" . $error[2];
-	}
-	$link = $pdo->lastInsertId();
-
-	$userid = getUid();
-	$username = retrieveUsername($pdo);
-	logUserEvent($userid, $username, EventTypes::SectionItems, $sectname);
-
-	return array('debug'=>$debug,'link'=>$link);
+if (!is_null($exampleid)){
+	$sname = $sectname . ($exampleid + 1);
+}else{
+	$sname= $sectname;
 }
+$debug="NONE!";
+$query2 = $pdo->prepare("INSERT INTO codeexample(cid,examplename,sectionname,uid,cversion,templateid) values (:cid,:ename,:sname,1,:cversion, :templateid);");
+$query2->bindParam(':cid', $courseid);
+$query2->bindParam(':cversion', $coursevers);
+$query2->bindParam(':ename', $sectname);
+$query2->bindParam(':sname', $sname);
+$query2->bindParam(":templateid", $templateNumber);
+if (!$query2->execute()) {
+	$error = $query2->errorInfo();
+	$debug = "Error updating entries" . $error[2];
+}
+$link = $pdo->lastInsertId();
+
+$userid = getUid();
+$username = retrieveUsername($pdo);
+logUserEvent($userid, $username, EventTypes::SectionItems, $sectname);
+
+return array('debug'=>$debug,'link'=>$link);
+

--- a/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
@@ -45,5 +45,6 @@ $userid = getUid();
 $username = retrieveUsername($pdo);
 logUserEvent($userid, $username, EventTypes::SectionItems, $sectname);
 
-return array('debug'=>$debug,'link'=>$link);
-
+$response = ['debug'=>$debug, 'link'=>$link];
+echo json_encode($response);
+exit;

--- a/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php
@@ -2,6 +2,41 @@
 include_once "./getUid_ms.php";
 include_once "./retrieveUsername_ms.php";
 
+//Here we add a http call for post requests
+header('Content-Type: application/json');
+
+// This makes the function only accept POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Only POST allowed']);
+    exit;
+}
+
+// Turn post values into locals
+$courseid = $_POST['courseid'];
+$coursevers = $_POST['coursevers'];
+$sectionname = $_POST['sectionname'];
+$link = $_POST['link'];
+$log_uuid = $_POST['log_uuid'];
+$templateNumber = $_POST['templateNumber'];
+
+// Here we call the original function
+$result = createNewCodeExample(
+    $pdo,
+    null,
+    $courseid,
+    $coursevers,
+    $sectionname,
+    $link,
+    $log_uuid,
+    $templateNumber
+);
+
+// Return the result as JSON
+echo json_encode($result);
+exit;
+
+//Here is where the microservice function starts
 function createNewCodeExample($pdo, $exampleid, $courseid, $coursevers, $sectname, $link, $log_uuid, $templateNumber=0){
 	if (!is_null($exampleid)){
 		$sname = $sectname . ($exampleid + 1);


### PR DESCRIPTION
Re-engineered to remove old includes and replaced with POST calls and recieves. Have tried inspecting sectioned.php for both files, none found. Have played around a bit and nothing seems to be broken. Dont know if the changed files are implemented yet. Fixes issue #16826 .