### PR TITLE
Refactored the diagram toolbar for mobile versions

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -320,8 +320,9 @@
         display: block !important;
         position: fixed;
         z-index: 10;
-        bottom: 7%;
-        left: calc(50% - 2%);
+        bottom: 5%;
+        left: 50%;
+        transform: translateX(-50%);
         transition: var(--normal-transition);
     }
 
@@ -347,11 +348,12 @@
     }
 
     #diagram-toolbar {
+        display: none !important;
         position: fixed;
         bottom: 0;
         left: 0;
         width: 100%;
-        display: flex;
+        /* display: flex; */
         align-items: center;
         justify-content: space-between;
         flex-wrap: nowrap;
@@ -463,6 +465,7 @@
 }
 
 #diagram-toolbar {
+    display: block;
     position: absolute;
     border-right: solid black 1px;
     background-color: var(--color-primary);

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2339,4 +2339,27 @@ window.addEventListener("resize", () => {
         ruler.style.top = "0px";
     }
 });
+
+/** 
+ * Improvement suggestion: Instead of attaching event listeners to each individual element, 
+ * delegate the event by attaching a single event-listener to the parent (e.g., #mb-diagram-toolbar). 
+ * Use e.target.tagName or e.target.classList to determine if a relevant child was clicked, 
+ * and handle the action accordingly.
+ */
+
+//Select all toolbar boxes from the mobile toolbar
+const elementToolbarBoxs = document.querySelectorAll(".mb-toolbar-main:not(.non-element)");
+
+elementToolbarBoxs.forEach(elementBox=>{
+    elementBox.addEventListener("click", handleToolbarClick);
+});
+
+
+//Select all toolbar boxes inside the sub menu
+const subMenuToolbarBoxs = document.querySelectorAll(".mb-sub-menu .mb-toolbar-box");
+
+subMenuToolbarBoxs.forEach(subMenuBox=>{
+    subMenuBox.addEventListener("click", changeActiveElement);
+});
+
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1303,6 +1303,265 @@
         </div>
     </div>
 
