### PR TITLE
Fixed: Wrong tool gets highlighted in the sub-menu

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -810,7 +810,7 @@
                                 <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> <!-- LIFELINE OBJECT !-->
+                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> <!-- LIFELINE OBJECT !-->
                             <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                             <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                 <p>Represents the passage of time.</p>
@@ -818,7 +818,7 @@
                                 <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
                             </span>
                             </div>
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> <!-- ACTIVATION !-->
                             <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                             <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                 <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>


### PR DESCRIPTION
The solution was to remove an class from the sequence activation box in the dropdown that was used to mark what element is active, and then add that class to the correct element that was being active. see figure 1 for result. 

The issue that was fixed: #17141 
