### PR TITLE
G3-2025-V5-#17181-error-when-trying-to-delete-a-non-section-header-moment-element

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -897,7 +897,7 @@ function markedItems(item = null, typeInput) {
           var parent = recieveCodeParent(active_lid);
 
           for (var i = 0; i < tempSelectedItemListLength; i++) {
-            if (selectedItemList[i] == parent){
+            if (selectedItemList[i] == parent && parent != null){
               document.getElementById(parent + "-checkbox").checked = false;
               selectedItemList.splice(i, 1);
             }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -892,14 +892,16 @@ function markedItems(item = null, typeInput) {
         selectedItemList.splice(i, 1);
         var removed = true;
 
-        // deselection of child -> deselect parent
+        // deselection of child -> deselect parent (if parent exists)
         if (tempKind != "section" && tempKind != "moment" && tempKind != "header"){ 
           var parent = recieveCodeParent(active_lid);
 
-          for (var i = 0; i < tempSelectedItemListLength; i++) {
-            if (selectedItemList[i] == parent && parent != null){
-              document.getElementById(parent + "-checkbox").checked = false;
-              selectedItemList.splice(i, 1);
+          if(parent != null){
+            for (var i = 0; i < tempSelectedItemListLength; i++) {
+              if (selectedItemList[i] == parent){
+                document.getElementById(parent + "-checkbox").checked = false;
+                selectedItemList.splice(i, 1);
+              }
             }
           }
         }


### PR DESCRIPTION
### Removed unnecessary searches (and unchecks) of null
- Since the issue stemmed from an uncheck upon an null, made sure that if the unchecked element doesn't have a "parent" (such as a connected section/header/moment), the journey to uncheck the parent shouldn't be conducted.
---
**One approach to testing this, and how to get to the functionality:**
Select course of your choice (which has duggor, ex. Testing Course) 
-> Log in 
-> Via fab button, create a new element, ex. a code dugga. _Note that link elements seem to be broken within the weekly branch, so I would advice to not create one of those._
-> Make sure that the new element doesn't have any section/moment above them. (I believe that the default location is at the top, and if so, nothing has to be moved.) It is also applicable on the type header, but only if the header is configured to a dugga within the dugga-list, not the page-title. 
-> Check & uncheck, test it out! The error message should be avoided with this fix applied. 
Original error can be found within: https://github.com/HGustavs/LenaSYS/issues/17181#issuecomment-2851363141

(image of selection box & placement)
![bild](https://github.com/user-attachments/assets/aa86cea9-0a47-452c-aa18-aa611a3a6964)


