### PR TITLE
Fixed: G1-2025-v5-#17130-sequence-actors-and-objects-connects-to-eachother-when-they-are-becoming-a-gruop

### DIFF
--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -226,6 +226,9 @@ function snapElementToLifeline(element, targetId) {
 // For mmoving sequenceActivation element to get a visually indicated snap to lifeline
 // threshold value is changeable within the parameter
 function visualSnapToLifeline(pos, threshold = 50) {
+   
+    // Restrict snapping to only sequence activations
+    if (pos.kind !== elementTypesNames.sequenceActivation) return null;
 
     // Check that there exists a sequenceActor or sequenceObject to snap to
     for (const ll of data) {


### PR DESCRIPTION
After testing many different things, I finally found out that the only thing needed was to add "if (pos.kind !== elementTypesNames.sequenceActivation) return null;". This ensures that the snapping logic is only applied to elements of the type sequenceActivation. If the current element is of any other type, the function will stop execution at this point and return null.