### PR TITLE
[#17302] Fixed unintended label interactions with "<" and ">"

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -272,7 +272,7 @@ function drawLine(line, targetGhost = false) {
         const canvas = document.getElementById('canvasOverlay');
         const canvasContext = canvas.getContext('2d');
         canvasContext.font = `${height}px ${canvasContext.font.split('px')[1]}`;
-        const labelValue = line.label.replaceAll('<', "&#60").replaceAll('>', "&#62");
+        const labelValue = line.label.replaceAll('<', "&#60;").replaceAll('>', "&#62;");
         const textWidth = canvasContext.measureText(line.label).width;
         const label = {
             id: line.id + "Label",


### PR DESCRIPTION
There's a converter built into the drawLine function that checks if the user has input the symbols "<" or ">". If they had, the input symbols would be converted to their HTML number values, most likely to avoid conflicting with any html that was to be sent by the rest of the function. There were however semicolons missing at the end of the HTML numbers, which caused further digits to change the HTML number completely. For example, if the user input "<24", the converter **should** have converted the string into "**_&# 60;24_**" which would've displayed as "<24" (_Had to put a space between "&#" and the numbers since it got converted in the text as well_). However since the semicolons were missing, the string was converted into "**_&# 6024_**", which is the HTML number for "ឈ", a Cambodian letter.

Semicolons have been added now so the label should no longer display incorrect symbols if "<" and ">" are included in the input.

![image](https://github.com/user-attachments/assets/7e02be98-832e-48c4-a2b1-3e1a23ba0015)
