### PR TITLE
Fixed: Box selection hover-box is cut off 

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1,31 +1,34 @@
 @keyframes loadingSpin {
-    0%{
+    0% {
         rotate: 0deg;
     }
-    100%{
+
+    100% {
         rotate: 360deg;
     }
 }
 
 @media screen and (min-height: 1199px) {
     #diagram-toolbar {
-        width:50px;
+        width: 50px;
     }
-    #svggrid{
+
+    #svggrid {
         left: 0px;
     }
-  }
-  
+}
+
 @media screen and (min-height: 1200px) {
     #diagram-toolbar {
-        width:70px;
+        width: 70px;
     }
-    #svggrid{
+
+    #svggrid {
         left: 20px;
     }
 }
 
-#loadingSpinner{
+#loadingSpinner {
     width: 100vw;
     height: 100vh;
     z-index: 9999;
@@ -36,64 +39,66 @@
 }
 
 #container {
-    position:absolute;
-    left:0;
-    top:0;
-    width:100%;
-    height:100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
     user-select: none;
     overflow: hidden;
 }
 
 #svgbacklayer {
-    position:absolute;
-    left:0;
-    top:0px;
-    width:100%;
-    height:100%;
+    position: absolute;
+    left: 0;
+    top: 0px;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
     z-index: -10;
 }
 
 #svggrid {
-    position:absolute;
-    top:0;
+    position: absolute;
+    top: 0;
     display: none;
-    width:100%;
-    height:100%;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
     z-index: -10;
 }
-#svgA4Template{
-    position:absolute;
-    left:0px;
-    top:0px;
-    width:100%;
-    height:100%;
+
+#svgA4Template {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
     z-index: -10;
 }
-#a4Template{
-    position:absolute;
-    left:0;
-    top:0;
+
+#a4Template {
+    position: absolute;
+    left: 0;
+    top: 0;
     display: none;
-    width:100%;
-    height:100%;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
     z-index: -10;
 }
 
 #svgoverlay {
-    position:absolute;
-    left:0px;
-    top:0px;
-    border:1px dotted green;
-    width:100%;
-    height:100%;
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    border: 1px dotted green;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
     z-index: 10;
-}		
+}
 
 #fab {
     position: fixed;
@@ -108,7 +113,7 @@
     background-color: #eb4;
     box-shadow: 6px 6px 10px #888;
     user-select: none;
-    cursor:pointer;
+    cursor: pointer;
     z-index: 5001;
 }
 
@@ -118,7 +123,8 @@
     width: 320px;
     bottom: 0px;
     z-index: 5000;
-    background-color: #eb4;    color: #FFF;
+    background-color: #eb4;
+    color: #FFF;
     border-top-left-radius: 15px;
     border-bottom-left-radius: 15px;
     box-shadow: 0px 6px 10px #888;
@@ -130,15 +136,15 @@
 #options-pane-button {
     display: inline-block;
     vertical-align: top;
-    transform-origin: top left;            
-    transform: translate(20px,0px) rotate(90deg);
+    transform-origin: top left;
+    transform: translate(20px, 0px) rotate(90deg);
     cursor: pointer;
     width: 780px;
     padding: 6px;
 }
 
 #options-pane-content {
-    margin-left:20px;
+    margin-left: 20px;
     vertical-align: top;
     display: inline-block;
 }
@@ -155,11 +161,12 @@
     box-shadow: 6px 6px 10px #888;
 }
 
-#diagramTypeDropdown, #diagramLoad{
+#diagramTypeDropdown,
+#diagramLoad {
     display: none;
 }
 
-#diagramTypeDropdown{
+#diagramTypeDropdown {
     width: 100%;
     margin-bottom: 10px;
 }
@@ -175,7 +182,7 @@
     position: absolute;
 }
 
-#pad_lock{
+#pad_lock {
     bottom: -5px;
     left: 3px;
     display: block;
@@ -187,20 +194,20 @@
     overflow: visible;
 }
 
