### PR TITLE
G1 2025 v6 17382 delete detection of overlapping

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1407,8 +1407,6 @@ function pasteClipboard(elements, elementsLines) {
     const newElements = [];
     const newLines = [];
 
-    let overlapDetected = false;
-
     // For every copied element create a new one and add to data
     elements.forEach(element => {
         // Make a new id and save it in an object
@@ -1426,11 +1424,6 @@ function pasteClipboard(elements, elementsLines) {
 
         // Check for overlap before adding
         addObjectToData(elementObj, false); // Add to data
-
-        if (entityIsOverlapping(elementObj.id, elementObj.x, elementObj.y)) {
-            data.splice(data.findIndex(e => e.id === elementObj.id), 1); // Remove the just-added element
-            overlapDetected = true;
-        }
     });
 
     // Create the new lines but do not saved in stateMachine

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -612,81 +612,37 @@ document.addEventListener('keydown', function (e) {
     // Moving object with arrow keys.
     if (isKeybindValid(e, keybinds.MOVING_OBJECT_UP)) {
         e.preventDefault();
-        let overlapDetected = false;
-        context.forEach(obj => {
-            if (entityIsOverlapping(obj.id, obj.x, obj.y - 1)) {
-                overlapDetected = true;
-                return;
-            }
-        });
-        if (!overlapDetected) {
-            if (settings.grid.snapToGrid) {
-                setPos(context, 0, settings.grid.gridSize / 2);
-            } else {
-                setPos(context, 0, 1);
-            }
+        if (settings.grid.snapToGrid) {
+            setPos(context, 0, settings.grid.gridSize / 2);
         } else {
-            displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
+            setPos(context, 0, 1);
         }
     }
 
     if (isKeybindValid(e, keybinds.MOVING_OBJECT_DOWN)) {
         e.preventDefault();
-        let overlapDetected = false;
-        context.forEach(obj => {
-            if (entityIsOverlapping(obj.id, obj.x, obj.y + 1)) {
-                overlapDetected = true;
-                return;
-            }
-        });
-        if (!overlapDetected) {
-            if (settings.grid.snapToGrid) {
-                setPos(context, 0, -settings.grid.gridSize / 2);
-            } else {
-                setPos(context, 0, -1);
-            }
+        if (settings.grid.snapToGrid) {
+            setPos(context, 0, -settings.grid.gridSize / 2);
         } else {
-            displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
+            setPos(context, 0, -1);
         }
     }
 
     if (isKeybindValid(e, keybinds.MOVING_OBJECT_LEFT)) {
         e.preventDefault();
-        let overlapDetected = false;
-        context.forEach(obj => {
-            if (entityIsOverlapping(obj.id, obj.x - 1, obj.y)) {
-                overlapDetected = true;
-                return;
-            }
-        });
-        if (!overlapDetected) {
-            if (settings.grid.snapToGrid) {
-                setPos(context, settings.grid.gridSize / 2, 0);
-            } else {
-                setPos(context, 1, 0);
-            }
+        if (settings.grid.snapToGrid) {
+            setPos(context, settings.grid.gridSize / 2, 0);
         } else {
-            displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
+            setPos(context, 1, 0);
         }
     }
 
     if (isKeybindValid(e, keybinds.MOVING_OBJECT_RIGHT)) {
         e.preventDefault();
-        let overlapDetected = false;
-        context.forEach(obj => {
-            if (entityIsOverlapping(obj.id, obj.x + 1, obj.y)) {
-                overlapDetected = true;
-                return;
-            }
-        });
-        if (!overlapDetected) {
-            if (settings.grid.snapToGrid) {
-                setPos(context, -settings.grid.gridSize / 2, 0);
-            } else {
-                setPos(context, -1, 0);
-            }
+        if (settings.grid.snapToGrid) {
+            setPos(context, -settings.grid.gridSize / 2, 0);
         } else {
-            displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
+            setPos(context, -1, 0);
         }
     }
 
@@ -993,17 +949,6 @@ function mouseMode_onMouseUp(event) {
                 clearContextLine();
                 if (ghostElement && event.button == 0) {
                     addObjectToData(ghostElement, false);
-                    // Check if the element to create would overlap others, returns if true
-                    if (entityIsOverlapping(ghostElement.id, ghostElement.x, ghostElement.y)) {
-                        displayMessage(messageTypes.ERROR, "Error: You can't create elements that overlap eachother.");
-                        console.error("Failed to create an element as it overlaps other element(s)");
-                        // Remove added element from data as it should remain
-                        data.splice(data.length - 1, 1);
-                        makeGhost();
-                        showdata();
-                        return;
-                    }
-                    //If not overlapping
                     stateMachine.save(ghostElement.id, StateChange.ChangeTypes.ELEMENT_CREATED);
                     makeGhost();
                     showdata();
@@ -1487,13 +1432,6 @@ function pasteClipboard(elements, elementsLines) {
             overlapDetected = true;
         }
     });
-
-    // If overlap is detected, abort pasting the elements, otherwise add 
-    if (overlapDetected) {
-        displayMessage(messageTypes.ERROR, "Error: You can't paste elements on top of eachother.");
-        console.error("Failed to paste the element as it overlaps other element(s)");
-        return;
-    }
 
     // Create the new lines but do not saved in stateMachine
     // TODO: Using addLine removes labels and arrows. Find way to save lines with all attributes.

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -321,23 +321,6 @@ function mup(event) {
             }
             break;
         case pointerStates.CLICKED_NODE:
-            if (resizeOverlapping) {
-                // Reset to original state if overlapping is detected
-                const element = data[findIndex(data, context[0].id)];
-                element.width = originalWidth;
-                element.height = originalHeight;
-                element.x = originalX;
-                element.y = originalY;
-                // Update DOM with the original properties
-                const elementDOM = document.getElementById(element.id);
-                elementDOM.style.width = originalWidth + 'px';
-                elementDOM.style.height = originalHeight + 'px';
-                elementDOM.style.left = originalX + 'px';
-                elementDOM.style.top = originalY + 'px';
-                showdata();
-                displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
-                resizeOverlapping = false;
-            }
             break;
         default:
             console.error(`State ${mouseMode} missing implementation at switch-case in mup()!`);

--- a/DuggaSys/diagram/helpers/element.js
+++ b/DuggaSys/diagram/helpers/element.js
@@ -71,76 +71,53 @@ function setPos(elements, x, y) {
         }
     });
 
-    if (overlappingObject) {
-        // If overlap is detected, move the overlapping object back by one step
-        const previousX = overlappingObject.x;
-        const previousY = overlappingObject.y;
+    elements.forEach(obj => {
 
-        // Move the object back one step
-        overlappingObject.x -= x / zoomfact;
-        overlappingObject.y -= y / zoomfact;
-
-        // Check again if the adjusted position still overlaps
-        if (entityIsOverlapping(overlappingObject.id, overlappingObject.x, overlappingObject.y)) {
-            // If it still overlaps, revert to the previous position
-            overlappingObject.x = previousX;
-            overlappingObject.y = previousY;
-
-            // Display error message
-            displayMessage(messageTypes.ERROR, "Error: You can't place elements too close together.");
-        } else {
-            // If no longer overlaps after adjustment, proceed with saving the new position
-            idList.push(overlappingObject.id);
+        // Check if element is locked and immovable
+        if (obj.isLocked) {
+            return;
         }
-    } else {
-        elements.forEach(obj => {
 
-            // Check if element is locked and immovable
-            if (obj.isLocked) {
-                return;
-            }
+        // If snapToGrid is activated
+        if (settings.grid.snapToGrid && !ctrlPressed) {
 
-            // If snapToGrid is activated
-            if (settings.grid.snapToGrid && !ctrlPressed) {
-
-                // Snap logic for rectangular elements
-                // Snaps to grid lines
-                const entityKinds = [
-                    elementTypesNames.EREntity,
-                    elementTypesNames.UMLEntity,
-                    elementTypesNames.IEEntity,
-                    elementTypesNames.SDEntity,
-                    elementTypesNames.note
-                ];
-                if (entityKinds.includes(obj.kind)) {
-                    const candidateX = obj.x - (x / zoomfact);
-                    const candidateY = obj.y - (y / zoomfact);
-                    obj.x = Math.round(candidateX / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
-                    obj.y = Math.round(candidateY / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
-                } else {
-
-                    // Snap logic for non-rectangular elements
-                    // Snaps to center
-                    obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.width / 2;
-                    obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.height / 2;
-                }
+            // Snap logic for rectangular elements
+            // Snaps to grid lines
+            const entityKinds = [
+                elementTypesNames.EREntity,
+                elementTypesNames.UMLEntity,
+                elementTypesNames.IEEntity,
+                elementTypesNames.SDEntity,
+                elementTypesNames.note
+            ];
+            if (entityKinds.includes(obj.kind)) {
+                const candidateX = obj.x - (x / zoomfact);
+                const candidateY = obj.y - (y / zoomfact);
+                obj.x = Math.round(candidateX / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
+                obj.y = Math.round(candidateY / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2);
             } else {
 
-                // For dragging elements without snapToGrid mode active
-                obj.x -= (x / zoomfact);
-                obj.y -= (y / zoomfact);
+                // Snap logic for non-rectangular elements
+                // Snaps to center
+                obj.x = Math.round((obj.x + obj.width / 2 - x / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.width / 2;
+                obj.y = Math.round((obj.y + obj.height / 2 - y / zoomfact) / (settings.grid.gridSize / 2)) * (settings.grid.gridSize / 2) - obj.height / 2;
             }
+        } else {
 
-            // Add the object-id to the idList
-            idList.push(obj.id);
-            // Make the coordinates without decimals
-            obj.x = Math.round(obj.x);
-            obj.y = Math.round(obj.y);
-        });
-
-        if (idList.length) {
-            stateMachine.save(idList, StateChange.ChangeTypes.ELEMENT_MOVED);
+            // For dragging elements without snapToGrid mode active
+            obj.x -= (x / zoomfact);
+            obj.y -= (y / zoomfact);
         }
+
+        // Add the object-id to the idList
+        idList.push(obj.id);
+        // Make the coordinates without decimals
+        obj.x = Math.round(obj.x);
+        obj.y = Math.round(obj.y);
+    });
+
+    if (idList.length) {
+        stateMachine.save(idList, StateChange.ChangeTypes.ELEMENT_MOVED);
     }
 
     // Update positions


### PR DESCRIPTION
I have removed overlapping of all the elements. You can resize, drag, create and move with the arrow keys over other elements. No error is shown either.

![image](https://github.com/user-attachments/assets/72808aaa-1e9f-4773-84fa-43b4c88cc615)

### Known issue
The z-index dose not update when you pick up a new element making it rather jarring to use and should be solved in a different issue. 

![image](https://github.com/user-attachments/assets/ea32f460-70cd-4a5b-b333-0167890e3710)