### PR TITLE
Updated the datesize v2.0

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -931,6 +931,7 @@ p {
   .dateSize {
     width: 25%;
     font-size: 10pt;
+    display: none;
   }
 	.internal-link {
         font-size: 10pt;


### PR DESCRIPTION
Updated the datesize so now iit automaticly hides the date if the screen is smaller than 570 pixels. Remember to actually switch to the correct branch while testing.