-#canvasOverlay{
-    pointer-events:none;
-    position:absolute;
-    left:0px;
-    top:0px;
-    width:100%;
-    height:100%;
+#canvasOverlay {
+    pointer-events: none;
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    width: 100%;
+    height: 100%;
 }
 
 .selected-course {
-    box-shadow:10px 10px 10px RGBA(0,0,0,0.3);
+    box-shadow: 10px 10px 10px RGBA(0, 0, 0, 0.3);
 }
 
-#diagram-header{
+#diagram-header {
     z-index: 1;
     position: relative;
     background-color: #FFF;
@@ -208,15 +215,16 @@
 
 #rulerOverlay {
     display: none;
-    position:absolute;
-    left:50px;
-    top:0;
-    width:100%;
-    height:100%;
+    position: absolute;
+    left: 50px;
+    top: 0;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
-    display:block;
+    display: block;
     z-index: 20;
 }
+
 #ruler-y {
     left: 20px;
     background-color: #000;
@@ -234,19 +242,21 @@
     position: absolute;
     z-index: 500;
 }
+
 #ruler-x-svg {
     background-color: #fff;
-    position:absolute;
-    width:100%;
-    height:40px;
-    z-index:2;
+    position: absolute;
+    width: 100%;
+    height: 40px;
+    z-index: 2;
 }
+
 #ruler-y-svg {
     background-color: #fff;
-    position:absolute;
-    width:40px;
-    height:100%;
-    z-index:2;
+    position: absolute;
+    width: 40px;
+    height: 100%;
+    z-index: 2;
 }
 
 #rulerCorner {
@@ -258,12 +268,12 @@
     top: 0px;
 }
 
-.diagramIcons{
+.diagramIcons {
     position: relative;
     margin: auto;
     width: 3.7vh;
     height: 3.7vh;
-    cursor:pointer;
+    cursor: pointer;
     border: solid 1px var(--color-primary);
     margin-top: 3px;
 }
@@ -271,43 +281,49 @@
 @media (max-height: 650px) {
     .diagramIcons {
         width: 3.3vh;
-        height: 3.3vh; 
+        height: 3.3vh;
     }
 }
 
 @media (max-height: 540px) {
     .diagramIcons {
         width: 3vh;
-        height: 3vh; 
+        height: 3vh;
     }
 }
 
-.diagramIcons:hover, .active{
+.diagramIcons:hover,
+.active {
     background: var(--color-primary-light);
     border: solid 1px var(--color-border-2);
 }
-.diagramIcons img{
-    height:100%;
+
+.diagramIcons img {
+    height: 100%;
 }
+
 .node {
     position: absolute;
     width: 8px;
     height: 8px;
     background: blue;
 }
+
 .node.mr {
     top: calc(50% - 4px);
     right: 0;
     cursor: ew-resize;
 }
+
 .node.ml {
     top: calc(50% - 4px);
     left: 0;
     cursor: ew-resize;
 }
+
 .node.md {
     right: calc(50% - 4px);
-    bottom: 0; 
+    bottom: 0;
     cursor: ns-resize;
 }
 
@@ -316,21 +332,24 @@
     cursor: ns-resize;
     top: 0;
 }
-.node.tr{
-    cursor: nesw-resize;
-}
-.node.tl{
-    cursor: nwse-resize;
-}
 
-.node.br{
-    cursor: nwse-resize;
-}
-.node.bl{
+.node.tr {
     cursor: nesw-resize;
 }
 
-.underline{
+.node.tl {
+    cursor: nwse-resize;
+}
+
+.node.br {
+    cursor: nwse-resize;
+}
+
+.node.bl {
+    cursor: nesw-resize;
+}
+
+.underline {
     text-underline-offset: 0.15em;
     text-decoration: underline;
 }
@@ -363,14 +382,17 @@
     background-color: var(--color-primary);
     z-index: 1000;
 }
+
 #diagram-toolbar>fieldset {
     padding: 2px;
     border-color: var(--color-primary-hover);
 }
+
 #diagram-toolbar>fieldset>legend {
     color: var(--color-text-header);
     font-size: 0.6em;
 }
+
 /* Diagram Messages */
 #diagram-message {
     width: 300px;
@@ -383,13 +405,15 @@
     pointer-events: none;
     vertical-align: bottom;
 }
