### PR TITLE
Fixed: G1 2025 v5 #17156 the rulers position is out of place when reloading the page on mobile version

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -326,24 +326,28 @@
     }
 
     #rulerOverlay{
+        left: 0;
         position: fixed !important;
     }
 
-    #diagram-toolbar{
-        position: fixed !important;
+    #ruler-y-svg {
+        left: 0;
+    }
+
+    #diagram-toolbar {
+        position: fixed;
         bottom: 0;
         left: 0;
         width: 100%;
-        height: var(--diagram-toolbar-height) !important;
         display: flex;
         align-items: center;
         justify-content: space-between;
         flex-wrap: nowrap;
         overflow-y: hidden;
         overflow-x: auto;
-        column-gap: .8rem;
+        column-gap: 0.8rem;
         transform: translateY(var(--diagram-toolbar-height));
-        transition: var(--normal-transition);
+        transition: transform 0.3s ease-in-out;
     }
 
     #diagram-toolbar.toolbar-active{
@@ -359,7 +363,7 @@
     }
 
     #zoom-container{
-        left: 5% !important;
+        visibility: hidden !important;
     }
 }
 
@@ -448,7 +452,6 @@
 
 #diagram-toolbar {
     position: absolute;
-    height: 100%;
     border-right: solid black 1px;
     background-color: var(--color-primary);
     z-index: 1000;


### PR DESCRIPTION
The issue should be solved.

Had to change a few things:
- Removed the zoom container when media=414px because I thought it just took up space, and I assume the user uses the fingers to zoom in and out on the phone. But if someone else thinks it should be there, it's an easy fix to put it back.
- Since the toolbar was removed from the left side, I had to change the ruler overlay to "left: 0" to remove the gap between the grid and the ruler on the left.


https://github.com/user-attachments/assets/68f8d9c5-e0e1-46d9-be4f-8ada7bc26cd9
