### PR TITLE
Fixed issue #17008

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -889,7 +889,7 @@ function drawElementNote(element, boxw, boxh, linew, texth) {
     const availableTextWidth = boxw - padding * 2;
 
     // Approximate number of characters per line based on font size
-    const avgCharWidth = texth * 0.6; // average char width in px
+    const avgCharWidth = texth * 0.48; // average char width in px
     const maxCharactersPerLine = Math.floor(availableTextWidth / avgCharWidth);
 
     const text = splitFull(element.attributes, maxCharactersPerLine);

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -884,13 +884,21 @@ function drawElementSequenceLoopOrAlt(element, boxw, boxh, linew, texth) {
  * @returns Returns a SVG for the note that is going to be drawn.
  */
 function drawElementNote(element, boxw, boxh, linew, texth) {
-    const maxCharactersPerLine = Math.floor((boxw / texth) * 1.05);
+    const padding = 10; // Padding in pixels
     const lineHeight = 1.5;
+    const availableTextWidth = boxw - padding * 2;
+
+    // Approximate number of characters per line based on font size
+    const avgCharWidth = texth * 0.6; // average char width in px
+    const maxCharactersPerLine = Math.floor(availableTextWidth / avgCharWidth);
+
     const text = splitFull(element.attributes, maxCharactersPerLine);
-    let length = (text.length > 4) ? text.length : 4;
-    let totalHeight = boxh + texth * length;
-    const maxWidth = (boxw - linew * 2);
-    const maxHeight = (boxh + (texth * length) - linew * 2)
+    const textLineCount = Math.max(4, text.length);
+    const totalHeight = boxh + texth * textLineCount * lineHeight;
+
+    const maxWidth = boxw - linew * 2;
+    const maxHeight = totalHeight - linew * 2;
+
     updateElementHeight(NOTEHeight, element, totalHeight);
     element.stroke = (element.fill == color.BLACK) ? color.WHITE : color.BLACK;
 
@@ -911,8 +919,11 @@ function drawElementNote(element, boxw, boxh, linew, texth) {
             stroke='${element.stroke}'
             fill='${element.fill}'
         />`;
+    // Draw each line of text with padding from the left
     for (let i = 0; i < text.length; i++) {
-        content += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', text[i]);
+        const x = padding;
+        const y = texth * (i + 1) * lineHeight;
+        content += drawText(x, y, 'start', text[i]);
     }
-    return drawSvg(boxw, boxh + texth * length, content);
+    return drawSvg(boxw, totalHeight, content);
 }


### PR DESCRIPTION
Improve note rendering by calculating character width more accurately and allowing text to fill full width.


https://github.com/user-attachments/assets/a01226b5-adba-4710-8bab-805505993494

