### PR TITLE
Fixed multiple alternative sequence-loop highlight color

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -873,18 +873,19 @@ function drawElementSequenceLoopOrAlt(element, boxw, boxh, linew, texth) {
     }
     //svg for the small label in top left corner
     content += `<path 
-                    d="M ${(7 * zoomfact) + linew},${linew}
-                        h ${100 * zoomfact}
-                        v ${25 * zoomfact}
-                        l ${-12.5 * zoomfact},${12.5 * zoomfact}
-                        H ${linew}
-                        V ${linew + (7 * zoomfact)}
-                        a ${7 * zoomfact},${7 * zoomfact} 0 0 1 ${7 * zoomfact},${(7 * zoomfact) * -1}
-                        z" 
-                    stroke-width='${linew}'
-                    stroke='${element.stroke}'
-                    fill='${element.fill}'
-                />`;
+                id="loopLabel"
+                d="M ${(7 * zoomfact) + linew},${linew}
+                    h ${100 * zoomfact}
+                    v ${25 * zoomfact}
+                    l ${-12.5 * zoomfact},${12.5 * zoomfact}
+                    H ${linew}
+                    V ${linew + (7 * zoomfact)}
+                    a ${7 * zoomfact},${7 * zoomfact} 0 0 1 ${7 * zoomfact},${(7 * zoomfact) * -1}
+                    z" 
+                stroke-width='${linew}'
+                stroke='${element.stroke}'
+                fill='${element.fill}'
+            />`;
     let textOne = drawText(50 * zoomfact + linew, 18.75 * zoomfact + linew, 'middle', element.altOrLoop);
     let textTwo = drawText(linew * 2, 37.5 * zoomfact + linew * 3 + texth / 1.5, 'auto', element.alternatives[0] ?? '', `fill=${fontColor}`);
     return drawSvg(boxw, boxh, content + textOne + textTwo);

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -144,7 +144,7 @@ function updateCSSForAllElements() {
                         fillColor = elementDiv.querySelector("g > circle"); // Accessing the circular "head" element
                     }
                     else if (element.kind == elementTypesNames.sequenceLoopOrAlt || element.kind == elementTypesNames.UMLSuperState) {
-                        fillColor =elementDiv.children[0].children[1]; // Accessing the top left rectangle
+                        fillColor = elementDiv.querySelector("#loopLabel"); // Accessing the top left rectangle
                     }
                     else {
                         fillColor = elementDiv.children[0].children[0]; // Accessing the whatever needs to be accessed


### PR DESCRIPTION
Fixes issue: #17436, the issue was that when adding alternatives to sequence loops, it broke the color manipulation of the element (my fault).

The small text area dynamically changes position relative to its parent (in the html-structure) when alternatives are added to the element. But since the color was manipulated with a static child reference, the color manipulation broke when adding alternatives. To fix it I added an ID to the <path> for the small top left text area and changed the color-updating logic filter on that instead of a statically defined child. This solved the issue and is much more reliable.

Before: 
![image](https://github.com/user-attachments/assets/2e373b37-7089-445c-bf3e-f4dd5ddd4ffe)

After:
![image](https://github.com/user-attachments/assets/106a6ce6-921f-450c-9111-d4f81725c554)
