### PR TITLE
Added general error handling for events. Use Windows with a Docker.

### DIFF
--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -242,6 +242,7 @@
 							$modal->showFilePermissionErrorModal("permissionError");
 							$modal->showDbCreationErrorModal("dbCreationError");
 							$modal->showSqlExecutionErrorModal("SqlError");
+							$modal->showOperationErrorModal("operationError");
 						?>
 						<div id="pageButtonContainer">
 							<button class="defaultButton pageButton" id="openModal" type="button" style="display: none;">View Problem</button>

--- a/newinstaller/tools/modal.js
+++ b/newinstaller/tools/modal.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
 		if (newDataError.data.includes("Connection to database could not be established.")) {
 			modal = document.getElementById("dbConnectionError");
 
-		} else if (newDataError.data.includes("Failed on step set_permissions")) {
+		}else if (newDataError.data.includes("Failed on step set_permissions")) {
 			modal = document.getElementById("permissionError");
 
 		}else if (newDataError.data.includes("Failed on step create_db")) {
@@ -18,7 +18,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
 		}else if (newDataError.data.includes("SQL error") || newDataError.data.includes("File error.")) {
 			modal = document.getElementById("SqlError");
-		}
+		}else {
+            modal = document.getElementById("operationError");
+            document.getElementById("failedStep").innerHTML = newDataError.data;
+        }
 
         dataError = newDataError;
         data = newData;
@@ -94,7 +97,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
 		}else if (dataError.data.includes("SQL error") || dataError.data.includes("File error.")) {
 			navigateTo('page1');
-		}
+		}else{
+            navigateTo('page1');
+        }
         
         closeModal();
         hideModalButton();

--- a/newinstaller/tools/modal.php
+++ b/newinstaller/tools/modal.php
@@ -138,4 +138,18 @@ class Modal {
 
         $modal->render();
     }
+
+    public static function showOperationErrorModal($id) {
+        $modal = new self(
+            $id,
+            'Operation Failed',
+            '<div id="failedStep"></div>',
+            [
+                ['text' => 'Retry', 'class' => 'progressButton', 'onclick' => 'Window.retryInstaller()'],
+                ['text' => 'Cancel', 'class' => 'backButton', 'onclick' => 'Window.closeModal()']
+            ]
+        );
+
+        $modal->render();
+    }
 }


### PR DESCRIPTION
Fixes #16992. 

There are four errors which are already implemented which are db connection, copy course files, creation of database and sql error.

I have added operation failed modal, because if none of these four errors are the cause, then show the operation error message in a modal.

To test operation error modal, you need to remove else if to show or 