### PR TITLE
Add dependencies to microservices in microserviceUI.php #17269

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -187,7 +187,23 @@ if (isset($_GET['id'])) {
         <?php } else { ?>
             <p>No outputs</p>
         <?php } ?>
-
+        <?php 
+            echo "<h3>Dependencies</h3>";
+        if (!empty($dependencies)) {
+            echo "<table>";
+            echo $microservice['ms_name'] . " depends on";
+            echo "<tr><th>Microservice</th><th>Path</th></tr>";
+            foreach ($dependencies as $dependency) {
+                echo '<tr>';
+                echo '<td>' . $dependency['depends_on'] . '</td>';
+                echo '<td>' . $dependency['path'] . '</td>';
+                echo '</tr>';
+            }
+        } else {
+            echo "<p>No dependencies</p>";
+        }
+        ?>
+        </table>
         <div style="display: flex; gap: 5px;">
             <form method="get">
                 <input type="hidden" name="id" value="<?php echo $microservice['id']; ?>">

--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -72,6 +72,12 @@ if (isset($_GET['id'])) {
         $stmt->execute([$_GET['id']]);
         $outputs = $stmt->fetchAll();
     }
+
+    if ($microservice) {
+        $stmt = $db->prepare("SELECT * FROM dependencies WHERE microservice_id = ?");
+        $stmt->execute([$_GET['id']]);
+        $dependencies = $stmt->fetchAll();
+    }
 }
 
 } catch (PDOException $e) {

--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -188,14 +188,14 @@ if (isset($_GET['id'])) {
             <p>No outputs</p>
         <?php } ?>
         <?php 
-            echo "<h3>Dependencies</h3>";
+        echo "<h3>Dependencies</h3>";
         if (!empty($dependencies)) {
             echo "<table>";
             echo $microservice['ms_name'] . " depends on";
             echo "<tr><th>Microservice</th><th>Path</th></tr>";
             foreach ($dependencies as $dependency) {
                 echo '<tr>';
-                echo '<td>' . $dependency['depends_on'] . '</td>';
+                echo '<td>' . "<a href=?id=" . $dependency['depends_on_id'] . ">" . $dependency['depends_on'] . '</td>';
                 echo '<td>' . $dependency['path'] . '</td>';
                 echo '</tr>';
             }

--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -191,7 +191,7 @@ if (isset($_GET['id'])) {
         echo "<h3>Dependencies</h3>";
         if (!empty($dependencies)) {
             echo "<table>";
-            echo $microservice['ms_name'] . " depends on";
+            echo "List of microservices that depends on '<b>" . $microservice['ms_name'] . "</b>'";
             echo "<tr><th>Microservice</th><th>Path</th></tr>";
             foreach ($dependencies as $dependency) {
                 echo '<tr>';


### PR DESCRIPTION
Added a table that outputs the microservices that the chosen microservice is depending on. I also made the name of the microservice clickable, if clicked the user will be taken to that microservice instead. Fixes #17269 

There was some styling for the a-tags, so there are currently buttons in the table. If that is undesirable we could create a issue that changes the styling (create a class that holds the styling instead of a-tags). Otherwise, leave as is. 

To test this, make sure to have the database installed and fille, then select a microservice that has documented dependencies in microserviceUI.php. 
 
<img width="945" alt="image" src="https://github.com/user-attachments/assets/f8bb4061-1a0a-4389-b649-2441303a019e" />

If there are no dependencies this will be outputted instead. 
<img width="945" alt="image" src="https://github.com/user-attachments/assets/f8e2a8e8-e663-4d24-a738-48470b0acc84" />
