### PR TITLE
Fixed: Implement hiding the toolbar for mobile version

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -301,6 +301,10 @@
 @media (max-width: 414px){
     .icon-wrapper{
         display: block !important;
+        position: fixed;
+        z-index: 10;
+        bottom: 7%;
+        left: calc(50% - 2%);
     }
 
     #diagram-replay-box{
@@ -313,6 +317,29 @@
 
     #rulerOverlay{
         position: fixed !important;
+    }
+
+    #diagram-toolbar{
+        position: fixed !important;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 5rem !important; /*Remember - Do it to an variable*/
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: nowrap;
+        overflow-y: hidden;
+        overflow-x: auto;
+        transform: translateY(100px);
+    }
+
+    #zoom-container{
+        left: 5% !important;
+    }
+
+    #rulerCorner{
+        z-index: 2 !important;
     }
 }
 
@@ -1036,4 +1063,12 @@
 ****************/
 .icon-wrapper{
     display: none;
+}
+
+.toggle-chevron{
+    font-size: 1.4rem;
+    background-color: var(--color-background-2);
+    padding: .3rem;
+    border-radius: 50%;
+    color: var(--color-text-secondary);
 }

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -298,6 +298,24 @@
     }
 }
 
+@media (max-width: 414px){
+    .icon-wrapper{
+        display: block !important;
+    }
+
+    #diagram-replay-box{
+        position: fixed !important;
+    }
+
+    #diagram-replay-message{
+        left: 10% !important;
+    }
+
+    #rulerOverlay{
+        position: fixed !important;
+    }
+}
+
 .diagramIcons:hover,
 .active {
     background: var(--color-primary-light);
@@ -1011,4 +1029,11 @@
 *****************/
 #replay-time-container {
     width: 250px;
+}
+
+/****************
+    Chevron-icons
+****************/
+.icon-wrapper{
+    display: none;
 }

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -7,6 +7,7 @@
 
 :root{
     --diagram-toolbar-height: 5rem;
+    --normal-transition: all 300ms ease-in-out;
 }
 @keyframes loadingSpin {
     0% {
@@ -309,6 +310,7 @@
         z-index: 10;
         bottom: 7%;
         left: calc(50% - 2%);
+        transition: var(--normal-transition);
     }
 
     .icon-wrapper.toolbar-active{
@@ -341,6 +343,7 @@
         overflow-x: auto;
         column-gap: .8rem;
         transform: translateY(var(--diagram-toolbar-height));
+        transition: var(--normal-transition);
     }
 
     #diagram-toolbar.toolbar-active{
@@ -357,10 +360,6 @@
 
     #zoom-container{
         left: 5% !important;
-    }
-
-    #rulerCorner{
-        z-index: 2 !important;
     }
 }
 

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1,3 +1,9 @@
+/*
+    Great for debugging and searching for causing overflows, uncomment it when using it and comment when it is not of use. 
+*/
+/* *{
+    outline: 2px solid lightgreen;
+} */
 @keyframes loadingSpin {
     0% {
         rotate: 0deg;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -4,6 +4,10 @@
 /* *{
     outline: 2px solid lightgreen;
 } */
+
+:root{
+    --diagram-toolbar-height: 5rem;
+}
 @keyframes loadingSpin {
     0% {
         rotate: 0deg;
@@ -307,6 +311,10 @@
         left: calc(50% - 2%);
     }
 
+    .icon-wrapper.toolbar-active{
+        margin-bottom: calc(var(--diagram-toolbar-height) - 2rem);
+    }
+
     #diagram-replay-box{
         position: fixed !important;
     }
@@ -324,14 +332,27 @@
         bottom: 0;
         left: 0;
         width: 100%;
-        height: 5rem !important; /*Remember - Do it to an variable*/
+        height: var(--diagram-toolbar-height) !important;
         display: flex;
         align-items: center;
         justify-content: space-between;
         flex-wrap: nowrap;
         overflow-y: hidden;
         overflow-x: auto;
-        transform: translateY(100px);
+        column-gap: .8rem;
+        transform: translateY(var(--diagram-toolbar-height));
+    }
+
+    #diagram-toolbar.toolbar-active{
+        transform: translateY(0px);
+    }
+
+    #diagram-toolbar fieldset:nth-of-type(1),
+    #diagram-toolbar fieldset:nth-of-type(3){
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        column-gap: .5rem;
     }
 
     #zoom-container{

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -96,6 +96,11 @@
     and window.devicePixelRatio have to be included -->
     <div id="pixellength" style="width:1000mm;;padding:0px;visibility:hidden;"></div>
 
+    <!-- The chevron/arrows used for toggling the diagram-toolbar-->
+    <div class="icon-wrapper">
+        <i class="material-icons toggle-chevron">keyboard_arrow_up</i>
+    </div>
+
     <!-- Toolbar for diagram -->
     <div id="diagram-toolbar">
         <fieldset>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -97,7 +97,7 @@
     <div id="pixellength" style="width:1000mm;;padding:0px;visibility:hidden;"></div>
 
     <!-- The chevron/arrows used for toggling the diagram-toolbar-->
-    <div class="icon-wrapper">
+    <div class="icon-wrapper" onclick="toggleToolbar();">
         <i class="material-icons toggle-chevron">keyboard_arrow_up</i>
     </div>
 

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -528,3 +528,25 @@ function hideErrorCheck(show) {
         document.getElementById("errorCheckField").style.display = "none";
     }
 }
+/**
+ * @description Toggles the visibility of the diagram toolbar 
+ */
+
+function toggleToolbar(){
+    let toggleBtn = document.querySelector(".icon-wrapper");
+    let toolbar = document.getElementById("diagram-toolbar");
+    let chevronIcon = document.querySelector(".toggle-chevron");
+
+    let ChevronActive = toggleBtn.classList.toggle("toolbar-active");
+    let toolbarActive = toolbar.classList.toggle("toolbar-active");
+
+    /*
+    * Determines wether to rotate the chevron icon if the toolbar and * toggleBtn is in a active state
+    */
+    if(ChevronActive && toolbarActive){
+        chevronIcon.style.transform = `rotate(180deg)`;
+    }
+    else{   
+        chevronIcon.style.transform = `rotate(0deg)`;
+    }
+}


### PR DESCRIPTION
This hopefully fixes the issue regarding implementing a way to hiding the toolbar so it does not disturb the user experience and limit the space available for modeling. I have eliminiated most of the overflows that were visible on the mobile version before (see video 1) and this switch with hiding the toolbar happens when the width of the device is 414px or less than 414px. 

This fix could still need som further styling and added functionality for opening the sub-menus. 

Fixed the issue: #17092

The toolbar before (video 1):

https://github.com/user-attachments/assets/2a4c380d-716e-4c07-baaf-f0e22c13a739

The toolbar now (video 2):

https://github.com/user-attachments/assets/98a7cf97-0c8a-4704-ba75-8994cdfdd26e




