### PR TITLE
Fixed: G1-2025-v5-#17009 moving short distance with box selection

### DIFF
--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -97,7 +97,7 @@ function getExtension(filename) {
  * @param {number} y
  * @returns {boolean}
  */
-function entityIsOverlapping(id, x, y) {
+function entityIsOverlapping(id, x, y, ignoreIds = []) {
     let isOverlapping = false;
     const foundIndex = findIndex(data, id);
 
@@ -109,57 +109,56 @@ function entityIsOverlapping(id, x, y) {
 
     arr.forEach(entityHeights => {
         entityHeights.forEach(entity => {
-            if (element.id == entity.id) eHeight = entity.height
+            if (element.id == entity.id) eHeight = entity.height;
         });
     });
 
     for (let i = 0; i < data.length; i++) {
-        
-        if (data[i].id === id) continue;
+        const other = data[i];
+        if (other.id === id || ignoreIds.includes(other.id)) continue;
 
         // No element can be placed over another of the same kind
-        if (data[i].kind !== element.kind) {
-        if ((data[i].kind === "sequenceActor" || data[i].kind === "sequenceObject") &&
+        if (other.kind !== element.kind) {
+        if ((other.kind === "sequenceActor" || other.kind === "sequenceObject") &&
         element.kind === "sequenceActivation") {
-        const headerHeight = getTopHeight(data[i]);          
-        const extra        = data[i].kind === "sequenceActor" ; 
-        const headerBottom = data[i].y + headerHeight + extra;
+        const headerHeight = getTopHeight(other);          
+        const extra        = other.kind === "sequenceActor"; 
+        const headerBottom = other.y + headerHeight + extra;
 
         if (y < headerBottom) return true;   
         continue;                            
     }
 
             // All sequence elements can be placed over loops, alternatives and activations and vice versa
-            else if (data[i].type === "SE" && (element.kind === "sequenceLoopOrAlt" || element.kind === "sequenceActivation")) continue;
-            else if (element.type === "SE" && (data[i].kind === "sequenceLoopOrAlt" || data[i].kind === "sequenceActivation")) continue;
+            else if (other.type === "SE" && (element.kind === "sequenceLoopOrAlt" || element.kind === "sequenceActivation")) continue;
+            else if (element.type === "SE" && (other.kind === "sequenceLoopOrAlt" || other.kind === "sequenceActivation")) continue;
 
             // Superstates can be placed on state-diagram elements and vice versa
             else if (!backgroundElement.includes(element.kind) &&
-                (data[i].kind === elementTypesNames.UMLSuperState ||
-                    data[i].kind === elementTypesNames.sequenceLoopOrAlt)
+                (other.kind === elementTypesNames.UMLSuperState ||
+                    other.kind === elementTypesNames.sequenceLoopOrAlt)
             ) continue;
-            else if (!backgroundElement.includes(data[i].kind) &&
+            else if (!backgroundElement.includes(other.kind) &&
                 (element.kind === elementTypesNames.UMLSuperState ||
                     element.kind === elementTypesNames.sequenceLoopOrAlt)
             ) continue;
         }
 
-        const x2 = data[i].x + data[i].width;
-        let y2 = data[i].y + data[i].y2 - data[i].y1;
+        const x2 = other.x + other.width;
+        let y2 = other.y + other.y2 - other.y1;
 
         arr.forEach(entityHeights => {
             entityHeights.forEach(entity => {
-                if (data[i].id == entity.id) y2 = data[i].y + entity.height;
+                if (other.id == entity.id) y2 = other.y + entity.height;
             });
         });
 
         if (element.kind === "ERRelation" || element.kind === "UMLRelation") {
             // Use default rectangle collision detection
             if (x < x2 &&
-                x + element.width > data[i].x &&
+                x + element.width > other.x &&
                 y < y2 &&
-                y + eHeight > data[i].y
-            ) {
+                y + eHeight > other.y) {
                 isOverlapping = true;
                 break;
             }
@@ -169,17 +168,16 @@ function entityIsOverlapping(id, x, y) {
         // Default collision detection where overlapping is derived from height and width of element in a rectangle shape
         // Some elements doesnt have a height so the second parameter gets the height manually
         if ((x < x2 &&
-            x + element.width > data[i].x &&
+            x + element.width > other.x &&
             y < y2 &&
-            y + eHeight > data[i].y
+            y + eHeight > other.y
         )||(
             x < x2 &&
-            x + element.width > data[i].x &&
+            x + element.width > other.x &&
             y < y2 &&
-            y + element.y2 - element.y1 > data[i].y
-        ))
-        {
-            isOverlapping = true;   
+            y + element.y2 - element.y1 > other.y
+        )) {
+            isOverlapping = true;
         }
 
     }

--- a/DuggaSys/diagram/helpers/element.js
+++ b/DuggaSys/diagram/helpers/element.js
@@ -54,6 +54,8 @@ function setPos(elements, x, y) {
     const idList = [];
     let overlappingObject = null;
 
+    const ignoreIds = elements.map(e => e.id);
+
     // Check for overlaps
     elements.forEach(elem => {
         let newX = elem.x - deltaX / zoomfact;
@@ -66,53 +68,39 @@ function setPos(elements, x, y) {
             newX -= elem.width / 2;
             newY -= elem.height / 2;
         }
-        if (entityIsOverlapping(elem.id, newX, newY)) {
+        if (entityIsOverlapping(elem.id, newX, newY, ignoreIds)) {
             overlappingObject = elem;
         }
     });
 
     if (overlappingObject) {
-        // If overlap is detected, move the overlapping object back by one step
-        const previousX = overlappingObject.x;
-        const previousY = overlappingObject.y;
+        // Display error message
+        displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
+        return;
+    }
 
-        // Move the object back one step
-        overlappingObject.x -= x / zoomfact;
-        overlappingObject.y -= y / zoomfact;
+    // Move all the elements in the group
+    elements.forEach(obj => {
+        if (obj.isLocked) return;
 
-        // Check again if the adjusted position still overlaps
-        if (entityIsOverlapping(overlappingObject.id, overlappingObject.x, overlappingObject.y)) {
-            // If it still overlaps, revert to the previous position
-            overlappingObject.x = previousX;
-            overlappingObject.y = previousY;
-
-            // Display error message
-            displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
+        if (settings.grid.snapToGrid && !ctrlPressed) {
+            obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
+            obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
+            obj.x -= obj.width / 2;
+            obj.y -= obj.height / 2;
         } else {
             // If no longer overlaps after adjustment, proceed with saving the new position
-            idList.push(overlappingObject.id);
+            obj.x -= (x / zoomfact);
+            obj.y -= (y / zoomfact);
         }
-    } else {
-        elements.forEach(obj => {
-            if (obj.isLocked) return;
-            if (settings.grid.snapToGrid && !ctrlPressed) {
-                // Calculate nearest snap point
-                obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
-                obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
-                // Set the new snap point to center of element
-                obj.x -= obj.width / 2;
-                obj.y -= obj.height / 2;
-            } else {
-                obj.x -= (x / zoomfact);
-                obj.y -= (y / zoomfact);
-            }
-            // Add the object-id to the idList
-            idList.push(obj.id);
-            // Make the coordinates without decimals
-            obj.x = Math.round(obj.x);
-            obj.y = Math.round(obj.y);
-        });
-        if (idList.length) stateMachine.save(idList, StateChange.ChangeTypes.ELEMENT_MOVED);
+
+        obj.x = Math.round(obj.x);
+        obj.y = Math.round(obj.y);
+        idList.push(obj.id);
+    });
+
+    if (idList.length) {
+        stateMachine.save(idList, StateChange.ChangeTypes.ELEMENT_MOVED);
     }
     // Update positions
     updatepos();


### PR DESCRIPTION
This PR updates the element movement logic to allow moving multiple elements as a group without triggering the "too close together" warning. The overlap check now correctly ignores elements that are part of the same group, while still preventing collisions with external elements.

Modified entityIsOverlapping(id, x, y, ignoreIds) to accept an optional ignoreIds array and skip overlap detection for those IDs.

Updated setPos() to pass the list of selected element IDs to entityIsOverlapping when moving multiple elements.


https://github.com/user-attachments/assets/8ac07fb3-e27f-4d9b-8df4-b7b818d3809d

