### PR TITLE
Changed callMicroserviceGET function parameter in curlService.php #17186

### DIFF
--- a/DuggaSys/microservices/curlService.php
+++ b/DuggaSys/microservices/curlService.php
@@ -36,7 +36,7 @@ function recieveMicroservicePOST(array $requiredKeys = []) {
 }
 //Supposed to be used instead of includes
 
-function callMicroserviceGET($microservicePath){
+function callMicroserviceGET(string $path){
     $baseURL = "https://" . $_SERVER['HTTP_HOST'] . "/LenaSYS/DuggaSys/microservices/";
     $url = $baseURL . $path;
   


### PR DESCRIPTION
There was an error in the callMicroserviceGET function in curlService.php. I have changed the parameter "$microservicePath" to "string  $path" since it's used in the URL and now the function should work.

fixes #17186