### PR TITLE
16836 implement scrolling the canvas in the mobile version

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -914,33 +914,48 @@ document.addEventListener("mouseout", function (event) {
 
 // --------------------------------------- Touch Events    --------------------------------
 
+/**
+ * @description Event function triggered when touch is registered on top of the container.
+ * @param {TouchEvent} event Triggered touch event.
+ */
+
+function tstart(event) {
+    // Only responds to single-finger touch
+    if (event.touches.length === 1) {
+        // Set the internal state to make the app know that user is dragging the container
+        pointerState = pointerStates.CLICKED_CONTAINER;
+        // Set initial touch position and saves the scroll offset
+        startX = event.touches[0].clientX;
+        startY = event.touches[0].clientY;
+        sscrollx = scrollx;
+        sscrolly = scrolly;
+    }
+}
+
 function tmoving(event) {
+    // Prevents scrolling in browser when panning the canvas
     event.preventDefault();
+
+    // Caches if more than one finger is used (Prevents interfering with pinch-gestures).
     if (event.touches.length != 1) return;
 
     const touch = event.touches[0];
     lastMousePos = new Point(touch.clientX, touch.clientY);
 
+    // Calculates how far the user has dragged the finger if the finger has moved
     if (pointerState === pointerStates.CLICKED_CONTAINER) {
         movingContainer = true;
         deltaX = startX - touch.clientX;
         deltaY = startY - touch.clientY;
         scrollx = sscrollx - Math.round(deltaX * zoomfact);
         scrolly = sscrolly - Math.round(deltaY * zoomfact);
+
+        //Refreshes all the visuals
         updateGridPos();
         updateA4Pos();
+        updatepos();
         drawRulerBars(scrollx, scrolly);
         calculateDeltaExceeded();
-    }
-}
-
-function tstart(event) {
-    if (event.touches.length === 1) {
-        pointerState = pointerStates.CLICKED_CONTAINER;
-        startX = event.touches[0].clientX;
-        startY = event.touches[0].clientY;
-        sscrollx = scrollx;
-        sscrolly = scrolly;
     }
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -910,6 +910,40 @@ document.addEventListener("mouseout", function (event) {
     }
 });
 
+document.getElementById("container").addEventListener("touchmove", tmoving, { passive: false });
+
+document.getElementById("container").addEventListener("touchstart", function(e) {
+    if (e.touches.length === 1) {
+        pointerState = pointerStates.CLICKED_CONTAINER;
+        startX = e.touches[0].clientX;
+        startY = e.touches[0].clientY;
+        sscrollx = scrollx;
+        sscrolly = scrolly;
+    }
+}, { passive: false });
+
+// --------------------------------------- Touch Events    --------------------------------
+
+function tmoving(event) {
+    event.preventDefault();
+    if (event.touches.length != 1) return;
+
+    const touch = event.touches[0];
+    lastMousePos = new Point(touch.clientX, touch.clientY);
+
+    if (pointerState === pointerStates.CLICKED_CONTAINER) {
+        movingContainer = true;
+        deltaX = startX - touch.clientX;
+        deltaY = startY - touch.clientY;
+        scrollx = sscrollx - Math.round(deltaX * zoomfact);
+        scrolly = sscrolly - Math.round(deltaY * zoomfact);
+        updateGridPos();
+        updateA4Pos();
+        drawRulerBars(scrollx, scrolly);
+        calculateDeltaExceeded();
+    }
+}
+
 // --------------------------------------- Mouse Events    --------------------------------
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -426,6 +426,8 @@ function getData() {
     document.getElementById("container").addEventListener("mouseup", mup);
     document.getElementById("container").addEventListener("mousemove", mmoving);
     document.getElementById("container").addEventListener("wheel", mwheel);
+    document.getElementById("container").addEventListener("touchmove", tmoving, { passive: false });
+    document.getElementById("container").addEventListener("touchstart", tstart, { passive: false });
     document.getElementById("options-pane").addEventListener("mousedown", mdown);
     // debugDrawSDEntity(); // <-- debugfunc to show an sd entity
     generateToolTips();
@@ -910,18 +912,6 @@ document.addEventListener("mouseout", function (event) {
     }
 });
 
-document.getElementById("container").addEventListener("touchmove", tmoving, { passive: false });
-
-document.getElementById("container").addEventListener("touchstart", function(e) {
-    if (e.touches.length === 1) {
-        pointerState = pointerStates.CLICKED_CONTAINER;
-        startX = e.touches[0].clientX;
-        startY = e.touches[0].clientY;
-        sscrollx = scrollx;
-        sscrolly = scrolly;
-    }
-}, { passive: false });
-
 // --------------------------------------- Touch Events    --------------------------------
 
 function tmoving(event) {
@@ -941,6 +931,16 @@ function tmoving(event) {
         updateA4Pos();
         drawRulerBars(scrollx, scrolly);
         calculateDeltaExceeded();
+    }
+}
+
+function tstart(event) {
+    if (event.touches.length === 1) {
+        pointerState = pointerStates.CLICKED_CONTAINER;
+        startX = event.touches[0].clientX;
+        startY = event.touches[0].clientY;
+        sscrollx = scrollx;
+        sscrolly = scrolly;
     }
 }
 


### PR DESCRIPTION
Implemented the ability to scroll on the grid/canvas with touch. Added events in _**diagram.js**_ that listens to events caused by a touch input. _**tmoving**_ function is handling the movement of the finger touch and the _**tstart**_ function is storing the start position of the finger.

_There is still more functions that has to be adjust to touch but this will be handled in other sub-issues related to the mobile implementation of the diagram tool._

**Before:**
_(No ability to use touch to scroll on canvas)_

https://github.com/user-attachments/assets/2c52eb53-576c-4d20-8990-ad2cf9417446


**After:**
_(**New feature!** Ability to scroll on canvas)_

https://github.com/user-attachments/assets/f0ae3339-5009-441b-984a-387b410cc5ba

