### PR TITLE
Add foreign key from microservice table to dependencies table in endpoint database #17212

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/dependenciesList.php
+++ b/DuggaSys/microservices/endpointDirectory/dependenciesList.php
@@ -8,13 +8,15 @@ $dependencies = $query->fetchAll(PDO::FETCH_ASSOC);
 
 echo "<h2>Dependencies in database</h2>";
 echo "<table border='1''>";
-echo "<tr><th>ID</th><th>Microservice</th><th>Depends on</th><th>Path</th></tr>";
+echo "<tr><th>ID</th><th>Microservice</th><th>MS ID</th><th>Depends on</th><th>Depends on ID</th><th>Path</th></tr>";
 
 foreach ($dependencies as $dependency) {
     echo "<tr>";
     echo "<td>" . $dependency['dependency_id'] . "</td>";
     echo "<td>" . $dependency['ms_name'] . "</td>";
+    echo "<td>" . $dependency['microservice_id'] . "</td>";
     echo "<td>" . $dependency['depends_on'] . "</td>";
+    echo "<td>" . $dependency['depends_on_id'] . "</td>";
     echo "<td>" . $dependency['path'] . "</td>";
     echo "</tr>";
 }

--- a/DuggaSys/microservices/endpointDirectory/fillDependenciesDb.php
+++ b/DuggaSys/microservices/endpointDirectory/fillDependenciesDb.php
@@ -55,13 +55,24 @@ foreach ($lines as $line) {
             $dependsOnName = $fileName;
         }
 
-        // insert into database 
-        // TODO: Fix so it insert with ID instead
+        // get id for current microservice
+        $stmt = $db->prepare("SELECT id FROM microservices WHERE ms_name = ?");
+        $stmt->execute([$currentMicroservice]);
+        $microserviceId = $stmt->fetchColumn();
+
+        // get id for the microservice that is depended on
+        $stmt = $db->prepare("SELECT id FROM microservices WHERE ms_name = ?");
+        $stmt->execute([$dependsOnName]);
+        $dependsOnId = $stmt->fetchColumn();
+
+        // insert wether id is found or not
         $stmt = $db->prepare("
-            INSERT INTO dependencies (ms_name, depends_on, path)
-            VALUES (?, ?, ?)
+            INSERT INTO dependencies (microservice_id, depends_on_id, ms_name, depends_on, path)
+            VALUES (?, ?, ?, ?, ?)
         ");
         $stmt->execute([
+            $microserviceId ?: null, // null if none was found
+            $dependsOnId ?: null,
             $currentMicroservice,
             $dependsOnName,
             $dependsOnPath

--- a/DuggaSys/microservices/endpointDirectory/fillDependenciesDb.php
+++ b/DuggaSys/microservices/endpointDirectory/fillDependenciesDb.php
@@ -55,14 +55,18 @@ foreach ($lines as $line) {
             $dependsOnName = $fileName;
         }
 
+        // normalize the names to always have the correct format
+        $searchNameCurrent = normalizeMsName($currentMicroservice);
+        $searchNameDepends = normalizeMsName($dependsOnName);
+
         // get id for current microservice
         $stmt = $db->prepare("SELECT id FROM microservices WHERE ms_name = ?");
-        $stmt->execute([$currentMicroservice]);
+        $stmt->execute([$searchNameCurrent]);
         $microserviceId = $stmt->fetchColumn();
 
         // get id for the microservice that is depended on
         $stmt = $db->prepare("SELECT id FROM microservices WHERE ms_name = ?");
-        $stmt->execute([$dependsOnName]);
+        $stmt->execute([$searchNameDepends]);
         $dependsOnId = $stmt->fetchColumn();
 
         // insert wether id is found or not
@@ -80,6 +84,15 @@ foreach ($lines as $line) {
 
     }
 
+}
+
+function normalizeMsName($name) {
+    // if name already ends with '_ms.php' return
+    if (str_ends_with($name, '_ms.php')) {
+        return $name;
+    }
+    // otherwise, add '_ms.php'
+    return $name . '_ms.php';
 }
 
 echo "Dependencies inserted.<br>";

--- a/DuggaSys/microservices/endpointDirectory/installEndpointDb.php
+++ b/DuggaSys/microservices/endpointDirectory/installEndpointDb.php
@@ -37,11 +37,13 @@ $db->exec("CREATE TABLE IF NOT EXISTS outputs (
 // this table will document inverse dependecies that microservies has
 $db->exec("CREATE TABLE IF NOT EXISTS dependencies (
     dependency_id INTEGER PRIMARY KEY AUTOINCREMENT, 
-    -- microservice_id INTEGER NOT NULL,
+    microservice_id INTEGER,
+    depends_on_id INTEGER,
     ms_name TEXT NOT NULL,
     depends_on TEXT NOT NULL,
-    path TEXT NOT NULL
-    -- FOREIGN KEY (microservice_id) REFERENCES microservices(id)
+    path TEXT NOT NULL,
+    FOREIGN KEY (microservice_id) REFERENCES microservices(id),
+    FOREIGN KEY (depends_on_id) REFERENCES microservices(id)
 );");
 
 echo "Database has been created<br>";


### PR DESCRIPTION
Added foreign key fields in the dependencies table. These can however be null and are intended to make queries easier. 

There are some inconsistencies in how the documentation is created and stored in the database. Some documentation has '_ms' in the name, some has '_ms.php' and some doesn't have any of them. In order to solve this, and still match microservice names to get the id and be able to insert the id in the dependencies table, I created a function. This function check the database for all the variants of the name and returns it when it finds it (or null if it didn't, since this usually means that there isn't any documentation yet). 

The microservice documentation isn't complete at the moment, so the test-data is limited. You can see the results below, but when more documentation has been created, more id's will appear. 
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/5f449c26-f937-4adc-b220-76d5bee05c84" />

To test this, first run 'setupEndpointDirectory.php'. You can then see the data in 'dependenciesList.php', and check if there is data under microservice id and depends on id. 
It would be great to also compare these id's to those that are visible in the 'microserviceUI.php' as well, to ensure that the microservices that has documentation gets registered in the dependenciesList.php. (I did this during testing, but it would be good to get a second opinion).  
