### PR TITLE
Undo/Redo for element attributes align with undo/redo of name

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -70,8 +70,8 @@ class StateMachine {
 
                 const lastText = this.lastTypedTextMap[elementId] || "";
 
-                // Check is a word boundary was typed (space or punctuation) and if change has happend it is logged (no change means no logging)
-                const isWordBoundary = currentText.length > lastText.length && /\s|[.,;!?]/.test(currentText.slice(-1));
+                // Check is a word boundary was typed (space or punctuation or longer than 4 symbols) and if change has happend it is logged (no change means no logging)
+                const isWordBoundary = currentText.length > lastText.length && (/\s|[.,;!?]/.test(currentText.slice(-1)) || currentText.length - lastText.length > 3);
                 const isNewText = currentText !== lastText;
 
                 if (isNewText && isWordBoundary) {
@@ -170,7 +170,7 @@ class StateMachine {
                 break;
         }
         stateMachine.numberOfChanges++;
-        updateLatestChange()
+        updateLatestChange();
     }
 
     /**


### PR DESCRIPTION
Updated the save()-function to handle attributes along with the name of elements. A user can now undo/redo parts of words rather than only single letters. 

If the last part of the word is less than 4 symbols (or the word is less than 4 symbols), it will not be redone as it falls below the minimum-limit of what is commited to memory.

__*NOTE:*__ At the moment this only works for name and attributes, and not functions as this has a separate sub-issue that is yet to be resolved.

https://github.com/user-attachments/assets/3e8b2aee-82f8-4577-9a8a-b9b6039cb0af