### PR TITLE
Admin panel for endpointDirectory_db.sqlite #17414

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
+++ b/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
@@ -12,6 +12,14 @@ try {
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $services = $db->query("SELECT * FROM microservices")->fetchAll();
 
+    // get microservices
+    $services = $db->query("SELECT * FROM microservices")->fetchAll();
+
+    // check if the table is empty
+    if (empty($services)) {
+        $dbEmpty = "Database is installed but empty.";
+    }
+
 } catch (PDOException $e) {
     $dbError = "Database is not installed.";
 }
@@ -29,7 +37,12 @@ try {
     <h1>Microservice Documentation Database Admin</h1>
     <?php
     if (isset($dbError)) {
-        echo "<p>$dbError <a href='#' id='installLink'>Install database</a></p>";
+        echo $dbError . "<br>";
+        echo "<a href='#' id='installLink'>Install database</a> (doesn't fill)</br>";
+        echo "<a href='#' id='setupLink'>Setup database</a> (fill)";
+    }
+    if (isset($dbEmpty)) {
+        echo $dbEmpty;
     }
     ?>
 </body>
@@ -44,6 +57,24 @@ try {
             .then(res => res.text())
             .then(data => {
                 alert('Database installed!');
+                // reload the page
+                location.reload();
+            })
+            .catch(error => {
+                alert('Something went wrong: ' + error);
+            });
+    });
+
+    // use optional chaining in case the element doesn't exist 
+    document.getElementById('setupLink')?.addEventListener('click', function (e) {
+        // prevent the links standard behaviour (so it wont navigate to new page)
+        e.preventDefault();
+        // send AJAX request to run the install script
+        fetch('setupEndpointDirectory.php')
+            // parse response as plain text
+            .then(res => res.text())
+            .then(data => {
+                alert('Database installed and filled!');
                 // reload the page
                 location.reload();
             })

--- a/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
+++ b/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
@@ -10,13 +10,14 @@ try {
     // database connection
     $db = new PDO('sqlite:endpointDirectory_db.sqlite');
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    $services = $db->query("SELECT * FROM microservices")->fetchAll();
 
     // get microservices
     $services = $db->query("SELECT * FROM microservices")->fetchAll();
+    // get dependencies
+    $dependencies = $db->query("SELECT * FROM microservices")->fetchAll();
 
     // check if the table is empty
-    if (empty($services)) {
+    if (empty($services) && empty($dependencies)) {
         $dbEmpty = "Database is installed but empty.";
     }
 
@@ -37,14 +38,15 @@ try {
     <h1>Microservice Documentation Database Admin</h1>
     <?php
     if (isset($dbEmpty)) {
-        echo $dbEmpty;
+        echo $dbEmpty . "<br>";
+        echo "<a href='#' id='fillLink'>Fill database</a>";
     }
     if (isset($dbError)) {
         echo $dbError . "<br>";
-        echo "<a href='#' id='installLink'>Install database</a> (doesn't fill)</br>";
+        echo "<a href='#' id='installLink'>Install database</a> (don't fill)<br>";
         echo "<a href='#' id='setupLink'>Setup database</a> (fill)";
     } else {
-        echo "<br><a href='#' id='deleteLink'>Delete database</a>";
+        echo "<a href='#' id='deleteLink'>Delete database</a><br>";
     }
     ?>
 </body>
@@ -73,6 +75,24 @@ try {
             .then(res => res.text())
             .then(data => {
                 alert('Database installed and filled!');
+                location.reload();
+            })
+            .catch(error => {
+                alert('Something went wrong: ' + error);
+            });
+    });
+
+    document.getElementById('fillLink')?.addEventListener('click', function (e) {
+        e.preventDefault();
+        // send AJAX request to both fill scripts
+        fetch('fillEndpointDb.php')
+            .then(res => res.text())
+            .then(data1 => {
+                return fetch('fillDependenciesDb.php');
+            })
+            .then(res => res.text())
+            .then(data2 => {
+                alert('Database has been filled!');
                 location.reload();
             })
             .catch(error => {

--- a/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
+++ b/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
@@ -16,9 +16,9 @@ try {
     // get dependencies
     $dependencies = $db->query("SELECT * FROM microservices")->fetchAll();
 
-    // check if the table is empty
+    // check if the tables are empty
     if (empty($services) && empty($dependencies)) {
-        $dbEmpty = "Database is installed but empty.";
+        $dbEmpty = "Database is installed, but empty.";
     }
 
 } catch (PDOException $e) {
@@ -35,20 +35,24 @@ try {
 </head>
 
 <body>
-    <h1>Microservice Documentation Database Admin</h1>
+    <h1>Microservice Directory Admin</h1>
     <?php
+    if (empty($dbEmpty) && empty($dbError)) {
+        echo "<p style='color: green;'>Database is installed and filled</p>";
+    }
     if (isset($dbEmpty)) {
-        echo $dbEmpty . "<br>";
-        echo "<a href='#' id='fillLink'>Fill database</a>";
+        echo "<p>$dbEmpty</p>";
+        echo "<a href='#' id='fillLink'>Fill database</a><br>";
     }
     if (isset($dbError)) {
-        echo $dbError . "<br>";
+        echo "<p style='color: red;'>$dbError</p>";
         echo "<a href='#' id='installLink'>Install database</a> (don't fill)<br>";
-        echo "<a href='#' id='setupLink'>Setup database</a> (fill)";
+        echo "<a href='#' id='setupLink'>Setup database</a> (fill)<br>";
     } else {
         echo "<a href='#' id='deleteLink'>Delete database</a><br>";
     }
     ?>
+    <p>Go to <a href="microserviceUI.php">microserviceUI</a></p>
 </body>
 <script>
     // use optional chaining in case the element doesn't exist 

--- a/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
+++ b/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
@@ -35,7 +35,9 @@ try {
 </head>
 
 <body>
-    <h1>Microservice Directory Admin</h1>
+    <div class="line">
+        <h1>Microservice Directory Admin</h1>
+    </div>
     <?php
     if (empty($dbEmpty) && empty($dbError)) {
         echo "<p style='color: green;'>Database is installed and filled</p>";
@@ -52,7 +54,7 @@ try {
         echo "<a href='#' id='deleteLink'>Delete database</a><br>";
     }
     ?>
-    <p>Go to <a href="microserviceUI.php">microserviceUI</a></p>
+    <a href="microserviceUI.php" class="a-button" style="margin-top: 20px;">Go to microserviceUI</a>
 </body>
 <script>
     // use optional chaining in case the element doesn't exist 

--- a/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
+++ b/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
@@ -36,13 +36,15 @@ try {
 <body>
     <h1>Microservice Documentation Database Admin</h1>
     <?php
+    if (isset($dbEmpty)) {
+        echo $dbEmpty;
+    }
     if (isset($dbError)) {
         echo $dbError . "<br>";
         echo "<a href='#' id='installLink'>Install database</a> (doesn't fill)</br>";
         echo "<a href='#' id='setupLink'>Setup database</a> (fill)";
-    }
-    if (isset($dbEmpty)) {
-        echo $dbEmpty;
+    } else {
+        echo "<br><a href='#' id='deleteLink'>Delete database</a>";
     }
     ?>
 </body>
@@ -65,22 +67,33 @@ try {
             });
     });
 
-    // use optional chaining in case the element doesn't exist 
     document.getElementById('setupLink')?.addEventListener('click', function (e) {
-        // prevent the links standard behaviour (so it wont navigate to new page)
         e.preventDefault();
-        // send AJAX request to run the install script
         fetch('setupEndpointDirectory.php')
-            // parse response as plain text
             .then(res => res.text())
             .then(data => {
                 alert('Database installed and filled!');
-                // reload the page
                 location.reload();
             })
             .catch(error => {
                 alert('Something went wrong: ' + error);
             });
+    });
+
+    document.getElementById('deleteLink')?.addEventListener('click', function (e) {
+        e.preventDefault();
+        // the user must confirm before deleting the database
+        if (confirm('Are you sure you want to delete the database? This action cannot be undone.')) {
+            fetch('deleteEndpointDb.php')
+                .then(res => res.text())
+                .then(data => {
+                    alert(data);
+                    location.reload();
+                })
+                .catch(error => {
+                    alert('Something went wrong: ' + error);
+                });
+        }
     });
 </script>
 

--- a/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
+++ b/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
@@ -40,16 +40,16 @@ try {
     </div>
     <?php
     if (empty($dbEmpty) && empty($dbError)) {
-        echo "<p style='color: green;'>Database is installed and filled</p>";
+        echo "<p style='color: green;'>Database is installed and filled with data</p>";
     }
     if (isset($dbEmpty)) {
         echo "<p>$dbEmpty</p>";
-        echo "<a href='#' id='fillLink'>Fill database</a><br>";
+        echo "<a href='#' id='fillLink'>Fill database with data</a><br>";
     }
     if (isset($dbError)) {
         echo "<p style='color: red;'>$dbError</p>";
-        echo "<a href='#' id='installLink'>Install database</a> (don't fill)<br>";
-        echo "<a href='#' id='setupLink'>Setup database</a> (fill)<br>";
+        echo "<a href='#' id='installLink'>Install database</a> (without data)<br>";
+        echo "<a href='#' id='setupLink'>Setup database</a> (with data)<br>";
     } else {
         echo "<a href='#' id='deleteLink'>Delete database</a><br>";
     }
@@ -80,7 +80,7 @@ try {
         fetch('setupEndpointDirectory.php')
             .then(res => res.text())
             .then(data => {
-                alert('Database installed and filled!');
+                alert('Database installed and filled with data!');
                 location.reload();
             })
             .catch(error => {

--- a/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
+++ b/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
@@ -1,0 +1,37 @@
+<?php
+
+session_start();
+
+if (!isset($_SESSION['token'])) {
+    $_SESSION['token'] = bin2hex(random_bytes(32));
+}
+
+try {
+    // database connection
+    $db = new PDO('sqlite:endpointDirectory_db.sqlite');
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $services = $db->query("SELECT * FROM microservices")->fetchAll();
+
+} catch (PDOException $e) {
+    $dbError = "Database is not installed.";
+}
+?>
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Admin Microservice Directory</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <h1>Microservice Documentation Database Admin</h1>
+    <?php
+    if (isset($dbError)) {
+        echo $dbError;
+    }
+    ?>
+</body>
+
+</html>

--- a/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
+++ b/DuggaSys/microservices/endpointDirectory/admin-endpointDirectory_db.php
@@ -29,9 +29,28 @@ try {
     <h1>Microservice Documentation Database Admin</h1>
     <?php
     if (isset($dbError)) {
-        echo $dbError;
+        echo "<p>$dbError <a href='#' id='installLink'>Install database</a></p>";
     }
     ?>
 </body>
+<script>
+    // use optional chaining in case the element doesn't exist 
+    document.getElementById('installLink')?.addEventListener('click', function (e) {
+        // prevent the links standard behaviour (so it wont navigate to new page)
+        e.preventDefault();
+        // send AJAX request to run the install script
+        fetch('installEndpointDb.php')
+            // parse response as plain text
+            .then(res => res.text())
+            .then(data => {
+                alert('Database installed!');
+                // reload the page
+                location.reload();
+            })
+            .catch(error => {
+                alert('Something went wrong: ' + error);
+            });
+    });
+</script>
 
 </html>

--- a/DuggaSys/microservices/endpointDirectory/deleteEndpointDb.php
+++ b/DuggaSys/microservices/endpointDirectory/deleteEndpointDb.php
@@ -1,0 +1,11 @@
+<?php
+$dbFile = 'endpointDirectory_db.sqlite';
+
+if (file_exists($dbFile)) {
+    unlink($dbFile);
+    echo "Database deleted.";
+} else {
+    http_response_code(404);
+    echo "Database file not found.";
+}
+?>


### PR DESCRIPTION
Created a page where you can install, fill and delete the endpoint directory database. Fixes #17414 

On 'admin-endpointDirectory_db.php' you can do things based on the current status of the database. If its installed, you can delete it, if its not installed you can install it, if its installed but not filled you can delete it or fill it etc. 
When testing this you can use 'microserviceUI.php' to see if the database if installed or not, and to check if its filled. 

At the moment there are no login requirements.  