+
 #diagram-message .timeIndicatorBar {
     height: 5px;
     width: calc(100% - 20px);
     bottom: 5px;
     left: 10px;
-    background: rgba(255,255,255,1);
+    background: rgba(255, 255, 255, 1);
 }
+
 #diagram-message>div {
     pointer-events: auto;
     margin: 5px;
@@ -412,8 +436,8 @@
 
 /*tooltip*/
 
-.toolTipText{
-    top:-63px;
+.toolTipText {
+    top: -63px;
     left: 175%;
     visibility: hidden;
     width: 250px;
@@ -426,20 +450,25 @@
     position: absolute;
     z-index: 2;
 }
-#highestToolTip{
+
+#highestToolTip {
     top: -15px;
 }
 
-.diagramIcons:hover .toolTipText{
+#mouseMode1 .toolTipText {
+    top: -43px;
+}
+
+.diagramIcons:hover .toolTipText {
     visibility: visible;
     transition-delay: 700ms;
 }
 
-#tooltip-OPTIONS{
+#tooltip-OPTIONS {
     left: 9.5%;
 }
 
-.colorMenu{
+.colorMenu {
     visibility: hidden;
     background: rgba(0, 0, 0, 0.8);
     border-radius: 5px;
@@ -467,7 +496,7 @@
     animation-duration: 0.5s;
 }
 
-.colorCircle:hover{
+.colorCircle:hover {
     stroke: white;
     cursor: pointer;
 }
@@ -482,23 +511,26 @@
     transition: 1s;
 }
 
-#options-pane-button .toolTipText{
-    transform: translate(-100px,170px) rotate(-90deg);
+#options-pane-button .toolTipText {
+    transform: translate(-100px, 170px) rotate(-90deg);
 }
-#options-pane-button:hover .toolTipText{
+
+#options-pane-button:hover .toolTipText {
     visibility: visible;
 }
-#fab .toolTipText{
-    transform: translate(-335px,-20px);
+
+#fab .toolTipText {
+    transform: translate(-335px, -20px);
     font-size: 16px;
     line-height: 20px;
 
 }
-#fab:hover .toolTipText{
+
+#fab:hover .toolTipText {
     visibility: visible;
 }
 
-.tooltip{
+.tooltip {
     position: absolute;
     z-index: 1;
 }
@@ -528,12 +560,13 @@
 
 /*Cardinality stuff*/
 
-.propertyCardinality{
-    padding-left:3px;
-    padding-right:3px;
+.propertyCardinality {
+    padding-left: 3px;
+    padding-right: 3px;
 }
+
 /* REPLAY */
-#diagram-replay-box{
+#diagram-replay-box {
     position: absolute;
     background-color: var(--color-primary);
     bottom: 0;
@@ -544,66 +577,75 @@
     visibility: hidden;
     color: var(--color-text-header);
 }
-#diagram-replay-message{
-     position: absolute;
-     background-color: rgba(0, 0, 0, 0.8);
-     width: 300px;
-     left: calc(50% - 50px);
-     bottom: 70px;
-     color: var(--color-text-header);
-     border-radius: 5px;
-     text-align: center;
-     z-index: 100;
+
+#diagram-replay-message {
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.8);
+    width: 300px;
+    left: calc(50% - 50px);
+    bottom: 70px;
+    color: var(--color-text-header);
+    border-radius: 5px;
+    text-align: center;
+    z-index: 100;
     visibility: hidden;
-     pointer-events: none;
- }
+    pointer-events: none;
+}
+
 /* toggle placement types */
-.togglePlacementTypeButton{
+.togglePlacementTypeButton {
     position: absolute;
     right: -10%;
     bottom: -10%;
     width: 6.2px;
     height: 6.2px;
 }
-#diagramPopOut{
+
+#diagramPopOut {
     position: absolute;
     right: 10%;
     width: 6.2px;
     height: 3.2px;
 }
