### PR TITLE
Moved fab button on mobile to right corner

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7848,6 +7848,7 @@ only screen and (max-device-width: 568px) {
     transform: rotate(90deg);
     transform-origin: top left;
   }
+  
 
   .fab-btn-list2 li {
     transform: rotate(225deg);
@@ -8191,6 +8192,9 @@ only screen and (max-device-width: 568px) {
 @media only screen and (max-width: 601px) {
   .fileView{
     width: 75%;
+  }
+  .fixed-action-button.extra-margin{
+    right:20px;
   }
 
 


### PR DESCRIPTION
Previously the fab button had an extensive right margin causing it to almost become centered on smaller width resolutions. This has been adjusted for smaller devices to have a more subtle margin. 

Previously

![chrome_hOnfeNatNF 1](https://github.com/user-attachments/assets/3fc0bdaf-657c-4fae-be09-35e4a71a93a9)


Now
![image](https://github.com/user-attachments/assets/ea0b8887-1467-4c28-8fce-5f45fce4780e)

This solution however may not be the best, may be worth looking into making the fab movable by the user, as it may be in the way depending on what page you are on.