### PR TITLE
Ignore the file "microservice_connection.md" in the Microservice directory database script #16994

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/fillEndpointDb.php
+++ b/DuggaSys/microservices/endpointDirectory/fillEndpointDb.php
@@ -38,6 +38,14 @@ $mdFiles = findMdFiles($basePath);
 foreach ($mdFiles as $mdFile) {
     $content = file_get_contents($mdFile);
 
+    // skip the file named 'microservice_connections.md', its content is not wanted in the database
+    if (basename($mdFile) === 'microservice_connections.md') {
+        continue;
+    }
+    // also skip the template file
+    if (basename($mdFile) === 'template.md') {
+        continue;
+    }
     // skip files that are not structured documentation
     if (!preg_match('/# Name of file\/service/i', $content)) {
         continue;


### PR DESCRIPTION
Added selections to the script that ignores some files that are not wanted in the database. In addition to 'microservice_connections.md' I also added a selections to ignore 'template.md' aswell. 
To check this you can refill the database by running 'setupEndpointDirectory.php' and check if there are unwanted entries from those documents in the microserviceUI.php. Fixes #16994 

Before these selections, the entries in the image below was inserted. The file has successfully ignored the md files if these are not in the database.

![image](https://github.com/user-attachments/assets/cc6d93d6-62ae-44b6-a6e7-5cf35c1bd21c)
