### PR TITLE
Fixed: Fix the rulers position so it adapts to mobile versions

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -859,7 +859,7 @@ function setupTouchAsMouseSupport() {
             // Singel touch, simulate mouse move event
             const mouseEvent = convertTouchToMouse(event, "mousemove");
             container.dispatchEvent(mouseEvent);
-        } else if (event.touches.length === 2 && initialPinchDistance !== null){
+        } else if (event.touches.length === 2 && initialPinchDistance !== null) {
             // Two fingers, handle pinch-zoom
             handlePinchZoom(event);
         }
@@ -1055,11 +1055,11 @@ function mmoving(event) {
                 // Check coordinates of moveable element and if they are within snap threshold
                 const moveableElementPos = screenToDiagramCoordinates(event.clientX, event.clientY);
                 const snapId = visualSnapToLifeline(moveableElementPos);
-                
+
                 // Visualize the context snapping to lifeline (only a visual indication)
                 if (snapId) {
                     const lLine = data.find(el => el.id === snapId);
-                    context[0].x = lLine.x + lLine.width/2 - context[0].width/2;
+                    context[0].x = lLine.x + lLine.width / 2 - context[0].width / 2;
                     startX = event.clientX;
                     deltaX = 0;
                 }
@@ -1663,13 +1663,13 @@ function hoverPlacementButton(index) {
 /**
  * @description Function to hide submenu
  * USED IN PHP
- */ 
+ */
 function hidePlacementType() {
     if (currentlyOpenSubmenu !== null) {
         let submenu = document.getElementById(`togglePlacementTypeBox${currentlyOpenSubmenu}`);
-        if (submenu){
+        if (submenu) {
             submenu.classList.remove("activeTogglePlacementTypeBox"); // Hide submenu
-        }             
+        }
         currentlyOpenSubmenu = null;
     }
 }
@@ -1794,7 +1794,7 @@ function storeDiagramInLocalStorage(key) {
         local = (local[0] == "{") ? local : `{${local}}`;
 
         let localDiagrams = JSON.parse(local);
-        objToSave.timestamp = new Date().getTime(); 
+        objToSave.timestamp = new Date().getTime();
         localDiagrams[key] = objToSave;
         localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
 
@@ -1805,11 +1805,11 @@ function storeDiagramInLocalStorage(key) {
 //Moastly the same as storeDiagramInLocalStorage
 //Uppdates the latestChange to always be in the latest state
 function updateLatestChange() {
-    if (stateMachine.currentHistoryIndex === -1){
-       return; 
+    if (stateMachine.currentHistoryIndex === -1) {
+        return;
     }
     stateMachine.removeFutureStates();
-  
+
     const objToSave = {
         historyLog: stateMachine.historyLog,
         initialState: stateMachine.initialState
@@ -2006,7 +2006,7 @@ function showModal() {
         diagramKeys = Object.keys(localDiagrams).sort((a, b) => {
             if (a === "AutoSave") return -1;
             if (b === "AutoSave") return 1;
-            return localDiagrams[b].timestamp - localDiagrams[a].timestamp; 
+            return localDiagrams[b].timestamp - localDiagrams[a].timestamp;
         });
     }
 
@@ -2243,7 +2243,7 @@ function removeLocalDiagram(item) {
     if (item !== 'latestChange') {
         delete localDiagrams[item];
         //Resets activeFile to null if the item deleted was the file currently saved to.
-        if (item == activeFile){
+        if (item == activeFile) {
             activeFile = null;
         }
         localStorage.setItem("diagrams", JSON.stringify(localDiagrams));
@@ -2279,4 +2279,18 @@ function resetDiagramAlert() {
 function resetDiagram() {
     loadMockupDiagram("JSON/EMPTYDiagramMockup.json");
 }
+
+window.addEventListener("resize", () => {
+    const ruler = document.getElementById("rulerOverlay");
+    if (!settings.ruler.isRulerActive) return;
+
+    if (window.innerWidth > 414) {
+        ruler.style.left = "50px";
+        ruler.style.top = "0px";
+    }
+    else {
+        ruler.style.left = "0px";
+        ruler.style.top = "0px";
+    }
+});
 //#endregion =====================================================================================

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -134,7 +134,7 @@ function toggleTestCase() {
  * @description Toggles the A4 template ON/OFF.
  */
 function toggleA4Template() {
-    const template = document.getElementById("a4Template");    
+    const template = document.getElementById("a4Template");
     const a4Rect = document.getElementById("a4Rect");
     const vRect = document.getElementById("vRect");
 
@@ -173,7 +173,7 @@ function setA4SizeFactor(e) {
 function toggleA4Vertical() {
     const vRect = document.getElementById("vRect");
     const a4Rect = document.getElementById("a4Rect");
-    
+
     vRect.style.display = "none";  // Hide horizontal
     a4Rect.style.display = "block";  // Show vertical
 }
@@ -184,7 +184,7 @@ function toggleA4Vertical() {
 function toggleA4Horizontal() {
     const vRect = document.getElementById("vRect");
     const a4Rect = document.getElementById("a4Rect");
-    
+
     a4Rect.style.display = "none";  // Hide vertical
     vRect.style.display = "block";  // Show horizontal
 }
@@ -225,15 +225,25 @@ function toggleRuler() {
 
     // Toggle active ruler + color change of button to clarify if button is pressed or not
     if (settings.ruler.isRulerActive) {
-        ruler.style.left = "-100px";
-        ruler.style.top = "-100px";
+        // ruler.style.left = "-100px";
+        // ruler.style.top = "-100px";
+        ruler.style.display = 'none';
         rulerToggleButton.style.backgroundColor = "transparent";
         rulerToggleButton.style.border = `3px solid ${color.PURPLE}`;
         rulerToggleButton.style.color = color.PURPLE;
         rulerToggleButton.style.fontWeight = "bold";
     } else {
-        ruler.style.left = "50px";
-        ruler.style.top = "0px";
+        ruler.style.display = 'block';
+
+        if (window.innerWidth > 414) {
+            ruler.style.left = "50px";
+            ruler.style.top = "0px";
+        }
+        else {
+            ruler.style.left = "0px";
+            ruler.style.top = "0px";
+        }
+
         rulerToggleButton.style.backgroundColor = color.PURPLE;
         rulerToggleButton.style.color = color.WHITE;
         rulerToggleButton.style.fontWeight = "normal";
@@ -487,7 +497,7 @@ function setElementColors(clickedCircleID) {
             context[i].stroke = color;
             elementIDs[i] = context[i].id;
         }
-        stateMachine.save(elementIDs,StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+        stateMachine.save(elementIDs, StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     } else {
         console.error(`${menu.id} is not a valid ID`);
     }
@@ -532,7 +542,7 @@ function hideErrorCheck(show) {
  * @description Toggles the visibility of the diagram toolbar 
  */
 
-function toggleToolbar(){
+function toggleToolbar() {
     let toggleBtn = document.querySelector(".icon-wrapper");
     let toolbar = document.getElementById("diagram-toolbar");
     let chevronIcon = document.querySelector(".toggle-chevron");
@@ -543,10 +553,10 @@ function toggleToolbar(){
     /*
     * Determines wether to rotate the chevron icon if the toolbar and * toggleBtn is in a active state
     */
-    if(ChevronActive && toolbarActive){
+    if (ChevronActive && toolbarActive) {
         chevronIcon.style.transform = `rotate(180deg)`;
     }
-    else{   
+    else {
         chevronIcon.style.transform = `rotate(0deg)`;
     }
 }


### PR DESCRIPTION
I have now fixed the rulers position so it adapts to both desktop and mobile version. So, when you toggle on both version they are positioned correctly based on their environment (other elements e.g. navbar on desktop). And if you resize the window they are positioned correctly so you dont need to toggle the ruler to make the position correct. see video 1 to see the result. 

PS: The code is now auto formatted/indented

fixed the issue: #17116

video 1


https://github.com/user-attachments/assets/404e4967-546f-44e3-8090-9a3121f7fbac


