### PR TITLE
Fixing GitHub repo key #17402

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -774,6 +774,7 @@
 				<input type='hidden' id='cidTrue' value='<?php echo $_GET["courseid"];?>'/>
 				<form action="" method="POST" id="repoLink">
 					<div class= 'inputwrapper'><span>Github repo link:</span><input onchange="checkGithubLinkClue('gitRepoURL')" oninput="checkGithubLink('gitRepoURL')" type="text" id="gitRepoURL" class="textinput" name="reponame" placeholder="https://github.com/username/repository"/></div>
+					<div class= 'inputwrapper'><span>Github repo key (optional):</span><input type="text" id="gitAPIKey" class="textinput" name="repokey" placeholder="12345"/></div>
 				</form>
 			</div>
 			<div class="formFooter">


### PR DESCRIPTION
I have just added a way for you to insert a github repo key.

I **think** this has solved the issue (at least it appears to work with normal repos now)
But I can't check if this works with a repo that actually needs a key as the keys are weird/hard to set up.

Just want to add that the entire linking github repos feature seems unstable at the best of times and I'm not even sure what it even does/achieves.

picture of how it looks now
![image](https://github.com/user-attachments/assets/ff96ec4f-3ea8-4825-a710-ea2c654e9c82)
