### PR TITLE
Fixed issue #15647-snap-to-lifeline-or-object-after-placement

### DIFF
--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -206,10 +206,16 @@ function snapElementToLifeline(element, targetId) {
     const lifeline = document.getElementById(targetId);
     if (!lifeline) return; // Exit if the DOM element doesn't exist
 
-    const ll = data.find(item =>
-        (item.kind === "sequenceActor" || item.kind === "sequenceObject") && 
-        item.id === target
-    );
+    // Search for the lifeline data in the main data array
+    for (let i = 0; i < data.length; i++) {
+        const ll = data[i];
+        if ((ll.kind === "sequenceActor" || ll.kind === "sequenceObject") && ll.id === targetId) {
+            // Snap the element horizontally to the center of the lifeline
+            element.x = ll.x + (ll.width / 2) - (element.width / 2);
+            updatepos(); // Refresh position on screen
+            break;
+        }
+    }
 
     if (!ll) return;
 
@@ -314,7 +320,7 @@ function findNearestLifeline(x, y) {
             const dx = Math.abs(centerX - x);
 
             // Only snaps to the lifeline if within the lifeline's range
-            if (dx < 50 && dx < minDistance && y >= topY && y >= botY) { 
+            if (dx < 50 && dx < minDistance) { 
                 minDistance = dx;
                 closestId = el.id;
             }


### PR DESCRIPTION
Fixed this issue **again**. Had to put back some disappearing code in some functions in helpers/mouse.js.

https://github.com/user-attachments/assets/a15def50-c895-4d13-9afa-6ec12e593c15