-.togglePlacementTypeBoxEntity{
+
+.togglePlacementTypeBoxEntity {
     display: none;
     position: absolute;
     left: 130%;
     bottom: 0;
     padding: 2px;
-    background-color:var(--color-primary);
-    
+    background-color: var(--color-primary);
+
 }
-.togglePlacementTypeBoxRI{
+
+.togglePlacementTypeBoxRI {
     display: none;
     position: absolute;
     left: 172%;
     bottom: 0;
-    padding:2px;
-    background-color:var(--color-primary);
-    
+    padding: 2px;
+    background-color: var(--color-primary);
+
 }
-.activeTogglePlacementTypeBox{
+
+.activeTogglePlacementTypeBox {
     display: flex;
     justify-content: left;
 }
-.activePlacementType{
+
+.activePlacementType {
     background: var(--color-primary-hover);
 }
-.hiddenPlacementType{
-    display:none;
-}
-.hiddenToolTiptext{
-    visibility:hidden;
+
+.hiddenPlacementType {
+    display: none;
 }
 
-.loadModalOverlay{
+.hiddenToolTiptext {
+    visibility: hidden;
+}
+
+.loadModalOverlay {
     position: absolute;
     top: 0;
     left: 0;
@@ -614,7 +656,7 @@
     background-color: rgba(0, 0, 0, 0.2);
 }
 
-.loadModal{
+.loadModal {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -626,7 +668,7 @@
     border: 1px solid #000;
 }
 
-.deleteLocalDiagram{
+.deleteLocalDiagram {
     margin-left: 10px;
     background-color: #DF2727 !important;
 }
@@ -635,24 +677,24 @@
     background-color: #961a1a !important;
 }
 
-#amountOfLoads{
+#amountOfLoads {
     text-align: center;
     font-size: 12px;
     font-style: italic;
 }
 
-#loadTitle{
+#loadTitle {
     font-size: 1.2rem;
     color: #815e9d;
 }
 
-#loadHeader{
+#loadHeader {
     display: flex;
     flex-direction: row;
     background-color: #eb4;
 }
 
-#loadContainer{
+#loadContainer {
     margin-top: 1rem;
     margin-bottom: 1rem;
     padding: 10px;
@@ -663,14 +705,14 @@
     overflow-y: auto;
 }
 
-#loadContainer button{
+#loadContainer button {
     border-style: none;
     background-color: #815e9d;
     color: white;
     padding: 5px;
 }
 
-#loadContainer button:hover{
+#loadContainer button:hover {
     cursor: pointer;
     background-color: #614875;
 }
@@ -681,37 +723,42 @@
     cursor: pointer;
     border: none;
     background-color: #da2727;
-  }
+}
 
