### PR TITLE
G3 2025 v3 #16722 view buttons position

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -4477,7 +4477,8 @@ function setViewMode(mode){
 
 //elementID is the ID that gets passed to the dropdown component.
 function showDropdown(elementID) {
-  let element = getElementById(elementID);
+  let element = document.getElementById(elementID);
+  element.classList.toggle("dropdown-content-show");
 }
 
 // Adds the ability to close dropdown by clicking anywhere on the page.

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -4475,6 +4475,21 @@ function setViewMode(mode){
   }
 }
 
+//elementID is the ID that gets passed to the dropdown component.
 function showDropdown(elementID) {
   let element = getElementById(elementID);
 }
+
+// Adds the ability to close dropdown by clicking anywhere on the page.
+window.addEventListener("click", function(event){
+  if (!event.target.matches(".dropButton")) {
+    let dropdowns = this.document.getElementsByClassName("dropdown-content");
+    let i;
+    for (i = 0; i < dropdowns.length; i++) {
+      let dropdown = dropdowns[i];
+      if (dropdown.classList.contains("dropdown-content-show")) {
+        dropdown.classList.remove("dropdown-content-show");
+      }
+    }
+  }
+});

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -4474,3 +4474,7 @@ function setViewMode(mode){
     section.classList.add("overview-mode");
   }
 }
+
+function showDropdown(elementID) {
+  let element = getElementById(elementID);
+}

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -101,6 +101,7 @@
 	<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 
 	<script type="text/babel" src="../Shared/components/Button.js"></script>
+	<script type="text/babel" src="../Shared/components/Dropdown.js"></script>
 
 	<script src="../Shared/dugga.js"></script>
 	<script src="sectioned.js"></script>
@@ -247,6 +248,17 @@
 			<!-- end hide button -->
 			
 			<div id='course-label'>
+					<div id="course-label-dropdown">
+						<script type="text/babel">
+							ReactDOM.createRoot(document.getElementById('course-label-dropdown')).render(
+								<>
+									<Dropdown dropdownName="View">
+										<Dropdown.Button onClick={() => {setViewMode('Normal')}}>Normal</Dropdown.Button>
+									</Dropdown>
+								</>
+							);
+						</script>
+					</div>
 					<span id='course-coursename' class='nowrap ellipsis' >UNK</span>
 					<span id='course-coursecode'>UNK</span>
 					<span id='course-versname' class='courseVersionField'>UNK</span>
@@ -287,14 +299,15 @@
 
 		<div id='courseList'>
 
-		<!-- View mode toggle buttons -->
+		<!-- View mode toggle buttons 
 		<div class="view-label">
 			<h2>View</h2>
   			<button class="submit-button" onclick="setViewMode('normal')">Normal</button>
   			<button class="submit-button" onclick="setViewMode('scroll')">Scroll</button>
  			<button class="submit-button" onclick="setViewMode('overview')">Overview</button>
 		</div>
-
+		
+		-->
 		<!-- Section List -->
 		<div id='Sectionlisti'>
 		

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -249,11 +249,14 @@
 			
 			<div id='course-label'>
 					<div id="course-label-dropdown">
