### PR TITLE
Visual snap indicator for mmoving element

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1051,6 +1051,21 @@ function mmoving(event) {
                 deltaX = startX - event.clientX;
                 deltaY = startY - event.clientY;
                 // We update position of connected objects
+
+                if (context.length === 1 && context[0].kind === elementTypesNames.sequenceActivation) {
+                    const pos = screenToDiagramCoordinates(event.clientX, event.clientY);
+                    const lifelineId = findNearestLifeline(pos.x, pos.y);
+                    if (lifelineId) {
+                      
+                      snapElementToLifeline(context[0], lifelineId);
+                      
+                      startX = event.clientX;
+                      startY = event.clientY;
+                      deltaX = 0;
+                      deltaY = 0;
+                    }
+                }
+
                 updatepos();
                 calculateDeltaExceeded();
             }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1052,18 +1052,15 @@ function mmoving(event) {
                 deltaY = startY - event.clientY;
                 // We update position of connected objects
 
-                if (context.length === 1 && context[0].kind === elementTypesNames.sequenceActivation) {
-                    const pos = screenToDiagramCoordinates(event.clientX, event.clientY);
-                    const lifelineId = findNearestLifeline(pos.x, pos.y);
-                    if (lifelineId) {
-                      
-                      snapElementToLifeline(context[0], lifelineId);
-                      
-                      startX = event.clientX;
-                      startY = event.clientY;
-                      deltaX = 0;
-                      deltaY = 0;
-                    }
+                
+                const moveableElementPos = screenToDiagramCoordinates(event.clientX, event.clientY);
+                const snapId = moveableSnapToLifeline(moveableElementPos);
+                
+                if (snapId) {
+                    const lLine = data.find(el => el.id === snapId);
+                    context[0].x = lLine.x + lLine.width/2 - context[0].width/2;
+                    startX = event.clientX;
+                    deltaX = 0;
                 }
 
                 updatepos();

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1052,17 +1052,17 @@ function mmoving(event) {
                 deltaY = startY - event.clientY;
                 // We update position of connected objects
 
-                
+                // Check coordinates of moveable element and if they are within snap threshold
                 const moveableElementPos = screenToDiagramCoordinates(event.clientX, event.clientY);
-                const snapId = moveableSnapToLifeline(moveableElementPos);
+                const snapId = visualSnapToLifeline(moveableElementPos);
                 
+                // Visualize the context snapping to lifeline (only a visual indication)
                 if (snapId) {
                     const lLine = data.find(el => el.id === snapId);
                     context[0].x = lLine.x + lLine.width/2 - context[0].width/2;
                     startX = event.clientX;
                     deltaX = 0;
                 }
-
                 updatepos();
                 calculateDeltaExceeded();
             }

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -217,20 +217,25 @@ function snapElementToLifeline(element, targetId) {
     }
 }
 
-// For mmoving sequenceActivation element to snap to lifeline
-function moveableSnapToLifeline(pos, threshold = 50) {
+// For mmoving sequenceActivation element to get a visually indicated snap to lifeline
+// threshold value is changeable within the parameter
+function visualSnapToLifeline(pos, threshold = 50) {
+
+    // Check that there exists a sequenceActor or sequenceObject to snap to
     for (const ll of data) {
-      if (ll.kind !== elementTypesNames.sequenceActor &&
-          ll.kind !== elementTypesNames.sequenceObject) continue;
-  
-      const topY    = ll.y + getTopHeight(ll);
-      const botY    = ll.y + ll.height;
-      const centerX = ll.x + ll.width/2;
-      const dx      = Math.abs(centerX - pos.x);
-  
-      if (dx < threshold && pos.y >= topY && pos.y <= botY) {
-        return ll.id;
-      }
+        if (ll.kind !== elementTypesNames.sequenceActor &&
+            ll.kind !== elementTypesNames.sequenceObject) continue;
+
+        // Get coordinates for sequenceActor/sequenceObject and compare to position of moving object
+        const topY = ll.y + getTopHeight(ll);
+        const botY = ll.y + ll.height;
+        const centerX = ll.x + ll.width / 2;
+        const dx = Math.abs(centerX - pos.x);
+
+        // Check if within snap threshold and boundaries of the lifeline
+        if (dx < threshold && pos.y >= topY && pos.y <= botY) {
+            return ll.id;
+        }
     }
     return null;
 }

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -217,6 +217,25 @@ function snapElementToLifeline(element, targetId) {
     }
 }
 
+// For mmoving sequenceActivation element to snap to lifeline
+function moveableSnapToLifeline(pos, threshold = 50) {
+    for (const ll of data) {
+      if (ll.kind !== elementTypesNames.sequenceActor &&
+          ll.kind !== elementTypesNames.sequenceObject) continue;
+  
+      const topY    = ll.y + getTopHeight(ll);
+      const botY    = ll.y + ll.height;
+      const centerX = ll.x + ll.width/2;
+      const dx      = Math.abs(centerX - pos.x);
+  
+      if (dx < threshold && pos.y >= topY && pos.y <= botY) {
+        return ll.id;
+      }
+    }
+    return null;
+}
+  
+
 /**
  * Snaps the ghostElement (hover preview) to the center of a lifeline and adjusts its Y-position.
  * @param {string} targetId - The ID of the lifeline to snap to.


### PR DESCRIPTION
When the sequenceActivation object has already been placed on the diagram grid and is moved close to a lifeline there is now a visualization which indicates snappable locations just like for the ghost version.

There are some issues with this interaction that were already there before. The hitboxes when placing something on a lifeline seem wonky and for some reason the actual snap applies everywhere along the lifeline's vertical line, even outside its boundaries. To fix this changes will need to be done to the actual snap logic, which could be the target for potential new sub-issues.

https://github.com/user-attachments/assets/9c6a215e-da10-49d1-ad84-a10181bef3a0



