### PR TITLE
Fixed: G1 2025 v6 #17469 elements snapping to lifeline

### DIFF
--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -304,6 +304,10 @@ function mup(event) {
                 setPos(context, deltaX, deltaY);
                 // Loop through each selected element
                 context.forEach(el => {
+
+                // Only check for Activation elements to snap
+                if (el.kind !== elementTypesNames.sequenceActivation) return;
+
                 // Find the nearest lifeline to the element's center position
                 const nearestLifelineId = findNearestLifeline(
                 el.x + el.width / 2, // X-center of the element


### PR DESCRIPTION
Now sequenceActivation should be the only element to actually snap to different lifelines. Just added an extra check before snapping.

https://github.com/user-attachments/assets/444ed525-798b-4021-a38f-d5096ba31e39


