### PR TITLE
Moving item creation for new item button #17260

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7727,7 +7727,7 @@ only screen and (max-device-width: 568px) {
 }
 
 .fixed-action-button2.sectioned2 {
-  right: 125px;
+  right: 50px;
 }
 
 .fixed-action-button3 {


### PR DESCRIPTION
All I have done is move the item create menu 75px to the right.

It looks like this now
![image](https://github.com/user-attachments/assets/e57ad0ca-1d89-48b9-a2b6-e5f951dfaf94)
