### PR TITLE
Added recursive relation for SE

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -155,7 +155,7 @@ function drawLine(line, targetGhost = false) {
     } else { // UML, IE or SD
         if (line.kind == lineKind.RECURSIVE) {
             str += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
-            str += drawRecursiveLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
+
         }
         else {
             str += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
@@ -561,7 +561,8 @@ function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) 
     const elementLength = felem.x2 - felem.x1;
     const startX = felem.x1 + elementLength - lineLength + offset.x1 * zoomfact;
     const startY = felem.y1  - lift + offset.y1 * zoomfact;
-    
+    const SEconst = 15 * zoomfact;
+    const arrowSize = 20 * zoomfact;
 
     if(line.type === entityType.IE) {
         points =
@@ -577,10 +578,26 @@ function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) 
             `${startX + lineLength},${startY + lineHeight + 15}`;
     }else if(line.type === entityType.SE){
         points =
-            `${startX},${startY + lineHeight  } ` +
-            `${startX},${startY} ` +
-            `${startX + lineLength},${startY} ` +
-            `${startX + lineLength},${startY+lineHeight  }`;
+            `${startX - SEconst + lift},${startY + lineHeight } ` +
+            `${startX - SEconst + lift + lineHeight},${startY + lineHeight } ` +
+            `${startX - SEconst + lift + lineHeight},${startY + lineLength + lineHeight } ` +
+            `${startX - SEconst + lift},${startY + lineLength + lineHeight }`;
+        
+        const endX = startX - SEconst + lift;
+        const endY = startY + lineLength + lineHeight;
+
+        str += `
+                <polygon
+                  points="
+                  ${endX},${endY} 
+                  ${endX + arrowSize},${endY - arrowSize/2} 
+                  ${endX + arrowSize},${endY + arrowSize/2}
+                  "
+                  fill="${lineColor}"
+                />
+          `;
+        
+        
     }else {
         points =
             `${startX},${startY + lineHeight  } ` +

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -575,7 +575,13 @@ function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) 
             `${startX},${startY} ` +
             `${startX + lineLength},${startY} ` +
             `${startX + lineLength},${startY + lineHeight + 15}`;
-    }else if(line.type !== entityType.IE && line.type !== entityType.SD){
+    }else if(line.type === entityType.SE){
+        points =
+            `${startX},${startY + lineHeight  } ` +
+            `${startX},${startY} ` +
+            `${startX + lineLength},${startY} ` +
+            `${startX + lineLength},${startY+lineHeight  }`;
+    }else {
         points =
             `${startX},${startY + lineHeight  } ` +
             `${startX},${startY} ` +

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -351,6 +351,12 @@ function drawLineProperties(line) {
             }
             break;
         case entityType.SE:
+
+            // Each recursive SE-line looks the same and shouldnt be modified
+            if (line.kind === lineKind.RECURSIVE){
+                break;
+            }
+            
             str += includeSELabel(line);
             str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);
             str += iconSelection([SELineIcons], line);

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -352,11 +352,13 @@ function drawLineProperties(line) {
             break;
         case entityType.SE:
 
-            // Each recursive SE-line looks the same and shouldnt be modified
+
             if (line.kind === lineKind.RECURSIVE){
+                str += includeSELabel(line);
+                str += `<h3 style="margin-bottom: 0; margin-top: 5px;">Label</h3>`;
                 break;
             }
-            
+
             str += includeSELabel(line);
             str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);
             str += iconSelection([SELineIcons], line);

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -84,7 +84,7 @@ function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, su
 
 function checkConnectionErrors(to, from) {
     if (from.id == to.id &&
-        (to.kind != elementTypesNames.SDEntity && to.kind != elementTypesNames.UMLEntity && to.kind != elementTypesNames.IEEntity)
+        (to.kind != elementTypesNames.SDEntity && to.kind != elementTypesNames.UMLEntity && to.kind != elementTypesNames.IEEntity && to.kind != "sequenceActivation")
     ) {
         return `Not possible to draw a line between: ${from.name} and ${to.name}, they are the same element`;
     }


### PR DESCRIPTION
Added the ability to set a recursive relation for a sequence activation box. This implementation causes the recursive relation to always be at the top of the box, which means that users will have to make additional boxes in sequence if they want to show the recursive sequence between two sequence changes. Labels should probably also be able to be added to the recursive sequence, but that does not work yet.
![image](https://github.com/user-attachments/assets/9b06a661-cffa-4bdf-bbca-0a2b4534b221)