### PR TITLE
Fixed box shadow definitions #17043

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -60,11 +60,13 @@ PLZ see "Handling and usage of Style.css" in the wiki before use
   --color-red-hover: #ce3d3d;
   --color-completed: #00cc00;
   --color-removed: #ff0000;
-  --box-shadow: rgba(0,0,0,0.2);
+  --box-shadow-normal: rgba(0,0,0,0.2);
   --color-line-dashed: rgba(97, 72, 117, 0);
 
   --box-shadow: rgba(0, 0, 0, 0.12);
-  --box-shadow-2: rgba(0, 0, 0, 0.5);
+  --box-shadow-dark: rgba(0,0,0,0.5);
+  --standard-shadow: 0 2px 5px 0 var(--box-shadow-normal), 0 2px 10px 0 rgba(0,0,0,0.1);
+  --light-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
 
   --color-fileLink-table-1: #ccc;
   --color-fileLink-table-2: #eae8eb;
@@ -1506,7 +1508,8 @@ header {
   z-index: 5000;
   top: 0px;
   left: 0px;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
 }
 
 header td {
@@ -2080,7 +2083,7 @@ div .navButt:hover {
   min-width: 200px;
   max-height: 80%;
   overflow-y: auto;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
   width: fit-content;
 }
 
@@ -2170,7 +2173,8 @@ div .navButt:hover {
   min-width: 200px;
   max-height: 80%;
   overflow-y: auto;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
 }
 
 .showsecurityquestion {
@@ -2181,7 +2185,9 @@ div .navButt:hover {
   min-width: 200px;
   max-height: 80%;
   overflow-y: auto;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
+
 }
 
 .resetcomplete {
@@ -2192,7 +2198,8 @@ div .navButt:hover {
   min-width: 200px;
   max-height: 80%;
   overflow-y: auto;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
 }
 
 .expiremessagebox,
@@ -2208,7 +2215,8 @@ div .navButt:hover {
   top: 30%;
   left: 50%;
   margin-left: -178px;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
 }
 
 #endsessionmessagebutton {
@@ -2697,7 +2705,8 @@ Generic functions END
   top: 30%;
   left: 50%;
   margin-left: -178px;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
 }
 
 #gradeExportPopUpButton {
@@ -3232,7 +3241,8 @@ label.login-label {
   font-size: 14px;
   transition: 1s background-color;
   text-align: center;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
 }
 
 .buttonLogoutBox {
@@ -3616,7 +3626,8 @@ input.diagram-sidebar-buttons {
   font-size: 14px;
   transition: 1s background-color;
   float: left;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
 }
 
 input.diagram-sidebar-buttons:hover {
@@ -3639,7 +3650,8 @@ button.diagram-menu-buttons {
   font-size: 14px;
   transition: 1s background-color;
   float: left;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
+
 }
 
 button.diagram-menu-buttons:hover {
@@ -3691,7 +3703,7 @@ input.hide-moments-button {
   text-align: center;
   bottom: 120%;
   transform: translateX(55%);
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
   transition: opacity .3s ease-in;
   pointer-events: none;
 }
@@ -4351,7 +4363,7 @@ span.arrow {
   border-radius: 3px;
   overflow: hidden;
   background: #fafafa url("../icons/desc_primary.svg") no-repeat 90% 50%;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
   background-position: right;
   margin-top: 7px;
   margin-left: 3px;
@@ -4718,7 +4730,7 @@ div.reset-pw:hover{
   padding: 5px;
   padding-bottom: 10px;
   line-height: 18px;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
   color: var(--color-text-list);
 }
 
@@ -5741,7 +5753,7 @@ rect[class*="activitymarker"]:hover {
 /* styling for fileed switching table button*/
 
 .switchContent {
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
   font-size: 14px;
   text-align: center;
   background-color: var(--color-primary);
@@ -6713,9 +6725,9 @@ only screen and (max-device-width: 568px) {
   position: absolute;
   bottom: 4px;
   z-index: 2;
-  -webkit-box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
-  -moz-box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
-  box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
+  -webkit-box-shadow: var(--light-shadow);
+  -moz-box-shadow: var(--light-shadow);
+  box-shadow: var(--light-shadow);
 }
 
 #selectDiv select {
@@ -6907,9 +6919,9 @@ only screen and (max-device-width: 568px) {
 /* Style for the div that presents the coordinants and zoomvalue in diagram */
 
 #valuesCanvas {
-  -webkit-box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
-  -moz-box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
-  box-shadow: 0px 2px 10px 1px rgba(219, 219, 219, 1);
+  -webkit-box-shadow: var(--light-shadow);
+  -moz-box-shadow: var(--light-shadow);
+  box-shadow: var(--light-shadow);
   padding-left: 10px;
   padding-right: 10px;
   border-radius: 6px;
@@ -7762,8 +7774,8 @@ only screen and (max-device-width: 568px) {
   text-decoration: none;
   text-align: center;
   transition: 0.2s ease-out;
-  -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px var(--box-shadow), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px var(--box-shadow), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: var(--standard-shadow);
+  box-shadow: var(--standard-shadow);
   cursor: pointer;
 }
 
@@ -8306,8 +8318,8 @@ only screen and (max-device-width: 568px) {
   float: right;
   line-height: 30px;
   text-align: center;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
-    position: absolute;
+  box-shadow: var(--standard-shadow);
+  position: absolute;
     bottom: 45px;
     right: 10px;
 }
@@ -8327,8 +8339,9 @@ only screen and (max-device-width: 568px) {
   float: right;
   line-height: 30px;
   text-align: center;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
-        position: absolute;
+  box-shadow: var(--standard-shadow);
+
+  position: absolute;
     bottom: 45px;
     right: 150px;
 }
@@ -8771,7 +8784,7 @@ div > div > .shortcut-keys:hover {
   min-width: 400px;
   max-height: 80%;
   overflow-y: auto;
-  box-shadow: 0 2px 5px 0 var(--box-shadow-2), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
 }
 
 .shortcuts-button-wrap {
@@ -8971,7 +8984,7 @@ div > div > .shortcut-keys:hover {
   float: right;
   line-height: 30px;
   text-align: center;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3), 0 2px 10px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: var(--standard-shadow);
 }
 
 


### PR DESCRIPTION
I fixed the redundant box shadow definitions in style.css by:

1. Identifying duplicated box-shadow code throughout the file
2. Creating standardized CSS variables in the  section:
--box-shadow-normal: rgba(0,0,0,0.2)
--box-shadow-dark: rgba(0,0,0,0.5)
--standard-shadow: for common shadow patterns
--light-shadow: for lighter shadow effects
3. Replacing all instances of repeated shadow code with these variables

