### PR TITLE
Burger menu added in dugga for mobile

### DIFF
--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -49,6 +49,7 @@ if(isset($_SESSION['uid'])){
 <body>
 
 	<?php
+	$courseed = true;
 	include '../Shared/navheader.php';
 	?>
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -113,6 +113,7 @@
 
 	<?php
 		$noup="SECTION";
+		$showDugga = true;
 		include '../Shared/navheader.php';
 	?>
 

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -20,6 +20,7 @@
 		<!-- To enable dark mode, these 2 files were added. -->
 	<link id="themeBlack" type="text/css" href="../Shared/css/blackTheme.css" rel="stylesheet">
 	<script src="darkmodeToggle.js"></script>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
 	<script src="../Shared/js/jquery-1.11.0.min.js"></script>
 	<script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
@@ -113,7 +114,6 @@
 
 	<?php
 		$noup="SECTION";
-		$showDugga = true;
 		include '../Shared/navheader.php';
 	?>
 

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -46,6 +46,38 @@ if(localStorage.getItem(localStorageItemKey)){
 	variantValue = JSON.parse(localStorage.getItem(localStorageItemKey)).variant.vid;
 }
 
+/*navburger*/
+function navBurgerChange(operation = 'click') {
+  var x = document.getElementById("navBurgerBox");
+
+  if (x.style.display === "block") {
+    x.style.display = "none";
+  } else {
+    x.style.display = "block";
+  }
+}
+
+//function to change darkmode from burger menu
+function burgerToggleDarkmode(operation = 'click') {
+  const storedTheme = localStorage.getItem('themeBlack');
+  if (storedTheme) {
+    themeStylesheet.href = storedTheme;
+  }
+  const themeToggle = document.getElementById('theme-toggle');
+  // if it's light -> go dark
+  if (themeStylesheet.href.includes('blackTheme')) {
+    themeStylesheet.href = "../Shared/css/style.css";
+    localStorage.setItem('themeBlack', themeStylesheet.href)
+    backgroundColorTheme = "#121212";
+  }
+  else if (!themeStylesheet.href.includes('blackTheme')) {
+    // if it's dark -> go light
+    themeStylesheet.href = "../Shared/css/blackTheme.css";
+    localStorage.setItem('themeBlack', themeStylesheet.href)
+    backgroundColorTheme = "#fff";
+  }
+}
+
 document.getElementById(function (){ // Used to set the position of the FAB above the cookie message
 	if(localStorage.getItem("cookieMessage")!="off")
 		document.getElementById(".fixed-action-button").style.bottom="64px";

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -82,7 +82,7 @@
 			//Burger menu that Contains the home, back and darkmode icons when window is small; Only shown if not superuser.
 			//Always on courseed.php ($noup is none). Contains only home and darkmode icons.
 			if(checklogin() == false|| $_SESSION['uid'] == 0 || (isStudentUser($_SESSION['uid'])) || $noup=='NONE'){
-				
+
 				echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></td>";
 				echo "<td class='navBurgerIcon' style='display: none;'> </td>";
 				echo "<div id='navBurgerBox' style='display: none;'>";
@@ -389,7 +389,55 @@
 							echo"</div>";
 							echo"</div>";
 					}
-			}			
+			}		
+
+				if (isset($showDugga)) {
+				  echo "<td class='navBurgerIcon fa fa-bars' id='hamburgerIcon' onclick='navBurgerChange()'><img src='../Shared/icons/hamburger_menu_google_fonts.svg' alt='Menu'></td>";
+				  echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+				}
+
+				// Place this HTML outside your <table>
+				echo '<div id="navBurgerBox" class="navBurgerBox" style="display: none;">';
+
+				echo '<div id="homeBurgerDiv">
+						<a id="homeBurger" href="../DuggaSys/courseed.php">
+						  <img alt="home" class="navBurgerButt" src="../Shared/icons/Home.svg">
+						</a>
+					  </div>';
+
+				echo '<div id="darkModeBurgerDiv">
+						<a id="darkModeBurger" onclick="burgerToggleDarkmode()">
+						  <img alt="Dark" class="navBurgerButt" title="Toggle between dark mode" src="../Shared/icons/ThemeToggle.svg">
+						</a>
+					  </div>';
+
+				if ($noup === 'COURSE') {
+				  // Go back button for COURSE
+				  echo "<div id='goBackBurgerDiv'>";
+				  echo "<a href='../DuggaSys/courseed.php'>";
+				  echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+				  echo "<span>Return</span>"; // Text for the go-back button
+				  echo "</a>";
+				  echo "</div>";
+				} 
+				else if ($noup === 'SECTION') {
+				  // Go back button for SECTION
+				  $backHref = ($_SESSION['courseid'] !== "UNK") 
+					? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
+					: "../DuggaSys/courseed.php";
+
+				  echo "<div id='goBackBurgerDiv'>";
+				  echo "<a href='$backHref'>";
+				  echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+				  //echo "<span>Return</span>"; // Text for the go-back button
+				  echo "</a>";
+				  echo "</div>";
+				}
+
+				echo '</div>'; // Close #navBurgerBox
+				
+
+
 			// Sort dialog - accessed / resulted /fileed					
 			
 			//old search bar for resulted

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -82,49 +82,80 @@
 			//Burger menu that Contains the home, back and darkmode icons when window is small; Only shown if not superuser.
 			//Always on courseed.php ($noup is none). Contains only home and darkmode icons.
 			if(checklogin() == false|| $_SESSION['uid'] == 0 || (isStudentUser($_SESSION['uid'])) || $noup=='NONE'){
+				if (isset($courseed)) {
+					echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></td>";
+					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+					echo "<div id='navBurgerBox' style='display: none;'>";
+					echo "	<div id='motdDiv' class='navButt' onclick='showServerMessage();' >";
+					echo "		<a id='motdBurger'>";
+					echo "			<img alt='motd' class='navBurgerButt' src='../Shared/icons/MOTD.svg'>";
+					echo "		</a>";
+					echo "	</div>";
 
-				echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></td>";
-				echo "<td class='navBurgerIcon' style='display: none;'> </td>";
-				echo "<div id='navBurgerBox' style='display: none;'>";
-			
-				echo "	<div id='motdDiv' class='navButt' onclick='showServerMessage();' >";
-				echo "		<a id='motdBurger'>";
-				echo "			<img alt='motd' class='navBurgerButt' src='../Shared/icons/MOTD.svg'>";
-				echo "		</a>";
-				echo "	</div>";
-
-				echo "	<div id='homeBurgerDiv'>";
-				echo "		<a id='homeBurger' href='../DuggaSys/courseed.php'>";
-				echo "			<img alt ='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>";
-				echo "		</a>";
-				echo "	</div>";
+					echo "	<div id='homeBurgerDiv'>";
+					echo "		<a id='homeBurger' href='../DuggaSys/courseed.php'>";
+					echo "			<img alt ='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>";
+					echo "		</a>";
+					echo "	</div>";
 				
-				echo "	<div id='goBackBurgerDiv'>";
-							// Code to not show the "go-back" button in courseed.php.
-							if($noup=='NONE'){
-								echo "<a id='goBackBurger'style='display: none;'>";
-							}
-							if($noup=='COURSE'){
-								echo "<a id='goBackBurger' href='../DuggaSys/courseed.php'>";
-							}
-							else if($noup=='SECTION'){
-								echo "<a id='goBackBurger' href='";
-								echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
-								echo "'>";
-							}
-				echo "				<img alt ='home' class='navBurgerButt' src='../Shared/icons/Up.svg'>";
-				echo "			</a>";
-				echo"		</div>";
+					echo "<div id='goBackBurgerDiv'>";
+					// Code to not show the "go-back" button in courseed.php.
+					if($noup=='NONE'){
+						echo "<a id='goBackBurger'style='display: none;'>";
+					}
+					if($noup=='COURSE'){
+						echo "<a id='goBackBurger' href='../DuggaSys/courseed.php'>";
+					}
+					else if($noup=='SECTION'){
+						echo "<a id='goBackBurger' href='";
+						echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
+						echo "'>";
+					}
+					echo "				<img alt ='home' class='navBurgerButt' src='../Shared/icons/Up.svg'>";
+					echo "			</a>";
+					echo "		</div>";
+					echo "	<div id='darkModeBurgerDiv'>";
+					echo "		<a id='darkModeBurger' onclick = 'burgerToggleDarkmode()'  >";
+					echo "			<img alt ='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'></>";
+					echo "		</a>";
+					echo "	</a>";
+					echo "</div>";
+					echo"</div>"; 
+				} 
+				else {
+					echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></td>";
+					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+				}
+				echo "<div id='navBurgerBox' class='navBurgerBox' style='display: none;'>";
+				echo "	<div id='homeBurgerDiv'>
+							<a id='homeBurger' href='../DuggaSys/courseed.php'>
+								<img alt='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>
+							</a>
+						 </div>";
+				echo "	<div id='darkModeBurgerDiv'>
+							<a id='darkModeBurger' onclick='burgerToggleDarkmode()'>
+								 <img alt='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'>
+							</a>
+						 </div>";
+						if ($noup == 'COURSE') {
+							echo "<div id='goBackBurgerDiv'>";
+							echo "<a href='../DuggaSys/courseed.php'>";
+							echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+							echo "</a>";
+							echo "</div>";
+						} 
+						else if ($noup == 'SECTION') {
+							$backHref = ($_SESSION['courseid'] !== "UNK") 
+							? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
+							: "../DuggaSys/courseed.php";
 
-				echo "	<div id='darkModeBurgerDiv'>";
-				echo "		<a id='darkModeBurger' onclick = 'burgerToggleDarkmode()'  >";
-				echo "			<img alt ='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'></>";
-				echo "		</a>";
-				echo "	</a>";
-				echo"	</div>";
-
-
-				echo"</div>";					
+							echo "<div id='goBackBurgerDiv'>";
+							echo "<a href='$backHref'>";
+							echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+							echo "</a>";
+							echo "</div>";
+						}
+				echo "</div>"; 
 			}
 			
 			// Always show home button which links to course homepage			
@@ -389,48 +420,49 @@
 							echo"</div>";
 							echo"</div>";
 					}
