### PR TITLE
Updated the datesize

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -884,6 +884,7 @@ p {
   .dateSize {
     width: 25%;
     font-size: 10pt;
+    display: none;
   }
 	.internal-link {
         font-size: 10pt;


### PR DESCRIPTION
Now it doesn't display the date after a breakpoint of max-width of 570 pixels