### PR TITLE
Promp for unsaved changes 

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1000,7 +1000,9 @@
     width: 100%;
 }
 
-
+/*****************
+   Confirm buttons
+*****************/
 .buttonGroup {
     text-align: center;
 }
@@ -1010,9 +1012,14 @@
     border: 0px;
     color: #fff;
     cursor: pointer;
-    width: 40px;
-    height: 25px;
-    transition: 1s background-color;
+    width: 65px;
+    height: 30px;
+    margin: 15px 10px, 10px 10px;
+}
+
+.confirmButton:hover {
+    background: #815e9d;
+    color: #FFF;
 }
 
 /****************

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1000,6 +1000,21 @@
     width: 100%;
 }
 
+
+.buttonGroup {
+    text-align: center;
+}
+
+.confirmButton {
+    background-color: #614875;
+    border: 0px;
+    color: #fff;
+    cursor: pointer;
+    width: 40px;
+    height: 25px;
+    transition: 1s background-color;
+}
+
 /****************
    REPLAY BOX 
 *****************/

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2180,7 +2180,7 @@ function closeModal() {
  * @returns {Promise} A promise that resolves when the user clicks either "yes" or "no".
  * @see loadDiagramFromLocalStorage
  **/
-function loadPopup() {
+function loadConfirmPopup() {
 
     if (stateMachine.numberOfChanges <= 0) { //early exit if no changes
       return Promise.resolve();    
@@ -2189,7 +2189,7 @@ function loadPopup() {
     //Caused problems with loading save to fast before the popup was closed otherwise.
     let promise = new Promise(resolve => {
       $("#confirmationPopup").css("display", "flex");
-      $("#confirmYes, #confirmNo").click(function() {
+      $("#confirmYes, #confirmNo, #closeWindow").click(function() {
           $("#confirmationPopup").hide();
           resolve(this.id === "confirmYes"); //resolvar if butten had id "confirmYes"
         });
@@ -2210,7 +2210,7 @@ function loadPopup() {
  */
 function loadDiagramFromLocalStorage(key) {
 
-    loadPopup().then(function() {   //loadPopup promise that checks if there exists unsaved changes.
+    loadConfirmPopup().then(function() {   //loadConfirmPopup promise that checks if there exists unsaved changes.
         if (localStorage.getItem("diagrams")) {
             let diagramFromLocalStorage = localStorage.getItem("diagrams");
             diagramFromLocalStorage = (diagramFromLocalStorage[0] == "{") ? diagramFromLocalStorage : `{${diagramFromLocalStorage}}`;

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1260,6 +1260,14 @@
             </div>
         </div>
     </div>
+
+    <div id="confirmationPopup" class="loginBoxContainer" style="display:none">  
+        <div class="formBox">
+            <p>You have unsaved changes, do you want to save them?</p>
+            <button id="confirmYes">Yes</button>
+            <button id="confirmNo">No</button>
+        </div>
+    </div>
     <!-- content END -->
     <?php
         include '../Shared/loginbox.php';

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1261,23 +1261,23 @@
         </div>
     </div>
 
+    <!-- Conformation Popup, use loadConfirmPopup function -->
     <div id="confirmationPopup" class="loginBoxContainer" style="display:none">  
         <div class="formBox">
            <div class="formBoxHeader">
-                <h3>
-                    You have unsaved changes!
-                </h3>
+                <h3 id="confirmPopupHeader">  </h3>
                 <div id="closeWindow" class="cursorPointer">
                     x
                 </div>
             </div>
-            <p> Do you want to save before leaving? </p>
+            <p id="confrimPopupText">  </p>
             <div class="buttonGroup">
                 <button class="confirmButton" id="confirmYes">Yes</button>
                 <button class="confirmButton"  id="confirmNo">No</button>
             </div>
         </div>
     </div>
+
     <!-- content END -->
     <?php
         include '../Shared/loginbox.php';

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1263,9 +1263,19 @@
 
     <div id="confirmationPopup" class="loginBoxContainer" style="display:none">  
         <div class="formBox">
-            <p>You have unsaved changes, do you want to save them?</p>
-            <button id="confirmYes">Yes</button>
-            <button id="confirmNo">No</button>
+           <div class="formBoxHeader">
+                <h3>
+                    You have unsaved changes!
+                </h3>
+                <div id="closeWindow" class="cursorPointer">
+                    x
+                </div>
+            </div>
+            <p> Do you want to save before leaving? </p>
+            <div class="buttonGroup">
+                <button class="confirmButton" id="confirmYes">Yes</button>
+                <button class="confirmButton"  id="confirmNo">No</button>
+            </div>
         </div>
     </div>
     <!-- content END -->


### PR DESCRIPTION
When a user have made changes and tries to load a new save without first saving a popup appears.
Asking if they want to save the changes they made to the current file. Yes, it loads the new files and saves the changes.
No,  loads new file but don't save changes.
![image](https://github.com/user-attachments/assets/61893268-99e9-48dc-8fda-6cda549f1bc5)
