### PR TITLE
Name of current file is being displayed to the user

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -71,6 +71,17 @@
     overflow: hidden;
 }
 
+#diagramFileName {
+    position: absolute;
+    z-index: 1000;
+    margin-left: 50vw;
+    margin-top: 6vh;
+    padding: 2px;
+    background-color: #fff;
+    border: #775886 1px solid;
+    text-align: center;
+}
+
 #svgbacklayer {
     position: absolute;
     left: 0;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2120,6 +2120,7 @@ function loadDiagramFromLocalStorage(key) {
                 activeFile = key;
                 loadDiagramFromString(obj[key]);
 
+                // The name of the loaded file is shown on screen for the user. It only appears if there is a file selected
                 const div = document.getElementById("diagramFileName");
                 const span = document.getElementById("openedFileName");
                 if (div && span) {

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2119,6 +2119,13 @@ function loadDiagramFromLocalStorage(key) {
             } else {
                 activeFile = key;
                 loadDiagramFromString(obj[key]);
+
+                const div = document.getElementById("diagramFileName");
+                const span = document.getElementById("openedFileName");
+                if (div && span) {
+                    span.textContent = key;
+                    div.style.display = "inline-block";
+                }
             }
         } else {
             // Failed to load content

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1106,12 +1106,17 @@
         </div>
     </div>
 
+    <div id='diagramFileName'> 
+        <p>Opened file: </p><span id='openedFileName'></span>
+    </div>
+
     <!-- Message prompt -->
     <div id="diagram-message"></div>
     
     <!-- Diagram drawing system canvas. -->
     <svg id="svgoverlay" preserveAspectRatio="none"></svg>
     <div id="container"></div><!-- Contains all elements (items) -->
+    
      <!-- One svg layer for background stuff and one for foreground stuff -->
     <svg id="svgbacklayer" preserveAspectRatio="none"></svg>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1106,8 +1106,9 @@
         </div>
     </div>
 
+    <!-- If a file is opened the name is displayed in this div -->
     <div id='diagramFileName' style='display: none;'> 
-        <p>Opened file: <span id='openedFileName'></span></p>
+        <p>Current file: <span id='openedFileName'></span></p>
     </div>
 
     <!-- Message prompt -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1106,8 +1106,8 @@
         </div>
     </div>
 
-    <div id='diagramFileName'> 
-        <p>Opened file: </p><span id='openedFileName'></span>
+    <div id='diagramFileName' style='display: none;'> 
+        <p>Opened file: <span id='openedFileName'></span></p>
     </div>
 
     <!-- Message prompt -->


### PR DESCRIPTION
Added an element that displays the name of the current file for the user. If no file has been opened, the div is not displayed at all. When a user is changing between files the name updates along with the file being loaded. All of the logic is handled at the same time as the file is loaded (in the same function), so there is no delay in showcasing the name or loading the diagram.

Currently the only way to display the name (so that the only place it shows up on is the diagram pages) is to display it in the drawing-area (or on top of the ruler) which might not be the most convenient place but seems to work well enough for the most part. 

https://github.com/user-attachments/assets/326194ef-2464-4435-be22-895e0d2feb30
