### PR TITLE
Feature added, hovering over diagram items in the toolbar opens the sub toolbar

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1693,29 +1693,6 @@ function holdPlacementButtonDown(num) {
     }
 }
 
-// Add hover-specific event listeners for elements
-for (let i = 0; i <= 4; i++) { // Adjust the range based on your number of elements
-    const element = document.getElementById("elementPlacement" + i);
-    
-    // For hover, use 'mouseenter' and 'mouseleave' to trigger the hoverPlacementButton
-    element.addEventListener('mouseenter', function() {
-        hoverPlacementButton(i);
-    });
-
-    element.addEventListener('mouseleave', function() {
-        hoverPlacementButton(i);
-    });
-
-    // Optionally, keep the original mousedown/mouseup if needed
-    element.addEventListener('mousedown', function() {
-        holdPlacementButtonDown(i);
-    });
-
-    element.addEventListener('mouseup', function() {
-        holdPlacementButtonDown(i);
-    });
-}
-
 /**
  * @description resets the mousepress.
  * USED IN PHP

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1683,21 +1683,13 @@ function hoverPlacementButton(num) {
 // Modified original function to work with hovering and also handle pressing if needed
 function holdPlacementButtonDown(num) {
     mousePressed = true;
-    if (document.getElementById("togglePlacementTypeBox" + num).classList.contains("activeTogglePlacementTypeBox")) {
-        mousePressed = false;
-        togglePlacementTypeBox(num);
-    }
-    // We don't need the timeout delay anymore since we're now handling hover instead of long-press
-    if (!!mousePressed) {
-        togglePlacementTypeBox(num);
-    }
 }
 
 /**
  * @description resets the mousepress.
  * USED IN PHP
  */