+    <!-- Mobile Version of the diagram-toolbar, STARTS HERE! -->
+    <!-- "mb", stands for mobile -->
+    <!-- "mb-toolbar-main", is the active element that is shown when the sub menu is closed/hidden -->
+    <!-- "title", a static and visible tooltip on top of every tooltip box -->
+    <!-- "data-mode", is used for receiving the correct tooltip -->
+    <!-- "data-elementtype", is used to match the active element with the element in the sub menu (see "activeSubMenuElement(...)") -->
+    <!-- "data-placementtype", stores the elements' placementtype used for "setElementPlacementType(...) "-->
+    <!-- "data-imagesrc", stores the image of the toolbar box -->
+    <!-- "aria-hidden", is used to improve accesibility (for screen readers). true = hidden : false = visible-->
+    <nav id="mb-diagram-toolbar" aria-hidden="true" style="display: none;">
+        <ul class="mb-nav-list">
+
+            <!-- Pointer -->
+            <li class="mb-nav-item" title="Pointer">
+                <div class="mb-toolbar-box mb-toolbar-main active" data-mode="Pointer" onclick='setMouseMode(0);'>
+                    <img src="../Shared/icons/diagram_pointer_white.svg" alt="Pointer"/>
+                </div>
+            </li>
+
+            <!-- Box Selection -->
+            <li class="mb-nav-item" title="Box Selection">
+                <div class="mb-toolbar-box mb-toolbar-main" data-mode="Box-Selection" onclick='setMouseMode(1);'>
+                    <img src="../Shared/icons/diagram_box_selection2.svg" alt="Box Selection"/>
+                </div>
+            </li>
+
+            <!-- Entities (ER, UML, IE, SD)-->
+            <li class="mb-nav-item has-dropdown" title="Entities">
+                <div class="mb-toolbar-box mb-toolbar-main"
+                    data-mode="ER-Entity" data-elementtype="ER-E" data-imagesrc="../Shared/icons/diagram_entity.svg" data-placementtype="0" onclick='setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);'>
+
+                    <img src="../Shared/icons/diagram_entity.svg" alt="ER entity" class="active-image"/>
+                </div>
+                <ul class="mb-sub-menu" aria-hidden="true"> <!-- Sub menu for entities, Starts Here-->
+                    <li>
+                        <div class="mb-toolbar-box" 
+                            data-mode="ER-Entity" data-elementtype="ER-E" data-imagesrc="../Shared/icons/diagram_entity.svg" data-placementtype="0" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box" 
+                            data-mode="UML-Class" data-elementtype="UML-C" data-imagesrc="../Shared/icons/diagram_UML_entity.svg" data-placementtype="4" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="IE-Entity" data-elementtype="IE-E" data-imagesrc="../Shared/icons/diagram_IE_entity.svg" data-placementtype="6" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="State-Diagram" data-elementtype="SD" data-imagesrc="../Shared/icons/diagram_state.svg" data-placementtype="8" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
+                        </div>
+                    </li>
+                </ul>
+                <div class="mb-dropdown-icon"><i class="material-icons">chevron_right</i></div>
+            </li>
+
+            <!-- The different types of relations (e.g. inheritance and attributes) -->
+            <li class="mb-nav-item has-dropdown" title="Relations">
+                <div class="mb-toolbar-box mb-toolbar-main"
+                    data-mode="ER-Relation" data-elementtype="ER-R" data-imagesrc="../Shared/icons/diagram_relation.svg" data-placementtype="1" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                    <img src="../Shared/icons/diagram_relation.svg"  alt="ER relation" class="active-image"/>
+                </div>
+                <ul class="mb-sub-menu" aria-hidden="true"> <!-- Sub menu for relations, Starts Here-->
+                    <li>
+                        <div class="mb-toolbar-box" 
+                            data-mode="ER-Relation" data-elementtype="ER-R" data-imagesrc="../Shared/icons/diagram_relation.svg" data-placementtype="1" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_relation.svg"  alt="ER relation"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="ER-Attribute" data-elementtype="ER-A" data-imagesrc="../Shared/icons/diagram_attribute.svg" data-placementtype="2" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box" 
+                            data-mode="UML-Inheritance" data-elementtype="UML-I" data-imagesrc="../Shared/icons/diagram_inheritance.svg" data-placementtype="5" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_inheritance.svg" alt="UML Inheritance"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box" 
+                            data-mode="IE-Inheritance" data-elementtype="IE-I" data-imagesrc="../Shared/icons/diagram_IE_inheritance.svg" data-placementtype="7" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
+                        </div>
+                    </li>
+                </ul>
+                <div class="mb-dropdown-icon"><i class="material-icons">chevron_right</i></div>
+            </li>
+
+            <li class="mb-nav-item" title="Line">
+                <div class="mb-toolbar-box mb-toolbar-main" data-mode="Line" onclick='clearContext(); setMouseMode(3);'>
+                    <img src="../Shared/icons/diagram_line.svg" alt="Line"/>
+                </div>
+            </li>
+
+            <!-- State Diagram Symbols -->
+            <li class="mb-nav-item has-dropdown" title="SD Symbols">
+                <div class="mb-toolbar-box mb-toolbar-main" 
+                    data-mode="UML-Initial-S" data-elementtype="UML-IS" data-imagesrc="../Shared/icons/diagram_UML_inital_state.svg" data-placementtype="9" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                    <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state" class="active-image"/>
+                </div>
+                <ul class="mb-sub-menu" aria-hidden="true"> <!-- Sub menu for State Diagram Symbols, Starts Here-->
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="UML-Initial-S" data-elementtype="UML-IS" data-imagesrc="../Shared/icons/diagram_UML_initial_state.svg" data-placementtype="9" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="UML-Final-S" data-elementtype="UML-FS" data-imagesrc="../Shared/icons/diagram_UML_final_state.svg" data-placementtype="10" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="UML-Super-S" data-elementtype="UML-SS" data-imagesrc="../Shared/icons/diagram_super_state.svg" data-placementtype="11" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
+                        </div>
+                    </li>
+                </ul>
+                <div class="mb-dropdown-icon"><i class="material-icons">chevron_right</i></div>
+            </li>
+
+            <!-- Sequence Diagram Symbols -->
+            <li class="mb-nav-item has-dropdown" title="Sequence D">
+                <div class="mb-toolbar-box mb-toolbar-main"
+                    data-mode="Sequence-Lifeline-A" data-elementtype="SL-A" data-imagesrc="../Shared/icons/diagram_lifeline.svg" data-placementtype="12" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                    <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline" class="active-image"/>
+                </div>
+                <ul class="mb-sub-menu" aria-hidden="true"> <!-- Sub menu for Sequence Diagram Symbols, Starts Here-->
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="Sequence-Lifeline-A" data-elementtype="SL-A" data-imagesrc="../Shared/icons/diagram_lifeline.svg" data-placementtype="12" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="Sequence-Lifeline-O" data-elementtype="SL-O" data-imagesrc="../Shared/icons/diagram_sequence_object.svg" data-placementtype="16" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="Sequence-Activation" data-elementtype="SA" data-imagesrc="../Shared/icons/diagram_activation.svg" data-placementtype="13" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="mb-toolbar-box"
+                            data-mode="Sequence-Loop" data-elementtype="SL" data-imagesrc="../Shared/icons/diagram_optionLoop.svg" data-placementtype="14" onclick="setElementPlacementType(parseInt(this.dataset.placementtype));setMouseMode(2);">
+
+                            <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
+                        </div>
+                    </li>
+                </ul>
+                <div class="mb-dropdown-icon"><i class="material-icons">chevron_right</i></div>
+            </li>
+
+            <!-- Note -->
+            <li class="mb-nav-item" title="Note">
+                <div class="mb-toolbar-box mb-toolbar-main" data-mode="Note" data-placementtype="15" onclick='setElementPlacementType(parseInt(this.dataset.placementtype)); setMouseMode(2);'>
+                    <img src="../Shared/icons/diagram_note.svg"/>
+                </div>
+            </li>
+
+            <!-- Camera -->
+            <li class="mb-nav-item" title="Camera">
+                <div class="mb-toolbar-box mb-toolbar-main non-element" data-mode="Camera" onclick="centerCamera(); nonElementToggle(this);">
+                    <img src="../Shared/icons/fullscreen.svg" alt="Reset view">
+                </div>
+            </li>
+
+            <!-- History and Replay Mode -->
+            <li class="mb-nav-item" title="History">
+                <div class="mb-toolbar-box mb-toolbar-main non-element" data-mode="Reset-Diagram" onclick="resetDiagramAlert(); nonElementToggle(this);">
+                    <img src="../Shared/icons/diagram_Refresh_Button.svg" alt="Reset diagram"/>
+                </div>
+                <div class="mb-toolbar-box mb-toolbar-main non-element" data-mode="Redo" onclick="toggleStepForward(); nonElementToggle(this);">
+                    <img src="../Shared/icons/diagram_stepforward.svg" alt="Redo"/>
+                </div>
+                <div class="mb-toolbar-box mb-toolbar-main non-element" data-mode="Undo" onclick="toggleStepBack(); nonElementToggle(this);">
+                    <img src="../Shared/icons/diagram_stepback.svg" alt="Undo"/>
+                </div>
+                <div class="mb-toolbar-box mb-toolbar-main non-element" data-mode="Replay-Mode" onclick="toggleReplay(); nonElementToggle(this);">
+                    <img src="../Shared/icons/diagram_replay.svg" alt="Enter replay mode"/>
+                </div>
+            </li>
+
+            <!-- ER-Table -->
+            <li class="mb-nav-item" title="ER-Table">
+                <div class="mb-toolbar-box mb-toolbar-main" data-mode="ER-Table" onclick="toggleErTable();">
+                    <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle ER-Table"/>
+                </div>
+            </li>
+            
+            <!-- Testcase -->
+            <li class="mb-nav-item" title="Testcase">
+                <div class="mb-toolbar-box mb-toolbar-main" data-mode="Testcase" onclick="toggleTestCase();">
+                    <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle test-cases"/>
+                </div>
+            </li>
+
+            <!-- Error Check-->
+            <!-- <li class="mb-nav-item">
+                <div id="errorCheckToggle" class="mb-toolbar-box" data-mode="Error-Check" onclick="toggleErrorCheck();">
+                    <img src="../Shared/icons/diagram_errorCheck.svg" alt="Toggle error check"/>
+                </div>
+            </li> -->
+
+            <!-- Save -->
+            <!-- <li class="mb-nav-item">
+                <div class="mb-toolbar-box" data-mode="Save" onclick="quickSaveDiagram();">
+                    <img src="../Shared/icons/diagram_save_icon.svg" alt="Save diagram"/>
+                </div>
+            </li> -->
+
+            <!-- Save as-->
+            <!-- <li class="mb-nav-item">
+                <div class="mb-toolbar-box" data-mode="Save-As" onclick="showSavePopout();">
+                    <img src="../Shared/icons/diagram_save_as_icon.svg" alt="Save diagram as"/>
+                </div>
+            </li> -->
+
+            <!-- Load -->
+            <!-- <li class="mb-nav-item">
+                <div class="mb-toolbar-box" data-mode="Load" onclick="showModal();">
+                    <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
+                </div>
+            </li>
+        </ul> -->
+    </nav>
+
     <!-- content END -->
     <?php
         include '../Shared/loginbox.php';

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -24,6 +24,7 @@
     <link type="text/css" href="../Shared/css/style.css" rel="stylesheet">
     <link type="text/css" href="./diagram.css" rel="stylesheet">
     <link type="text/css" href="../Shared/css/jquery-ui-1.10.4.min.css" rel="stylesheet">
