### PR TITLE
Fix return options on curlService Get function - Issue #17114

### DIFF
--- a/DuggaSys/microservices/curlService.php
+++ b/DuggaSys/microservices/curlService.php
@@ -41,7 +41,7 @@ function callMicroserviceGET($microservicePath){
     $url = $baseURL . $path;
   
     $ch = curl_init($url);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, false);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     $response = curl_exec($ch);
     curl_close($ch);
 


### PR DESCRIPTION
Put the return option to true instead of false on the GET function.

Fixes issue #17114
