### PR TITLE
Fixed margin for the subicon tooltips

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -710,8 +710,8 @@
     height:34px;
 }
 .placementTypeToolTipText{
-    top:0%;
-    left:100%;
+    top: -55%;
+    left: 110%;
     visibility: hidden;
     width: 250px;
     background: rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1e6e0c56-7f4c-4ecd-8873-ef0bfe6ff044)
After:
![image](https://github.com/user-attachments/assets/921d38cc-f57d-4340-9d3c-42f7510e4b14)
