### PR TITLE
G3-2025-V4-#16925-delete-without-selection-header

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -746,7 +746,7 @@ function markedItems(item = null, typeInput) {
   var subItems = [];
 
   //if the checkbox belongs to one of these kinds then all elements below it should also be selected.
-  if (kind == "section" || kind == "moment") {
+  if (kind == "section" || kind == "moment" || kind == "header") {
     var itemInSection = true;
     var sectionStart = false;
     $("#Sectionlist").find(".item").each(function (i) {
@@ -2013,7 +2013,7 @@ function returnedSection(data) {
           str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
             "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += `<img style='filter: invert(1);' class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick='confirmBox(\"openConfirmBox\", this);'>`;
+          src='../Shared/icons/Trashcan.svg' onclick='markedItems(this, "trash"); confirmBox(\"openConfirmBox\", this);'>`;
           str += "</td>";
         }
         


### PR DESCRIPTION
**Since sections already had the functionality, added it to header-type items as well.**
Unsure if this will be used, since I haven't found any headers with trashcans from browsing existing ones. Although, if trashcans were added to them, the problem is solved. for additonal information surrounding delete via trashcan, view: https://github.com/HGustavs/LenaSYS/pull/16879#event-17385722221

**One approach to testing this, and how to get to the functionality:**
select course of your choice (which has duggor, ex. Testing Course) -> log in -> from here, if you press the cogwheel on a dugga you can change its type. By doing this, you can "create" applicable headers.

