### PR TITLE
Fixed: G1 2025 v6 #17316 snapping to lifeline occurs infinitely along the vertical line

### DIFF
--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -312,7 +312,7 @@ function mup(event) {
 
         // If a nearby lifeline is found, snap the element to it
         if (nearestLifelineId) {
-         //   snapElementToLifeline(el, nearestLifelineId);
+            snapElementToLifeline(el, nearestLifelineId);
         }
     });
 }

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -312,7 +312,7 @@ function mup(event) {
 
         // If a nearby lifeline is found, snap the element to it
         if (nearestLifelineId) {
-            snapElementToLifeline(el, nearestLifelineId);
+         //   snapElementToLifeline(el, nearestLifelineId);
         }
     });
 }

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -320,7 +320,7 @@ function findNearestLifeline(x, y) {
             const dx = Math.abs(centerX - x);
 
             // Only snaps to the lifeline if within the lifeline's range
-            if (dx < 50 && dx < minDistance) { 
+            if (dx < 50 && dx < minDistance && y >= topY && y <= botY) { 
                 minDistance = dx;
                 closestId = el.id;
             }


### PR DESCRIPTION
Added some check conditions that were missing on the y-axis of the lifeline causing elements to snap infinitely along the vertical line. This should not be possible anymore and snaps only occur to the actual lifeline.

https://github.com/user-attachments/assets/49bde8a2-cec7-4743-8530-47c2d5ffe69b

