### PR TITLE
G2 2025 v4 #16896

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/fillEndpointDb.php
+++ b/DuggaSys/microservices/endpointDirectory/fillEndpointDb.php
@@ -284,6 +284,11 @@ foreach ($mdFiles as $mdFile) {
                         break;
                     }
 
+                    // skip placeholder-text in the template
+                    if (trim($nextLine) === '*Includes and microservices used*') {
+                        continue;
+                    }
+
                     $used[] = $nextLine;
                 }
 

--- a/DuggaSys/microservices/endpointDirectory/fillEndpointDb.php
+++ b/DuggaSys/microservices/endpointDirectory/fillEndpointDb.php
@@ -78,6 +78,10 @@ foreach ($mdFiles as $mdFile) {
                     if ($line === '' || preg_match('/^#+ /', $line)) {
                         break;
                     }
+                    // skip template placeholder text
+                    if ($line === '*Description of what the service do and its function in the system.*') {
+                        continue;
+                    }
                     $descLines[] = $line;
                 }
                 // connect the rows if a row was found 

--- a/DuggaSys/microservices/endpointDirectory/fillEndpointDb.php
+++ b/DuggaSys/microservices/endpointDirectory/fillEndpointDb.php
@@ -174,6 +174,11 @@ foreach ($mdFiles as $mdFile) {
                         break;
                     }
 
+                    // remove "- " if it exists at start
+                    if (strpos($methodLine, '- ') === 0) {
+                        $methodLine = substr($methodLine, 2);
+                    }
+
                     $methods[] = $methodLine;
                 }
 

--- a/DuggaSys/microservices/endpointDirectory/installEndpointDb.php
+++ b/DuggaSys/microservices/endpointDirectory/installEndpointDb.php
@@ -11,9 +11,6 @@ $db->exec("CREATE TABLE IF NOT EXISTS microservices (
     ms_name TEXT NOT NULL,
     description TEXT,
     calling_methods TEXT,
-    output TEXT,
-    output_type TEXT,
-    output_description TEXT,
     microservices_used TEXT
 );");
 
@@ -24,6 +21,16 @@ $db->exec("CREATE TABLE IF NOT EXISTS parameters (
     parameter_name TEXT,
     parameter_type TEXT,
     parameter_description TEXT,
+    FOREIGN KEY (microservice_id) REFERENCES microservices(id)
+);");
+
+// this one to many relationship between microservices and outputs exists since a microservice can have multiple outputs
+$db->exec("CREATE TABLE IF NOT EXISTS outputs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    microservice_id INTEGER NOT NULL,
+    output_name TEXT,
+    output_type TEXT,
+    output_description TEXT,
     FOREIGN KEY (microservice_id) REFERENCES microservices(id)
 );");
 

