### PR TITLE
Fixed: G1 2025 v6 #17277 visualization of snap to lifeline is not showing anymore

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1067,7 +1067,7 @@ function mmoving(event) {
                 const snapId = visualSnapToLifeline(moveableElementPos);
 
                 // Visualize the context snapping to lifeline (only a visual indication)
-                if (snapId) {
+                if (snapId && context[0]?.kind === elementTypesNames.sequenceActivation) {
                     const lLine = data.find(el => el.id === snapId);
                     context[0].x = lLine.x + lLine.width / 2 - context[0].width / 2;
                     startX = event.clientX;

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -232,9 +232,6 @@ function snapElementToLifeline(element, targetId) {
 // For mmoving sequenceActivation element to get a visually indicated snap to lifeline
 // threshold value is changeable within the parameter
 function visualSnapToLifeline(pos, threshold = 50) {
-   
-    // Restrict snapping to only sequence activations
-   // if (pos.kind !== elementTypesNames.sequenceActivation) return null;
 
     // Check that there exists a sequenceActor or sequenceObject to snap to
     for (const ll of data) {

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -234,7 +234,7 @@ function snapElementToLifeline(element, targetId) {
 function visualSnapToLifeline(pos, threshold = 50) {
    
     // Restrict snapping to only sequence activations
-    if (pos.kind !== elementTypesNames.sequenceActivation) return null;
+   // if (pos.kind !== elementTypesNames.sequenceActivation) return null;
 
     // Check that there exists a sequenceActor or sequenceObject to snap to
     for (const ll of data) {


### PR DESCRIPTION
The visual indicator of a snap to lifeline is now back and working even when dragging an already placed element. The visualization is only observable for sequenceActivation elements.

https://github.com/user-attachments/assets/72fbd32e-b50c-4823-acc8-ce600570b240

