### PR TITLE
Replaced jQuery with vanilla JavaScript from line 4668 to end of file #16775

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -4924,7 +4924,7 @@ function setShowPane(id) {
 		if(i == id){
 			wrapper.style.display = "inline";
 			wrapper.style.gridColumn = "a/b";
-			wrapper.style.gtidRow = "a/1";
+			wrapper.style.gridRow = "a/1";
 		}
 		else{
 			wrapper.style.display = "none";
@@ -4992,9 +4992,11 @@ function showIframe(path, name, kind) {
 		});
         
         // Load the right file in to the preview window
-        $.getScript("fileed.js", function(){
-            loadPreview(path, name, kind);
-        });
+		let s = document.createElement('script');
+		s.src = "fileed.js";
+		s.onload = () => loadPreview(path, name, kind);
+		document.head.appendChild(s);
+
     }).catch(function (err) {
         // Display potential errors as a warning
         console.warn('Something went wrong.', err);


### PR DESCRIPTION
Replaced remaining jQuery code with vanilla JavaScript from line 4668 to end of codeviewer.js. 
Replaced $.getScript with manual script loading.
Fixed typo in setShowPane() where "gtidRow" was corrected to "gridRow".