--- a/DuggaSys/microservices/endpointDirectory/microserviceList.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceList.php
@@ -10,27 +10,38 @@ $microservices = $msQuery->fetchAll(PDO::FETCH_ASSOC);
 echo "<pre>";
 
 foreach ($microservices as $ms) {
-    echo "<table style='border: 1px solid black; margin-bottom: 10px; text-align: left;'>";
-    echo "<tr><th style='border: 1px solid black;'>Microservice</th><td style='border: 1px solid black';>" . $ms['ms_name'] . "</td>";
-    echo "<tr><th style='border: 1px solid black';>Description</th><td style='border: 1px solid black';>" . $ms['description'] . "</td>";
+    echo "<table border='1' style='margin-bottom: 10px; text-align: left;'>";
+    echo "<tr><th>Microservice</th><td>" . $ms['ms_name'] . "</td>";
+    echo "<tr><th>Description</th><td>" . $ms['description'] . "</td>";
     // get parameters connected to the microservice
     $paramStmt = $db->prepare("SELECT * FROM parameters WHERE microservice_id = ?");
     $paramStmt->execute([$ms['id']]);
     $params = $paramStmt->fetchAll(PDO::FETCH_ASSOC);
     if (!empty($params)) {
         foreach ($params as $p) {
-            echo "<tr><th style='border: 1px solid black';>Parameter</th><td style='border: 1px solid black';>" . $p['parameter_name'] . "</td>";
-            echo "<tr><th style='border: 1px solid black';>Parameter Type</th><td style='border: 1px solid black';>" . $p['parameter_type'] . "</td>";
-            echo "<tr><th style='border: 1px solid black';>Parameter Description</th><td style='border: 1px solid black';>" . $p['parameter_description'] . "</td>";
+            echo "<tr><th>Parameter</th><td>" . $p['parameter_name'] . "</td>";
+            echo "<tr><th>Parameter Type</th><td>" . $p['parameter_type'] . "</td>";
+            echo "<tr><th>Parameter Description</th><td>" . $p['parameter_description'] . "</td>";
         }
     } else {
-        echo "<tr><th style='border: 1px solid black';>Parameter</th><td style='border: 1px solid black';>No parameters</td>";
+        echo "<tr><th>Parameter</th><td>No parameters</td>";
     }
-    echo "<tr><th style='border: 1px solid black';>Calling Methods</th><td style='border: 1px solid black';>" . $ms['calling_methods'] . "</td>";
-    echo "<tr><th style='border: 1px solid black';>Output</th><td style='border: 1px solid black';>" . $ms['output'] . "</td>";
-    echo "<tr><th style='border: 1px solid black';>Output Type</th><td style='border: 1px solid black';>" . $ms['output_type'] . "</td>";
-    echo "<tr><th style='border: 1px solid black';>Output Description</th><td style='border: 1px solid black';>" . $ms['output_description'] . "</td>";
-    echo "<tr><th style='border: 1px solid black';>Microservices Used</th><td style='border: 1px solid black';>" . $ms['microservices_used'] . "</td>";
+    echo "<tr><th>Calling Methods</th><td>" . $ms['calling_methods'] . "</td>";
+    // get outputs connected to the microservice
+    $outputStmt = $db->prepare("SELECT * FROM outputs WHERE microservice_id = ?");
+    $outputStmt->execute([$ms['id']]);
+    $outputs = $outputStmt->fetchAll(PDO::FETCH_ASSOC);
+    if (!empty($outputs)) {
+        foreach ($outputs as $o) {
+            echo "<tr><th>Output</th><td>" . $o['output_name'] . "</td>";
+            echo "<tr><th>Output Type</th><td>" . $o['output_type'] . "</td>";
+            echo "<tr><th>Output Description</th><td>" . $o['output_description'] . "</td>";
+        }
+    } else {
+        echo "<tr><th>Parameter</th><td>No outputs</td>";
+    }
+    echo "<tr><th>Microservices Used</th><td>" . $ms['microservices_used'] . "</td>";
+    echo "</table>";
 }
 
 echo "</pre>";

--- a/DuggaSys/microservices/endpointDirectory/newMDStructureTest.md
+++ b/DuggaSys/microservices/endpointDirectory/newMDStructureTest.md
@@ -19,6 +19,7 @@ Testing a third line
 - POST
 
 ## Output Data and Format
+*Output Data will be described in lists*
 - Output: Output1
    - Type: Type1
    - Description: Description1
@@ -32,6 +33,7 @@ fetch('api/endpoint', {
 `
 
 ### Microservices Used
+*Includes and microservices used*
 another_ms
 microservices_used_example_ms
 

--- a/DuggaSys/microservices/endpointDirectory/newMDStructureTest.md
+++ b/DuggaSys/microservices/endpointDirectory/newMDStructureTest.md
@@ -24,6 +24,10 @@ Testing a third line
    - Type: Type1
    - Description: Description1
 
+- Output: Output2
+   - Type: Type2
+   - Description: Description2
+
 ## Examples of Use
 `
 fetch('api/endpoint', {

--- a/DuggaSys/microservices/endpointDirectory/newMDStructureTest.md
+++ b/DuggaSys/microservices/endpointDirectory/newMDStructureTest.md
@@ -16,7 +16,7 @@ Testing a third line
    - Description: This parameter is used for something else
 
 ## Calling Methods
-POST
+- POST
 
 ## Output Data and Format
 - Output: Output1


### PR DESCRIPTION
Some fixes for the microservice documentation database. Fixes #16896 
- Added skips to placeholder texts in the documentation template (if these are not removed when writing documentation they will now be skipped).
- Added a skip for the "-" sign in the calling methods field
- Created a separate table for outputs (that has a 1-M relationship to microservices). A microservice can now have multiple outputs. Outputs was stored in the same table as microservices in the previous version, which means that it could only have one output. (Multiple outputs can be seen in image 2) 

In order to test this you might need to recreate the microservice database. Follow the steps below.

1. Delete 'endpointDirectory_db.sqlite' from the endpointDirectory folder (if you have it).
2. Run 'installEndpointDb.php'.
3. Run 'fillEndpoint.php'.
You should now be able to see the data from the database in 'microserviceList.php' if you open it.

Image 1 marks what part that should be skipped in the new version, and image 2 displays how the table should look like now.

Image 1:
<img width="779" alt="Skärmavbild 2025-04-28 kl  08 56 24" src="https://github.com/user-attachments/assets/1e3e2b12-4a3b-48f1-aa91-640e74a30e87" />

Image 2:
<img width="507" alt="Skärmavbild 2025-04-28 kl  08 24 58" src="https://github.com/user-attachments/assets/78f9b422-7fe4-4c8d-92ff-f61163a7b8d4" />