### PR TITLE
Change the styling of a-tags in MicroserviceUI #17340

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -247,7 +247,7 @@ if (isset($_GET['id'])) {
             echo $service['description'];
         }
         echo '</td>';
-        echo '<td><a href="?id=' . $service['id'] . '">View</a></td>';
+        echo '<td><a href="?id=' . $service['id'] . '" class="a-button">View</a></td>';
         echo '</tr>';
     }
     ?>

--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -110,7 +110,7 @@ if (isset($_GET['id'])) {
             <p><label>Calling Methods:<br><input type="text" name="calling_methods" required value="<?php echo htmlspecialchars($editMicroservice['calling_methods']); ?>"></label></p>
             <p><label>Microservices Used:<br></b><input type="text" name="microservices_used" value="<?php echo htmlspecialchars($editMicroservice['microservices_used']); ?>" required></label></p>
             <button type="submit">Save Changes</button>
-            <a href="?id=<?php echo $editMicroservice['id']; ?>">Cancel</a>
+            <a href="?id=<?php echo $editMicroservice['id']; ?>" class="a-button">Cancel</a>
         </form>
     <?php } ?>
     
@@ -129,7 +129,7 @@ if (isset($_GET['id'])) {
                 <input type="text" name="search" placeholder="Search name/description">
                     <button type="submit">Search</button>
                 <?php if (isset($_GET['search'])): ?>
-                    <a href="?">Reset</a>
+                    <a href="?" class="a-button">Reset</a>
                 <?php endif; ?>
             </form>
 
@@ -142,7 +142,7 @@ if (isset($_GET['id'])) {
                 </select>
                 <button type="submit">Filter</button>
                 <?php if (isset($_GET['filter_method'])): ?>
-                    <a href="?">Reset</a>
+                    <a href="?" class="a-button">Reset</a>
                 <?php endif; ?>
             </form>
 
@@ -230,7 +230,7 @@ if (isset($_GET['id'])) {
             </form>
         </div>
 
-        <p><a href="?">Back to list</a></p>
+        <p><a href="?" class="a-button">Back to list</a></p>
         
     <?php } else { ?>
         <table>

--- a/DuggaSys/microservices/endpointDirectory/style.css
+++ b/DuggaSys/microservices/endpointDirectory/style.css
@@ -7,7 +7,7 @@ body {
 }
 
 h1 {
-    text-align: center;
+  text-align: center;
 }
 
 table {
@@ -28,11 +28,11 @@ th {
 }
 
 tr:nth-child(odd) {
-    background-color: #f2f2f2;
+  background-color: #f2f2f2;
 }
 
 tr:hover {
-    background-color: lightgray;
+  background-color: lightgray;
 }
 
 form {
@@ -55,36 +55,36 @@ form {
   margin-bottom: 20px;
 }
 
-.button-container{
-    display: flex; 
-    gap: 10px;
+.button-container {
+  display: flex;
+  gap: 10px;
 }
 
 input {
-    border: 1px solid black;
-    border-radius: 18px;
-    height: 25px;
-    padding: 5px;
+  border: 1px solid black;
+  border-radius: 18px;
+  height: 25px;
+  padding: 5px;
 }
 
 button,
-a {
-    border: 2px solid black;
-    background-color: black;
-    color: white;
-    padding: 10px;
-    border-radius: 20px;
-    cursor: pointer;
-    transition: all 0.5s;
+.a-button {
+  border: 2px solid black;
+  background-color: black;
+  color: white;
+  padding: 10px;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: all 0.5s;
 }
 
 button:hover,
-a:hover {
-    background-color: white;
-    color: black;
+.a-button:hover {
+  background-color: white;
+  color: black;
 }
 
 a {
-    text-decoration: none;    
-    display: inline-block;
+  text-decoration: none;
+  display: inline-block;
 }


### PR DESCRIPTION
Added a class to a-tags (in microserviceUI.php) that are buttons and added the class to the stylesheet instead of the a-tag.  A-tags that are not supposed to be buttons are now links. Fixes #17340 

<img width="859" alt="image" src="https://github.com/user-attachments/assets/c7c50d4f-3830-44f6-94f7-ccff63693b23" />
