### PR TITLE
Loading file and saving

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2073,6 +2073,7 @@ function loadDiagramFromLocalStorage(key) {
         if (obj[key] === undefined) {
             console.error("Undefined key")
         } else {
+            activeFile = key;
             loadDiagramFromString(obj[key]);
         }
     } else {


### PR DESCRIPTION
When the user loads another file and proceeds to make changes and save that save now targets the correct loaded file instead of the previous one. 

https://github.com/user-attachments/assets/9bcadeb0-db2c-460c-a706-93e3986fc484

