### PR TITLE
Added edit functionality

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -1,4 +1,10 @@
 <?php
+session_start();
+
+if (!isset($_SESSION['token'])) {
+    $_SESSION['token'] = bin2hex(random_bytes(32));
+}
+
 try {
 // database
 $db = new PDO('sqlite:endpointDirectory_db.sqlite');
@@ -16,6 +22,10 @@ if (isset($_POST['deleteID'])) {
 
 // update functionality
 if (isset($_POST['updateID'])) {
+    if (!isset($_POST['token']) || $_POST['token'] !== $_SESSION['token']) {
+        http_response_code(403);
+        exit('Invalid CSRF token');
+    }
     $id = $_POST['updateID'];
     $name = $_POST['ms_name'];
     $description = $_POST['description'];
@@ -89,6 +99,7 @@ if (isset($_GET['id'])) {
             <h1>Edit Microservice</h1>
         </div>
         <form method="post">
+            <input type="hidden" name="token" value="<?php echo $_SESSION['token']; ?>">
             <input type="hidden" name="updateID" value="<?php echo $editMicroservice['id']; ?>">
             <p><b><label>Microservice name:<br><input type="text" name="ms_name" value="<?php echo htmlspecialchars($editMicroservice['ms_name']); ?>" required></label></p>
             <p><label>Description:<br><textarea name="description" rows="5" cols="40"><?php echo htmlspecialchars($editMicroservice['description']); ?></textarea></label></p>

--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -14,6 +14,26 @@ if (isset($_POST['deleteID'])) {
     exit();
 }
 
+// update functionality
+if (isset($_POST['updateID'])) {
+    $id = $_POST['updateID'];
+    $name = $_POST['ms_name'];
+    $description = $_POST['description'];
+    $methods = $_POST['calling_methods'];
+    $used = $_POST['microservices_used'];
+
+    $stmt = $db->prepare("UPDATE microservices SET ms_name = ?, description = ?, calling_methods = ?, microservices_used = ? WHERE id = ?");
+    $stmt->execute([$name, $description, $methods, $used, $id]);
+    header("Location: ?id=" . $id);
+    exit();
+}
+
+if (isset($_GET['edit']) && isset($_GET['id'])) {
+    $stmt = $db->prepare("SELECT * FROM microservices WHERE id = ?");
+    $stmt->execute([$_GET['id']]);
+    $editMicroservice = $stmt->fetch();
+}
+
 // search functionality safe from injections
 if (isset($_GET['search'])) {
     $searchTerm = "%".$_GET['search']."%";
@@ -63,6 +83,21 @@ if (isset($_GET['id'])) {
     </style>
 </head>
 <body>
+
+    <?php if (isset($editMicroservice)) { ?>
+        <div class="line">
+            <h1>Edit Microservice</h1>
+        </div>
+        <form method="post">
+            <input type="hidden" name="updateID" value="<?php echo $editMicroservice['id']; ?>">
+            <p><b><label>Microservice name:<br><input type="text" name="ms_name" value="<?php echo htmlspecialchars($editMicroservice['ms_name']); ?>" required></label></p>
+            <p><label>Description:<br><textarea name="description" rows="5" cols="40"><?php echo htmlspecialchars($editMicroservice['description']); ?></textarea></label></p>
+            <p><label>Calling Methods:<br><input type="text" name="calling_methods" required value="<?php echo htmlspecialchars($editMicroservice['calling_methods']); ?>"></label></p>
+            <p><label>Microservices Used:<br></b><input type="text" name="microservices_used" value="<?php echo htmlspecialchars($editMicroservice['microservices_used']); ?>" required></label></p>
+            <button type="submit">Save Changes</button>
+            <a href="?id=<?php echo $editMicroservice['id']; ?>">Cancel</a>
+        </form>
+    <?php } ?>
     
     <?php    
     if (isset($dbError)) {
@@ -143,7 +178,9 @@ if (isset($_GET['id'])) {
         <?php } ?>
 
         <div style="display: flex; gap: 5px;">
-            <form method="">
+            <form method="get">
+                <input type="hidden" name="id" value="<?php echo $microservice['id']; ?>">
+                <input type="hidden" name="edit" value="1">
                 <button type="submit">Edit</button>
             </form>
 


### PR DESCRIPTION
Fixes #16967 and adds edit functionality to the microservice UI. Editable attributes include the microservice name, description, calling methods, and microservices used. The parameters and outputs values are intentionally not editable through this form due to complexity and the need to maintain the structure/associations between microservices. IF these attributes should be made editable despite the potential issues, I recommend creating a separate issue for implementing their edit functionality.