### PR TITLE
Updated save() function

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -70,8 +70,8 @@ class StateMachine {
 
                 const lastText = this.lastTypedTextMap[elementId] || "";
 
-                // Check is a word boundary was typed (space or punctuation) and if change has happend it is logged (no change means no logging)
-                const isWordBoundary = currentText.length > lastText.length && /\s|[.,;!?]/.test(currentText.slice(-1));
+                // Check is a word boundary was typed (space or punctuation or longer than 4 symbols) and if change has happend it is logged (no change means no logging)
+                const isWordBoundary = currentText.length > lastText.length && (/\s|[.,;!?]/.test(currentText.slice(-1)) || currentText.length - lastText.length > 3);
                 const isNewText = currentText !== lastText;
 
                 if (isNewText && isWordBoundary) {
@@ -170,7 +170,7 @@ class StateMachine {
                 break;
         }
         stateMachine.numberOfChanges++;
-        updateLatestChange()
+        updateLatestChange();
     }
 
     /**


### PR DESCRIPTION
Updated the Save() function to detect a word boundary by checking for space/punctuation or if the word is longer than 4 symbols, if any of these conditions are tru the change is comitted to memory. 
Undo/redo now somewhat works for single words rather than one letter at a time (or the complete change at a time), if a single word is inputted the undo/redo will handle 4 symbols at a time, which arguably might not be the ideal scenario, but allows the user more control for the undo/redo-functionality. 

__*NOTE:*__ This issue **only** handles the entity name, the attributes/functions are still to be fixed (separate sub-issues).


https://github.com/user-attachments/assets/76f65c66-f9cd-4751-815b-bf18f3a1f5ac