### PR TITLE
G3-2025-V5 #17142 Fix course creation error/prevention

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3816,10 +3816,11 @@ function validateCourseID(courseid, dialogid) {
   return false
 }
 
-function validateMOTD(motd, syntaxdialogid, rangedialogid) {
+function validateMOTD(motd, syntaxdialogid, rangedialogid, dialogid) {
   var emotd = document.getElementById(motd);
   var Emotd = /(^$)|(^[-a-zåäöA-ZÅÄÖ0-9_+§&%# ?!,.]*$)/;
   var EmotdRange = /^.{0,50}$/;
+  var errorMsg = document.getElementById(dialogid);
   var errorMsg1 = document.getElementById(syntaxdialogid);
   var errorMsg2 = document.getElementById(rangedialogid);
   if (emotd.value.match(Emotd)) {


### PR DESCRIPTION
Fixes #17142. 
The function that validates the 'Message of the day' text had a missing variable (errorMsg) that is now declared. 
![image](https://github.com/user-attachments/assets/a3d73736-9df8-471f-9497-294e2ea95890)

For testing I created a new course, filled in the necessary information and saved the information and started adding items to the course. If set to default, the created version will always be loaded, otherwise the same information has to be filled in again. 

The screenshot below shows that the editing for a course now works:
![image](https://github.com/user-attachments/assets/9e38eeef-4f97-4d63-878c-b51b129a7699)
