### PR TITLE
Dashed recursive line

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -966,7 +966,7 @@ function mouseMode_onMouseUp(event) {
                         // checks if a ghostline already exists and if so sets the relation recursively.
                         if (ghostLine != null) {
                             // create a line from the element to itself
-                            addLine(context[0], context[0], "Recursive");
+                            addLine(context[0], context[0], "Normal", true);
                             clearContext();
                             // Bust the ghosts
                             ghostElement = null;

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -30,7 +30,7 @@ function drawLine(line, targetGhost = false) {
 
     // Sets the to-coordinates to the same as the from-coordinates after getting line attributes
     // if the line is recursive
-    if (line.kind === lineKind.RECURSIVE) {
+    if (line.recursive) {
         [fx, fy, tx, ty, offset] = getLineAttributes(felem, felem, line.ctype);
         //Setting start position for the recursive line, to originate from the top.
         fx = felem.cx;
@@ -104,7 +104,7 @@ function drawLine(line, targetGhost = false) {
             lineStr += double(-1, 2);
         }
     } else if ((line.type == entityType.SD && line.innerType != SDLineType.SEGMENT)) {
-        if (line.kind == lineKind.RECURSIVE) {
+        if (line.recursive) {
             lineStr += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
 
         } else if ((fy > ty) && (line.ctype == lineDirection.UP)) {
@@ -158,7 +158,7 @@ function drawLine(line, targetGhost = false) {
                     fill='none' stroke='${lineColor}' stroke-width='${strokewidth * zoomfact}' stroke-dasharray='${strokeDash}'
                 />`;
     } else { // UML, IE or SD
-        if (line.kind == lineKind.RECURSIVE) {
+        if (line.recursive) {
             lineStr += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
         }
         else {
@@ -168,7 +168,7 @@ function drawLine(line, targetGhost = false) {
     }
 
     //Drawing Arrow and other line icons for UML abnd IE lines
-    if (line.kind === lineKind.RECURSIVE) {
+    if (line.recursive) {
         //Arrow/icon location dependant on element length, so its always in the top right corner of the element.
         const length = 40 * zoomfact;
         const elementLength = felem.x2 - felem.x1;
@@ -197,7 +197,7 @@ function drawLine(line, targetGhost = false) {
         startY += offset.y1 * zoomfact; 
     
     //Draws the Segmented version for arrow and not straight line
-    if(line.kind === lineKind.RECURSIVE){
+    if(line.recursive){
         if(line.startIcon === SDLineIcons.ARROW){
             lineStr += iconPoly(SD_ARROW[line.ctype], startX, startY, lineColor, color.BLACK);
         }
@@ -334,7 +334,7 @@ function drawLine(line, targetGhost = false) {
         const rectPosY = labelCenterY - (textheight * zoomfact + zoomfact * 3) / 2;
 
         //Add label with styling based on selection.
-        if (line.kind === lineKind.RECURSIVE) {
+        if (line.recursive) {
             //Calculatin the lable possition based on element size, so it follows when resized.
             const length = 20 * zoomfact;
             const lift   = 80 * zoomfact; 
@@ -562,7 +562,7 @@ function drawLineLabel(line, label, lineColor, labelStr, x, y, isStart, felem) {
     let textWidth = canvasContext.measureText(label).width;
 
 
-    if(line.kind === lineKind.RECURSIVE){
+    if(line.recursive){
         //Calculatin the cardinality possition based on element size, so it follows when resized.
         const lift   = 55 * zoomfact; 
         const {length, elementLength, startX, startY } = recursiveParam(felem);

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -290,14 +290,19 @@ function option(object, icon) {
  * @param {Array} arr An array for the different selection for the menu.
  * @return Returns a header for the radio menu and returns the radio menu with the different selection.
  */
+
 function radio(line, arr) {
-    let result = `<h3 style="margin-bottom: 0; margin-top: 5px;">Kinds</h3>`;
-    arr.forEach(lineKind => {
-        let checked = (line.kind == lineKind) ? 'checked' : '';
-        result += `<input type="radio" id="lineRadio${lineKind}" name="lineKind" value='${lineKind}' ${checked} onchange='changeLineProperties();'>
-                   <label for='lineRadio${lineKind}'>${lineKind}</label>
-                   <br>`
-    });    
+    let result = "";
+    console.log(line.kind + " " + lineKind.RECURSIVE);
+    if(line.kind !== lineKind.RECURSIVE){
+        result = `<h3 style="margin-bottom: 0; margin-top: 5px;">Kinds</h3>`;
+        arr.forEach(lineKind => {
+            let checked = (line.kind == lineKind) ? 'checked' : '';
+            result += `<input type="radio" id="lineRadio${lineKind}" name="lineKind" value='${lineKind}' ${checked} onchange='changeLineProperties();'>
+                    <label for='lineRadio${lineKind}'>${lineKind}</label>
+                    <br>`
+        });    
+    }
     return result;
 }
 

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -294,7 +294,6 @@ function option(object, icon) {
 function radio(line, arr) {
     let result = "";
     console.log(line.kind + " " + lineKind.RECURSIVE);
-    if(line.kind !== lineKind.RECURSIVE){
         result = `<h3 style="margin-bottom: 0; margin-top: 5px;">Kinds</h3>`;
         arr.forEach(lineKind => {
             let checked = (line.kind == lineKind) ? 'checked' : '';
@@ -302,7 +301,6 @@ function radio(line, arr) {
                     <label for='lineRadio${lineKind}'>${lineKind}</label>
                     <br>`
         });    
-    }
     return result;
 }
 
@@ -1924,9 +1922,6 @@ function changeLineProperties() {
 
     // updates the line
     for (const [key, value] of Object.entries(StateChange.GetLineProperties())) {
-        if((key === "kind" && contextLine[0].kind === "Recursive" && value === "Dashed") || (key === "kind" &&contextLine[0].kind === "Recursive" && value === "Normal")){
-            continue;
-        }
         contextLine[0][key] = value;
     }
 

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -1916,9 +1916,12 @@ function multipleColorsTest() {
  * @description Applies new changes to line attributes in the data array of lines.
  */
 function changeLineProperties() {        
-    
+
     // updates the line
     for (const [key, value] of Object.entries(StateChange.GetLineProperties())) {
+        if((key === "kind" && contextLine[0].kind === "Recursive" && value === "Dashed") || (key === "kind" &&contextLine[0].kind === "Recursive" && value === "Normal")){
+            continue;
+        }
         contextLine[0][key] = value;
     }
 

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -293,7 +293,6 @@ function option(object, icon) {
 
 function radio(line, arr) {
     let result = "";
-    console.log(line.kind + " " + lineKind.RECURSIVE);
         result = `<h3 style="margin-bottom: 0; margin-top: 5px;">Kinds</h3>`;
         arr.forEach(lineKind => {
             let checked = (line.kind == lineKind) ? 'checked' : '';
@@ -1919,14 +1918,11 @@ function multipleColorsTest() {
  * @description Applies new changes to line attributes in the data array of lines.
  */
 function changeLineProperties() {        
-
     // updates the line
     for (const [key, value] of Object.entries(StateChange.GetLineProperties())) {
         contextLine[0][key] = value;
     }
-
     // save all the changes
     stateMachine.save(contextLine[0].id, StateChange.ChangeTypes.LINE_ATTRIBUTE_CHANGED);
-
     showdata();
 }

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -5,7 +5,7 @@
  * @param {String} kind The kind of line that should be added.
  * @param {boolean} stateMachineShouldSave Should this line be added to the stateMachine.
  */
-function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, successMessage = true, cardinal) {
+function addLine(fromElement, toElement, kind, isRecursive = false, stateMachineShouldSave = true, successMessage = true, cardinal) {
     let result;
 
     if (lineAlwaysFrom.includes(toElement.kind) ||
@@ -47,7 +47,8 @@ function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, su
             id: makeRandomID(),
             fromID: fromElement.id,
             toID: toElement.id,
-            kind: kind
+            kind: kind,
+            recursive: isRecursive  
         };
 
         // If the new line has an entity FROM or TO, add a cardinality ONLY if it's passed as a parameter.
@@ -66,7 +67,8 @@ function addLine(fromElement, toElement, kind, stateMachineShouldSave = true, su
             id: makeRandomID(),
             fromID: fromElement.id,
             toID: toElement.id,
-            kind: kind
+            kind: kind,
+            recursive: isRecursive  
         };
         // If the new line has an entity FROM or TO, add a cardinality ONLY if it's passed as a parameter.
         if (isLineConnectedTo(newLine, elementTypesNames.EREntity)) {


### PR DESCRIPTION
The recursive line can now be changed to dashed and back using the radio buttons in the options menu.

[Screencast from 2025-05-08 13-25-07.webm](https://github.com/user-attachments/assets/5917e5aa-bf5a-4cef-aedb-f7a70be1af12)
