### PR TITLE
Fixed issue #17319. Use only Windows with XAMPP

### DIFF
--- a/newinstaller/tools/configuration_manager.php
+++ b/newinstaller/tools/configuration_manager.php
@@ -12,11 +12,12 @@ class ConfigurationManager {
 	 * @param string $callback the function to call when printing information
 	 * @param bool $verbose If verbose it prints more information than normal
 	 */
-	public function __construct(string $save_file, string $callback = null, bool $verbose = false) {
+	public function __construct(string $save_file, ?string $callback = null, bool $verbose = false) {
 		$this->save_file = $save_file;
 		$this->callback = $callback;
 		$this->verbose = $verbose;
 		$this->parameters = [];
+		$this->write_config(); // Write or create config
 		$this->read_config(); // Load existing config
 	}
 


### PR DESCRIPTION
Fixes issue #17319, to test it, either remove or backup the `coursesyspw.php` file located at `C:/xampp/htdocs/coursesyspw.php`. After you did this, follow these steps in new lenasys installer:

Step 1: Select Windows
Step 2: Select both checkboxes
Step 3: Database name: lenaDB, MySQL user: Daniel, Hostname: localhost, MySQL user password: 1234, and for the rest, uncheck.
Step 4: Root username: root and Root password: empty
Step 5: Select all options
Step 6: Click install-button.

The new installer will create the file `coursesyspw` in the same directory and successfully installed the lenasys.