### PR TITLE
16863 the lines overlap the labels when the lines cross each other

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -103,7 +103,7 @@ function drawLine(line, targetGhost = false) {
         }
     } else if ((line.type == entityType.SD && line.innerType != SDLineType.SEGMENT)) {
         if (line.kind == lineKind.RECURSIVE) {
-            str += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
+            lineStr += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
 
         } else if ((fy > ty) && (line.ctype == lineDirection.UP)) {
             //UMLFinalState seems to always end up as telem after line has been drawn even if drawn line originated from it

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -4,7 +4,11 @@
  * @param {boolean} targetGhost Is the targeted line a ghost line
  */
 function drawLine(line, targetGhost = false) {
-    let str = "";
+    let str = ""; // both lines and labels
+
+    let lineStr = ""; // only the lines, polylines, arrows etc
+    let labelStr = ""; // labels and albel backgrounds
+
     // Element line is drawn from/to
     let felem = data[findIndex(data, line.fromID)];
     let telem;
@@ -15,7 +19,7 @@ function drawLine(line, targetGhost = false) {
         telem = data[findIndex(data, line.toID)];
         isCurrentlyDrawing = false;
     }
-    if (!felem || !telem) return;
+    if (!felem || !telem) return { lineStr: "", labelStr: "" };
     line.type = (telem.type == entityType.note) ? telem.type : felem.type;
     let strokeDash = (line.kind == lineKind.DASHED || line.type == entityType.note) ? "10" : "0";
     let lineColor = isDarkTheme() ? color.WHITE : color.BLACK;
@@ -71,7 +75,7 @@ function drawLine(line, targetGhost = false) {
     if (line.type == entityType.ER) {
         [fx, fy, tx, ty, offset] = getLineAttributes(felem, telem, line.ctype);
         if (line.kind == lineKind.NORMAL) {
-            str += `<line 
+            lineStr += `<line 
                         id='${line.id}' 
                         x1='${fx + offset.x1}' y1='${fy + offset.y1}' 
                         x2='${tx + offset.x2}' y2='${ty + offset.y2}' 
@@ -95,8 +99,8 @@ function drawLine(line, targetGhost = false) {
                 
                 />`;
             };
-            str += double(1, 1);
-            str += double(-1, 2);
+            lineStr += double(1, 1);
+            lineStr += double(-1, 2);
         }
     } else if ((line.type == entityType.SD && line.innerType != SDLineType.SEGMENT)) {
         if (line.kind == lineKind.RECURSIVE) {
@@ -144,7 +148,7 @@ function drawLine(line, targetGhost = false) {
 
         }
 
-        str += `<line 
+        lineStr += `<line 
                     id='${line.id}' 
                     x1='${fx + offset.x1 * zoomfact}' 
                     y1='${fy + offset.y1 * zoomfact}' 
@@ -154,11 +158,11 @@ function drawLine(line, targetGhost = false) {
                 />`;
     } else { // UML, IE or SD
         if (line.kind == lineKind.RECURSIVE) {
-            str += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
-            str += drawRecursiveLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
+            lineStr += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
+            lineStr += drawRecursiveLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
         }
         else {
-            str += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
+            lineStr += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
         }
 
     }
@@ -174,12 +178,12 @@ function drawLine(line, targetGhost = false) {
         //Same values for UML and IE as they use the same icons, just different element values.
         if(line.type !== entityType.SD || line.type !== entityType.SE){
             line.ctype = lineDirection.UP;  //So arrows point down
-            str += drawLineIcon(line.startIcon, line.ctype, startX, startY, lineColor, line);
-            str += drawLineIcon(line.endIcon, line.ctype, (startX + length), startY, lineColor, line);
+            lineStr += drawLineIcon(line.startIcon, line.ctype, startX, startY, lineColor, line);
+            lineStr += drawLineIcon(line.endIcon, line.ctype, (startX + length), startY, lineColor, line);
         }
     }else {
-        str += drawLineIcon(line.startIcon, line.ctype, fx + offset.x1, fy + offset.y1, lineColor, line);
-        str += drawLineIcon(line.endIcon, line.ctype.split('').reverse().join(''), tx + offset.x2, ty + offset.y2, lineColor, line);
+        lineStr += drawLineIcon(line.startIcon, line.ctype, fx + offset.x1, fy + offset.y1, lineColor, line);
+        lineStr += drawLineIcon(line.endIcon, line.ctype.split('').reverse().join(''), tx + offset.x2, ty + offset.y2, lineColor, line);
     }
     // Always allow arrowheads to render if icon is ARROW
     // If the line is SEGMENTED (has 90-degree bends), draw a fixed arrowhead with iconPoly.
@@ -191,9 +195,9 @@ function drawLine(line, targetGhost = false) {
         // Handle start arrow
         if (line.startIcon === SDLineIcons.ARROW) {
             if (line.innerType === SDLineType.SEGMENT) {
-                str += iconPoly(SD_ARROW[line.ctype], from.x, from.y, lineColor, color.BLACK);
+                lineStr += iconPoly(SD_ARROW[line.ctype], from.x, from.y, lineColor, color.BLACK);
             } else {
-                str += drawArrowPoint(
+                lineStr += drawArrowPoint(
                     calculateArrowBase(to, from, 10 * zoomfact),
                     from,
                     lineColor,
@@ -206,9 +210,9 @@ function drawLine(line, targetGhost = false) {
         if (line.endIcon === SDLineIcons.ARROW) {
             const reverseCtype = line.ctype.split('').reverse().join('');
             if (line.innerType === SDLineType.SEGMENT) {
-                str += iconPoly(SD_ARROW[reverseCtype], to.x, to.y, lineColor, color.BLACK);
+                lineStr += iconPoly(SD_ARROW[reverseCtype], to.x, to.y, lineColor, color.BLACK);
             } else {
-                str += drawArrowPoint(
+                lineStr += drawArrowPoint(
                     calculateArrowBase(from, to, 10 * zoomfact),
                     to,
                     lineColor,
@@ -223,21 +227,21 @@ function drawLine(line, targetGhost = false) {
         if (line.startLabel && line.startLabel != '') {
             const fxCardinality = fx + offset.x1;
             const fyCardinality = fy + offset.y1;
-            str += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fxCardinality, fyCardinality, true, felem);
+            labelStr += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fxCardinality, fyCardinality, true, felem);
         }
         if (line.endLabel && line.endLabel != '') {
             const txCardinality = tx + offset.x1;
             const tyCardinality = ty + offset.y2;
-            str += drawLineLabel(line, line.endLabel, lineColor, 'endLabel', txCardinality, tyCardinality, false, felem);
+            labelStr += drawLineLabel(line, line.endLabel, lineColor, 'endLabel', txCardinality, tyCardinality, false, felem);
         }
     } else {
         if (line.cardinality) {
-            str += drawLineCardinality(line, lineColor, fx, fy, tx, ty, felem, telem);
+            labelStr += drawLineCardinality(line, lineColor, fx, fy, tx, ty, felem, telem);
         }
     }
         
     if (isSelected) {
-        str += `<rect 
+        labelStr += `<rect 
                     x='${((fx + tx) / 2) - (2 * zoomfact)}' 
                     y='${((fy + ty) / 2) - (2 * zoomfact)}' 
                     width='${4 * zoomfact}' 
@@ -321,7 +325,7 @@ function drawLine(line, targetGhost = false) {
             let startX = felem.x1 + elementLength - length;
             let startY = felem.y1  - lift;
 
-            str += `<rect
+            labelStr += `<rect
                         class='text cardinalityLabel'
                         id='${line.id + 'Label'}'
                         x='${((startX)) - textWidth / 2}'
@@ -329,7 +333,7 @@ function drawLine(line, targetGhost = false) {
                         width='${(textWidth + zoomfact * 4)}'
                         height='${textheight * zoomfact}'
                     />`;
-            str += `<text
+            labelStr += `<text
                         class='cardinalityLabelText'
                         dominant-baseline='middle'
                         text-anchor='middle'
@@ -340,7 +344,7 @@ function drawLine(line, targetGhost = false) {
                     </text>`;
         } else {
             // For non-recursive lines
-            str += `<rect
+            labelStr += `<rect
                         class='text cardinalityLabel'
                         id='${line.id + 'Label'}'
                         x='${rectPosX}'
@@ -348,7 +352,7 @@ function drawLine(line, targetGhost = false) {
                         width='${(textWidth + zoomfact * 4)}'
                         height='${textheight * zoomfact + zoomfact * 3}'
                     />`;
-            str += ` <text
+            labelStr += ` <text
                         class='cardinalityLabelText'
                         dominant-baseline='middle'
                         text-anchor='middle'
@@ -359,7 +363,7 @@ function drawLine(line, targetGhost = false) {
                     </text>`;
         }
     }
-    return str;
+    return { lineStr, labelStr };
 }
 
 /**
@@ -943,7 +947,8 @@ function drawArrowPoint(base, point, lineColor, strokeWidth) {
  * @returns String containing all the new lines-elements
  */
 function redrawArrows() {
-    let str = '';
+    let linesStr = "";
+    let labelsStr = "";
     // Clear all lines and update with dom object dimensions
     for (let i = 0; i < data.length; i++) {
         clearLinesForElement(data[i]);
@@ -966,16 +971,20 @@ function redrawArrows() {
     }
     // Draw each line using sorted line ends when applicable
     for (let i = 0; i < lines.length; i++) {
-        str += drawLine(lines[i]);
+        const { lineStr, labelStr } = drawLine(lines[i]);
+        linesStr += lineStr;
+        labelsStr += labelStr;
     }
     if (ghostLine && ghostElement) {
-        str += drawLine(ghostLine, true);
+        const { lineStr, labelStr } = drawLine(ghostLine, true);
+        linesStr += lineStr;
+        labelsStr += labelStr;
     }
     // Remove all neighbour maps from elements
     for (let i = 0; i < data.length; i++) {
         delete data[i].neighbours;
     }
-    return str;
+    return linesStr + labelsStr;
 }
 
 /**

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -4,10 +4,9 @@
  * @param {boolean} targetGhost Is the targeted line a ghost line
  */
 function drawLine(line, targetGhost = false) {
-    //let str = ""; // both lines and labels
 
     let lineStr = ""; // only the lines, polylines, arrows etc
-    let labelStr = ""; // labels and albel backgrounds
+    let labelStr = ""; // labels and label backgrounds
 
     // Element line is drawn from/to
     let felem = data[findIndex(data, line.fromID)];

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -4,7 +4,7 @@
  * @param {boolean} targetGhost Is the targeted line a ghost line
  */
 function drawLine(line, targetGhost = false) {
-    let str = ""; // both lines and labels
+    //let str = ""; // both lines and labels
 
     let lineStr = ""; // only the lines, polylines, arrows etc
     let labelStr = ""; // labels and albel backgrounds


### PR DESCRIPTION
In drawLine(), the lines and labels are now separated into two variables, lineStr and labelStr. This allows all the lines to be drawn first, followed by the labels, which prevents lines from overlapping the labels associated with other lines.

This solves the issue #16863.

**Before:**
<img width="527" alt="Skärmavbild 2025-04-29 kl  10 56 38" src="https://github.com/user-attachments/assets/cdca462d-acfd-4757-8aac-d28e5a76373b" />

**After:**

https://github.com/user-attachments/assets/e0f53d4d-47fe-4d02-86a1-f9f4d68ce0cb

<img width="793" alt="Skärmavbild 2025-04-29 kl  10 42 26" src="https://github.com/user-attachments/assets/4ed55cd4-c98b-4be6-84d4-9b44d9e9c661" />