### PR TITLE
Fixed issue #17280

### DIFF
--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -119,15 +119,24 @@ function entityIsOverlapping(id, x, y, ignoreIds = []) {
 
         // No element can be placed over another of the same kind
         if (other.kind !== element.kind) {
-        if ((other.kind === "sequenceActor" || other.kind === "sequenceObject") &&
-        element.kind === "sequenceActivation") {
-        const headerHeight = getTopHeight(other);          
-        const extra        = other.kind === "sequenceActor"; 
-        const headerBottom = other.y + headerHeight + extra;
-
-        if (y < headerBottom) return true;   
-        continue;                            
-    }
+            if ((other.kind === "sequenceActor" || other.kind === "sequenceObject") &&
+            element.kind === "sequenceActivation") {
+        
+                const bodyX = other.x;
+                const bodyWidth = other.width;
+                const bodyY = other.y;
+                const bodyHeight = getTopHeight(other);
+            
+                // Block placeing on the actor/objects body
+                if (
+                    x + element.width > bodyX &&
+                    x < bodyX + bodyWidth &&
+                    y + element.height > bodyY &&
+                    y < bodyY + bodyHeight
+                ) return true;
+            
+                continue;
+            }
 
             // All sequence elements can be placed over loops, alternatives and activations and vice versa
             else if (other.type === "SE" && (element.kind === "sequenceLoopOrAlt" || element.kind === "sequenceActivation")) continue;


### PR DESCRIPTION
The issue about activation boxes cannot be placed on the grid over a sequence actor/object is solved. It's still an issue that it's snaps like it was a lifeline even above/under the real lifeline but that's not a part of this issue. You can now place the activation anywhere you want, except on the actors/objects body, which is correct.

https://github.com/user-attachments/assets/3a757762-54f3-48c9-bc25-b46ebaafa0c3

