### PR TITLE
Remove header from sectionedService.md #17329

### DIFF
--- a/DuggaSys/microservices/Microservices Documentation/sectionedService.md
+++ b/DuggaSys/microservices/Microservices Documentation/sectionedService.md
@@ -1,5 +1,3 @@
-# sectionedService Documentation
-
 # Name of file/service
 createListEntry_ms
 


### PR DESCRIPTION
Removed the header in sectionedService.md that created an unwanted entry in the database. Fixes #17329 

If you run 'setupEndpointDirectoryDb.php' the entry in the image below should no longer be in the database (only the middle entry in the image). 

<img width="833" alt="Image" src="https://github.com/user-attachments/assets/e98df183-fe00-42dd-9c52-29d3b1d39455" />