-.hiddenLoad{
+.hiddenLoad {
     display: none;
 }
 
-.placementTypeIcon img{
+.placementTypeIcon img {
     position: absolute;
     top: 0px;
     width: 6.2px;
     height: 6.2px;
     z-index: 2;
 }
-.placementTypeBoxIcons{
+
+.placementTypeBoxIcons {
     margin: auto;
     width: 34px;
     height: 34px;
-    cursor:pointer;
+    cursor: pointer;
     border: solid 1px var(--color-primary);
 }
-.placementTypeBoxIcons:hover, .active{
+
+.placementTypeBoxIcons:hover,
+.active {
     background: var(--color-primary-light);
     border: solid 1px var(--color-border-2);
 }
-.placementTypeBoxIcons img{
-    width:34px;
-    height:34px;
+
+.placementTypeBoxIcons img {
+    width: 34px;
+    height: 34px;
 }
-.placementTypeToolTipText{
-    top:0%;
-    left:100%;
+
+.placementTypeToolTipText {
+    top: 0%;
+    left: 100%;
     visibility: hidden;
     width: 250px;
     background: rgba(0, 0, 0, 0.8);
@@ -723,24 +770,30 @@
     position: absolute;
     z-index: 2;
 }
-.placementTypeBoxIcons:hover .placementTypeToolTipText{
+
+.placementTypeBoxIcons:hover .placementTypeToolTipText {
     visibility: visible;
 }
+
 /*  options panel  */
 .options-fieldset {
     width: 90%;
     margin: auto;
 }
+
 .options-fieldset-show {
     display: block;
 }
+
 .options-fieldset-hidden {
     display: none;
 }
+
 #ERTable {
     user-select: text;
 }
-#zoom-container{
+
+#zoom-container {
     visibility: visible;
     position: absolute;
     width: auto;
@@ -754,26 +807,31 @@
     padding: 1px;
     z-index: 900;
 }
+
 .diagramZoomIcons img {
     height: 27px;
     width: 27px;
 }
+
 #zoom-message {
     height: 30px;
     width: 40px;
 }
+
 .diagramZoomIcons {
     height: 27px;
     width: 27px;
     float: left;
     border: 1px solid transparent;
 }
+
 .diagramZoomIcons:hover {
     border: solid 1px var(--color-primary-light);
 }
+
 .zoomToolTipText {
     bottom: 40px;
-    left:0%;
+    left: 0%;
     visibility: hidden;
     width: 250px;
     background: rgba(0, 0, 0, 0.8);
@@ -783,7 +841,7 @@
     padding: 5px 0;
     pointer-events: none;
     position: absolute;
-    z-index:20;
+    z-index: 20;
 }
 
 
@@ -803,7 +861,7 @@
     height: 100px;
 }
 
-#grid > path {
+#grid>path {
     fill: none;
     stroke: gray;
     /*stroke: 0.8 0.8;*/
@@ -817,7 +875,8 @@
     fill: url(#grid);
 }
 
-#origoX, #origoY {
+#origoX,
+#origoY {
     stroke: rgb(105, 105, 105);
     stroke-width: 8;
 }
@@ -830,34 +889,35 @@
 }
 
 
-#a4Rect, #vRect {
-    display: none; 
+#a4Rect,
+#vRect {
+    display: none;
 }
 
 #a4Rect {
-    stroke:rgb(50, 50, 50);
-    stroke-width:2;
+    stroke: rgb(50, 50, 50);
+    stroke-width: 2;
     stroke-dasharray: 5 3;
     fill: #ffffee;
     fill-opacity: 0.4;
 }
 
 #vRect {
-    stroke:rgb(50, 50, 50);
-    stroke-width:2; 
-    stroke-dasharray: 5 3; 
+    stroke: rgb(50, 50, 50);
+    stroke-width: 2;
+    stroke-dasharray: 5 3;
     fill: #ffffee;
     fill-opacity: 0.4;
 }
 
 #a4Text {
- /* no styling yet */
+    /* no styling yet */
 }
 
 /****************
   ZOOM CONTAINER 
 *****************/
-#zoom-message-box{
+#zoom-message-box {
     width: 75px;
     left: 100px;
     bottom: 5px;
@@ -868,8 +928,8 @@
     pointer-events: none;
 }
 
-#zoom-message-box > img {
-    width: 25%; 
+#zoom-message-box>img {
+    width: 25%;
     height: 27px;
 }
 
@@ -877,11 +937,11 @@
    OPTION PANE 
 *****************/
 #rulerSnapToGrid {
-    background-color: transparent; 
-    border: #614875; 
-    border-width: 3px; 
-    border-style: solid; 
-    color: #614875; 
+    background-color: transparent;
+    border: #614875;
+    border-width: 3px;
+    border-style: solid;
+    color: #614875;
     font-weight: bold;
 }
 
@@ -905,14 +965,14 @@
 
 #diagramDropDownToggle {
     background-color: transparent;
-    border:#614875;
-    border-width:3px;
-    border-style:solid;
-    color:#614875;
+    border: #614875;
+    border-width: 3px;
+    border-style: solid;
+    color: #614875;
     font-weight: bold;
 }
 
-.disabledIcon{
+.disabledIcon {
     background-color: #8d68ab;
 }
 
@@ -927,10 +987,10 @@
 }
 
 #a4HorizontalButton {
-    display:none;
+    display: none;
 }
 
-#option-import > input {
+#option-import>input {
     width: 100%;
 }
 


### PR DESCRIPTION
The solution was to add a specific css by targeting only the tooltip text that is a child of the element with the id "mouseMode1", only meant for the tooltip text for the box selection, so the remainder of the tooltip texts dont get affected by this change of position.

PS: Auto indented the css