### PR TITLE
Fixed: 16817 the testcase does not update when removing a label and if the text of the label is not visible if closed in

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -1733,7 +1733,7 @@ function generateStateDiagramInfo() {
         }
         // Add any connected entity to the output string, and if it has not been "seen" it is added to the queue.
         for (let i = 0; i < connections.length; i++) {
-            if (connections[i][LABEL] == undefined) {
+            if (connections[i][LABEL] == undefined || connections[i][LABEL].trim() === "") {
                 output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}"</p>`;
             } else if (re.test(connections[i][LABEL])) {
                 output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with guard "${connections[i][LABEL]}"</p>`;

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -1738,7 +1738,7 @@ function generateStateDiagramInfo() {
             } else if (re.test(connections[i][LABEL])) {
                 output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with guard "${connections[i][LABEL]}"</p>`;
             } else {
-                output += `<p>"${head[ENTITY].name}" goes to "${connections[i][ENTITY].name}" with label "${connections[i][LABEL]}"</p>`;
+                output += `<p>"${escapeHtml(head[ENTITY].name)}" goes to "${escapeHtml(connections[i][ENTITY].name)}" with label "${escapeHtml(connections[i][LABEL])}"</p>`;
             }
             if (connections[i][SEEN] === false) {
                 connections[i][SEEN] = true;


### PR DESCRIPTION
Fixed so the text in the properties-box doesn't delete the text between the "<>", and when you remove the label, the testcase updates correctly and doesn't say that the line has a label anymore. All I had to do was to add _escapeHtml_ in the output for the label in the testcase.

<img width="857" alt="image" src="https://github.com/user-attachments/assets/f971f2f6-5033-40eb-ab56-e03743faff24" />