+						<!-- View mode toggle buttons  --> 
 						<script type="text/babel">
 							ReactDOM.createRoot(document.getElementById('course-label-dropdown')).render(
 								<>
-									<Dropdown dropdownName="View">
-										<Dropdown.Button onClick={() => {setViewMode('Normal')}}>Normal</Dropdown.Button>
+									<Dropdown dropdownName="View" className="view-label">
+										<Button className="submit-button" title="Normal View" onClick={() => {setViewMode('normal')}}>Normal</Button>
+										<Button className="submit-button" title="Scroll View" onClick={() => {setViewMode('scroll')}}>Scroll</Button>
+										<Button className="submit-button" title="Overview" onClick={() => {setViewMode('overview')}}>Overview</Button>
 									</Dropdown>
 								</>
 							);

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -253,7 +253,7 @@
 						<script type="text/babel">
 							ReactDOM.createRoot(document.getElementById('course-label-dropdown')).render(
 								<>
-									<Dropdown dropdownName="View" onClick={() => showDropdown('course-label-dropdown-content')} className="view-label" id="course-label-dropdown-content">
+									<Dropdown dropdownName="View" onClick={() => showDropdown('course-label-dropdown-content')} id="course-label-dropdown-content">
 										<Button className="submit-button" title="Normal View" onClick={() => {setViewMode('normal')}}>Normal</Button>
 										<Button className="submit-button" title="Scroll View" onClick={() => {setViewMode('scroll')}}>Scroll</Button>
 										<Button className="submit-button" title="Overview" onClick={() => {setViewMode('overview')}}>Overview</Button>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -253,7 +253,7 @@
 						<script type="text/babel">
 							ReactDOM.createRoot(document.getElementById('course-label-dropdown')).render(
 								<>
-									<Dropdown dropdownName="View" className="view-label">
+									<Dropdown dropdownName="View" onClick={() => showDropdown('course-label-dropdown-content')} className="view-label" id="course-label-dropdown-content">
 										<Button className="submit-button" title="Normal View" onClick={() => {setViewMode('normal')}}>Normal</Button>
 										<Button className="submit-button" title="Scroll View" onClick={() => {setViewMode('scroll')}}>Scroll</Button>
 										<Button className="submit-button" title="Overview" onClick={() => {setViewMode('overview')}}>Overview</Button>

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -247,24 +247,25 @@
 		
 			<!-- end hide button -->
 			
+			<div id="course-header-dropdown">
+				<!-- View mode toggle buttons -->
+				<script type="text/babel">
+					ReactDOM.createRoot(document.getElementById('course-header-dropdown')).render(
+						<>
+							<Dropdown dropdownName="View" onClick={() => showDropdown('course-header-dropdown-content')} id="course-header-dropdown-content">
+								<Button className="submit-button" title="Normal View" onClick={() => {setViewMode('normal')}}>Normal</Button>
+								<Button className="submit-button" title="Scroll View" onClick={() => {setViewMode('scroll')}}>Scroll</Button>
+								<Button className="submit-button" title="Overview" onClick={() => {setViewMode('overview')}}>Overview</Button>
+							</Dropdown>
+						</>
+					);
+				</script>
+			</div>
+
 			<div id='course-label'>
-					<div id="course-label-dropdown">
-						<!-- View mode toggle buttons  --> 
-						<script type="text/babel">
-							ReactDOM.createRoot(document.getElementById('course-label-dropdown')).render(
-								<>
-									<Dropdown dropdownName="View" onClick={() => showDropdown('course-label-dropdown-content')} id="course-label-dropdown-content">
-										<Button className="submit-button" title="Normal View" onClick={() => {setViewMode('normal')}}>Normal</Button>
-										<Button className="submit-button" title="Scroll View" onClick={() => {setViewMode('scroll')}}>Scroll</Button>
-										<Button className="submit-button" title="Overview" onClick={() => {setViewMode('overview')}}>Overview</Button>
-									</Dropdown>
-								</>
-							);
-						</script>
-					</div>
-					<span id='course-coursename' class='nowrap ellipsis' >UNK</span>
-					<span id='course-coursecode'>UNK</span>
-					<span id='course-versname' class='courseVersionField'>UNK</span>
+				<span id='course-coursename' class='nowrap ellipsis' >UNK</span>
+				<span id='course-coursecode'>UNK</span>
+				<span id='course-versname' class='courseVersionField'>UNK</span>
 			</div>
 
 

--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -301,16 +301,7 @@
 		<!-- FAB END -->
 
 		<div id='courseList'>
-
-		<!-- View mode toggle buttons 
-		<div class="view-label">
-			<h2>View</h2>
-  			<button class="submit-button" onclick="setViewMode('normal')">Normal</button>
-  			<button class="submit-button" onclick="setViewMode('scroll')">Scroll</button>
- 			<button class="submit-button" onclick="setViewMode('overview')">Overview</button>
-		</div>
 		
-		-->
 		<!-- Section List -->
 		<div id='Sectionlisti'>
 		

--- a/Shared/components/Dropdown.js
+++ b/Shared/components/Dropdown.js
@@ -8,13 +8,3 @@ const Dropdown = ({ children, dropdownName, onClick, className = "" }) => {
         </div>
     );
 };
-
-const Button = ({ children, onClick }) => {
-    return (
-        <button onClick={onClick}>
-            {children}
-        </button>
-    );
-};
-
-Dropdown.Button = Button;

--- a/Shared/components/Dropdown.js
+++ b/Shared/components/Dropdown.js
@@ -1,9 +1,10 @@
-import React from "react";
-
-const Dropdown = ({ children, className = "" }) => {
+const Dropdown = ({ children, dropdownName, onClick, className = "" }) => {
     return (
-        <div className={'dropdown ${className}'}>
-            {children}
+        <div className={`dropdown ${className}`}>
+            <button onClick={onClick} className="dropButton">{dropdownName}</button>
+            <div className="dropdown-content">
+                {children}
+            </div>
         </div>
     );
 };
@@ -17,5 +18,3 @@ const Button = ({ children, onClick }) => {
 };
 
 Dropdown.Button = Button;
-
-export default Dropdown;

--- a/Shared/components/Dropdown.js
+++ b/Shared/components/Dropdown.js
@@ -1,7 +1,7 @@
 const Dropdown = ({ children, dropdownName, onClick, className = "", id="" }) => {
     return (
         <div className={`dropdown ${className}`}>
-            <button onClick={onClick} className="submit-button">{dropdownName}</button>
+            <button onClick={onClick} className="dropButton submit-button">{dropdownName}</button>
             <div className="dropdown-content dropdown-content-hide" id={id}>
                 {children}
             </div>

--- a/Shared/components/Dropdown.js
+++ b/Shared/components/Dropdown.js
@@ -1,3 +1,10 @@
+/**
+ * Animated reusable dropdown component.
+ * It takes a number of children which then acts as the rows. The onClick props should use the function
+ * showDropdown inside of sectioned.js. The id of the dropdown should be passed as a parameter to the function.
+ * The dropdownName props is the text that will be displayed on the button that opens the dropdown. 
+ */
+
 const Dropdown = ({ children, dropdownName, onClick, className = "", id="" }) => {
     return (
         <div className={`dropdown ${className}`}>

--- a/Shared/components/Dropdown.js
+++ b/Shared/components/Dropdown.js
@@ -1,7 +1,10 @@
 const Dropdown = ({ children, dropdownName, onClick, className = "", id="" }) => {
     return (
         <div className={`dropdown ${className}`}>
-            <button onClick={onClick} className="dropButton submit-button">{dropdownName}</button>
+            <button onClick={onClick} className="dropButton submit-button">
+                <img src="/LenaSYS/Shared/icons/hamburger_menu_google_fonts.svg"/>
+                {dropdownName}
+            </button>
             <div className="dropdown-content dropdown-content-hide" id={id}>
                 {children}
             </div>

--- a/Shared/components/Dropdown.js
+++ b/Shared/components/Dropdown.js
@@ -1,8 +1,8 @@
 const Dropdown = ({ children, dropdownName, onClick, className = "", id="" }) => {
     return (
-        <div className={`dropdown dropdown-content-hide ${className}`}>
-            <button onClick={onClick} className="dropButton">{dropdownName}</button>
-            <div className="dropdown-content" id={id}>
+        <div className={`dropdown ${className}`}>
+            <button onClick={onClick} className="submit-button">{dropdownName}</button>
+            <div className="dropdown-content dropdown-content-hide" id={id}>
                 {children}
             </div>
         </div>

--- a/Shared/components/Dropdown.js
+++ b/Shared/components/Dropdown.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+const Dropdown = ({ children, className = "" }) => {
+    return (
+        <div className={'dropdown ${className}'}>
+            {children}
+        </div>
+    );
+};
+
+const Button = ({ children, onClick }) => {
+    return (
+        <button onClick={onClick}>
+            {children}
+        </button>
+    );
+};
+
+Dropdown.Button = Button;
+
+export default Dropdown;

--- a/Shared/components/Dropdown.js
+++ b/Shared/components/Dropdown.js
@@ -1,8 +1,8 @@
-const Dropdown = ({ children, dropdownName, onClick, className = "" }) => {
+const Dropdown = ({ children, dropdownName, onClick, className = "", id="" }) => {
     return (
-        <div className={`dropdown ${className}`}>
+        <div className={`dropdown dropdown-content-hide ${className}`}>
             <button onClick={onClick} className="dropButton">{dropdownName}</button>
-            <div className="dropdown-content">
+            <div className="dropdown-content" id={id}>
                 {children}
             </div>
         </div>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -846,6 +846,24 @@ p {
   }
 }
 
+.dropButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 1em;
+  padding: 0.5em auto;
+}
+
+@keyframes dropDownSlide {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .dropdown-content {
   display: none;
   position: absolute;
@@ -854,6 +872,23 @@ p {
   
   &.dropdown-content-show {
     display: flex;
+
+    > button {
+      opacity: 0;
+      transform: translateY(-10px);
+      animation: dropDownSlide 0.3s ease-out forwards;
+    }
+
+    /*To stagger the animation*/
+    > button:nth-child(1) { animation-delay: 0.05s; }
+    > button:nth-child(2) { animation-delay: 0.10s; }
+    > button:nth-child(3) { animation-delay: 0.15s; }
+    > button:nth-child(4) { animation-delay: 0.20s; }
+    > button:nth-child(5) { animation-delay: 0.25s; }
+    > button:nth-child(6) { animation-delay: 0.30s; }
+    > button:nth-child(7) { animation-delay: 0.35s; }
+    > button:nth-child(8) { animation-delay: 0.40s; }
+    > button:nth-child(9) { animation-delay: 0.45s; }
   }
 
   & button {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -896,11 +896,6 @@ p {
   }
 }
 
-#course-label-dropdown {
-  display: flex;
-  justify-content: flex-start;
-}
-
 #sectionList_arrowStatisticsClosed{
   display: inline;
 }
@@ -2740,9 +2735,11 @@ resulted.php END
  * --------------================################================--------------*/
  
  #courseHeader {
-  display:flex; 
-  align-items:center; 
-  justify-content:flex-end; 
+  display:flex;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  width: 100%;
  }
 
  #course-newitem {
@@ -2759,13 +2756,13 @@ resulted.php END
   margin-right:10px;
  }
 
- #course-label {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  flex-grow: 1;
- }
+#course-label {
+  /*Temporary fix because flex and grid does not work properly at the time.
+  TODO: Implement a flex or grid layout properly.*/
+ position: absolute;
+ left: 50%;
+ transform: translateX(-50%);
+}
 
 #editSectionLoginBox {
  width:460px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -873,22 +873,22 @@ p {
   &.dropdown-content-show {
     display: flex;
 
-    > button {
+    > * {
       opacity: 0;
       transform: translateY(-10px);
       animation: dropDownSlide 0.3s ease-out forwards;
     }
 
     /*To stagger the animation*/
-    > button:nth-child(1) { animation-delay: 0.05s; }
-    > button:nth-child(2) { animation-delay: 0.10s; }
-    > button:nth-child(3) { animation-delay: 0.15s; }
-    > button:nth-child(4) { animation-delay: 0.20s; }
-    > button:nth-child(5) { animation-delay: 0.25s; }
-    > button:nth-child(6) { animation-delay: 0.30s; }
-    > button:nth-child(7) { animation-delay: 0.35s; }
-    > button:nth-child(8) { animation-delay: 0.40s; }
-    > button:nth-child(9) { animation-delay: 0.45s; }
+    > *:nth-child(1) { animation-delay: 0.05s; }
+    > *:nth-child(2) { animation-delay: 0.10s; }
+    > *:nth-child(3) { animation-delay: 0.15s; }
+    > *:nth-child(4) { animation-delay: 0.20s; }
+    > *:nth-child(5) { animation-delay: 0.25s; }
+    > *:nth-child(6) { animation-delay: 0.30s; }
+    > *:nth-child(7) { animation-delay: 0.35s; }
+    > *:nth-child(8) { animation-delay: 0.40s; }
+    > *:nth-child(9) { animation-delay: 0.45s; }
   }
 
   & button {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -830,6 +830,7 @@ p {
  text-decoration: underline;
 }
 /*End of recent feedback from the teacher*/
+
 #Sectionlist {
   margin: 10px;
   background-color: var(--color-background);
@@ -860,7 +861,6 @@ p {
   }
 }
 
-/*WIP:Placera dropdown CSS utanför så att alla dropdowns har samma CSS?*/
 #course-label-dropdown {
   display: flex;
   justify-content: flex-start;
@@ -2725,7 +2725,11 @@ resulted.php END
  }
 
  #course-label {
-  flex-grow:1
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  flex-grow: 1;
  }
 
 #editSectionLoginBox {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -843,9 +843,33 @@ p {
     background-color: #5e4776;  
     color: white;               
   }
-
+  /* Working on dropdown.
   & .view-label {
     padding: 0.5rem;
+  }
+  */
+}
+/*WIP:Placera dropdown CSS utanför så att alla dropdowns har samma CSS?*/
+#course-label-dropdown {
+  display: flex;
+  justify-content: flex-start;
+
+  & .dropdown-content {
+    display: none;
+    position: absolute;
+    z-index: 1;
+
+    display: flex;
+    flex-direction: column;
+    
+    & .dropdown-content-show {
+      display: flex;
+      flex-direction: column;
+    }
+
+    & button {
+      margin: 0;
+    }
   }
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -843,34 +843,30 @@ p {
     background-color: #5e4776;  
     color: white;               
   }
-  /* Working on dropdown.
-  & .view-label {
-    padding: 0.5rem;
-  }
-  */
 }
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  z-index: 1;
+
+  display: flex;
+  flex-direction: column;
+  
+  & .dropdown-content-show {
+    display: flex;
+    flex-direction: column;
+  }
+
+  & button {
+    margin: 0;
+  }
+}
+
 /*WIP:Placera dropdown CSS utanför så att alla dropdowns har samma CSS?*/
 #course-label-dropdown {
   display: flex;
   justify-content: flex-start;
-
-  & .dropdown-content {
-    display: none;
-    position: absolute;
-    z-index: 1;
-
-    display: flex;
-    flex-direction: column;
-    
-    & .dropdown-content-show {
-      display: flex;
-      flex-direction: column;
-    }
-
-    & button {
-      margin: 0;
-    }
-  }
 }
 
 #sectionList_arrowStatisticsClosed{

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -849,13 +849,10 @@ p {
   display: none;
   position: absolute;
   z-index: 1;
-
-  display: flex;
   flex-direction: column;
   
-  & .dropdown-content-show {
+  &.dropdown-content-show {
     display: flex;
-    flex-direction: column;
   }
 
   & button {

--- a/Shared/icons/hamburger_menu_google_fonts.svg
+++ b/Shared/icons/hamburger_menu_google_fonts.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e3e3e3"><path d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z"/></svg>


### PR DESCRIPTION
## What's changed:
I have added a reusable React Dropdown component that's placed inside of Shared/components. The actual implementation uses the Button component found in the same directory. An open source icon from Google fonts has also been added. When the dropdown is pressed, each row quickly slides down with a small delay added to each one for a nicer effect. The dropdown will animate up to 9 buttons placed inside it, if more is needed, CSS keyframes will need to be mofified to accomodate it. A function to close the dropdown by clicking anywhere on the page has also been implemented. 

This dropdown is then used to move the view buttons onto the header, which removes the unneccesary space underneath them previously. The placement is similar to that of the mockup in the issue and can be seen in the video below.

### Dropdown example
![image](https://github.com/user-attachments/assets/11f0e3a1-1085-4484-9f1c-0c0e695e1344)

### Dropdown example when clicked
![image](https://github.com/user-attachments/assets/5b190791-8902-4aee-93b3-fd11f94eb0f6)

### Dropdown animation example
https://github.com/user-attachments/assets/677cd7ca-3551-4d4c-bd59-f0201f490212


