### PR TITLE
Fixed: Implement FAB "button"

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -101,6 +101,11 @@
         <i class="material-icons toggle-chevron">keyboard_arrow_up</i>
     </div>
 
+    <!-- The FAB-btn for the diagram.php, STARTS HERE!-->
+    <div class="fixed-action-button diagram-fab">
+        <button class="fab-btn-lg btn-floating diagram-btn-fab">+</button>
+    </div>
+
     <!-- Toolbar for diagram -->
     <div id="diagram-toolbar">
         <fieldset>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7939,6 +7939,25 @@ only screen and (max-device-width: 568px) {
   transform-origin: right center 0;
 }
 
+/********************************
+        FAB diagram.php
+*********************************/
+.diagram-fab{
+  bottom: 10vh;
+  right: 15vw;
+  display: none;
+}
+.diagram-btn-fab{
+  line-height: 0;
+  display: grid;
+  place-items: center;
+}
+
+@media only screen and (max-width: 414px){
+  .diagram-fab{
+    display: block;
+  }
+}
 /*===============================*/
 
 /* FAB action buttons background */


### PR DESCRIPTION
I have implemented the FAB-btn. The FAB-btn as of now is correctly positioned based on the mockup https://github.com/HGustavs/LenaSYS/issues/16813#issuecomment-2847517767, and the FAB-btn is only being displayed on mobile versions and not desktop or tablet versions. More specifically when the screens width is 414px or less than that, see figure 1.  I have also tried to reuse as much as possible from the other fab-btns available on section editor. 

Fixed the issue: #17162

figure 1 
![image](https://github.com/user-attachments/assets/bcbea0ea-609f-4393-971b-66b46e568239)
