### PR TITLE
[#1720] Fixed odd behaviour with selected elements after snapping from out of bounds

### DIFF
--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -74,7 +74,8 @@ function updateCSSForAllElements() {
             var disjointLine1Color;
             var disjointLine2Color;
 
-            if (data[i].isLocked) useDelta = false;
+            //Element won't update its position relative to the cursor if useDelta is false. 
+            if (data[i].isLocked || pointerState == pointerStates.CLICKED_CONTAINER || boxSelectionInUse) useDelta = false;
             updateElementDivCSS(element, elementDiv, useDelta);
 
             // Apply visual highlights and colors if not in Edge creation mode


### PR DESCRIPTION
**TLDR:** The program didn't account for the object still being selected after snapping back from out of bounds, causing any selection action afterwards where the mouse is pressed down to move the object(s) relative to the cursor position.

Previously, when moving an object outside of the grid viewport the object would snap back to its previous position. The object was still selected after this snap-back happened, which caused some weird interactions with the pointer- and box selection tools.

**When using the pointer tool, the element would move independently of the grid when grabbing the background after having snapped back:**

https://github.com/user-attachments/assets/3519ca75-c7ce-4b16-9f76-239905ce362e

When using boxselect, the object would snap to a different location when the boxselect intersected with the element (_video in issue description_)

The issue here was that the elements were being moved relative to the cursor position, even when they weren't explicitly having the mouse inside the selection, since the object was still selected. The solution to this is to make it so that useDelta (_the variable which determines "Whether to apply delta offset from drag operations" (include cursor position in calculations)_) was false when grabbing the background or using box select. This prevents the element from moving relative to the cursor position, which fixes the issue.

**Now, the element stays in place on the grid when using the pointer:**

https://github.com/user-attachments/assets/dc0b24cf-e731-4ed4-a208-2d9b8381ecb0

**When using the box select tool the element no longer snaps weirdly when inside the selection area:**

https://github.com/user-attachments/assets/e832f896-7c3d-4640-b234-00e232b53391

From the testing I did this solution completely solved it, so this should prevent the bug from happening again. 