### PR TITLE
17208 sequence table recursive relation labels

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -550,7 +550,13 @@
     top: -43px;
 }
 
-.diagramIcons[data-single="true"]:hover .toolTipText {
+
+.diagramIcons:hover .toolTipText {
+    visibility: visible;
+    transition-delay: 700ms;
+}
+
+.disabledIcon:hover .toolTipText {
     visibility: visible;
     transition-delay: 700ms;
 }
@@ -1069,6 +1075,9 @@
     background-color: #8d68ab;
 }
 
+    .disabledIcon:hover .toolTipText {
+        visibility: visible;
+    }
 #a4options {
     display: flex;
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -60,16 +60,71 @@ class StateMachine {
                 });
                 break;
             case StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED:
-                for (const element of StateChange.ElementsAreLocked()) {
-                    if (Array.isArray(id)) id = getItemsFromNestedArrays(id)[0];
+                // Normalize ID if it is in an Array
+                const elementId = Array.isArray(id) ? getItemsFromNestedArrays(id)[0] : id;
+                const element = Element.FindElementById(elementId);
+
+                const currentText = element.name || "";
+
+                if (!this.lastTypedTextMap) this.lastTypedTextMap = {};
+
+                const currentFields = {
+                    name: element.name || "",
+                    attributes: element.attributes || ""
+                };
+
+                const lastFields = this.lastTypedTextMap[elementId] || {
+                    name: "",
+                    attributes: ""
+                };
+
+                let hasChanged = false;
+
+                for (const key of ["name", "attributes"]) {
+                    const currentText = (currentFields[key] ?? "").toString();
+                    const lastText = (lastFields[key] ?? "").toString();
+
+                    // Check is a word boundary was typed (space or punctuation or longer than 4 symbols) and if change has happend it is logged (no change means no logging)
+                    const isWordBoundary = currentText.length > lastText.length && (/\s|[.,;!?]/.test(currentText.slice(-1)) || currentText.length - lastText.length > 3);
+                    const isNewText = currentText !== lastText;
+
+                    if (isNewText && isWordBoundary) {
+                        hasChanged = true;
+                        break;
+                    }
+                }
+
+                if (hasChanged) {
+                    // Save a full snapshot of the element to the history log
+                    // Ensures undo/redo works correctly without corrupting or losing the element
                     this.pushToHistoryLog({
-                        ...element,
-                        ...Element.GetFillColor(id),
-                        ...Element.GetStrokeColor(id),
+                        id: elementId,
+                        changeType: StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED,
+                        isLocked: element.isLocked,
+                        attributes: element.attributes,
+                        functions: element.functions,
+                        name: element.name, 
+                        stereotype: element.stereotype, 
+    
+                        // Correctly reconstructs element
+                        kind: element.kind,
+                        x: element.x,
+                        y: element.y,
+                        width: element.width,
+                        height: element.height, 
+    
+                        ...Element.GetFillColor(elementId),
+                        ...Element.GetStrokeColor(elementId),
                         ...StateChange.GetSequenceAlternatives(),
-                        ...Element.GetProperties(id),
                         state: StateChange.ChangeElementState()
                     });
+                    this.lastTypedTextMap[elementId] = {
+                        name: currentFields.name,
+                        attributes: currentFields.attributes
+                    };
+    
+                    this.numberOfChanges++;
+                    updateLatestChange();
                 }
                 break;
             case StateChange.ChangeTypes.ELEMENT_RESIZED:
@@ -138,7 +193,7 @@ class StateMachine {
                 break;
         }
         stateMachine.numberOfChanges++;
-        updateLatestChange()
+        updateLatestChange();
     }
 
     /**

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -70,17 +70,19 @@ class StateMachine {
 
                 const currentFields = {
                     name: element.name || "",
-                    attributes: element.attributes || ""
+                    attributes: element.attributes || "",
+                    functions: element.functions || ""
                 };
 
                 const lastFields = this.lastTypedTextMap[elementId] || {
                     name: "",
-                    attributes: ""
+                    attributes: "",
+                    functions: ""
                 };
 
                 let hasChanged = false;
 
-                for (const key of ["name", "attributes"]) {
+                for (const key of ["name", "attributes", "functions"]) {
                     const currentText = (currentFields[key] ?? "").toString();
                     const lastText = (lastFields[key] ?? "").toString();
 
@@ -120,7 +122,8 @@ class StateMachine {
                     });
                     this.lastTypedTextMap[elementId] = {
                         name: currentFields.name,
-                        attributes: currentFields.attributes
+                        attributes: currentFields.attributes,
+                        functions: currentFields.functions
                     };
     
                     this.numberOfChanges++;

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -196,7 +196,7 @@ function drawLine(line, targetGhost = false) {
         startX += offset.x1 * zoomfact;
         startY += offset.y1 * zoomfact; 
     
-    //Draws the Segmented version for arrow and not straight line
+    //Draws both the straight and the segmented lines
     if(line.kind === lineKind.RECURSIVE){
         if(line.startIcon === SDLineIcons.ARROW){
             lineStr += iconPoly(SD_ARROW[line.ctype], startX, startY, lineColor, color.BLACK);
@@ -209,31 +209,15 @@ function drawLine(line, targetGhost = false) {
     }else{
         // Handle start arrow
         if (line.startIcon === SDLineIcons.ARROW) {
-            if (line.innerType === SDLineType.SEGMENT) {
-                lineStr += iconPoly(SD_ARROW[line.ctype], from.x, from.y, lineColor, color.BLACK);
-            } else {
-                lineStr += drawArrowPoint(
-                    calculateArrowBase(to, from, 10 * zoomfact),
-                    from,
-                    lineColor,
-                    strokewidth
-                );
-            }
+            const arrowStartPos = calculateArrowPosition(fx, fy, tx, ty, "start", line.innerType);
+            lineStr += iconPoly(SD_ARROW[line.ctype], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK);
         }
 
         // Handle end arrow
         if (line.endIcon === SDLineIcons.ARROW) {
+            const arrowEndPos = calculateArrowPosition(fx, fy, tx, ty, "end", line.innerType);
             const reverseCtype = line.ctype.split('').reverse().join('');
-            if (line.innerType === SDLineType.SEGMENT) {
-                lineStr += iconPoly(SD_ARROW[reverseCtype], to.x, to.y, lineColor, color.BLACK);
-            } else {
-                lineStr += drawArrowPoint(
-                    calculateArrowBase(from, to, 10 * zoomfact),
-                    to,
-                    lineColor,
-                    strokewidth
-                );
-            }
+            lineStr += iconPoly(SD_ARROW[reverseCtype], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK);
         }
     }    
         
@@ -335,7 +319,7 @@ function drawLine(line, targetGhost = false) {
 
         //Add label with styling based on selection.
         if (line.kind === lineKind.RECURSIVE) {
-            //Calculatin the lable possition based on element size, so it follows when resized.
+            //Calculation the lable possition based on element size, so it follows when resized.
             const length = 20 * zoomfact;
             const lift   = 80 * zoomfact; 
             let {lineLength, elementLength, startX, startY } = recursiveParam(felem);
@@ -381,6 +365,22 @@ function drawLine(line, targetGhost = false) {
         }
     }
     return { lineStr, labelStr };
+}
+
+// Calculates the arrowhead position at the start or end of a line, adjusting for target size if needed.
+function calculateArrowPosition(fx, fy, tx, ty, position, lineType, targetWidth = 0, targetHeight = 0) {
+    const dx = tx - fx;
+    const dy = ty - fy;
+    const length = Math.sqrt(dx * dx + dy * dy);
+    
+    const offsetX = (targetWidth / 2) * (dx / length);
+    const offsetY = (targetHeight / 2) * (dy / length);
+
+    if (position === "start") {
+        return { x: fx, y: fy };
+    } else if (position === "end") {
+        return { x: tx - offsetX, y: ty - offsetY };
+    }
 }
 
 /**

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -5,6 +5,29 @@
  * @param {boolean} targetGhost Is the targeted line a ghost line
  */
 
