### PR TITLE
Changed to curlService in retrieveHighscoreService_ms and highscoreservice_ms  #17117

### DIFF
--- a/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
+++ b/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
@@ -37,23 +37,13 @@ logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "highscoreservice.php
 // Services
 //------------------------------------------------------------------------------------------------
 
-//Re-engineer
-$baseURL = "http://" . $_SERVER['HTTP_HOST'];
-$url = $baseURL . "/LenaSYS/DuggaSys/microservices/highscoreService/retrieveHighscoreService_ms.php?" . http_build_query([
+ //Using curlService to send POST data
+ $postData = [
     'did' => $duggaid,
     'lid' => $variant
-]);
+ ];
+$response = callMicroservicePOST("../highscoreService/retrieveHighscoreService_ms.php", $postData, true );
 
-$ch = curl_init($url);
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-$response = curl_exec($ch);
-curl_close($ch);
-/* //Change to curlService
-$response = callMicroservicePOST("../highscoreService/retrieveHighscoreService_ms.php", [
-    'did' => $duggaid,
-    'lid' => $variant
-], true );
-*/
 $data = json_decode($response, true);
 echo json_encode($data);
 

--- a/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
+++ b/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
@@ -11,7 +11,7 @@ include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
 include_once "../sharedMicroservices/getUid_ms.php";
 //include_once "retrieveHighscoreService_ms.php";
-include_once "../microservices/curlService.php";
+include_once "../curlService.php";
 
 // Connect to database and start session
 pdoConnect();

--- a/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
+++ b/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
@@ -11,6 +11,7 @@ include_once "../../../Shared/sessions.php";
 include_once "../../../Shared/basic.php";
 include_once "../sharedMicroservices/getUid_ms.php";
 //include_once "retrieveHighscoreService_ms.php";
+include_once "../microservices/curlService.php";
 
 // Connect to database and start session
 pdoConnect();
@@ -47,7 +48,12 @@ $ch = curl_init($url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 $response = curl_exec($ch);
 curl_close($ch);
-
+/* //Change to curlService
+$response = callMicroservicePOST("../highscoreService/retrieveHighscoreService_ms.php", [
+    'did' => $duggaid,
+    'lid' => $variant
+], true );
+*/
 $data = json_decode($response, true);
 echo json_encode($data);
 

--- a/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
+++ b/DuggaSys/microservices/highscoreService/highscoreservice_ms.php
@@ -42,7 +42,7 @@ logServiceEvent($log_uuid, EventTypes::ServiceServerStart, "highscoreservice.php
     'did' => $duggaid,
     'lid' => $variant
  ];
-$response = callMicroservicePOST("../highscoreService/retrieveHighscoreService_ms.php", $postData, true );
+$response = callMicroservicePOST("highscoreService/retrieveHighscoreService_ms.php", $postData, true );
 
 $data = json_decode($response, true);
 echo json_encode($data);

--- a/DuggaSys/microservices/highscoreService/retrieveHighscoreService_ms.php
+++ b/DuggaSys/microservices/highscoreService/retrieveHighscoreService_ms.php
@@ -1,5 +1,6 @@
 <?php
 include_once "../../../Shared/basic.php";
+include_once "../microservices/curlService.php";
 
 // Include basic application services! Include more if needed
 date_default_timezone_set("Europe/Stockholm");
@@ -8,8 +9,9 @@ include_once "../../../Shared/sessions.php";
 pdoConnect();
 session_start();
 
-$duggaid = getOP('did');
-$variant = getOP('lid');
+$data = recieveMicroservicePOST(['did', 'lid']);
+$duggaid = $data['did'];
+$variant = $data['lid'];
 $debug = "";
 
 //------------------------------------------------------------------------------------------------
@@ -74,8 +76,6 @@ $array = array(
     "highscores" => $rows,
     "user" => $user
 );
-
-//echo json_encode($array);
 
 // logServiceEvent($log_uuid, EventTypes::ServiceServerEnd, "highscoreservice.php",$userid,$info);
 

--- a/DuggaSys/microservices/highscoreService/retrieveHighscoreService_ms.php
+++ b/DuggaSys/microservices/highscoreService/retrieveHighscoreService_ms.php
@@ -1,6 +1,6 @@
 <?php
 include_once "../../../Shared/basic.php";
-include_once "../microservices/curlService.php";
+include_once "../curlService.php";
 
 // Include basic application services! Include more if needed
 date_default_timezone_set("Europe/Stockholm");


### PR DESCRIPTION
Fixes #17117 . I've changed the microservice retrieveHighscoreService_ms and its inverse dependency file highscoreservice_ms to use the curlService functions for POST. These files weren't re-engineered correctly before since the cURL options for POST weren't set and the data wasn't received in retrieveHighscoreService_ms. From what I have found it's still the old highscoreservice.php being used and not these microservices so I haven't been able to test it properly. It should be changed in the future to use these files instead. The reviewer can tell me if you find something different. 