### PR TITLE
Single elements now turn purple upon selection

### DIFF
--- a/DuggaSys/diagram/classes/rect.js
+++ b/DuggaSys/diagram/classes/rect.js
@@ -123,21 +123,6 @@ class Rect {
     }
 
     /**
-     * @description Checks if the innermost 50% of provided rect is within this rect. Used as a less strict check during box selection.
-     * @param {Rect} other
-     * @returns {boolean}
-     */
-    partialOverlap(other) {
-        const lower = 0.25;
-        const upper = 0.75;
-        let x1 = this.left < other.left + other.width * lower;
-        let x2 = this.right > other.left + other.width * upper;
-        let y1 = this.top < other.top + other.height * lower;
-        let y2 = this.bottom > other.top + other.height * upper;
-        return x1 && x2 && y1 && y2;
-    }
-
-    /**
      * @description Checks if the provided rect overlaps with this rect at any point.
      * @param {Rect} other
      * @returns {boolean}

--- a/DuggaSys/diagram/helpers/boxSelect.js
+++ b/DuggaSys/diagram/helpers/boxSelect.js
@@ -22,7 +22,7 @@ function getElementsInsideCoordinateBox(selectionRect) {
     const elements = [];
     data.forEach(element => {
         // Box collision test
-        if (selectionRect.partialOverlap(Rect.FromElement(element))) {
+        if (selectionRect.overlap(Rect.FromElement(element))) {
             elements.push(element);
         }
     });

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -84,7 +84,7 @@ function updateCSSForAllElements() {
                     for (let index = 0; index < 3; index++) {
                         fillColor = elementDiv.children[index].children[0].children[0];
                         fontColor = elementDiv.children[index].children[0];
-                        if (markedOverOne()) {
+                        if (contextLengthCheck()) {
                             fillColor.style.fill = color.LIGHT_PURPLE;
                             fontColor.style.fill = color.WHITE;
                         } else {
@@ -98,7 +98,7 @@ function updateCSSForAllElements() {
                     for (let index = 0; index < 2; index++) {
                         fillColor = elementDiv.children[index].children[0].children[0];
                         fontColor = elementDiv.children[index].children[0];
-                        if (markedOverOne()) {
+                        if (contextLengthCheck()) {
                             fillColor.style.fill = color.LIGHT_PURPLE;
                             fontColor.style.fill = color.WHITE;
                         } else {
@@ -112,7 +112,7 @@ function updateCSSForAllElements() {
                     for (let index = 0; index < 2; index++) {
                         fillColor = elementDiv.children[index].children[0].children[0];
                         fontColor = elementDiv.children[index].children[0];
-                        if (markedOverOne()) {
+                        if (contextLengthCheck()) {
                             fillColor.style.fill = color.LIGHT_PURPLE;
                             fontColor.style.fill = color.WHITE;
                         } else {
@@ -127,7 +127,7 @@ function updateCSSForAllElements() {
                         fillColor = elementDiv.children[0].children[index];
                         fontColor = elementDiv.children[0];
 
-                        if (markedOverOne()) {
+                        if (contextLengthCheck()) {
                             fillColor.style.fill = color.LIGHT_PURPLE;
                             fontColor.style.fill = color.WHITE;
                         } else {
@@ -140,7 +140,7 @@ function updateCSSForAllElements() {
                     fillColor = elementDiv.children[0].children[0];
                     fontColor = elementDiv.children[0];
                     weakKeyUnderline = elementDiv.children[0].children[2];
-                    if (markedOverOne()) {
+                    if (contextLengthCheck()) {
                         fillColor.style.fill = color.LIGHT_PURPLE;
                         fontColor.style.fill = color.WHITE;
                         // If its a weakKey attribute, update underline color
@@ -205,7 +205,7 @@ function updateCSSForAllElements() {
                     fillColor = elementDiv.children[0].children[0];
                     fontColor = elementDiv.children[0];
                     weakKeyUnderline = elementDiv.children[0].children[2];
-                    if (markedOverOne()) {
+                    if (contextLengthCheck()) {
                         fillColor.style.fill = `${element.fill}`;
                         fontContrast();
                         if (element.state == "weakKey") {
@@ -249,9 +249,9 @@ function updateCSSForAllElements() {
      * @description Checks if multiple elements or lines are selected/highlighted
      * Used to determine whether to apply multi-select highlight visuals
      */
-    function markedOverOne() {
+    function contextLengthCheck() {
         
-        return inContext && context.length > 1 || inContext && context.length > 0 && contextLine.length > 0;
+        return inContext && context.length > 0 || inContext && context.length > 0 && contextLine.length > 0;
     }
 
 


### PR DESCRIPTION
Single elements did not turn purple upon selection with either the pointer or the box selection. This patch has fixes this issue and all elements turn purple when selected now. The picture below demostrates this: a single ER entity is selected and is clearly purple.

![image](https://github.com/user-attachments/assets/d398b7e3-bd21-4c0e-b440-898ade972085)

Fixes: #17213 