-			}		
+			}
+			/*=====BURGER DROPDOWN MENU SHOWDUGGA=====*/
+			if ($noup == 'SECTION') {
+				if(checklogin() && (isSuperUser($_SESSION['uid']) || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'st') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'w') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'sv'))){
+					echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()' ></td>";
+					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+				}
+			}
+			echo "<div id='navBurgerBox' class='navBurgerBox' style='display: none;'>";
 
-					if (isset($showDugga)) {
-					  echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'><img src='../Shared/icons/hamburger_menu_google_fonts.svg' alt='Menu'></td>";
-					  echo "<td class='navBurgerIcon' style='display: none;'> </td>";
-					}
+			echo "<div id='homeBurgerDiv'>
+					<a id='homeBurger' href='../DuggaSys/courseed.php'>
+						<img alt='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>
+					</a>
+				 </div>";
 
-					echo "<div id='navBurgerBox' class='navBurgerBox' style='display: none;'>";
+			echo "<div id='darkModeBurgerDiv'>
+					<a id='darkModeBurger' onclick='burgerToggleDarkmode()'>
+						 <img alt='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'>
+					</a>
+			      </div>";
 
-					echo "<div id='homeBurgerDiv'>
-							<a id='homeBurger' href='../DuggaSys/courseed.php'>
-							  <img alt='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>
-							</a>
-						  </div>";
+			if ($noup === 'COURSE') {
+				echo "<div id='goBackBurgerDiv'>";
+				echo "<a href='../DuggaSys/courseed.php'>";
+				echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+				echo "<span>Return</span>"; 
+				echo "</a>";
+				echo "</div>";
+			} 
+			else if ($noup === 'SECTION') {
+				$backHref = ($_SESSION['courseid'] !== "UNK") 
+					? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
+					: "../DuggaSys/courseed.php";
 
-					echo "<div id='darkModeBurgerDiv'>
-							<a id='darkModeBurger' onclick='burgerToggleDarkmode()'>
-							  <img alt='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'>
-							</a>
-						  </div>";
-
-					if ($noup === 'COURSE') {
-					  echo "<div id='goBackBurgerDiv'>";
-					  echo "<a href='../DuggaSys/courseed.php'>";
-					  echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-					  echo "<span>Return</span>"; 
-					  echo "</a>";
-					  echo "</div>";
-					} 
-					else if ($noup === 'SECTION') {
-					  $backHref = ($_SESSION['courseid'] !== "UNK") 
-						? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
-						: "../DuggaSys/courseed.php";
-
-					  echo "<div id='goBackBurgerDiv'>";
-					  echo "<a href='$backHref'>";
-					  echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-					  echo "</a>";
-					  echo "</div>";
-					}
-					echo '</div>'; 
-				
+				echo "<div id='goBackBurgerDiv'>";
+				echo "<a href='$backHref'>";
+				echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+				echo "</a>";
+				echo "</div>";
+			}
+			echo '</div>'; 
 
 
 			// Sort dialog - accessed / resulted /fileed					

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -123,6 +123,7 @@
 					echo"</div>"; 
 				} 
 				else {
+					//Display default tools/buttons of burger dropdown menu, search(ctrl + f) for "Burger dropdown menu show dugga" 
 					echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></td>";
 					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
 				}