-function holdPlacementButtonUp() {
+function holdPlacementButtonUp(num) {
     mousePressed = false;
 }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1672,27 +1672,48 @@ function setElementPlacementType(type = elementTypes.EREntity) {
 }
 
 /**
- * @description Function to open a subtoolbar when pressing down on a button for a certan period of time
+ * @description Function to open a subtoolbar when hovering over a button
  * USED IN PHP
  */
+function hoverPlacementButton(num) {
+    // Directly toggle the subtoolbar when hovering, without the delay
+    togglePlacementTypeBox(num);
+}
+
+// Modified original function to work with hovering and also handle pressing if needed
 function holdPlacementButtonDown(num) {
     mousePressed = true;
     if (document.getElementById("togglePlacementTypeBox" + num).classList.contains("activeTogglePlacementTypeBox")) {
         mousePressed = false;
         togglePlacementTypeBox(num);
     }
-    setTimeout(() => {
-        if (!!mousePressed) {
-            togglePlacementTypeBox(num);
-        }
-    }, 500);
+    // We don't need the timeout delay anymore since we're now handling hover instead of long-press
+    if (!!mousePressed) {
+        togglePlacementTypeBox(num);
+    }
 }
 
-/**
- * @description Function to open a subtoolbar when rightclicking a button
- */
-function rightClickOpenSubtoolbar(num) {
-    togglePlacementTypeBox(num);
+// Add hover-specific event listeners for elements
+for (let i = 0; i <= 4; i++) { // Adjust the range based on your number of elements
+    const element = document.getElementById("elementPlacement" + i);
+    
+    // For hover, use 'mouseenter' and 'mouseleave' to trigger the hoverPlacementButton
+    element.addEventListener('mouseenter', function() {
+        hoverPlacementButton(i);
+    });
+
+    element.addEventListener('mouseleave', function() {
+        hoverPlacementButton(i);
+    });
+
+    // Optionally, keep the original mousedown/mouseup if needed
+    element.addEventListener('mousedown', function() {
+        holdPlacementButtonDown(i);
+    });
+
+    element.addEventListener('mouseup', function() {
+        holdPlacementButtonDown(i);
+    });
 }
 
 /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -581,18 +581,6 @@ elements.forEach(element => {
     }
 });
 
-for (let i = 0; i <= maxNum; i++) {
-    let element = document.getElementById("elementPlacement" + i);
-    if (element) {
-        // Add event listener for click
-        element.addEventListener("mousedown", function (event) {
-            if (event.button === 2) {
-                rightClickOpenSubtoolbar(i);
-            }
-        });
-    }
-}
-
 document.addEventListener('contextmenu', event => {
     event.preventDefault();
 });
@@ -1672,12 +1660,42 @@ function setElementPlacementType(type = elementTypes.EREntity) {
 }
 
 /**
+ * @description Variable to hold current subtoolbar
+ * USED LOCALLY
+ */
+let currentlyOpenSubmenu = null;
+
+/**
  * @description Function to open a subtoolbar when hovering over a button
  * USED IN PHP
  */
-function hoverPlacementButton(num) {
-    // Directly toggle the subtoolbar when hovering, without the delay
-    togglePlacementTypeBox(num);
+function hoverPlacementButton(index) {
+    // First, hide the old submenu if a new button is hovered
+    if (currentlyOpenSubmenu !== null && currentlyOpenSubmenu !== index) {
+        hidePlacementType();
+    }
+
+    let submenu = document.getElementById(`togglePlacementTypeBox${index}`);
+    if (submenu) {
+        submenu.classList.add("activeTogglePlacementTypeBox");
+        currentlyOpenSubmenu = index;
+    } else {
+        currentlyOpenSubmenu = null;
+    }
+}
+
+/**
+ * @description Function to hide submenu
+ * USED IN PHP
+ */ 
+function hidePlacementType() {
+    if (currentlyOpenSubmenu !== null) {
+        let submenu = document.getElementById(`togglePlacementTypeBox${currentlyOpenSubmenu}`);
+        if (submenu){
+            submenu.classList.remove("activeTogglePlacementTypeBox"); // Hide submenu
+        }             
+        currentlyOpenSubmenu = null;
+    }
 }
 
 // Modified original function to work with hovering and also handle pressing if needed

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -100,14 +100,14 @@
     <div id="diagram-toolbar">
         <fieldset>
             <legend aria-hidden="true">Modes</legend>
-                <div id="mouseMode0" class="diagramIcons toolbarMode active" onclick='setMouseMode(0);'>
+                <div id="mouseMode0" onmouseenter='hidePlacementType()' class="diagramIcons toolbarMode active" onclick='setMouseMode(0);'>
                     <img src="../Shared/icons/diagram_pointer_white.svg" alt="Pointer"/>
                     <span class="toolTipText" id="highestToolTip"><b>Pointer</b><br>
                         <span>Allows you to select and move different elements as well as navigate the workspace</span><br>
                         <span id="tooltip-POINTER" class="key_tooltip">Keybinding:</span>
                     </span>
                 </div>
-                <div id="mouseMode1" class="diagramIcons toolbarMode" onclick='setMouseMode(1);'>
+                <div id="mouseMode1" onmouseenter='hidePlacementType()' class="diagramIcons toolbarMode" onclick='setMouseMode(1);'>
                     <img src="../Shared/icons/diagram_box_selection2.svg" alt="Box Selection"/>
                     <span class="toolTipText"><b>Box Selection</b><br>
                         <p>Click and drag to select multiple elements within the selected area</p><br>
@@ -119,7 +119,7 @@
                          class="ERButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(0); setMouseMode(2);'
                          onmouseenter='hoverPlacementButton(0)'><!--<-- UML functionality -->
-                        <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
+                         <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                         <span class="toolTipText"><b>ER entity</b><br>
                             <p>Add an ER entity to the diagram</p>
                             <p>Each entity represents an object which is a representation of concepts or data.</p>
@@ -131,7 +131,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>    
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(0), hidePlacementType()'>
                         <div id="togglePlacementTypeBox0" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
@@ -190,7 +190,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(4), hidePlacementType()'>
                         <div id="togglePlacementTypeBox4" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
@@ -250,7 +250,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(6), hidePlacementType()'>
                         <div id="togglePlacementTypeBox6" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
@@ -310,7 +310,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(8), hidePlacementType()'>
                         <div id="togglePlacementTypeBox8" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
@@ -370,7 +370,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div> 
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(1), hidePlacementType()'>
                         <div id="togglePlacementTypeBox1" class="togglePlacementTypeBox togglePlacementTypeBoxRI"><!--<-- UML functionality start-->
                             <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER relation"/>
@@ -429,7 +429,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>  
-                    <div id="diagramPopOut">  
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(5), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox5" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
@@ -488,7 +488,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>  
-                    <div id="diagramPopOut">  
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(7), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox7" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
@@ -546,7 +546,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>  
-                    <div id="diagramPopOut">  
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(2), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox2" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
@@ -588,7 +588,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="mouseMode3" class="diagramIcons toolbarMode" onclick='clearContext(); setMouseMode(3);'>
+                <div id="mouseMode3" onmouseenter='hidePlacementType()' class="diagramIcons toolbarMode" onclick='clearContext(); setMouseMode(3);'>
                     <img src="../Shared/icons/diagram_line.svg" alt="Line"/>
                     <span class="toolTipText"><b>Line</b><br>
                         <p>Make a line between elements</p><br>
@@ -611,7 +611,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>    
-                    <div id="diagramPopOut"><!--Initial state -->
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(9), hidePlacementType()'><!--Initial state -->
                         <div id="togglePlacementTypeBox9" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
@@ -661,7 +661,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>
-                    <div id="diagramPopOut"><!--Initial state -->
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(10), hidePlacementType()'><!--Initial state -->
                         <div id="togglePlacementTypeBox10" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
@@ -711,7 +711,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>
-                    <div id="diagramPopOut"><!--Initial state -->
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(11), hidePlacementType()'><!--Initial state -->
                         <div id="togglePlacementTypeBox11" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
@@ -765,7 +765,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(12), hidePlacementType()'>
                         <div id="togglePlacementTypeBox12" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> <!-- LIFELINE ACTOR !-->
                             <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline object"/>
@@ -822,7 +822,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>    
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(16), hidePlacementType()'>
                         <div id="togglePlacementTypeBox16" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> <!-- LIFELINE ACTOR !-->
                             <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
@@ -879,7 +879,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>    
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(13), hidePlacementType()'>
                         <div id="togglePlacementTypeBox13" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> <!-- LIFELINE ACTOR !-->
                             <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
@@ -934,7 +934,7 @@
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
                     </div>    
-                    <div id="diagramPopOut">
+                    <div id="diagramPopOut" onmouseleave='hoverPlacementButton(14), hidePlacementType()'>
                         <div id="togglePlacementTypeBox14" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> <!-- LIFELINE ACTOR !-->
                             <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
@@ -977,7 +977,7 @@
                 </div> <!-- SEQUENCE CONDITION/LOOP END -->
                 <!-- SEQUENCE POP-OUT END -->
                 <!-- NOTE -->
-                <div id="elementPlacement15" class="diagramIcons toolbarMode" onclick='setElementPlacementType(15); setMouseMode(2);'>
+                <div id="elementPlacement15" onmouseenter='hidePlacementType()' class="diagramIcons toolbarMode" onclick='setElementPlacementType(15); setMouseMode(2);'>
                     <img src="../Shared/icons/diagram_note.svg"/>
                     <span class="toolTipText"><b>Note</b><br>
                         <p>Creates a note</p><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -118,8 +118,7 @@
                     <div id="elementPlacement0"
                          class="ERButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(0); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(0)'
-                         onmouseleave="hoverPlacementButton()"><!--<-- UML functionality -->
+                         onmouseenter='hoverPlacementButton(0)'><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                         <span class="toolTipText"><b>ER entity</b><br>
                             <p>Add an ER entity to the diagram</p>
@@ -179,8 +178,7 @@
                     <div id="elementPlacement4"
                          class="UMLButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(4); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(4)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(4)'>
                         <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                         <span class="toolTipText"><b>UML class</b><br>
                             <p>Add an UML class to the diagram</p>
@@ -239,8 +237,7 @@
                     <div id="elementPlacement6"
                          class="IEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(6); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(6)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(6)'>
                         <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                         <span class="toolTipText"><b>IE entity</b><br>
                             <p>Add an IE entity to the diagram</p>
@@ -300,8 +297,7 @@
                     <div id="elementPlacement8" 
                         class="SDButton diagramIcons toolbarMode" 
                         onclick='setElementPlacementType(8); setMouseMode(2);'
-                        onmouseenter='hoverPlacementButton(8);'
-                         onmouseleave="hoverPlacementButton()">
+                        onmouseenter='hoverPlacementButton(8);'>
                         <img src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                         <span class="toolTipText"><b>State diagram state</b><br>
                             <p>Add state diagram state to the diagram</p>
@@ -362,8 +358,7 @@
                     <div id="elementPlacement1"
                          class="ERButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(1); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(1);'
-                         onmouseleave="hoverPlacementButton()"> <!--<-- UML functionality -->
+                         onmouseenter='hoverPlacementButton(1);'> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"  alt="ER relation"/>
                         <span class="toolTipText"><b>ER relation</b><br>
                             <p>Add a ER relation to the diagram</p>
@@ -421,8 +416,7 @@
                     <div id="elementPlacement5"
                          class="UMLButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(5); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(5)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(5)'>
                         <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                         <span class="toolTipText"><b>UML inheritance</b><br>
                             <p>Add an UML inheritance to the diagram</p>
@@ -481,8 +475,7 @@
                     <div id="elementPlacement7"
                          class="IEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(7); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(7)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(7)'>
                         <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                         <span class="toolTipText"><b>IE inheritance</b><br>
                             <p>Add an IE inheritance to the diagram</p>
@@ -541,8 +534,7 @@
                     <div id="elementPlacement2"
                          class="ERAttribute diagramIcons toolbarMode"
                          onclick='setElementPlacementType(2); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(2)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(2)'>
                         <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                         <span class="toolTipText"><b>ER Attribute</b><br>
                             <p>Add a ER attribute to the diagram</p>
@@ -607,8 +599,7 @@
                     <div id="elementPlacement9"
                          class="SDButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(9); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(9)'
-                         onmouseleave="hoverPlacementButton()"><!--<-- UML functionality -->
+                         onmouseenter='hoverPlacementButton(9)'><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                         <span class="toolTipText"><b>UML initial state</b><br>
                             <p>Creates an initial state for UML.</p>
@@ -658,8 +649,7 @@
                     <div id="elementPlacement10"
                          class="SDButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(10); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(10)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(10)'>
                         <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                         <span class="toolTipText"><b>UML final state</b><br>
                             <p>Creates a final state for UML.</p>
@@ -709,8 +699,7 @@
                     <div id="elementPlacement11" 
                          class="SDButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(11); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(11)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(11)'>
                         <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                         <span class="toolTipText"><b>UML super state</b><br>
                             <p>Creates a super state.</p>
@@ -763,8 +752,7 @@
                     <div id="elementPlacement12"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(12); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(12)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(12)'>
                          <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                         <span class="toolTipText"><b>Sequence lifeline</b><br>
                             <p>Creates a lifeline for a sequnece diagram</p>
@@ -822,12 +810,11 @@
                     <div id="elementPlacement16"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(16); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(16)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(16)'>
                          <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence activation"/>
-                        <span class="toolTipText"><b>Sequence activation</b><br>
+                        <span class="toolTipText"><b>Sequence lifeline (object)</b><br>
                             <p>Creates an activation box.</p>
-                            <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
+                            <p>Represents the passage of time.</p>
                             <br>
                             <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
                         </span>
@@ -880,8 +867,7 @@
                     <div id="elementPlacement13"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(13); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(13)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(13)'>
                          <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                         <span class="toolTipText"><b>Sequence activation</b><br>
                             <p>Creates an activation box.</p>
@@ -938,8 +924,7 @@
                     <div id="elementPlacement14"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(14); setMouseMode(2);'
-                         onmouseenter='hoverPlacementButton(14)'
-                         onmouseleave="hoverPlacementButton()">
+                         onmouseenter='hoverPlacementButton(14)'>
                          <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="toolTipText"><b>Sequence Condition</b><br>
                                 <p>Creates a option loop or alternative.</p><br>
@@ -992,7 +977,7 @@
                 </div> <!-- SEQUENCE CONDITION/LOOP END -->
                 <!-- SEQUENCE POP-OUT END -->
                 <!-- NOTE -->
-                <div id="elementPlacement15" class="diagramIcons toolbarMode" onclick='setElementPlacementType(15); setMouseMode(2);' onmouseup='holdPlacementButtonUp();'>
+                <div id="elementPlacement15" class="diagramIcons toolbarMode" onclick='setElementPlacementType(15); setMouseMode(2);'>
                     <img src="../Shared/icons/diagram_note.svg"/>
                     <span class="toolTipText"><b>Note</b><br>
                         <p>Creates a note</p><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -118,8 +118,8 @@
                     <div id="elementPlacement0"
                          class="ERButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(0); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(0)"><!--<-- UML functionality -->
+                         onmouseenter='hoverPlacementButton(0)'
+                         onmouseleave="hoverPlacementButton()"><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                         <span class="toolTipText"><b>ER entity</b><br>
                             <p>Add an ER entity to the diagram</p>
@@ -179,8 +179,8 @@
                     <div id="elementPlacement4"
                          class="UMLButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(4); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp();'
-                         onmousedown="holdPlacementButtonDown(4)">
+                         onmouseenter='hoverPlacementButton(4)'
+                         onmouseleave="hoverPlacementButton()">
                         <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                         <span class="toolTipText"><b>UML class</b><br>
                             <p>Add an UML class to the diagram</p>
@@ -239,8 +239,8 @@
                     <div id="elementPlacement6"
                          class="IEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(6); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp();'
-                         onmousedown="holdPlacementButtonDown(6)">
+                         onmouseenter='hoverPlacementButton(6)'
+                         onmouseleave="hoverPlacementButton()">
                         <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                         <span class="toolTipText"><b>IE entity</b><br>
                             <p>Add an IE entity to the diagram</p>
@@ -300,8 +300,8 @@
                     <div id="elementPlacement8" 
                         class="SDButton diagramIcons toolbarMode" 
                         onclick='setElementPlacementType(8); setMouseMode(2);'
-                        onmouseup='holdPlacementButtonUp();'
-                        onmousedown='holdPlacementButtonDown(8);'>
+                        onmouseenter='hoverPlacementButton(8);'
+                         onmouseleave="hoverPlacementButton()">
                         <img src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                         <span class="toolTipText"><b>State diagram state</b><br>
                             <p>Add state diagram state to the diagram</p>
@@ -362,8 +362,8 @@
                     <div id="elementPlacement1"
                          class="ERButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(1); setMouseMode(2);'
-                         onmouseenter='holdPlacementButtonUp();'
-                         onmouseleave="holdPlacementButtonDown(1)"> <!--<-- UML functionality -->
+                         onmouseenter='hoverPlacementButton(1);'
+                         onmouseleave="hoverPlacementButton()"> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"  alt="ER relation"/>
                         <span class="toolTipText"><b>ER relation</b><br>
                             <p>Add a ER relation to the diagram</p>
@@ -421,8 +421,8 @@
                     <div id="elementPlacement5"
                          class="UMLButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(5); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp();'
-                         onmousedown="holdPlacementButtonDown(5)">
+                         onmouseenter='hoverPlacementButton(5)'
+                         onmouseleave="hoverPlacementButton()">
                         <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                         <span class="toolTipText"><b>UML inheritance</b><br>
                             <p>Add an UML inheritance to the diagram</p>
@@ -481,8 +481,8 @@
                     <div id="elementPlacement7"
                          class="IEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(7); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp();'
-                         onmousedown="holdPlacementButtonDown(7)">
+                         onmouseenter='hoverPlacementButton(7)'
+                         onmouseleave="hoverPlacementButton()">
                         <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                         <span class="toolTipText"><b>IE inheritance</b><br>
                             <p>Add an IE inheritance to the diagram</p>
@@ -541,8 +541,8 @@
                     <div id="elementPlacement2"
                          class="ERAttribute diagramIcons toolbarMode"
                          onclick='setElementPlacementType(2); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp();'
-                         onmousedown="holdPlacementButtonDown(2)">
+                         onmouseenter='hoverPlacementButton(2)'
+                         onmouseleave="hoverPlacementButton()">
                         <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                         <span class="toolTipText"><b>ER Attribute</b><br>
                             <p>Add a ER attribute to the diagram</p>
@@ -607,8 +607,8 @@
                     <div id="elementPlacement9"
                          class="SDButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(9); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(9)"><!--<-- UML functionality -->
+                         onmouseenter='hoverPlacementButton(9)'
+                         onmouseleave="hoverPlacementButton()"><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                         <span class="toolTipText"><b>UML initial state</b><br>
                             <p>Creates an initial state for UML.</p>
@@ -658,8 +658,8 @@
                     <div id="elementPlacement10"
                          class="SDButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(10); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp();'
-                         onmousedown="holdPlacementButtonDown(10)">
+                         onmouseenter='hoverPlacementButton(10)'
+                         onmouseleave="hoverPlacementButton()">
                         <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                         <span class="toolTipText"><b>UML final state</b><br>
                             <p>Creates a final state for UML.</p>
@@ -709,8 +709,8 @@
                     <div id="elementPlacement11" 
                          class="SDButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(11); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp();'
-                         onmousedown="holdPlacementButtonDown(11)">
+                         onmouseenter='hoverPlacementButton(11)'
+                         onmouseleave="hoverPlacementButton()">
                         <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                         <span class="toolTipText"><b>UML super state</b><br>
                             <p>Creates a super state.</p>
@@ -763,8 +763,8 @@
                     <div id="elementPlacement12"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(12); setMouseMode(2);'
-                         onmouseenter='holdPlacementButtonUp()'
-                         onmouseleave="holdPlacementButtonDown(12)">
+                         onmouseenter='hoverPlacementButton(12)'
+                         onmouseleave="hoverPlacementButton()">
                          <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                         <span class="toolTipText"><b>Sequence lifeline</b><br>
                             <p>Creates a lifeline for a sequnece diagram</p>
@@ -822,8 +822,8 @@
                     <div id="elementPlacement16"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(16); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(16)">
+                         onmouseenter='hoverPlacementButton(16)'
+                         onmouseleave="hoverPlacementButton()">
                          <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence activation"/>
                         <span class="toolTipText"><b>Sequence activation</b><br>
                             <p>Creates an activation box.</p>
@@ -880,8 +880,8 @@
                     <div id="elementPlacement13"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(13); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(13)">
+                         onmouseenter='hoverPlacementButton(13)'
+                         onmouseleave="hoverPlacementButton()">
                          <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                         <span class="toolTipText"><b>Sequence activation</b><br>
                             <p>Creates an activation box.</p>
@@ -938,8 +938,8 @@
                     <div id="elementPlacement14"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(14); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(14)">
+                         onmouseenter='hoverPlacementButton(14)'
+                         onmouseleave="hoverPlacementButton()">
                          <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="toolTipText"><b>Sequence Condition</b><br>
                                 <p>Creates a option loop or alternative.</p><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -362,8 +362,8 @@
                     <div id="elementPlacement1"
                          class="ERButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(1); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp();'
-                         onmousedown="holdPlacementButtonDown(1)"> <!--<-- UML functionality -->
+                         onmouseenter='holdPlacementButtonUp();'
+                         onmouseleave="holdPlacementButtonDown(1)"> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"  alt="ER relation"/>
                         <span class="toolTipText"><b>ER relation</b><br>
                             <p>Add a ER relation to the diagram</p>
@@ -763,8 +763,8 @@
                     <div id="elementPlacement12"
                          class="SEButton diagramIcons toolbarMode"
                          onclick='setElementPlacementType(12); setMouseMode(2);'
-                         onmouseup='holdPlacementButtonUp()'
-                         onmousedown="holdPlacementButtonDown(12)">
+                         onmouseenter='holdPlacementButtonUp()'
+                         onmouseleave="holdPlacementButtonDown(12)">
                          <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                         <span class="toolTipText"><b>Sequence lifeline</b><br>
                             <p>Creates a lifeline for a sequnece diagram</p>


### PR DESCRIPTION
The user previously had to click and hold half a second for the subtoolbar to open and use related items for the diagram, as seen in the video below.

Old sub-toolbar, accessed by clicking and holding item.
https://github.com/user-attachments/assets/3eb01b80-ef7d-4e80-a2f1-89746057dc7d

With this patch, the user now only needs to hover over an item for related items in the sub-toolbar to show up. This is a more user friendly/ faster interface. Demonstrated in the video below.

New sub-toolbar, accessed by hovering over item.
https://github.com/user-attachments/assets/54b67f7f-9390-4044-9770-b698c2b671c9