### PR TITLE
Fix #17010, state diagram recursive arrows

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -201,7 +201,6 @@ function drawLine(line, targetGhost = false) {
             lineStr += iconPoly(SD_ARROW[line.ctype], startX, startY, lineColor, color.BLACK);
         }
         if(line.endIcon === SDLineIcons.ARROW){
-            console.log("startx: " + startX)
             lineStr += iconPoly(SD_ARROW[line.ctype], startX + length, startY +(10 * zoomfact), lineColor, color.BLACK);
         }
         
@@ -609,12 +608,13 @@ function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) 
     //Draw the recursive line top right of the element.
     //Using the elemtns length to dynamicly change when re-sized.
     const lineHeight = 60 * zoomfact; 
-    const lineLength = 40 * zoomfact; 
     const lift   = 55 * zoomfact; 
     const SEconst = 15 * zoomfact;
     const arrowSize = 20 * zoomfact;
 
     let {length, elementLength, startX, startY} = recursiveParam(felem);
+    
+    const lineLength = length;
     startX += offset.x1 * zoomfact;
     startY += offset.y1 - lift;
 
@@ -669,6 +669,11 @@ function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) 
           `;
     return str;
 }
+
+
+/** Localization the basic parameters for the recursive lines.    
+ * @param {Object} felem the element the arrows originates from.
+ */
 
 function recursiveParam(felem){
     const length = 40 * zoomfact;

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -158,7 +158,7 @@ function drawLine(line, targetGhost = false) {
                 />`;
     } else { // UML, IE or SD
         if (line.kind == lineKind.RECURSIVE) {
-            str += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
+            lineStr += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
         }
         else {
             lineStr += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
@@ -191,6 +191,22 @@ function drawLine(line, targetGhost = false) {
         let to = new Point(tx + offset.x2 * zoomfact, ty + offset.y2 * zoomfact);
         let from = new Point(fx + offset.x1 * zoomfact, fy + offset.y1 * zoomfact);
 
+        const lineLength = 40 * zoomfact; 
+        const elementLength = felem.x2 - felem.x1;
+        const startX = felem.x1 + elementLength - lineLength + offset.x1 * zoomfact;
+        const startY = felem.y1 + offset.y1 * zoomfact;
+
+    //Draws the Segmented version for arrow and not straight line
+    if(line.kind === lineKind.RECURSIVE){
+        if(line.startIcon === SDLineIcons.ARROW){
+            lineStr += iconPoly(SD_ARROW[line.ctype], startX, startY, lineColor, color.BLACK);
+        }
+        if(line.endIcon === SDLineIcons.ARROW){
+            lineStr += iconPoly(SD_ARROW[line.ctype], startX + lineLength, startY +(10 * zoomfact), lineColor, color.BLACK);
+        }
+        
+
+    }else{
         // Handle start arrow
         if (line.startIcon === SDLineIcons.ARROW) {
             if (line.innerType === SDLineType.SEGMENT) {
@@ -219,6 +235,8 @@ function drawLine(line, targetGhost = false) {
                 );
             }
         }
+    }    
+        
     }
 
     // Draws the cardinality labels for the line for UML

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -191,18 +191,18 @@ function drawLine(line, targetGhost = false) {
         let to = new Point(tx + offset.x2 * zoomfact, ty + offset.y2 * zoomfact);
         let from = new Point(fx + offset.x1 * zoomfact, fy + offset.y1 * zoomfact);
 
-        const lineLength = 40 * zoomfact; 
-        const elementLength = felem.x2 - felem.x1;
-        const startX = felem.x1 + elementLength - lineLength + offset.x1 * zoomfact;
-        const startY = felem.y1 + offset.y1 * zoomfact;
-
+        let {length, elementLength, startX, startY} = recursiveParam(felem);
+        startX += offset.x1 * zoomfact;
+        startY += offset.y1 * zoomfact; 
+    
     //Draws the Segmented version for arrow and not straight line
     if(line.kind === lineKind.RECURSIVE){
         if(line.startIcon === SDLineIcons.ARROW){
             lineStr += iconPoly(SD_ARROW[line.ctype], startX, startY, lineColor, color.BLACK);
         }
         if(line.endIcon === SDLineIcons.ARROW){
-            lineStr += iconPoly(SD_ARROW[line.ctype], startX + lineLength, startY +(10 * zoomfact), lineColor, color.BLACK);
+            console.log("startx: " + startX)
+            lineStr += iconPoly(SD_ARROW[line.ctype], startX + length, startY +(10 * zoomfact), lineColor, color.BLACK);
         }
         
 
@@ -338,9 +338,9 @@ function drawLine(line, targetGhost = false) {
             //Calculatin the lable possition based on element size, so it follows when resized.
             const length = 20 * zoomfact;
             const lift   = 80 * zoomfact; 
-            const elementLength = felem.x2 - felem.x1;
-            let startX = felem.x1 + elementLength - length;
-            let startY = felem.y1  - lift;
+            let {lineLength, elementLength, startX, startY } = recursiveParam(felem);
+            startY -= lift;
+            startX += length;
 
             labelStr += `<rect
                         class='text cardinalityLabel'
@@ -547,17 +547,16 @@ function drawLineLabel(line, label, lineColor, labelStr, x, y, isStart, felem) {
 
     if(line.kind === lineKind.RECURSIVE){
         //Calculatin the cardinality possition based on element size, so it follows when resized.
-        const length = 50 * zoomfact;
         const lift   = 55 * zoomfact; 
-        const elementLength = felem.x2 - felem.x1;
-        x = felem.x1 + elementLength - length;
-        y = felem.y1  - lift;
+        const {length, elementLength, startX, startY } = recursiveParam(felem);
+        x = startX
+        y = startY - lift;
 
         if(labelStr == "startLabel"){
-            x -= 0;
+            x -= 10;
             y -= 0;
         }else if(labelStr == "endLabel"){
-            x += length + 10;
+            x += length +10;
             y -= 0;
         } 
     }else {
@@ -612,11 +611,12 @@ function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) 
     const lineHeight = 60 * zoomfact; 
     const lineLength = 40 * zoomfact; 
     const lift   = 55 * zoomfact; 
-    const elementLength = felem.x2 - felem.x1;
-    const startX = felem.x1 + elementLength - lineLength + offset.x1 * zoomfact;
-    const startY = felem.y1  - lift + offset.y1 * zoomfact;
     const SEconst = 15 * zoomfact;
     const arrowSize = 20 * zoomfact;
+
+    let {length, elementLength, startX, startY} = recursiveParam(felem);
+    startX += offset.x1 * zoomfact;
+    startY += offset.y1 - lift;
 
     if(line.type === entityType.IE) {
         points =
@@ -650,8 +650,6 @@ function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) 
                   fill="${lineColor}"
                 />
           `;
-        
-        
     }else {
         points =
             `${startX},${startY + lineHeight  } ` +
@@ -670,6 +668,15 @@ function drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem) 
             />
           `;
     return str;
+}
+
+function recursiveParam(felem){
+    const length = 40 * zoomfact;
+    const elementLength = felem.x2 - felem.x1;
+    const startX = felem.x1 + elementLength -length;
+    const startY = felem.y1;
+
+    return {length, elementLength, startX, startY};
 }
 
 /**


### PR DESCRIPTION
State diagrams now have working arrows for their recursive line.
Also consolidated the main parts of the recursive variables inside a separate function to remove multiple variables with the same name and values spread out in each recursive section.
![image](https://github.com/user-attachments/assets/8677bfd9-3f5f-495d-8bcd-d57ac4bdf424)
