### PR TITLE
G3 2025 V6 changed default visibility of objects

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -2412,10 +2412,10 @@ function toggleButtonClickHandler() {
 
   if (!showHidden) {
     toggleButton.src = '../Shared/icons/eye_closed_icon.svg';
-    toggleButton.title = 'Hide hidden items';
+    toggleButton.title = 'Show hidden items';
   } else {
     toggleButton.src = '../Shared/icons/eye_icon.svg';
-    toggleButton.title = 'Show hidden items';
+    toggleButton.title = 'Hide hidden items';
   }
 
   toggleHidden();

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -29,7 +29,7 @@ var numberOfItems;
 var backgroundColorTheme;
 var isLoggedIn = false;
 var inputColorTheme;
-let showHidden = false;
+let showHidden = true;
 let count = 0;
 
 function initInputColorTheme() {
@@ -2410,7 +2410,7 @@ function toggleButtonClickHandler() {
 
   showHidden = !showHidden;
 
-  if (showHidden) {
+  if (!showHidden) {
     toggleButton.src = '../Shared/icons/eye_closed_icon.svg';
     toggleButton.title = 'Hide hidden items';
   } else {


### PR DESCRIPTION
Changed the default visibility new objects to be true, as before it was automatically hiding new objects. Also switched which icon should be used at which point to reflect the actual state of the button.

Before:
<img width="1725" alt="Screenshot 2025-05-08 at 14 57 34" src="https://github.com/user-attachments/assets/f928decb-5039-4191-ae3b-96d72892095b" />
Now:
<img width="1729" alt="Screenshot 2025-05-08 at 14 58 12" src="https://github.com/user-attachments/assets/2b87b45c-5947-4feb-9c86-4080a4e5a382" />