### PR TITLE
Updated line.js and options.js

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -353,8 +353,15 @@ function drawLine(line, targetGhost = false) {
         //Add label with styling based on selection.
         if (line.kind === lineKind.RECURSIVE) {
             //Calculation the lable possition based on element size, so it follows when resized.
-            const length = 20 * zoomfact;
-            const lift   = 80 * zoomfact; 
+            let length = 20 * zoomfact;
+            let lift   = 80 * zoomfact; 
+
+            // Customize values only for SE
+                if (line.type === entityType.SE) {
+                     length = 70 * zoomfact; 
+                     lift = 20 * zoomfact;
+                }
+
             let {lineLength, elementLength, startX, startY } = recursiveParam(felem);
             startY -= lift;
             startX += length;

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -5,6 +5,29 @@
  * @param {boolean} targetGhost Is the targeted line a ghost line
  */
 
+function getPerpendicularOffset(x1, y1, x2, y2, distance) {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.hypot(dx, dy) || 1;
+
+    let nx = (-dy / len) * distance;
+    let ny = ( dx / len) * distance;
+
+    if (Math.abs(dx) >= Math.abs(dy)) {
+        if (ny > 0) {
+            nx *= -1;
+            ny *= -1;
+        }
+    } else {
+        if (nx < 0) {
+            nx *= -1;
+            ny *= -1;
+        }
+    }
+
+    return { x: nx, y: ny };
+}
+
 function drawLine(line, targetGhost = false) {
 
     let lineStr = ""; // only the lines, polylines, arrows etc
@@ -310,8 +333,18 @@ function drawLine(line, targetGhost = false) {
         const labelPositionY = labelPosY - zoomfact;
 
         // Label positioning for regual (non-recursive) lines
-        const labelCenterX = label.centerX - (2 * zoomfact);
-        const labelCenterY = label.centerY;
+        const pad = 16 * zoomfact;
+
+        // real start / end points of this segment
+        const xStart = fx + offset.x1;
+        const yStart = fy + offset.y1;
+        const xEnd   = tx + offset.x2;
+        const yEnd   = ty + offset.y2;
+
+        const {x: offX, y: offY} = getPerpendicularOffset(xStart, yStart, xEnd,   yEnd, pad);
+
+        const labelCenterX = label.centerX + offX;
+        const labelCenterY = label.centerY + offY;
 
         // Centers the background rectangle around the text
         const rectPosX = labelCenterX - textWidth / 2 - zoomfact * 2;

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -389,7 +389,7 @@ function drawLineProperties(line) {
             str += `<h3 style="margin-bottom: 0; margin-top: 5px;">Label</h3>`;
             break;
     }
-    str += saveButton('changeLineProperties();');
+    str += saveButton('changeLineProperties();generateContextProperties();');
     return str;
 }
 
@@ -1926,4 +1926,5 @@ function changeLineProperties() {
     stateMachine.save(contextLine[0].id, StateChange.ChangeTypes.LINE_ATTRIBUTE_CHANGED);
 
     showdata();
+    generateContextProperties();
 }

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -374,20 +374,19 @@ function drawLineProperties(line) {
                 str += select('lineType', optSD, false);
             }
             break;
-        case entityType.SE:
-
-
-            if (line.kind === lineKind.RECURSIVE){
-                str += includeSELabel(line);
-                str += `<h3 style="margin-bottom: 0; margin-top: 5px;">Label</h3>`;
+            case entityType.SE:
+                if (line.kind === lineKind.RECURSIVE) {
+                    str += includeSELabel(line);
+                   // break; // Only show label for recursive, skip rest
+                   const hiddenIcons = iconSelection([SELineIcons], line);
+        str += `<div style="display:none;">${hiddenIcons}</div>`;
+                }
+            
+                //str += includeSELabel(line);
+                //str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);
+                str += iconSelection([SELineIcons], line);
                 break;
-            }
-
-            str += includeSELabel(line);
-            str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);
-            str += iconSelection([SELineIcons], line);
-            str += `<h3 style="margin-bottom: 0; margin-top: 5px;">Label</h3>`;
-            break;
+            
     }
     str += saveButton('changeLineProperties();generateContextProperties();');
     return str;


### PR DESCRIPTION
Updated line.js and options.js
line.js
• Fixed line‑label clipping.
• Added function getPerpendicularOffset(x1, y1, x2, y2, distance) so the text label stays centred *above* the line at every rotation.

options.js
• Line‑label still won’t stay inside the input box after you click "Save".
  – Tried forcing a sidebar refresh (`generateContextProperties()`), but the
    value is still blank on redraw.

![image](https://github.com/user-attachments/assets/5b3dfd46-16b5-4793-ae39-aef02397b784)
![image](https://github.com/user-attachments/assets/9f5b5e06-ce86-4bbc-ad25-fd06a532a771)
