### PR TITLE
Added autosave to input for textareas

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -56,6 +56,12 @@ function generateContextProperties() {
         str += saveButton('toggleEntityLocked();', 'lockbtn', locked ? "Unlock" : "Lock");
     }
     propSet.innerHTML = str;
+    var inputs = propSet.querySelectorAll('input, textarea');
+    for (var i = 0; i < inputs.length; i++) {
+        inputs[i].addEventListener('input', function() {
+            saveProperties();
+        });
+    }
     multipleColorsTest();
 }
 


### PR DESCRIPTION
This functionality gives all input textareas an autosave feature so that when you change colour of the background for the entity the text is always saved beforehand. At the same time you write in the input textarea the entity recieves and updates the text inside it. 

Although this functionality makes the save button useless, it still solves the problem at hand:)