### PR TITLE
[#17075] snap to grid doesnt align elements with the grids x axis

### DIFF
--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -103,7 +103,7 @@ const elementTypesNames = {
     sequenceObject: "sequenceObject",
     sequenceActivation: "sequenceActivation",
     sequenceLoopOrAlt: "sequenceLoopOrAlt",
-    note: "Note",
+    note: "note",
     UMLRelation: "UMLRelation",
 };
 

--- a/DuggaSys/diagram/defaults.js
+++ b/DuggaSys/diagram/defaults.js
@@ -151,7 +151,7 @@ const defaults = {
     note: {
         name: "Note",
         type: entityType.note,
-        kind: "note",
+        kind: elementTypesNames.note,
         width: 200,
         height: 50,
         minWidth: 150,

--- a/DuggaSys/diagram/helpers/element.js
+++ b/DuggaSys/diagram/helpers/element.js
@@ -103,7 +103,8 @@ function setPos(elements, x, y) {
                     elementTypesNames.EREntity,
                     elementTypesNames.UMLEntity,
                     elementTypesNames.IEEntity,
-                    elementTypesNames.SDEntity
+                    elementTypesNames.SDEntity,
+                    elementTypesNames.note
                 ];
                 if (entityKinds.includes(obj.kind)) {
                     const candidateX = obj.x - (x / zoomfact);

--- a/DuggaSys/diagram/helpers/element.js
+++ b/DuggaSys/diagram/helpers/element.js
@@ -94,11 +94,17 @@ function setPos(elements, x, y) {
         }
     } else {
         elements.forEach(obj => {
+
+            // Check if element is locked and immovable
             if (obj.isLocked) {
                 return;
             }
 
+            // If snapToGrid is activated
             if (settings.grid.snapToGrid && !ctrlPressed) {
+
+                // Snap logic for rectangular elements
+                // Snaps to grid lines
                 const entityKinds = [
                     elementTypesNames.EREntity,
                     elementTypesNames.UMLEntity,
@@ -109,17 +115,22 @@ function setPos(elements, x, y) {
                 if (entityKinds.includes(obj.kind)) {
                     const candidateX = obj.x - (x / zoomfact);
                     const candidateY = obj.y - (y / zoomfact);
-                    obj.x = Math.round(candidateX / (settings.grid.gridSize/2)) * (settings.grid.gridSize/2);
-                    obj.y = Math.round(candidateY / (settings.grid.gridSize/2)) * (settings.grid.gridSize/2);
+                    obj.x = Math.round(candidateX / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
+                    obj.y = Math.round(candidateY / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
                 } else {
+
+                    // Snap logic for non-rectangular elements
+                    // Snaps to center
                     obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.width / 2;
                     obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.height / 2;
                 }
             } else {
+
+                // For dragging elements without snapToGrid mode active
                 obj.x -= (x / zoomfact);
                 obj.y -= (y / zoomfact);
             }
-            
+
             // Add the object-id to the idList
             idList.push(obj.id);
             // Make the coordinates without decimals

--- a/DuggaSys/diagram/helpers/element.js
+++ b/DuggaSys/diagram/helpers/element.js
@@ -94,29 +94,41 @@ function setPos(elements, x, y) {
         }
     } else {
         elements.forEach(obj => {
-            if (obj.isLocked) return;
+            if (obj.isLocked) {
+                return;
+            }
+
             if (settings.grid.snapToGrid && !ctrlPressed) {
-                console.log('Snap-to-grid branch for', obj.id);
-                // Calculate nearest snap point
-                obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
-                obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
-                // Set the new snap point to center of element
-                obj.x -= obj.width / 2;
-                obj.y -= obj.height / 2;
-                console.log('obj value x and y in snapToGrid:', obj.x, obj.y);
+                const entityKinds = [
+                    elementTypesNames.EREntity,
+                    elementTypesNames.UMLEntity,
+                    elementTypesNames.IEEntity,
+                    elementTypesNames.SDEntity
+                ];
+                if (entityKinds.includes(obj.kind)) {
+                    const candidateX = obj.x - (x / zoomfact);
+                    obj.x = Math.round(candidateX / (settings.grid.gridSize/2)) * (settings.grid.gridSize/2);
+                } else {
+                    obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.width / 2;
+                }
+                obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.height / 2;
             } else {
                 obj.x -= (x / zoomfact);
                 obj.y -= (y / zoomfact);
             }
+            
             // Add the object-id to the idList
             idList.push(obj.id);
             // Make the coordinates without decimals
             obj.x = Math.round(obj.x);
             obj.y = Math.round(obj.y);
-            console.log('value without decimals x and y in snapToGrid:', obj.x, obj.y);
         });
-        if (idList.length) stateMachine.save(idList, StateChange.ChangeTypes.ELEMENT_MOVED);
+
+        if (idList.length) {
+            stateMachine.save(idList, StateChange.ChangeTypes.ELEMENT_MOVED);
+        }
     }
+
     // Update positions
     updatepos();
 }

--- a/DuggaSys/diagram/helpers/element.js
+++ b/DuggaSys/diagram/helpers/element.js
@@ -54,8 +54,6 @@ function setPos(elements, x, y) {
     const idList = [];
     let overlappingObject = null;
 
-    const ignoreIds = elements.map(e => e.id);
-
     // Check for overlaps
     elements.forEach(elem => {
         let newX = elem.x - deltaX / zoomfact;
@@ -68,30 +66,31 @@ function setPos(elements, x, y) {
             newX -= elem.width / 2;
             newY -= elem.height / 2;
         }
-        if (entityIsOverlapping(elem.id, newX, newY, ignoreIds)) {
+        if (entityIsOverlapping(elem.id, newX, newY)) {
             overlappingObject = elem;
         }
     });
 
     if (overlappingObject) {
-        // Display error message
-        displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
-        return;
-    }
+        // If overlap is detected, move the overlapping object back by one step
+        const previousX = overlappingObject.x;
+        const previousY = overlappingObject.y;
 
-    // Move all the elements in the group
-    elements.forEach(obj => {
-        if (obj.isLocked) return;
+        // Move the object back one step
+        overlappingObject.x -= x / zoomfact;
+        overlappingObject.y -= y / zoomfact;
 
-        if (settings.grid.snapToGrid && !ctrlPressed) {
-            obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
-            obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
-            obj.x -= obj.width / 2;
-            obj.y -= obj.height / 2;
+        // Check again if the adjusted position still overlaps
+        if (entityIsOverlapping(overlappingObject.id, overlappingObject.x, overlappingObject.y)) {
+            // If it still overlaps, revert to the previous position
+            overlappingObject.x = previousX;
+            overlappingObject.y = previousY;
+
+            // Display error message
+            displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
         } else {
             // If no longer overlaps after adjustment, proceed with saving the new position
-            obj.x -= (x / zoomfact);
-            obj.y -= (y / zoomfact);
+            idList.push(overlappingObject.id);
         }
     } else {
         elements.forEach(obj => {

--- a/DuggaSys/diagram/helpers/element.js
+++ b/DuggaSys/diagram/helpers/element.js
@@ -107,11 +107,13 @@ function setPos(elements, x, y) {
                 ];
                 if (entityKinds.includes(obj.kind)) {
                     const candidateX = obj.x - (x / zoomfact);
+                    const candidateY = obj.y - (y / zoomfact);
                     obj.x = Math.round(candidateX / (settings.grid.gridSize/2)) * (settings.grid.gridSize/2);
+                    obj.y = Math.round(candidateY / (settings.grid.gridSize/2)) * (settings.grid.gridSize/2);
                 } else {
                     obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.width / 2;
+                    obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.height / 2;
                 }
-                obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.height / 2;
             } else {
                 obj.x -= (x / zoomfact);
                 obj.y -= (y / zoomfact);

--- a/DuggaSys/diagram/helpers/element.js
+++ b/DuggaSys/diagram/helpers/element.js
@@ -96,12 +96,14 @@ function setPos(elements, x, y) {
         elements.forEach(obj => {
             if (obj.isLocked) return;
             if (settings.grid.snapToGrid && !ctrlPressed) {
+                console.log('Snap-to-grid branch for', obj.id);
                 // Calculate nearest snap point
                 obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
                 obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
                 // Set the new snap point to center of element
                 obj.x -= obj.width / 2;
                 obj.y -= obj.height / 2;
+                console.log('obj value x and y in snapToGrid:', obj.x, obj.y);
             } else {
                 obj.x -= (x / zoomfact);
                 obj.y -= (y / zoomfact);
@@ -111,6 +113,7 @@ function setPos(elements, x, y) {
             // Make the coordinates without decimals
             obj.x = Math.round(obj.x);
             obj.y = Math.round(obj.y);
+            console.log('value without decimals x and y in snapToGrid:', obj.x, obj.y);
         });
         if (idList.length) stateMachine.save(idList, StateChange.ChangeTypes.ELEMENT_MOVED);
     }


### PR DESCRIPTION
When using snapToGrid rectangular elements now snap to grid lines instead of snapping irregularly beside them. Other shapes snap to their center. Overall it gives the user an easier time to line up elements on the grid which seems to be the original purpose of the feature. I also made some changes to note and added elementTypeNames to its kind to match the other elements. For some reason note was previously just a string.

https://github.com/user-attachments/assets/92aeae88-6d4d-45ab-8845-0ed95f0744a3