@@ -416,8 +417,7 @@
 				if ($noup === 'COURSE') {
 					echo "<div id='goBackBurgerDiv'>";
 					echo "<a href='../DuggaSys/courseed.php'>";
-					echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-					echo "<span>Return</span>"; 
+					echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>"; 
 					echo "</a>";
 					echo "</div>";
 				} 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -126,36 +126,6 @@
 					echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></td>";
 					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
 				}
-				echo "<div id='navBurgerBox' class='navBurgerBox' style='display: none;'>";
-				echo "	<div id='homeBurgerDiv'>
-							<a id='homeBurger' href='../DuggaSys/courseed.php'>
-								<img alt='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>
-							</a>
-						 </div>";
-				echo "	<div id='darkModeBurgerDiv'>
-							<a id='darkModeBurger' onclick='burgerToggleDarkmode()'>
-								 <img alt='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'>
-							</a>
-						 </div>";
-						if ($noup == 'COURSE') {
-							echo "<div id='goBackBurgerDiv'>";
-							echo "<a href='../DuggaSys/courseed.php'>";
-							echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-							echo "</a>";
-							echo "</div>";
-						} 
-						else if ($noup == 'SECTION') {
-							$backHref = ($_SESSION['courseid'] !== "UNK") 
-							? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
-							: "../DuggaSys/courseed.php";
-
-							echo "<div id='goBackBurgerDiv'>";
-							echo "<a href='$backHref'>";
-							echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-							echo "</a>";
-							echo "</div>";
-						}
-				echo "</div>"; 
 			}
 			
 			// Always show home button which links to course homepage			
