### PR TITLE
Tooltip fix issue #17237

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -550,7 +550,13 @@
     top: -43px;
 }
 
-.diagramIcons[data-single="true"]:hover .toolTipText {
+
+.diagramIcons:hover .toolTipText {
+    visibility: visible;
+    transition-delay: 700ms;
+}
+
+.disabledIcon:hover .toolTipText {
     visibility: visible;
     transition-delay: 700ms;
 }
@@ -1069,6 +1075,9 @@
     background-color: #8d68ab;
 }
 
+    .disabledIcon:hover .toolTipText {
+        visibility: visible;
+    }
 #a4options {
     display: flex;
 }


### PR DESCRIPTION
There was missing functionality specifically for "disabledicons" when hovering hence why the tooltips was not being shown, so this was implemented and the tooltips started showing for "save" and "save as", as well. After this was solved some slight tweaks was made with the transition delays when hovering so all the buttons behave the same and consistent.