### PR TITLE
G3-2025-V6-#17179 Links crash lenasys

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1953,7 +1953,7 @@ function returnedSection(data) {
             "cursor:pointer;margin-left:8px;", item['entryname'], false, param)}</span></div>`;
         } else if (itemKind == 5) {
           // Link
-          if (item['link'].substring(0, 4) === "http") {
+          if (item['link'] !== null && item['link'] !== undefined && item['link'].substring(0, 4) === "http") {
             str += makeanchor(item['link'], hideState, "cursor:pointer;margin-left:8px;",
               item['entryname'], false, {});
           } else {


### PR DESCRIPTION
Links can now be created without crashing LenaSYS
![image](https://github.com/user-attachments/assets/974603e0-fcf1-43e8-82d4-a69bb2d162a4)

Added a null and undefined check to stop the if statement executing .substring on a null or undefined link. If one of these evaluates to false, the if statements stops and throws an error instead of crashing. To test, create a new link in sectioned.php. 