### PR TITLE
Null-check for window resize in codeviewer.js

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -1455,13 +1455,19 @@ function execSkip() {
 window.addEventListener("load", function () {
 	var windowHeight = window.innerHeight;
 	var textHeight = windowHeight - 50;
-	document.getElementById("table-scroll").style.height = textHeight + "px";
+	var tableScrollContainer = document.getElementById("table-scroll");
+	if (tableScrollContainer) {
+		tableScrollContainer.style.height = textHeight + "px";
+	}
 });
 
 window.addEventListener("resize", function () {
 	var windowHeight = window.innerHeight;
 	var textHeight = windowHeight - 50;
-	document.getElementById("table-scroll").style.height = textHeight + "px";
+	var tableScrollContainer = document.getElementById("table-scroll");
+	if (tableScrollContainer) {
+		tableScrollContainer.style.height = textHeight + "px";
+	}
 	closeBurgerMenu(); // close burgerMenu when window resize
 });
 


### PR DESCRIPTION
Added null-checks for window resize in `codeviewer.js` to not throw unexpected error.