### PR TITLE
A4 template options change-up (#17429)

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1092,6 +1092,17 @@
     display: none;
 }
 
+#a4OptionsDropdown,
+#a4Load {
+    display: none;
+    margin-bottom: 15px;
+}
+
+#a4OptionsDropdown {
+    width: 100%;
+    margin-bottom: 10px;
+}
+
 #option-import>input {
     width: 100%;
 }

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1193,7 +1193,7 @@
                 <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
                 <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Ruler</button><br><br>
                 <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Dropdown()">A4 template</button><br><br>
-                <div id="dropdownContent">
+                <div id="dropDownContent">
                     <select id="a4OptionsDropdown" onchange="applyA4Option();">
                         <option value="vertical">Vertical</option>
                         <option value="horizontal">Horizontal</option>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -1192,10 +1192,13 @@
                 <button id="gridToggle" class="saveButton" onclick="toggleGrid();">Grid</button><br><br>
                 <button id="rulerSnapToGrid" class="saveButton" onclick="toggleSnapToGrid()">Snap to grid</button><br><br>
                 <button id="rulerToggle" class="saveButton" onclick="toggleRuler()">Ruler</button><br><br>
-                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Template()">A4 template</button><br><br>
-                <div id="a4Options">
-                    <button id="a4VerticalButton" onclick="toggleA4Vertical()">Vertical</button>
-                    <button id="a4HorizontalButton" onclick="toggleA4Horizontal()">Horizontal</button>
+                <button id="a4TemplateToggle" class="saveButton" onclick="toggleA4Dropdown()">A4 template</button><br><br>
+                <div id="dropdownContent">
+                    <select id="a4OptionsDropdown" onchange="applyA4Option();">
+                        <option value="vertical">Vertical</option>
+                        <option value="horizontal">Horizontal</option>
+                    </select>
+                    <button class="saveButton" id="a4Load" onclick="toggleA4Template()">Load</button>
                 </div>
                 <button id="darkmodeToggle" class="saveButton" onclick="toggleDarkmode()">Darkmode</button><br><br>
                 <button id="diagramDropDownToggle" class="saveButton" onclick="toggleDiagramDropdown()">Example diagrams </button><br><br>

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -146,19 +146,47 @@ function toggleA4Template() {
         vRect.style.display = "none";
         a4Rect.style.display = "none";
         document.getElementById("a4OptionsDropdownContainer").style.display = "none";
-        document.getElementById("a4HorizontalButton").style.display = "none";
+        
         document.getElementById("a4TemplateToggle").style.backgroundColor = "transparent";
         document.getElementById("a4TemplateToggle").style.color = color.PURPLE;
         document.getElementById("a4TemplateToggle").style.fontWeight = "bold";
     } else {
         template.style.display = "block";
         document.getElementById("a4OptionsDropdownContainer").style.display = "block";
-        document.getElementById("a4HorizontalButton").style.display = "inline-block";
+        
         document.getElementById("a4TemplateToggle").style.backgroundColor = color.PURPLE;
         document.getElementById("a4TemplateToggle").style.color = color.WHITE;
         document.getElementById("a4TemplateToggle").style.fontWeight = "normal";
     }
     document.getElementById("a4TemplateToggle").style.border = `3px solid ${color.PURPLE}`;
+}
+
+function toggleA4Dropdown() {
+    const dropdown = document.getElementById("a4OptionsDropdown");
+    const load = document.getElementById("a4Load");
+    const btn = document.getElementById("a4TemplateToggle");
+
+    if (window.getComputedStyle(dropdown).display === "none") {
+        load.style.display = "block";
+        dropdown.style.display = "block";
+    } else {
+        load.style.display = "none";
+        dropdown.style.display = "none";
+    }
+
+    document.getElementById("a4TemplateToggle").classList.toggle("active");
+
+    if (window.getComputedStyle(dropdown).display === "none") {
+        btn.style.backgroundColor = "transparent";
+        btn.style.border = `3px solid ${color.PURPLE}`;
+        btn.style.color = color.PURPLE;
+        btn.style.fontWeight = "bold";
+    } else {
+        btn.style.backgroundColor = color.PURPLE;
+        btn.style.color = color.WHITE;
+        btn.style.fontWeight = "normal";
+        btn.style.border = `3px solid ${color.PURPLE}`;
+    }
 }
 
 function setA4SizeFactor(e) {

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -145,14 +145,14 @@ function toggleA4Template() {
         template.style.display = "none";
         vRect.style.display = "none";
         a4Rect.style.display = "none";
-        document.getElementById("a4VerticalButton").style.display = "none";
+        document.getElementById("a4OptionsDropdownContainer").style.display = "none";
         document.getElementById("a4HorizontalButton").style.display = "none";
         document.getElementById("a4TemplateToggle").style.backgroundColor = "transparent";
         document.getElementById("a4TemplateToggle").style.color = color.PURPLE;
         document.getElementById("a4TemplateToggle").style.fontWeight = "bold";
     } else {
         template.style.display = "block";
-        document.getElementById("a4VerticalButton").style.display = "inline-block";
+        document.getElementById("a4OptionsDropdownContainer").style.display = "block";
         document.getElementById("a4HorizontalButton").style.display = "inline-block";
         document.getElementById("a4TemplateToggle").style.backgroundColor = color.PURPLE;
         document.getElementById("a4TemplateToggle").style.color = color.WHITE;
@@ -187,6 +187,19 @@ function toggleA4Horizontal() {
 
     a4Rect.style.display = "none";  // Hide vertical
     vRect.style.display = "block";  // Show horizontal
+}
+
+/**
+ * @description Applies the selected A4 option: vertical or horizontal
+ */
+function applyA4Option() {
+    const selectedOption = document.getElementById("a4OptionsDropdown").value;
+
+    if (selectedOption === "vertical") {
+        toggleA4Vertical();
+    } else if (selectedOption === "horizontal") {
+        toggleA4Horizontal();
+    }
 }
 
 /**


### PR DESCRIPTION
Fixed the HTML, JS, and CSS to match with the "Example diagram"-button and functionality. The A4 template can now be toggled from a dropdown, and is not too close to the Darkmode-button. 

![image](https://github.com/user-attachments/assets/e8cb9ad8-ba94-4f69-acfd-2e931ddeabfb)

![image](https://github.com/user-attachments/assets/35eaf5f9-41fc-4f1f-a919-ac60529a5c50)

![image](https://github.com/user-attachments/assets/8686b48e-dd8f-4b01-8997-3d01eceef976)

![image](https://github.com/user-attachments/assets/26d1d3cf-c07d-4b6d-b2a6-2a7d87fcd923)