@@ -431,37 +401,37 @@
 			}
 			echo "<div id='navBurgerBox' class='navBurgerBox' style='display: none;'>";
 
-			echo "<div id='homeBurgerDiv'>
-					<a id='homeBurger' href='../DuggaSys/courseed.php'>
-						<img alt='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>
-					</a>
-				 </div>";
+				echo "<div id='homeBurgerDiv'>
+						<a id='homeBurger' href='../DuggaSys/courseed.php'>
+							<img alt='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>
+						</a>
+					 </div>";
 
-			echo "<div id='darkModeBurgerDiv'>
-					<a id='darkModeBurger' onclick='burgerToggleDarkmode()'>
-						 <img alt='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'>
-					</a>
-			      </div>";
+				echo "<div id='darkModeBurgerDiv'>
+						<a id='darkModeBurger' onclick='burgerToggleDarkmode()'>
+							 <img alt='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'>
+						</a>
+					  </div>";
 
-			if ($noup === 'COURSE') {
-				echo "<div id='goBackBurgerDiv'>";
-				echo "<a href='../DuggaSys/courseed.php'>";
-				echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-				echo "<span>Return</span>"; 
-				echo "</a>";
-				echo "</div>";
-			} 
-			else if ($noup === 'SECTION') {
-				$backHref = ($_SESSION['courseid'] !== "UNK") 
-					? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
-					: "../DuggaSys/courseed.php";
+				if ($noup === 'COURSE') {
+					echo "<div id='goBackBurgerDiv'>";
+					echo "<a href='../DuggaSys/courseed.php'>";
+					echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+					echo "<span>Return</span>"; 
+					echo "</a>";
+					echo "</div>";
+				} 
+				else if ($noup === 'SECTION') {
+					$backHref = ($_SESSION['courseid'] !== "UNK") 
+						? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
+						: "../DuggaSys/courseed.php";
 
-				echo "<div id='goBackBurgerDiv'>";
-				echo "<a href='$backHref'>";
-				echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-				echo "</a>";
-				echo "</div>";
-			}
+					echo "<div id='goBackBurgerDiv'>";
+					echo "<a href='$backHref'>";
+					echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+					echo "</a>";
+					echo "</div>";
+				}
 			echo '</div>'; 
 
 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -346,7 +346,7 @@
 
 							// Refresh button for Github repo in hamburger menu
 							echo "<div id='refreshBurger' onclick='refreshGithubRepo(".$_SESSION['courseid'].");' style ='cursor:pointer;'>";
-            	echo "<span id='refreshBTN' title='Download Github Repo' value='Refresh' href='#'>";
+            				echo "<span id='refreshBTN' title='Download Github Repo' value='Refresh' href='#'>";
 							echo "<img alt='refresh icon'  class='burgerButt refreshBurgerIMG' src='../Shared/icons/gitrefresh.svg'>";
 							echo "</span";
 							echo "<a class='burgerButtText' href='#' >Download github repo</a></div>";