+    <link type="text/css" href="../Shared/css/mobile-diagram.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
         <!-- To enable dark mode, these 2 files were added. -->

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -540,19 +540,128 @@ function showErrorCheck(show) {
 
 function toggleToolbar() {
     let toggleBtn = document.querySelector(".icon-wrapper");
-    let toolbar = document.getElementById("diagram-toolbar");
+    let toolbar = document.getElementById("mb-diagram-toolbar");
     let chevronIcon = document.querySelector(".toggle-chevron");
 
     let ChevronActive = toggleBtn.classList.toggle("toolbar-active");
-    let toolbarActive = toolbar.classList.toggle("toolbar-active");
+    let toolbarActive = toolbar.classList.toggle("active");
 
     /*
     * Determines wether to rotate the chevron icon if the toolbar and * toggleBtn is in a active state
     */
     if (ChevronActive && toolbarActive) {
         chevronIcon.style.transform = `rotate(180deg)`;
+        toolbar.setAttribute("aria-hidden", "false")
     }
     else {
         chevronIcon.style.transform = `rotate(0deg)`;
+        toolbar.setAttribute("aria-hidden", "true")
     }
+}
+
+/**
+ * @description Function that toggles the active state of the toolbar modes and opening sub menus if they exist.
+ * @param {*} e event-object that is used for finding the current elements next element sibling
+ */
+function handleToolbarClick(e){
+    e.stopPropagation(); //Stops event bubbling
+    const clickedElement = e.currentTarget;
+    let nextSibling = clickedElement.nextElementSibling;
+    let activeElement = document.querySelector(".mb-toolbar-main.active");
+    let dropIcon = clickedElement.parentNode.querySelector(".mb-dropdown-icon i");
+
+    //Does not close sub menus if the clicked element is a sub menu element
+    if(clickedElement.closest(".mb-sub-menu")) return;
+
+    //Does not change the active state of the if the clicked element already is the active element in the toolbar
+    if(!clickedElement || clickedElement===activeElement) return;
+
+    //acts a falsy check which means if the activeElement exists then it executes the if-statement
+    if(activeElement){
+        activeElement.classList.remove("active");
+    }
+    clickedElement.classList.add("active");
+
+    //Closes every sub menu except the one that is being opened (nextSibling)
+    document.querySelectorAll(".mb-sub-menu.show").forEach(subMenu=>{
+        if(subMenu!==nextSibling){
+            subMenu.setAttribute("aria-hidden", "true"); //For screen readers, basically says that the sub menu is closed/hidden
+            subMenu.classList.remove("show");
+            let dropIcon = subMenu.parentNode.querySelector(".mb-dropdown-icon i");
+            if(dropIcon) dropIcon.classList.remove("rotation");
+        }
+    });
+
+    if(dropIcon) dropIcon.classList.add("rotation");
+
+    //Only opens a sub menu if the sibling of clicked element exist and is a sub menu
+    if(nextSibling && nextSibling.classList.contains("mb-sub-menu")){
+        nextSibling.classList.add("show");
+        nextSibling.setAttribute("aria-hidden", "false");
+        activeSubMenuElement(e.currentTarget);
+    }
+}
+
+/**
+ * @description Function that marks which element that is being active in the sub menu
+ * @param {*} element event-object that contains information about the clicked element
+ */
+function activeSubMenuElement(element){
+    let dropdownItems = document.querySelectorAll(".mb-sub-menu .mb-toolbar-box");
+    let elementType = element.dataset.elementtype;
+
+    /*Loops through all the sub menu elements, and checks if the active element and the sub menu have the same elementtype (e.g. ER-E === ER-E). */
+    dropdownItems.forEach(item=>{
+        item.classList.remove("active");
+        let itemType = item.dataset.elementtype;
+        if(itemType===elementType){
+            item.classList.add("active");
+        }
+    });
+}
+
+/**
+ * @description Function that changes which element that is active after choosing a sub menu element
+ * @param {*} e event-object that contains information about the clicked element
+ */
+function changeActiveElement(e){
+    //Finds the closest parent to the clicked element 
+    //Used to only update the active element in the same parent
+    let dropdownList = e.currentTarget.closest(".has-dropdown");
+    if(!dropdownList) return;
+
+    //Always chooses the first element of the parent, which is always the active element
+    let firstActiveElement = dropdownList.querySelector(".mb-toolbar-box");
+    if(!firstActiveElement) return;
+
+    // Finds the image inside the firstActiveElement
+    let activeImage = firstActiveElement.querySelector(".active-image");
+    if(!activeImage) return;
+
+    //Fetches all the information necessary from the clicked sub menu element in the form of datasets
+    let imageSrc = e.currentTarget.dataset.imagesrc;
+    let placementType = e.currentTarget.dataset.placementtype;
+    let elementType = e.currentTarget.dataset.elementtype;
+    let elementMode = e.currentTarget.dataset.mode;
+    
+    //Switches the active elements datasets with the sub menus datasets
+    activeImage.src = imageSrc;
+    firstActiveElement.dataset.mode = elementMode;
+    firstActiveElement.dataset.elementtype = elementType;
+    firstActiveElement.dataset.placementtype = placementType;
+    firstActiveElement.dataset.imagesrc = imageSrc;
+    activeSubMenuElement(e.currentTarget);
+}
+
+/**
+ * @description Function that lets the user know that the item was clicked but is not being focused. 
+ * @param {*} el it references to the element that was clicked
+ */
+function nonElementToggle(el){
+    el.classList.add("active");
+
+    //Removes the class after 1500ms/1.5s
+    setTimeout(()=>{
+        el.classList.remove("active");
+    }, 1500);
 }

--- a/Shared/css/mobile-diagram.css
+++ b/Shared/css/mobile-diagram.css
@@ -1,0 +1,109 @@
+@media screen and (max-width: 414px) {
+    #mb-diagram-toolbar {
+        display: block !important;
+        position: fixed;
+        inset: auto auto 0 0;
+        width: 100%;
+        height: auto;
+        padding-inline: .5rem;
+        background-color: var(--color-primary);
+        overflow-x: auto;
+        z-index: 21;
+        box-sizing: border-box;
+        transform: translateY(200px);
+        transition: var(--normal-transition);
+    }
+
+    #mb-diagram-toolbar.active {
+        transform: translateY(0px);
+    }
+
+    #mb-diagram-toolbar img {
+        width: 40px;
+        aspect-ratio: 1;
+        box-sizing: border-box;
+        padding: .2rem;
+    }
+
+    .mb-toolbar-box {
+        width: 50px;
+        aspect-ratio: 1;
+        display: grid;
+        place-items: center;
+        border-radius: .5rem;
+        border: none;
+    }
+
+    #mb-diagram-toolbar .mb-sub-menu {
+        /*Hides the sub menu*/
+        display: none;
+    }
+
+    #mb-diagram-toolbar .mb-sub-menu.show {
+        /*Adds this class when the sub menu is open*/
+        display: flex;
+    }
+
+    .mb-nav-item {
+        position: relative;
+        border: 1px solid #ececec;
+        display: flex;
+        align-items: center !important;
+        column-gap: .4rem;
+        border-radius: .5rem;
+
+        >div{
+            margin-bottom: 0rem !important;
+        }
+    }
+
+    .mb-nav-item::after {
+        /*Style for the static and visible tooltips*/
+        content: attr(title);
+        position: absolute;
+        top: -1.8vh !important;
+        left: 0;
+        width: 100%;
+        color: #ececec;
+        font-size: .7rem;
+        white-space: nowrap;
+        text-align: center;
+    }
+
+    #mb-diagram-toolbar ul {
+        list-style: none;
+        display: flex;
+        flex-flow: row !important;
+        align-items: center;
+        column-gap: 1rem;
+        padding-left: 0rem;
+    }
+
+    .mb-dropdown-icon {
+        top: 35% !important;
+        right: -3vw !important;
+        color: #f0f0f0;
+        background-color: var(--color-primary);
+        border-radius: none !important;
+
+        >i {
+            font-size: 1rem;
+        }
+    }
+
+    .mb-dropdown-icon i.rotation {
+        /*Adds this class when the sub menu is open*/
+        transform: rotate(180deg);
+    }
+
+    .mb-toolbar-box.active {
+        /*Adds this class to the active element in the toolbar*/
+        background-color: rgba(0, 0, 0, .2);
+    }
+
+    .mb-sub-menu .mb-toolbar-box.active {
+        /*Adds this class to sub menu element that matches the active element*/
+        background-color: rgba(0, 0, 0, .1);
+        border: none;
+    }
+}


### PR DESCRIPTION
I have refactored and improved the diagram toolbar for the mobile version of the diagram page. video 1 shows how the toolbar works as of now. You can now open sub menus and switch the active drawing element by clicking one of the sub menu elements.
 
This solution works by using data-attributes to store information about the different toolbar boxes and the active toolbar box switches data-attributes if one of the sub menu boxes are clicked. When choosing a element to draw, it shows which sub menu element that is active by checking if the active and sub menu element have the same dataset. 

test this solution on different browsers. 

video 1

https://github.com/user-attachments/assets/42b46832-c3a5-4f8f-8ee0-42bb0437b1ec

