### PR TITLE
[#17198] Fixed error check key triggering outside of intended usage

### DIFF
--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -523,17 +523,13 @@ function toggleErrorCheck() {
 }
 
 /**
- * @description hides the error check button when not allowed
+ * @description Function that toggles the visibility of the error check button in the diagram toolbar depending on input.
+ * @param {boolean} show Boolean which defines visibility. "true" enables it, and "false" disables it.
  */
-function hideErrorCheck(show) {
+//Previously named "hideErrorCheck", functionality is the same - but showing the check while "hideErrorCheck(true)" was a bit confusing and misleading.
+function showErrorCheck(show) {
     if (show) {
         document.getElementById("errorCheckField").style.display = "flex";
-        // Enables error check by pressing 'h', only when error check button is visible
-        document.addEventListener("keyup", event => {
-            if (event.key === 'h') {
-                toggleErrorCheck();
-            }
-        });
     } else {
         document.getElementById("errorCheckField").style.display = "none";
     }

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -92,7 +92,7 @@ function returnedDugga(data)
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type;
             // getting the error checker allowed or not
-            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
+            document.getElementById("diagram-iframe").contentWindow.showErrorCheck(param.errorActive);
             // Getting the instructions to the side of the dugga -currently using filelink which is wrong
              if(param.filelink != undefined)
             {
@@ -106,7 +106,7 @@ function returnedDugga(data)
         else{
             var diagramType={ER:true,UML:true,IE:true};
             document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
-            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(true);
+            document.getElementById("diagram-iframe").contentWindow.showErrorCheck(true);
         }
         document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();//<-- UML functionality end
     }


### PR DESCRIPTION
**For reviewer:** To test this fix you need to be in _showDugga.php_ (Start from "_./LenaSYS/DuggaSys/courseed.php_", click on "_Demo-Course_", scroll down to "_Tillgängliga Duggor_" and click on "_Diagram Dugga_").

(**TLDR:** The fix was to remove an extra keylistener for the keybind in a separate function that was independent of diagram.js. The error check keybind should no longer trigger outside of intended situations.)

The reported issue here was that the error check keybind (h) triggered when writing in input fields, which wasn't supposed to happen. Upon further investigation it was discovered that the error check keybind triggered twice when not having selected an object. This only happened if you weren't logged into lenaSYS. If you were logged in as "brom" (an admin user) the bug didn't happen.

The problem ended up not being in _diagram.js_ at all, but rather in a small function in _toggle.js_ that was called on from a function in _diagram_dugga.js_ that in turn was called on from a function in _dugga.js_.

The function _returnedDugga(data)_ in toggle.js has a part that checks if the user is a teacher. If the user isn't a teacher, an else-case is applied. In this, the code calls upon a function called _showErrorCheck_ (previously hideErrorCheck).

```
function returnedDugga(data)
{
        duggaData = data;
...
    if (data.param.length!=0){
        var param = JSON.parse(data.param);
...
        //checking if the user is a teacher or if there's no variant by checking if the paramater object is empty
        if(!(Object.keys(param).length === 0) && data.isTeacher == 0){
...
            // getting the error checker allowed or not
            document.getElementById("diagram-iframe").contentWindow.showErrorCheck(param.errorActive);
...
        }
        else{
            var diagramType={ER:true,UML:true,IE:true};
            document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
            document.getElementById("diagram-iframe").contentWindow.showErrorCheck(true);
        }
        document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();//<-- UML functionality end
    }
...
}
```

This "showErrorCheck" function was the culprit in all of this, having an extra keylistener in it, that was active if the parameter boolean was **true**. This parameter is always true in the else-case, and apparently false if the user is a teacher. This is what caused the bug to happen, with the program having two keylisteners for the error check keybind. The one in _diagram.js_ was working properly, but the one in _toggle.js_ operated outside of the restrictions put in the former file, causing it to trigger when it shouldn't have.

Function before changes (named hideErrorCheck here):

```
function hideErrorCheck(show) {
    if (show) {
        document.getElementById("errorCheckField").style.display = "flex";
        // Enables error check by pressing 'h', only when error check button is visible
        document.addEventListener("keyup", event => {
            if (event.key === 'h') {
                toggleErrorCheck();
            }
        });
    } else {
        document.getElementById("errorCheckField").style.display = "none";
    }
}
```

I ended up removing the extra keylistener since it didn't seem to affect anything else outside of this. I also decided to rename the function hideErrorCheck and it's references to showErrorCheck since the previous name was a bit misleading with how it worked and how it was documented. On top of that I updated the documentation for the function to give it a bit more clarity.