@@ -391,50 +391,45 @@
 					}
 			}		
 
-				if (isset($showDugga)) {
-				  echo "<td class='navBurgerIcon fa fa-bars' id='hamburgerIcon' onclick='navBurgerChange()'><img src='../Shared/icons/hamburger_menu_google_fonts.svg' alt='Menu'></td>";
-				  echo "<td class='navBurgerIcon' style='display: none;'> </td>";
-				}
+					if (isset($showDugga)) {
+					  echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'><img src='../Shared/icons/hamburger_menu_google_fonts.svg' alt='Menu'></td>";
+					  echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+					}
 
-				// Place this HTML outside your <table>
-				echo '<div id="navBurgerBox" class="navBurgerBox" style="display: none;">';
+					echo "<div id='navBurgerBox' class='navBurgerBox' style='display: none;'>";
 
-				echo '<div id="homeBurgerDiv">
-						<a id="homeBurger" href="../DuggaSys/courseed.php">
-						  <img alt="home" class="navBurgerButt" src="../Shared/icons/Home.svg">
-						</a>
-					  </div>';
+					echo "<div id='homeBurgerDiv'>
+							<a id='homeBurger' href='../DuggaSys/courseed.php'>
+							  <img alt='home' class='navBurgerButt' src='../Shared/icons/Home.svg'>
+							</a>
+						  </div>";
 
-				echo '<div id="darkModeBurgerDiv">
-						<a id="darkModeBurger" onclick="burgerToggleDarkmode()">
-						  <img alt="Dark" class="navBurgerButt" title="Toggle between dark mode" src="../Shared/icons/ThemeToggle.svg">
-						</a>
-					  </div>';
+					echo "<div id='darkModeBurgerDiv'>
+							<a id='darkModeBurger' onclick='burgerToggleDarkmode()'>
+							  <img alt='Dark' class='navBurgerButt' title='Toggle between dark mode' src='../Shared/icons/ThemeToggle.svg'>
+							</a>
+						  </div>";
 
-				if ($noup === 'COURSE') {
-				  // Go back button for COURSE
-				  echo "<div id='goBackBurgerDiv'>";
-				  echo "<a href='../DuggaSys/courseed.php'>";
-				  echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-				  echo "<span>Return</span>"; // Text for the go-back button
-				  echo "</a>";
-				  echo "</div>";
-				} 
-				else if ($noup === 'SECTION') {
-				  // Go back button for SECTION
-				  $backHref = ($_SESSION['courseid'] !== "UNK") 
-					? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
-					: "../DuggaSys/courseed.php";
+					if ($noup === 'COURSE') {
+					  echo "<div id='goBackBurgerDiv'>";
+					  echo "<a href='../DuggaSys/courseed.php'>";
+					  echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+					  echo "<span>Return</span>"; 
+					  echo "</a>";
+					  echo "</div>";
+					} 
+					else if ($noup === 'SECTION') {
+					  $backHref = ($_SESSION['courseid'] !== "UNK") 
+						? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] 
+						: "../DuggaSys/courseed.php";
 
-				  echo "<div id='goBackBurgerDiv'>";
-				  echo "<a href='$backHref'>";
-				  echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
-				  //echo "<span>Return</span>"; // Text for the go-back button
-				  echo "</a>";
-				  echo "</div>";
-				}
-
-				echo '</div>'; // Close #navBurgerBox
+					  echo "<div id='goBackBurgerDiv'>";
+					  echo "<a href='$backHref'>";
+					  echo "<img src='../Shared/icons/Up.svg' alt='Go Back'>";
+					  echo "</a>";
+					  echo "</div>";
+					}
+					echo '</div>'; 
 				
 
 


### PR DESCRIPTION
Burger menu has been added to dugga.js for mobile. The burger dropdown menu contains the navigation tools: home, toggle darkmode/lightmode and return/back.

It's an ugly solution but it works. I am aware that the burger icon is not consistent with the others, the positioning of the burger menus are different for each burger menu(there are three in total), in fact the burger menu in sectioned and courseed differed from the start.

The navheader.php file is currently messy, unstructured, and not scalable for long-term use. It contains a significant amount of redundant code that PHP may tolerate. All these greatly hinders readability and maintainability.

There are currently three burger menus in total, all using duplicate and inconsistent IDs. This is the reason why the hamburger icon fails to appear in showDugga.php which led to this ugly solution. A more refined solution would be to consistently and uniquely name the element IDs for each burger menu. The current approach is not a viable long-term solution and may lead to further issues in the future.

