### PR TITLE
G3-2025-V6-#17384-course-version-dropdown-not-fully-clickable

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -4371,8 +4371,7 @@ span.arrow {
   box-shadow: var(--standard-shadow);
   background-position: right;
   margin-top: 7px;
-  margin-left: 3px;
-  width: 90%;
+  width: 100%;
 }
 
 .course-dropdown-div select {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1625,7 +1625,7 @@ margin-block-end: 10px;
 }
 #courseVersionDropDown{
   vertical-align: top;
-  max-width: 60px;
+  max-width: 50px; 
 }
 
 .burgerButt {
@@ -4378,6 +4378,7 @@ span.arrow {
   width: inherit;
   white-space: nowrap;
   overflow: hidden;
+  padding-right: 15px;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
**Adjustments:** 
- Changed the width styling of _.course-dropdown-div_ to 100% instead of 90%, since it got brought down to the drop-down and removed interactivity in the last 10% (which housed the dropdown-arrow)
- Since this essentially made the width larger, I changed the max width to be a bit smaller - to possibly make up for it.
- I also added padding which prevents the text from covering the dropdown arrow, boosting readability.

---
**How to test:**
-> login
-> Enter course of your choice (ex. Testing-Course)

The affected element is the CourseVersion-dropdown marked in red within the image below:
![image](https://github.com/user-attachments/assets/88a34576-2c2d-4d30-be08-8bcb2abcae76)
It should now be fully "clickable" - so the "button" is expected to respond with an dropdown.