### PR TITLE
Fixed saved file issue .

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1756,6 +1756,7 @@ function storeDiagramInLocalStorage(key) {
         local = (local[0] == "{") ? local : `{${local}}`;
 
         let localDiagrams = JSON.parse(local);
+        objToSave.timestamp = new Date().getTime(); 
         localDiagrams[key] = objToSave;
         localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
 
@@ -1940,10 +1941,17 @@ function showModal() {
     let localDiagrams;
 
     let local = localStorage.getItem("diagrams");
+
+
+    // Parse saved diagrams from localstorage and sort them so autosave always remains at top and all other saves are ordered by most recent timestamp to appear closest to top.
     if (local) {
         local = (local[0] == "{") ? local : `{${local}}`;
         localDiagrams = JSON.parse(local);
-        diagramKeys = Object.keys(localDiagrams);
+        diagramKeys = Object.keys(localDiagrams).sort((a, b) => {
+            if (a === "AutoSave") return -1;
+            if (b === "AutoSave") return 1;
+            return localDiagrams[b].timestamp - localDiagrams[a].timestamp; 
+        });
     }
 
     // Remove all elements


### PR DESCRIPTION
Fixed issue where saves with numeric names could appear above AutoSave. This update introduces custom sorting that keeps AutoSave fixed at the top at all times, and then sorts all other saves by their timestamp, showing the most recent ones first (closest to top) for a more natural behavior.

![image](https://github.com/user-attachments/assets/61ac2c88-1339-493c-a4d9-0c2966bcd05a)
