### PR TITLE
added styling to mobile buttons

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7733,6 +7733,10 @@ only screen and (max-device-width: 568px) {
     font-size: small;
   }
 
+  .submit-button {
+    margin: 12px 2px 4px 2px;
+  }
+
   input.submit-button-newitem {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-weight: bold;
@@ -7787,6 +7791,33 @@ only screen and (max-device-width: 568px) {
   }
   #showElements, #hideElement {
     display: none;
+  }
+}
+@media screen and (max-width: 350px) {
+
+  input.submit-button-newitem {
+    width: 20px;
+    height: 20px;
+    font-size: 12px;
+  }
+
+  #loadDuggaButton {
+    font-size: xx-small;
+    min-width: 30px;
+    height: 20px;
+  }
+
+  #course-label {
+    font-size: 16px;
+    position: fixed;
+    margin-bottom: 40px;
+    text-align: center;
+    height: 0.5cm;
+    width: 4cm;
+  }
+
+  .submit-button {
+    margin: 12px 2px 4px 2px;
   }
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7725,6 +7725,47 @@ only screen and (max-device-width: 568px) {
     display:none;
   }
 
+  .fixed-action-button3 {
+    position: absolute;
+    top: 20px;
+    right: 24px;
+    z-index: 1;
+    font-size: small;
+  }
+
+  input.submit-button-newitem {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: bold;
+    background-color: var(--color-accent);
+    border: 0px;
+    width: 30px;
+    height: 20px;
+    color: rgb(97, 73, 116);
+    cursor: pointer;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    padding-left: 7px;
+    margin-left: 10px;
+    padding-right:7px; 
+    margin-right: 10px;
+    font-size: 16px;
+    text-align: center;
+    transition: 1s background-color;
+    -webkit-appearance: none; 
+    float: left;
+  }
+
+  #loadDuggaButton {
+    float: left;
+    width: auto;
+    font-size: small;
+    min-width: 40px;
+    height: 20px;
+    line-height: 20px;
+    padding: 0px;
+    margin: 2px 2px 2px 2px;   
+  }
+
   #showElements {
     margin-right: 10px !important;
   }
@@ -7738,11 +7779,12 @@ only screen and (max-device-width: 568px) {
 only screen and (max-device-width: 568px) {
   #course-label {
     font-size: 16px;
+    margin-top: 10px;
     margin-right: 25px;
-    position: relative;
+    position: fixed;
     text-align: center;
     height: 1.6cm;
-    width: 1.6cm;
+    width: 6.6cm;
   }
   #showElements, #hideElement {
     display: none;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7779,16 +7779,19 @@ only screen and (max-device-width: 568px) {
 only screen and (max-device-width: 568px) {
   #course-label {
     font-size: 16px;
-    margin-top: 10px;
-    margin-right: 25px;
     position: fixed;
+    margin-bottom: 40px;
     text-align: center;
-    height: 1.6cm;
-    width: 6.6cm;
+    height: 0.5cm;
+    width: 4cm;
   }
   #showElements, #hideElement {
     display: none;
   }
+}
+
+.submit-button {
+  margin: 12px 2px 4px 2px;
 }
 
 #Courselist div.fixed-action-button a:hover {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7819,22 +7819,6 @@ only screen and (max-device-width: 568px) {
   #showElements, #hideElement {
     display: none;
   }
-  
-  #course-coursename,
-  #course-coursecode,
-  #course-versname {
-    text-align: center;
-    display: block; 
-    width: 100%;
-    margin-bottom: 5px; 
-    margin-left: auto;
-    margin-right: auto;
-    word-wrap: break-word;
-  }
-
-  #course-label span {
-    padding: 2px 5px; 
-  }
 
   .fixed-action-button {
     position: fixed;


### PR DESCRIPTION
buttons are smaller and equidistant, as well with slightly more spacing to reduce chance of mistapping. They look good on all the aspect ratios I have tried (most popular phone ARs). Also moved course name and code so it's not in the way. Since only styling has been changed I don't see how functionality should differ but I haven't found any issues.

<img width="359" alt="Screenshot 2025-05-02 at 11 38 15" src="https://github.com/user-attachments/assets/d78c3423-f590-4e69-80af-e37aa1d65d6c" />

This is the old styling with larger buttons and overlapping text.

<img width="360" alt="Screenshot 2025-05-02 at 11 39 22" src="https://github.com/user-attachments/assets/8d70a857-20b7-4212-a485-d50fd763bb99" />

This is the new styling with slightly smaller buttons and centered text.