### PR TITLE
G3-2025-V4-#16880-deletion-of-section-without-children

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -854,23 +854,49 @@ function markedItems(item = null, typeInput) {
   if (kind == "section" || kind == "moment") {
     var itemInSection = true;
     var sectionStart = false;
+    const elements = document.querySelectorAll('#Sectionlist .item');
 
-    $("#Sectionlist").find(".item").each(function (i) {
-      var tempItem = this.getAttribute('value');
+    for (let i = 0 ; i < elements.length ; i++){
+      const element = elements[i];
+      var tempItem = element.getAttribute('value');
+
       console.log('affected item: ' + tempItem);
 
       // if part of a section, add it to subItems.
       if (itemInSection && sectionStart) {
         var tempDisplay = document.getElementById("lid" + tempItem).style.display;
-        var tempKind = this ? this.closest('tr').getAttribute('value'): null;
+        var tempKind = element ? element.closest('tr').getAttribute('value'): null;
+
+        // if not part of current section, stop looking.
+        if (tempDisplay != "none" && (tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
+          itemInSection = false;
+          console.log('item isnt in section. ( ' + tempItem + ' ) ');
+          break;
+        } 
+        else {
+          subItems.push(tempItem);
+          console.log('pushed to subitems: ' + tempItem );
+        }
+      } 
+      
+      else if (tempItem == active_lid){ 
+        sectionStart = true;
+      }
+    }
+
+    /*document.querySelectorAll('#Sectionlist .item').forEach(function(element, i){
+      var tempItem = element.getAttribute('value');
+      console.log('affected item: ' + tempItem);
+
+      // if part of a section, add it to subItems.
+      if (itemInSection && sectionStart) {
+        var tempDisplay = document.getElementById("lid" + tempItem).style.display;
+        var tempKind = element ? element.closest('tr').getAttribute('value'): null;
 
         // if not part of current section, (should stop looking.)
         if (tempDisplay != "none" && (tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
           itemInSection = false;
           console.log('item isnt in section. ( ' + tempItem + ' ) ');
-
-          // stop looking?
-
         } 
         else {
           subItems.push(tempItem);
@@ -882,7 +908,7 @@ function markedItems(item = null, typeInput) {
         sectionStart = true;
       }
 
-    });
+    });*/
   }
 
   // handles selections

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -860,7 +860,7 @@ function markedItems(item = null, typeInput) {
       const element = elements[i];
       var tempItem = element.getAttribute('value');
 
-      console.log('affected item: ' + tempItem);
+      //console.log('affected item: ' + tempItem);
 
       // if part of a section, add it to subItems.
       if (itemInSection && sectionStart) {
@@ -870,12 +870,12 @@ function markedItems(item = null, typeInput) {
         // if not part of current section, stop looking.
         if (tempDisplay != "none" && (tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
           itemInSection = false;
-          console.log('item isnt in section. ( ' + tempItem + ' ) ');
+          //console.log('item isnt in section. ( ' + tempItem + ' ) ');
           break;
         } 
         else {
           subItems.push(tempItem);
-          console.log('pushed to subitems: ' + tempItem );
+          //console.log('pushed to subitems: ' + tempItem );
         }
       } 
       
@@ -883,32 +883,7 @@ function markedItems(item = null, typeInput) {
         sectionStart = true;
       }
     }
-
-    /*document.querySelectorAll('#Sectionlist .item').forEach(function(element, i){
-      var tempItem = element.getAttribute('value');
-      console.log('affected item: ' + tempItem);
-
-      // if part of a section, add it to subItems.
-      if (itemInSection && sectionStart) {
-        var tempDisplay = document.getElementById("lid" + tempItem).style.display;
-        var tempKind = element ? element.closest('tr').getAttribute('value'): null;
-
-        // if not part of current section, (should stop looking.)
-        if (tempDisplay != "none" && (tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
-          itemInSection = false;
-          console.log('item isnt in section. ( ' + tempItem + ' ) ');
-        } 
-        else {
-          subItems.push(tempItem);
-          console.log('pushed to subitems: ' + tempItem );
-        }
-      } 
-      
-      else if (tempItem == active_lid){ 
-        sectionStart = true;
-      }
-
-    });*/
+    
   }
 
   // handles selections
@@ -916,12 +891,51 @@ function markedItems(item = null, typeInput) {
     let tempSelectedItemListLength = selectedItemList.length;
     for (let i = 0; i < tempSelectedItemListLength; i++) {
 
+      var tempKind = item ? item.closest('tr').getAttribute('value'): null;
+      console.log('this is tempKind' + tempKind);
+
       //removes & unchecks items from selectedItemList, avoided if called via non-section trashcan.
       if (selectedItemList[i] === active_lid && typeInput != "trash") {
         document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
         selectedItemList.splice(i, 1);
         var removed = true;
+
+        if (tempKind != "section" || tempKind != "moment" || tempKind != "header"){
+          var itemInSection = true;
+          var sectionEnd = false;
+          const elements = document.querySelectorAll('#Sectionlist .item');
+      
+          for (let i = elements.length - 1 ; i >= 0 ; i--){
+            const element = elements[i];
+            var tempItem = element.getAttribute('value');
+            console.log('affected item: ' + tempItem);
+
+            if (itemInSection && sectionEnd) {
+              var tempKind = element ? element.closest('tr').getAttribute('value'): null;
+      
+              // if not part of current section, stop looking.
+              if ((tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
+                itemInSection = false;
+                console.log('item is section header: ( ' + tempItem + ' ) ');
+                
+                // removes the section-header from selectedItemList, and unchecks it
+                document.getElementById(tempItem + "-checkbox").checked = false;
+                for (let i = 0; i < tempSelectedItemListLength; i++) {
+                  if (selectedItemList[i] === tempItem){
+                    selectedItemList.splice(i, 1);
+                  }
+                }
+                break;
+              } 
+            } 
+            else if (tempItem == active_lid){ 
+              sectionEnd = true;
+              console.log('this is first!');
+            }
+          }
+        }
       }
+
       //unchecks children of section
       for (var j = 0; j < subItems.length; j++) {
         if (selectedItemList[i] == subItems[j]) {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -894,23 +894,25 @@ function markedItems(item = null, typeInput) {
       //removes & unchecks items from selectedItemList, avoided if called via non-section trashcan.
       if (selectedItemList[i] === active_lid && typeInput != "trash") {
         
-        //console.log('lid: ' + active_lid + '- ' + tempKind);
+        //console.log('lid: ' + active_lid + '- ' + tempKind)
+               
+        document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
+        selectedItemList.splice(i, 1);
+        var removed = true;
 
         // deselection of child -> deselect parent
         if (tempKind != "section" && tempKind != "moment" && tempKind != "header"){ 
           let parent = recieveCodeParent(active_lid);
-          //console.log('parent: ' + parent);
-          document.getElementById(parent + "-checkbox").checked = false;
+
+          console.log('parent recieved: ' + parent);
+
           for (let i = 0; i < tempSelectedItemListLength; i++) {
-            if (selectedItemList[i] === parent){
+            if (selectedItemList[i] == parent){
+              console.log('parent found and unchecked: ' + parent);
+              document.getElementById(parent + "-checkbox").checked = false;
               selectedItemList.splice(i, 1);
             }
           }
-        }
-        else {            
-          document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
-          selectedItemList.splice(i, 1);
-          var removed = true;
         }
       }
 
@@ -1012,7 +1014,7 @@ function recieveCodeParent(item){
   for (let i = elements.length - 1 ; i >= 0 ; i--){
     const element = elements[i];
     var tempItem = element.getAttribute('value');
-    console.log('affected item: ' + tempItem);
+    //console.log('affected item: ' + tempItem);
 
     if (itemInSection && sectionStart) {
       var tempKind = element ? element.closest('tr').getAttribute('value'): null;

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -860,9 +860,7 @@ function markedItems(item = null, typeInput) {
       const element = elements[i];
       var tempItem = element.getAttribute('value');
 
-      //console.log('affected item: ' + tempItem);
-
-      // if part of a section, add it to subItems.
+      // if part of a section, add to subItems.
       if (itemInSection && sectionStart) {
         var tempDisplay = document.getElementById("lid" + tempItem).style.display;
         var tempKind = element ? element.closest('tr').getAttribute('value'): null;
@@ -876,39 +874,30 @@ function markedItems(item = null, typeInput) {
           subItems.push(tempItem);
         }
       } 
-      
       else if (tempItem == active_lid){ 
         sectionStart = true;
       }
     }
   }
 
-  // handles selections
+  // handles selections & deselections
   if (selectedItemList.length != 0) {
     let tempSelectedItemListLength = selectedItemList.length;
-    for (let i = 0; i < tempSelectedItemListLength; i++) {
-
+    for (var i = 0; i < tempSelectedItemListLength; i++) {
       var tempKind = item ? item.closest('tr').getAttribute('value'): null;
-      console.log('this is tempKind' + tempKind);
 
       //removes & unchecks items from selectedItemList, avoided if called via non-section trashcan.
-      if (selectedItemList[i] === active_lid && typeInput != "trash") {
-        
-        //console.log('lid: ' + active_lid + '- ' + tempKind)
-               
+      if (selectedItemList[i] === active_lid && typeInput != "trash") {        
         document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
         selectedItemList.splice(i, 1);
         var removed = true;
 
         // deselection of child -> deselect parent
         if (tempKind != "section" && tempKind != "moment" && tempKind != "header"){ 
-          let parent = recieveCodeParent(active_lid);
+          var parent = recieveCodeParent(active_lid);
 
-          console.log('parent recieved: ' + parent);
-
-          for (let i = 0; i < tempSelectedItemListLength; i++) {
+          for (var i = 0; i < tempSelectedItemListLength; i++) {
             if (selectedItemList[i] == parent){
-              console.log('parent found and unchecked: ' + parent);
               document.getElementById(parent + "-checkbox").checked = false;
               selectedItemList.splice(i, 1);
             }
@@ -933,8 +922,7 @@ function markedItems(item = null, typeInput) {
           activeLidInList = true;
           break;
         }
-      }
-      if (activeLidInList == false){
+      } if (activeLidInList == false){
         selectedItemList.push(active_lid);
         document.getElementById(active_lid + "-checkbox").checked = true;
     }
@@ -946,7 +934,7 @@ function markedItems(item = null, typeInput) {
     }
   } 
   
-  // adds everything under section to selectedItems (if nothing selected beforehand)
+  // adds everything under section to selectedItems
   else {
     selectedItemList.push(active_lid);
     for (var j = 0; j < subItems.length; j++) {
@@ -960,8 +948,7 @@ function markedItems(item = null, typeInput) {
     document.querySelector('#hideElement').disabled = false;
     document.querySelector('#hideElement').style.opacity = 1;
     showVisibilityIcons();
-  }
-  if (selectedItemList.length == 0) {
+  } if (selectedItemList.length == 0) {
     // Disable ghost button when no checkboxes is checked
     console.log('no element selected');
     document.querySelector('#hideElement').disabled = true;
@@ -1022,15 +1009,11 @@ function recieveCodeParent(item){
       // if section head, parent found.
       if ((tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
         itemInSection = false;
-        console.log('item is section header: ( ' + tempItem + ' ) ');
         parent = tempItem;
         return parent;
       } 
-    } 
-
-    else if (tempItem == item){ 
+    } else if (tempItem == item){ 
       sectionStart = true;
-      console.log('this is our unchecked item!');
     }
   }
 }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -854,20 +854,34 @@ function markedItems(item = null, typeInput) {
   if (kind == "section" || kind == "moment") {
     var itemInSection = true;
     var sectionStart = false;
+
     $("#Sectionlist").find(".item").each(function (i) {
       var tempItem = this.getAttribute('value');
+      console.log('affected item: ' + tempItem);
 
+      // if part of a section, add it to subItems.
       if (itemInSection && sectionStart) {
         var tempDisplay = document.getElementById("lid" + tempItem).style.display;
         var tempKind = this ? this.closest('tr').getAttribute('value'): null;
 
-
+        // if not part of current section, (should stop looking.)
         if (tempDisplay != "none" && (tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
           itemInSection = false;
-        } else {
+          console.log('item isnt in section. ( ' + tempItem + ' ) ');
+
+          // stop looking?
+
+        } 
+        else {
           subItems.push(tempItem);
+          console.log('pushed to subitems: ' + tempItem );
         }
-      } else if (tempItem == active_lid) sectionStart = true;
+      } 
+      
+      else if (tempItem == active_lid){ 
+        sectionStart = true;
+      }
+
     });
   }
 

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -870,12 +870,10 @@ function markedItems(item = null, typeInput) {
         // if not part of current section, stop looking.
         if (tempDisplay != "none" && (tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
           itemInSection = false;
-          //console.log('item isnt in section. ( ' + tempItem + ' ) ');
           break;
         } 
         else {
           subItems.push(tempItem);
-          //console.log('pushed to subitems: ' + tempItem );
         }
       } 
       
@@ -883,7 +881,6 @@ function markedItems(item = null, typeInput) {
         sectionStart = true;
       }
     }
-    
   }
 
   // handles selections
@@ -896,43 +893,24 @@ function markedItems(item = null, typeInput) {
 
       //removes & unchecks items from selectedItemList, avoided if called via non-section trashcan.
       if (selectedItemList[i] === active_lid && typeInput != "trash") {
-        document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
-        selectedItemList.splice(i, 1);
-        var removed = true;
+        
+        //console.log('lid: ' + active_lid + '- ' + tempKind);
 
-        if (tempKind != "section" || tempKind != "moment" || tempKind != "header"){
-          var itemInSection = true;
-          var sectionEnd = false;
-          const elements = document.querySelectorAll('#Sectionlist .item');
-      
-          for (let i = elements.length - 1 ; i >= 0 ; i--){
-            const element = elements[i];
-            var tempItem = element.getAttribute('value');
-            console.log('affected item: ' + tempItem);
-
-            if (itemInSection && sectionEnd) {
-              var tempKind = element ? element.closest('tr').getAttribute('value'): null;
-      
-              // if not part of current section, stop looking.
-              if ((tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
-                itemInSection = false;
-                console.log('item is section header: ( ' + tempItem + ' ) ');
-                
-                // removes the section-header from selectedItemList, and unchecks it
-                document.getElementById(tempItem + "-checkbox").checked = false;
-                for (let i = 0; i < tempSelectedItemListLength; i++) {
-                  if (selectedItemList[i] === tempItem){
-                    selectedItemList.splice(i, 1);
-                  }
-                }
-                break;
-              } 
-            } 
-            else if (tempItem == active_lid){ 
-              sectionEnd = true;
-              console.log('this is first!');
+        // deselection of child -> deselect parent
+        if (tempKind != "section" && tempKind != "moment" && tempKind != "header"){ 
+          let parent = recieveCodeParent(active_lid);
+          //console.log('parent: ' + parent);
+          document.getElementById(parent + "-checkbox").checked = false;
+          for (let i = 0; i < tempSelectedItemListLength; i++) {
+            if (selectedItemList[i] === parent){
+              selectedItemList.splice(i, 1);
             }
           }
+        }
+        else {            
+          document.getElementById(selectedItemList[i] + "-checkbox").checked = false;
+          selectedItemList.splice(i, 1);
+          var removed = true;
         }
       }
 
@@ -1025,6 +1003,35 @@ function clearHideItemList() {
   selectedItemList = [];
 }
 
+// Finds code-duggas parent - used in markedItems() for unselection of section
+function recieveCodeParent(item){
+  var itemInSection = true;
+  var sectionStart = false;
+  const elements = document.querySelectorAll('#Sectionlist .item');
+
+  for (let i = elements.length - 1 ; i >= 0 ; i--){
+    const element = elements[i];
+    var tempItem = element.getAttribute('value');
+    console.log('affected item: ' + tempItem);
+
+    if (itemInSection && sectionStart) {
+      var tempKind = element ? element.closest('tr').getAttribute('value'): null;
+
+      // if section head, parent found.
+      if ((tempKind == "section" || tempKind == "moment" || tempKind == "header")) {
+        itemInSection = false;
+        console.log('item is section header: ( ' + tempItem + ' ) ');
+        parent = tempItem;
+        return parent;
+      } 
+    } 
+
+    else if (tempItem == item){ 
+      sectionStart = true;
+      console.log('this is our unchecked item!');
+    }
+  }
+}
 
 function closeSelect() {
 


### PR DESCRIPTION
**Prevented deletion of section whiles items within the section still exists.** 
- Streamlined selection of Section/Header/Moment - items by making sure that it stops when it found the next section (meaning current sections items end.)
- Made sure that if a code-dugga has been deselected, the connected section is also deselected. This means that the section can not be deleted without everything within it also being deleted.
- Created function for gathering the code-duggas parent (section) that might also be reused in the future.

**One approach to testing this, and how to get to the functionality:**
select course of your choice (which has duggor, ex. Testing Course) -> log in -> test selection box!
- box marked in red should be able to select all items within the section (and deselect if everything is selected). 
It should also be deselected when a deselection of items within the section happens - which is this fix.

![bild](https://github.com/user-attachments/assets/9bd28f80-c498-43d3-8a65-90ee6d6577be)

_Note to be discarded if deemed unnecessary: The solution could possibly be made more effective. If so, should probably be another issue since it **_might_** involve revamping the selection system - and may not currently be worth it. (Just a headsup)_
