### PR TITLE
Quickfix: removal of hashtag symbol 

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2392,12 +2392,12 @@ function showCanvasLinkBox(operation, btnobj) {
     document.execCommand('copy');
     textArea.remove();
 
-    document.getElementById('#canvasLinkBox').style.display='flex';
-    document.getElementById('#close-item-button').focus();
+    document.getElementById("canvasLinkBox").style.display="flex";
+    document.getElementById("close-item-button").focus();
 
     document.getElementById("canvasLinkText").value = canvasLink;
   } else if (operation == "close") {
-    document.getElementById('#canvasLinkBox').style.display='none'
+    document.getElementById("canvasLinkBox").style.display = "none";
   }
 }
 
@@ -2523,8 +2523,8 @@ function returnedHighscore(data) {
     str += "<td>Score: " + data["user"]["score"] + "</td>";
     str += "</tr>";
   }
-  var highscorelist = document.getElementById('HighscoreTable').innerHTML = str;
-  document.getElementById("#HighscoreBox").style.display='block';
+  var highscorelist = document.getElementById("HighscoreTable").innerHTML = str;
+  document.getElementById("HighscoreBox").style.display="block";
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Quickfix of PR [#16894](https://github.com/HGustavs/LenaSYS/pull/16894) : removed the hashtag symbol to correct the syntax issue derived from PR [#16894](https://github.com/HGustavs/LenaSYS/pull/16894) . Highscore pop-up dialog broke because of wrong syntax and is now fixed.

`getElementById()` does not need a `#` symbol to retrieve the id of an element. If it has a `#` symbol then it either ignores the symbol and then tries to retrieve the element by id or code breaks.

Converting the jQuery code to JavaScript between L2248-2272 is a complex task. It requires further investigation into the JavaScript equivalent of the `sortable()` jQuery function, which may lead to the creation of a new issue.
