### PR TITLE
Fixed: Sequence elements turn purple upon selection.

### DIFF
--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -137,7 +137,18 @@ function updateCSSForAllElements() {
                     }
                     // Update normal elements, and relations i.e default case
                 } else { 
-                    fillColor = elementDiv.children[0].children[0];
+                    if (element.kind == elementTypesNames.sequenceObject) {
+                        fillColor = elementDiv.querySelector("g > rect"); // Accessing the rectangle element
+                    }
+                    else if (element.kind == elementTypesNames.sequenceActor) {
+                        fillColor = elementDiv.querySelector("g > circle"); // Accessing the circular "head" element
+                    }
+                    else if (element.kind == elementTypesNames.sequenceLoopOrAlt || element.kind == elementTypesNames.UMLSuperState) {
+                        fillColor =elementDiv.children[0].children[1]; // Accessing the top left rectangle
+                    }
+                    else {
+                        fillColor = elementDiv.children[0].children[0]; // Accessing the whatever needs to be accessed
+                    }
                     fontColor = elementDiv.children[0];
                     weakKeyUnderline = elementDiv.children[0].children[2];
                     if (contextLengthCheck()) {

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -243,7 +243,11 @@ function updateCSSForAllElements() {
 
     function fontContrast() {
         // Set text to white if background is black or pink, else black
-        fontColor.style.fill = element.fill == color.BLACK || element.fill == color.PINK ? color.WHITE : color.BLACK;
+        if (element.fill == color.BLACK || element.fill == color.PINK) {
+            fontColor.style.fill = color.WHITE;
+        } else {
+            fontColor.style.fill = color.BLACK;
+        }
     }
     /**
      * @description Checks if multiple elements or lines are selected/highlighted


### PR DESCRIPTION
A previous pull request I made (#17241) fixed an issue where single-selected elements didn't turn purple upon selection. However, it also introduced a new bug that caused the text color to turn white for certain sequence elements and the UML super state element. This became problematic because the background color wasn't updating correctly to purple on selection, making the white text appear to disappear.

I've now patched this issue by extending the earlier fix to include these elements as well, ensuring they also turn purple when selected. Additionally, I’ve verified that everything continues to work correctly with dark mode enabled.

Before: 
![image](https://github.com/user-attachments/assets/1f696f7c-a4fd-46e6-95ab-e56fdc16bb38)

After: 
![image](https://github.com/user-attachments/assets/4ac29845-2da4-4d38-9445-4a80234f37d1)

Fixes: #17245