### PR TITLE
Implemented stereotypes for UML-elements

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1386,6 +1386,7 @@ function saveProperties() {
         }
         addToLine("primaryKey", "*");
         addToLine("attributes", "-");
+        addToLine("stereotype", "");
         addToLine("functions", "+");
     }
     stateMachine.save(element.id, StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);

--- a/DuggaSys/diagram/classes/element.js
+++ b/DuggaSys/diagram/classes/element.js
@@ -24,6 +24,7 @@ class Element {
             functions = null,
             altOrLoop = null,
             alternatives = null,
+            stereotype = null,
         } = {}
     ) {
         this.name = name;
@@ -44,6 +45,7 @@ class Element {
         this.primaryKey = primaryKey;
         this.altOrLoop = altOrLoop;
         this.alternatives = alternatives;
+        this.stereotype = stereotype;
     }
     static Default(type) {
         return new Element(defaults[Object.keys(elementTypes).find(key => elementTypes[key] === type)]);
@@ -108,7 +110,8 @@ class Element {
         return {
             attributes: element.attributes,
             functions: element.functions,
-            name: element.name
+            name: element.name,
+            stereotype: element.stereotype,
         }
     }
 }

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -340,11 +340,15 @@ function drawElementUMLEntity(element, boxw, boxh, linew, texth) {
     let height = texth * (headerLines.length + 1) * lineHeight;
     let headRect = drawRect(boxw, height, linew, element);
     let headText = "";
+    let headStereotype = "";
+    if (element.stereotype != "" && element.stereotype != null) {
+        headStereotype = drawText(boxw / 2, texth * 0.8 * lineHeight, 'middle', `«${element.stereotype}»`);
+    }
     for (let i = 0; i < headerLines.length; i++) {
-        const y = texth * (i + 1) * lineHeight;
+        const y = texth * (i + 1.5) * lineHeight;
         headText += drawText(boxw / 2, y, 'middle', headerLines[i]);
     }
-    let headSvg = drawSvg(boxw, height, headRect + headText);
+    let headSvg = drawSvg(boxw, height, headRect + headText + headStereotype);
     str += drawDiv('uml-header', `width: ${boxw}; height: ${height - linew * 2}px`, headSvg);
 
     // Content, Attributes

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -99,11 +99,21 @@ function escapeHtml(str) {
  */
 function textarea(name, property, element) {
     const safeText = escapeHtml(textboxFormatString(element[property]));
-    return `<div style='color:${color.WHITE};'>${name}</div>
+    if (property == "stereotype"){
+        return `<div style='color:${color.WHITE};'>${name}</div>
+            <textarea 
+                id='elementProperty_${property}' 
+                rows='1' style='width:98%;resize:none;'
+            >${textboxFormatString(safeText)}</textarea>`;
+    }
+    else{
+        return `<div style='color:${color.WHITE};'>${name}</div>
             <textarea 
                 id='elementProperty_${property}' 
                 rows='4' style='width:98%;resize:none;'
             >${textboxFormatString(safeText)}</textarea>`;
+    }
+    
 }
 
 /**
@@ -186,6 +196,7 @@ function drawElementProperties(element) {
             str += dropdown('Variant', 'normal', entityState, element);
             break;
         case elementTypesNames.UMLEntity:
+            str += textarea('Stereotype', 'stereotype', element);
             str += nameInput(element);
             str += textarea('Attributes', 'attributes', element);
             str += textarea('Functions', 'functions', element);


### PR DESCRIPTION
Implemented the stereotype header for uml-elements. Is also added in local storage so it can be saved and loaded. 

![image](https://github.com/user-attachments/assets/a3b20346-76eb-40cc-a073-8f5865d79513)