+function getPerpendicularOffset(x1, y1, x2, y2, distance) {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.hypot(dx, dy) || 1;
+
+    let nx = (-dy / len) * distance;
+    let ny = ( dx / len) * distance;
+
+    if (Math.abs(dx) >= Math.abs(dy)) {
+        if (ny > 0) {
+            nx *= -1;
+            ny *= -1;
+        }
+    } else {
+        if (nx < 0) {
+            nx *= -1;
+            ny *= -1;
+        }
+    }
+
+    return { x: nx, y: ny };
+}
+
 function drawLine(line, targetGhost = false) {
 
     let lineStr = ""; // only the lines, polylines, arrows etc
@@ -310,8 +333,18 @@ function drawLine(line, targetGhost = false) {
         const labelPositionY = labelPosY - zoomfact;
 
         // Label positioning for regual (non-recursive) lines
-        const labelCenterX = label.centerX - (2 * zoomfact);
-        const labelCenterY = label.centerY;
+        const pad = 16 * zoomfact;
+
+        // real start / end points of this segment
+        const xStart = fx + offset.x1;
+        const yStart = fy + offset.y1;
+        const xEnd   = tx + offset.x2;
+        const yEnd   = ty + offset.y2;
+
+        const {x: offX, y: offY} = getPerpendicularOffset(xStart, yStart, xEnd,   yEnd, pad);
+
+        const labelCenterX = label.centerX + offX;
+        const labelCenterY = label.centerY + offY;
 
         // Centers the background rectangle around the text
         const rectPosX = labelCenterX - textWidth / 2 - zoomfact * 2;

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -389,7 +389,7 @@ function drawLineProperties(line) {
             str += `<h3 style="margin-bottom: 0; margin-top: 5px;">Label</h3>`;
             break;
     }
-    str += saveButton('changeLineProperties();');
+    str += saveButton('changeLineProperties();generateContextProperties();');
     return str;
 }
 
@@ -1926,4 +1926,5 @@ function changeLineProperties() {
     stateMachine.save(contextLine[0].id, StateChange.ChangeTypes.LINE_ATTRIBUTE_CHANGED);
 
     showdata();
+    generateContextProperties();
 }

--- a/DuggaSys/diagram/helpers/mouse.js
+++ b/DuggaSys/diagram/helpers/mouse.js
@@ -206,10 +206,16 @@ function snapElementToLifeline(element, targetId) {
     const lifeline = document.getElementById(targetId);
     if (!lifeline) return; // Exit if the DOM element doesn't exist
 
-    const ll = data.find(item =>
-        (item.kind === "sequenceActor" || item.kind === "sequenceObject") && 
-        item.id === target
-    );
+    // Search for the lifeline data in the main data array
+    for (let i = 0; i < data.length; i++) {
+        const ll = data[i];
+        if ((ll.kind === "sequenceActor" || ll.kind === "sequenceObject") && ll.id === targetId) {
+            // Snap the element horizontally to the center of the lifeline
+            element.x = ll.x + (ll.width / 2) - (element.width / 2);
+            updatepos(); // Refresh position on screen
+            break;
+        }
+    }
 
     if (!ll) return;
 
@@ -314,7 +320,7 @@ function findNearestLifeline(x, y) {
             const dx = Math.abs(centerX - x);
 
             // Only snaps to the lifeline if within the lifeline's range
-            if (dx < 50 && dx < minDistance && y >= topY && y >= botY) { 
+            if (dx < 50 && dx < minDistance) { 
                 minDistance = dx;
                 closestId = el.id;
             }

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -137,7 +137,18 @@ function updateCSSForAllElements() {
                     }
                     // Update normal elements, and relations i.e default case
                 } else { 
-                    fillColor = elementDiv.children[0].children[0];
+                    if (element.kind == elementTypesNames.sequenceObject) {
+                        fillColor = elementDiv.querySelector("g > rect"); // Accessing the rectangle element
+                    }
+                    else if (element.kind == elementTypesNames.sequenceActor) {
+                        fillColor = elementDiv.querySelector("g > circle"); // Accessing the circular "head" element
+                    }
+                    else if (element.kind == elementTypesNames.sequenceLoopOrAlt || element.kind == elementTypesNames.UMLSuperState) {
+                        fillColor =elementDiv.children[0].children[1]; // Accessing the top left rectangle
+                    }
+                    else {
+                        fillColor = elementDiv.children[0].children[0]; // Accessing the whatever needs to be accessed
+                    }
                     fontColor = elementDiv.children[0];
                     weakKeyUnderline = elementDiv.children[0].children[2];
                     if (contextLengthCheck()) {
@@ -243,7 +254,11 @@ function updateCSSForAllElements() {
 
     function fontContrast() {
         // Set text to white if background is black or pink, else black
-        fontColor.style.fill = element.fill == color.BLACK || element.fill == color.PINK ? color.WHITE : color.BLACK;
+        if (element.fill == color.BLACK || element.fill == color.PINK) {
+            fontColor.style.fill = color.WHITE;
+        } else {
+            fontColor.style.fill = color.BLACK;
+        }
     }
     /**
      * @description Checks if multiple elements or lines are selected/highlighted

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -523,17 +523,13 @@ function toggleErrorCheck() {
 }
 
 /**
- * @description hides the error check button when not allowed
+ * @description Function that toggles the visibility of the error check button in the diagram toolbar depending on input.
+ * @param {boolean} show Boolean which defines visibility. "true" enables it, and "false" disables it.
  */
-function hideErrorCheck(show) {
+//Previously named "hideErrorCheck", functionality is the same - but showing the check while "hideErrorCheck(true)" was a bit confusing and misleading.
+function showErrorCheck(show) {
     if (show) {
         document.getElementById("errorCheckField").style.display = "flex";
-        // Enables error check by pressing 'h', only when error check button is visible
-        document.addEventListener("keyup", event => {
-            if (event.key === 'h') {
-                toggleErrorCheck();
-            }
-        });
     } else {
         document.getElementById("errorCheckField").style.display = "none";
     }

--- a/DuggaSys/templates/diagram_dugga.js
+++ b/DuggaSys/templates/diagram_dugga.js
@@ -92,7 +92,7 @@ function returnedDugga(data)
             // getting the diagram types allowed and calling a function in diagram.js where the values are now set <-- UML functionality start
             document.getElementById("diagram-iframe").contentWindow.diagramType = param.diagram_type;
             // getting the error checker allowed or not
-            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(param.errorActive);
+            document.getElementById("diagram-iframe").contentWindow.showErrorCheck(param.errorActive);
             // Getting the instructions to the side of the dugga -currently using filelink which is wrong
              if(param.filelink != undefined)
             {
@@ -106,7 +106,7 @@ function returnedDugga(data)
         else{
             var diagramType={ER:true,UML:true,IE:true};
             document.getElementById("diagram-iframe").contentWindow.diagramType = diagramType;
-            document.getElementById("diagram-iframe").contentWindow.hideErrorCheck(true);
+            document.getElementById("diagram-iframe").contentWindow.showErrorCheck(true);
         }
         document.getElementById("diagram-iframe").contentWindow.showDiagramTypes();//<-- UML functionality end
     }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3110,7 +3110,14 @@ input {
   padding-left: 5px;
 }
 
-
+#pad_lock {
+    bottom: -5px;
+    left: 3px;
+    display: block;
+    position: absolute;
+    background: inherit;
+    filter: invert(65%);
+}
 
 label.login-label {
   display: block;


### PR DESCRIPTION
Updated line.js and options.js
line.js
• Fixed line‑label clipping.
• Added function getPerpendicularOffset(x1, y1, x2, y2, distance) so the text label stays centred *above* the line at every rotation.

options.js
• Line‑label still won’t stay inside the input box after you click "Save".
  – Tried forcing a sidebar refresh (`generateContextProperties()`), but the
    value is still blank on redraw.

![image](https://github.com/user-attachments/assets/5b3dfd46-16b5-4793-ae39-aef02397b784)
![image](https://github.com/user-attachments/assets/9f5b5e06-ce86-4bbc-ad25-fd06a532a771)
