### PR TITLE
Add Microservice directory database installation to New Installer #17386

### DIFF
--- a/newinstaller/tools/install_engine.php
+++ b/newinstaller/tools/install_engine.php
@@ -155,6 +155,9 @@ class InstallEngine {
 		$operations["init_db"] = function() use ($installer, $verbose) {
 			$installer->execute_sql_file("SQL/init_db.sql", verbose: $verbose);
 		};
+		$operations["setup_endpoint_directory"] = function() use ($verbose) {
+			setup_endpoint_directory($verbose);
+		};
 		$operations["save_credentials"] = function() use ($cm, $settings, $distributed_environment) {
 			$parameters = [
 				"DB_USER" => $settings->username,

--- a/newinstaller/tools/install_engine.php
+++ b/newinstaller/tools/install_engine.php
@@ -4,8 +4,6 @@ foreach (glob("tools/*.php") as $tools) {
 	include_once $tools;
 }
 
-require_once __DIR__ . "/../DuggaSys/microservices/endpointDirectory/setupEndpointDirectory.php";
-
 class InstallEngine {
 
 	/**
@@ -156,7 +154,11 @@ class InstallEngine {
 			$installer->execute_sql_file("SQL/init_db.sql", verbose: $verbose);
 		};
 		$operations["setup_endpoint_directory"] = function() use ($verbose) {
-			setup_endpoint_directory($verbose);
+			try {
+				setup_endpoint_directory($verbose);
+			} catch (Throwable $e) {
+				SSESender::transmit("Error in setup_endpoint_directory: " . $e->getMessage(), true);
+			}
 		};
 		$operations["save_credentials"] = function() use ($cm, $settings, $distributed_environment) {
 			$parameters = [

--- a/newinstaller/tools/install_engine.php
+++ b/newinstaller/tools/install_engine.php
@@ -4,6 +4,8 @@ foreach (glob("tools/*.php") as $tools) {
 	include_once $tools;
 }
 
+require_once __DIR__ . "/../DuggaSys/microservices/endpointDirectory/setupEndpointDirectory.php";
+
 class InstallEngine {
 
 	/**

--- a/newinstaller/tools/setup_endpoint_directory.php
+++ b/newinstaller/tools/setup_endpoint_directory.php
@@ -1,0 +1,19 @@
+<?php
+
+function setup_endpoint_directory($verbose = false) {
+    if ($verbose) {
+        SSESender::transmit("Starting setup of endpoint directory...");
+    }
+    
+    ini_set('display_errors', 1);
+    error_reporting(E_ALL);
+
+    // path to the database file
+    $dbFile = __DIR__ . '/../DuggaSys/microservices/endpointDirectory/endpointDirectory_db.sqlite';
+    // create and fill the database using setup script
+    require_once __DIR__ . '/../../DuggaSys/microservices/endpointDirectory/setupEndpointDirectory.php';
+
+    if ($verbose) {
+        SSESender::transmit("Endpoint directory setup completed.");
+    }
+}


### PR DESCRIPTION
In 'newinstaller', I created a script (setup_endpoint_directory.php) in the tools folder, that script will be included in the foreach loop in 'install_engine.php'. I also created an operation in 'install_engine.php' that runs the setup script. Fixes #17386 

To test this, run the new installer. After installing you should be able to open [microserviceUI.php](http://localhost/LenaSYS/DuggaSys/microservices/endpointDirectory/microserviceUI.php) and see data. If it's empty, something went wrong. 
The idea is that 'endpointDirectory_db.sqlite' should be created and filled with data after running the new installer. To easily confirm this you can manually remove it in the 'endpointDirectory' folder before running the new installer.  