### PR TITLE
Line labels now dont move when cardinality is added

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -221,14 +221,15 @@ function drawLine(line, targetGhost = false) {
 
     if (felem.type != entityType.ER || telem.type != entityType.ER) {
         if (line.startLabel && line.startLabel != '') {
-            fx += offset.x1;
-            fy += offset.y1;
-            str += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fx, fy, true, felem);
+            const fxCardinality = fx + offset.x1;
+            const fyCardinality = fy + offset.y1;
+            str += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fxCardinality, fyCardinality, true, felem);
         }
         if (line.endLabel && line.endLabel != '') {
-            tx += offset.x1;
-            ty += offset.y2;
-            str += drawLineLabel(line, line.endLabel, lineColor, 'endLabel', tx, ty, false, felem);
+            const txCardinality = tx + offset.x1;
+            const tyCardinality = ty + offset.y2;
+
+            str += drawLineLabel(line, line.endLabel, lineColor, 'endLabel', txCardinality, tyCardinality, false, felem);
         }
     } else {
         if (line.cardinality) {

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -229,7 +229,6 @@ function drawLine(line, targetGhost = false) {
         if (line.endLabel && line.endLabel != '') {
             const txCardinality = tx + offset.x1;
             const tyCardinality = ty + offset.y2;
-
             str += drawLineLabel(line, line.endLabel, lineColor, 'endLabel', txCardinality, tyCardinality, false, felem);
         }
     } else {
@@ -237,6 +236,7 @@ function drawLine(line, targetGhost = false) {
             str += drawLineCardinality(line, lineColor, fx, fy, tx, ty, felem, telem);
         }
     }
+        
     if (isSelected) {
         str += `<rect 
                     x='${((fx + tx) / 2) - (2 * zoomfact)}' 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -219,6 +219,7 @@ function drawLine(line, targetGhost = false) {
         }
     }
 
+    // Draws the cardinality labels for the line for UML
     if (felem.type != entityType.ER || telem.type != entityType.ER) {
         if (line.startLabel && line.startLabel != '') {
             const fxCardinality = fx + offset.x1;


### PR DESCRIPTION
Solution to #16869
Fixed so that when cardinality values are added to a line, they no longer effect the positionering of that same lines label.
Previously cardinality added offset the fils global variables fx, fy, tx and ty. Now instead its a self contained variable just for cardinality. 

https://github.com/user-attachments/assets/9d897d94-8e0e-4c0e-9d7b-05e83f1a9e02

