### PR TITLE
G3-2025-V4-issue-16720-tables-second-try

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1659,12 +1659,6 @@ function returnedSection(data) {
         menuState.idCounter++;
         // All are visible according to database
         
-        // Create a row in the main table
-        str += `<tr id='lid${item['lid']}' value='${item['lid']}' value='${makeTextArray(item['kind'], valarr)}'`;
-        str += " >";
-        
-
-
         var hideState = "";
         if (parseInt(item['visible']) === 0) hideState = " hidden"
         else if (parseInt(item['visible']) === 3) hideState = " deleted"

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1645,7 +1645,6 @@ function returnedSection(data) {
         if(deadline==null) {
           deadline = item['deadline'];
         }
-        //str += "<tr>";
 
         // Separating sections into different classes
         var valarr = ["header", "section", "code", "test", "moment", "link", "group", "message"];
@@ -1657,20 +1656,11 @@ function returnedSection(data) {
           str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " courseRow'>";
         }
 
-        //str += "</tr>";
-
         menuState.idCounter++;
         // All are visible according to database
         
-
         // Content table
-        str += `<tr id='lid${item['lid']}' value='${item['lid']}'><tr value='${makeTextArray(item['kind'], valarr)}'`;
-
-        //if (kk % 2 == 0) {
-        //  str += " class='hi' ";
-        //} else {
-        //  str += " class='lo' ";
-        //}
+        str += `<table id='lid${item['lid']}' value='${item['lid']}'><tr value='${makeTextArray(item['kind'], valarr)}'`;
         str += " >";
         
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1659,8 +1659,8 @@ function returnedSection(data) {
         menuState.idCounter++;
         // All are visible according to database
         
-        // Content table
-        str += `<table id='lid${item['lid']}' value='${item['lid']}'><tr value='${makeTextArray(item['kind'], valarr)}'`;
+        // Create a row in the main table
+        str += `<tr id='lid${item['lid']}' value='${item['lid']}' value='${makeTextArray(item['kind'], valarr)}'`;
         str += " >";
         
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1473,7 +1473,7 @@ function returnedGroups(data) {
       j = 1;
       if (grp != "") {
         str += "</tbody>";
-        str += "</table>";
+        //str += "</table>";
         str += `<div style='text-align:right;border-top:2px solid #434343'>
         <a style='white-space:nowrap' href='mailto:${grpemail}'>Email group</a></div>`
         grpemail = "";
@@ -1490,7 +1490,7 @@ function returnedGroups(data) {
   }
   if (grp != "") {
     str += "</tbody>";
-    str += "</table>";
+    //str += "</table>";
     str += `<div style='text-align:right;border-top:2px solid #434343'><a
     href='mailto:${grpemail}'>Email group</a></div>`
     grpemail = "";
@@ -1629,7 +1629,8 @@ function returnedSection(data) {
     str += "</div>";
     /*str += "<input id='loadDuggaButton' class='submit-button large-button' type='button' value='Load Dugga' onclick='showLoadDuggaPopup();' />"; */
 
-    
+    str += "<div id='Sectionlistc'>";
+    str += "<table id='SectionlistTable'>";
     
     // For now we only have two kinds of sections
     if (data['entries'].length > 0) {
@@ -1644,6 +1645,7 @@ function returnedSection(data) {
         if(deadline==null) {
           deadline = item['deadline'];
         }
+        //str += "<tr>";
 
         // Separating sections into different classes
         var valarr = ["header", "section", "code", "test", "moment", "link", "group", "message"];
@@ -1655,19 +1657,24 @@ function returnedSection(data) {
           str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " courseRow'>";
         }
 
+        //str += "</tr>";
+
         menuState.idCounter++;
         // All are visible according to database
+        
 
-        //str += `<tr id='lid${item['lid']}' value='${item['lid']}'><tr value='${makeTextArray(item['kind'], valarr)}' >`;
+        // Content table
+        str += `<tr id='lid${item['lid']}' value='${item['lid']}'><tr value='${makeTextArray(item['kind'], valarr)}'`;
 
         //if (kk % 2 == 0) {
         //  str += " class='hi' ";
         //} else {
         //  str += " class='lo' ";
         //}
+        str += " >";
+        
 
-        
-        
+
         var hideState = "";
         if (parseInt(item['visible']) === 0) hideState = " hidden"
         else if (parseInt(item['visible']) === 3) hideState = " deleted"
@@ -1688,7 +1695,6 @@ function returnedSection(data) {
           var marked;
           var submitted;
           var lastSubmit = null;
-          
 
           for (var jjj = 0; jjj < data['results'].length; jjj++) {
             var lawtem = data['results'][jjj];
@@ -1722,8 +1728,6 @@ function returnedSection(data) {
 
             }
           }
-          str += "<div id='Sectionlistc'>";
-          str += "<table id='SectionlistTable'>";
 
           if (retdata['writeaccess']) {
             if (itemKind === 3) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1629,8 +1629,7 @@ function returnedSection(data) {
     str += "</div>";
     /*str += "<input id='loadDuggaButton' class='submit-button large-button' type='button' value='Load Dugga' onclick='showLoadDuggaPopup();' />"; */
 
-    str += "<div id='Sectionlistc'>";
-    str += "<table id='SectionlistTable'>";
+    
     
     // For now we only have two kinds of sections
     if (data['entries'].length > 0) {
@@ -1666,6 +1665,8 @@ function returnedSection(data) {
         //} else {
         //  str += " class='lo' ";
         //}
+
+        
         
         var hideState = "";
         if (parseInt(item['visible']) === 0) hideState = " hidden"
@@ -1687,6 +1688,7 @@ function returnedSection(data) {
           var marked;
           var submitted;
           var lastSubmit = null;
+          
 
           for (var jjj = 0; jjj < data['results'].length; jjj++) {
             var lawtem = data['results'][jjj];
@@ -1720,6 +1722,8 @@ function returnedSection(data) {
 
             }
           }
+          str += "<div id='Sectionlistc'>";
+          str += "<table id='SectionlistTable'>";
 
           if (retdata['writeaccess']) {
             if (itemKind === 3) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1473,7 +1473,7 @@ function returnedGroups(data) {
       j = 1;
       if (grp != "") {
         str += "</tbody>";
-        //str += "</table>";
+        str += "</table>";
         str += `<div style='text-align:right;border-top:2px solid #434343'>
         <a style='white-space:nowrap' href='mailto:${grpemail}'>Email group</a></div>`
         grpemail = "";
@@ -1490,7 +1490,7 @@ function returnedGroups(data) {
   }
   if (grp != "") {
     str += "</tbody>";
-    //str += "</table>";
+    str += "</table>";
     str += `<div style='text-align:right;border-top:2px solid #434343'><a
     href='mailto:${grpemail}'>Email group</a></div>`
     grpemail = "";

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1473,7 +1473,7 @@ function returnedGroups(data) {
       j = 1;
       if (grp != "") {
         str += "</tbody>";
-        str += "</table>";
+        //str += "</table>";
         str += `<div style='text-align:right;border-top:2px solid #434343'>
         <a style='white-space:nowrap' href='mailto:${grpemail}'>Email group</a></div>`
         grpemail = "";
@@ -1490,7 +1490,7 @@ function returnedGroups(data) {
   }
   if (grp != "") {
     str += "</tbody>";
-    str += "</table>";
+    //str += "</table>";
     str += `<div style='text-align:right;border-top:2px solid #434343'><a
     href='mailto:${grpemail}'>Email group</a></div>`
     grpemail = "";
@@ -1630,6 +1630,8 @@ function returnedSection(data) {
     /*str += "<input id='loadDuggaButton' class='submit-button large-button' type='button' value='Load Dugga' onclick='showLoadDuggaPopup();' />"; */
 
     str += "<div id='Sectionlistc'>";
+    str += "<table id='SectionlistTable'>";
+    
     // For now we only have two kinds of sections
     if (data['entries'].length > 0) {
       var kk = 0;
@@ -1643,6 +1645,7 @@ function returnedSection(data) {
         if(deadline==null) {
           deadline = item['deadline'];
         }
+        //str += "<tr>";
 
         // Separating sections into different classes
         var valarr = ["header", "section", "code", "test", "moment", "link", "group", "message"];
@@ -1654,12 +1657,14 @@ function returnedSection(data) {
           str += "<div id='" + makeTextArray(item['kind'], valarr) + menuState.idCounter + data.coursecode + "' class='" + makeTextArray(item['kind'], valarr) + " courseRow'>";
         }
 
+        //str += "</tr>";
+
         menuState.idCounter++;
         // All are visible according to database
+        
 
         // Content table
-        str += `<table id='lid${item['lid']}' value='${item['lid']}'
-        ><tr value='${makeTextArray(item['kind'], valarr)}'`;
+        str += `<tr id='lid${item['lid']}' value='${item['lid']}'><tr value='${makeTextArray(item['kind'], valarr)}'`;
 
         //if (kk % 2 == 0) {
         //  str += " class='hi' ";
@@ -1667,6 +1672,7 @@ function returnedSection(data) {
         //  str += " class='lo' ";
         //}
         str += " >";
+        
 
 
         var hideState = "";
@@ -2155,7 +2161,7 @@ function returnedSection(data) {
         }
 
         str += "</tr>";
-        str += "</table></div>";
+        //str += "</table></div>";
       } // End of for-loop
 
     } else {
@@ -2163,7 +2169,7 @@ function returnedSection(data) {
       str += "<div id='noAccessMessage' class='bigg'>";
       str += "<span>You either have no access or there isn't anything under this course</span>";
       str += "</div>";
-    }
+    } str += "</table>";
 
     str += "</div></div>";
 
@@ -2281,7 +2287,7 @@ function returnedSection(data) {
 
 
 
-  }
+  } 
   
   //Force elements that are deleted to not show up unless pressing undo delete or reloading the page
   for(var i = 0; i < delArr.length; i++){
@@ -2328,7 +2334,7 @@ function returnedSection(data) {
   document.getElementById('toggleElements').addEventListener('click', toggleButtonClickHandler);
   toggleHidden();
 }
- 
+
 function toggleHidden() { //Look for all td's that have the class "hidden"
   const hiddenTds = document.querySelectorAll('#Sectionlistc td.hidden');
   const hiddenDivs = [];
@@ -4451,7 +4457,7 @@ function createUserFeedbackTable(data) {
     str += "</tr>";
   }
 
-  str += "</tbody></table>";
+  str += "</tbody>"; //</table>
   return str;
 }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1658,6 +1658,14 @@ function returnedSection(data) {
 
         menuState.idCounter++;
         // All are visible according to database
+
+        //str += `<tr id='lid${item['lid']}' value='${item['lid']}'><tr value='${makeTextArray(item['kind'], valarr)}' >`;
+
+        //if (kk % 2 == 0) {
+        //  str += " class='hi' ";
+        //} else {
+        //  str += " class='lo' ";
+        //}
         
         var hideState = "";
         if (parseInt(item['visible']) === 0) hideState = " hidden"

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1619,11 +1619,7 @@ function returnedSection(data) {
       hiddenInline = "inline";
     }
 
-
-    //Swimlane and 'Load Dugga' button.
-
-
-
+    //Swimlane //and 'Load Dugga' button.
     str += "<div id='statisticsSwimlanes'>";
     str += "<svg id='swimlaneSVG' xmlns='http://www.w3.org/2000/svg'></svg>";
     str += "</div>";
@@ -1631,6 +1627,7 @@ function returnedSection(data) {
 
     str += "<div id='Sectionlistc'>";
     str += "<table id='SectionlistTable'>";
+    
     
     // For now we only have two kinds of sections
     if (data['entries'].length > 0) {
@@ -1646,6 +1643,7 @@ function returnedSection(data) {
           deadline = item['deadline'];
         }
         //str += "<tr>";
+        
 
         // Separating sections into different classes
         var valarr = ["header", "section", "code", "test", "moment", "link", "group", "message"];
@@ -2253,6 +2251,7 @@ function returnedSection(data) {
 
       $("#Sectionlistc").sortable({
         handle: ".dragbleArea",
+        items: "tr", //added so tr's could also be dragable
         helper: 'clone',
         update: function (event, ui) {
           str = "";
@@ -2261,7 +2260,6 @@ function returnedSection(data) {
             ido = $(this).attr('id');
             phld = $(this).attr('placeholder')
             str += i + "XX" + ido.substr(1) + "XX" + phld;
-
           });
 
           AJAXService("REORDER", {
@@ -2270,7 +2268,6 @@ function returnedSection(data) {
           resave = true;
           return false;
         }
-
       });
       // But disable sorting if there is a #noAccessMessage
       if ($("#noAccessMessage").length) {


### PR DESCRIPTION
> **~~~~DO NOT MERGE THIS, IT IS A VERY BAD PR~~~~**

made tables for Sectionlistc into a real table with each item being its own row instead of a new table. 

But there are alot of dependencies... there is now no styling for the tables, and the functionalities do not work anymore. The drag-and-drop does not work, since it seems to be made for dragging entire tables, not rows. The same is applicable to the delete-function, which shows the dialog but does not delete anything anymore. 
I will list the functions that still work below, since that will take less time.

The functionality that still works is:

- Click on Dugga-name to see dugga
![image](https://github.com/user-attachments/assets/664c6a74-5237-462f-b2fa-5dc63f93facb)

- Open link in new tab
![image](https://github.com/user-attachments/assets/4f0dc677-63e3-46b1-b404-8d04ea6c7834)

- Get Canvas Link
![image](https://github.com/user-attachments/assets/887eb787-8282-41dc-a04d-cfbc7e62d490)

- Settings
![image](https://github.com/user-attachments/assets/13ac0eb8-5f69-450b-b589-bc19b9872b20)

Oh and there is also a bunch of divs being created over the table. If removed all other tables vill stop existing.
![image](https://github.com/user-attachments/assets/ac4419ad-6493-4e31-b4da-216b5bbc6dc3)

This issue needs to be divided into sub-issues.

**TO BE CLEAR: DO NOT MERGE THIS, I just need it for the future when creating sub-issues**
