### PR TITLE
Undo/Redo now affects functions as well

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -70,17 +70,19 @@ class StateMachine {
 
                 const currentFields = {
                     name: element.name || "",
-                    attributes: element.attributes || ""
+                    attributes: element.attributes || "",
+                    functions: element.functions || ""
                 };
 
                 const lastFields = this.lastTypedTextMap[elementId] || {
                     name: "",
-                    attributes: ""
+                    attributes: "",
+                    functions: ""
                 };
 
                 let hasChanged = false;
 
-                for (const key of ["name", "attributes"]) {
+                for (const key of ["name", "attributes", "functions"]) {
                     const currentText = (currentFields[key] ?? "").toString();
                     const lastText = (lastFields[key] ?? "").toString();
 
@@ -120,7 +122,8 @@ class StateMachine {
                     });
                     this.lastTypedTextMap[elementId] = {
                         name: currentFields.name,
-                        attributes: currentFields.attributes
+                        attributes: currentFields.attributes,
+                        functions: currentFields.functions
                     };
     
                     this.numberOfChanges++;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -70,8 +70,8 @@ class StateMachine {
 
                 const lastText = this.lastTypedTextMap[elementId] || "";
 
-                // Check is a word boundary was typed (space or punctuation) and if change has happend it is logged (no change means no logging)
-                const isWordBoundary = currentText.length > lastText.length && /\s|[.,;!?]/.test(currentText.slice(-1));
+                // Check is a word boundary was typed (space or punctuation or longer than 4 symbols) and if change has happend it is logged (no change means no logging)
+                const isWordBoundary = currentText.length > lastText.length && (/\s|[.,;!?]/.test(currentText.slice(-1)) || currentText.length - lastText.length > 3);
                 const isNewText = currentText !== lastText;
 
                 if (isNewText && isWordBoundary) {
@@ -170,7 +170,7 @@ class StateMachine {
                 break;
         }
         stateMachine.numberOfChanges++;
-        updateLatestChange()
+        updateLatestChange();
     }
 
     /**


### PR DESCRIPTION
Updated the save()-function to be able to hande undo/redo for functions along with the pre-existing name and attributes. A user can now undo/redo parts of words rather than only single letters.

If the last part of the word is less than 4 symbols (or the word is less than 4 symbols), it will not be redone as it falls below the minimum-limit of what is commited to memory.

https://github.com/user-attachments/assets/4b1cb1e7-6d00-465c-bd5a-225ca40d7f06