### PR TITLE
Made sequence-diagram lines behave appropriately 

### DIFF
--- a/DuggaSys/diagram/classes/element.js
+++ b/DuggaSys/diagram/classes/element.js
@@ -31,8 +31,6 @@ class Element {
         this.id = id;
         this.x = x;
         this.y = y;
-        this.anchorX;
-        this.anchorY;
         this.width = width;
         this.height = height;
         this.minWidth = minWidth;

--- a/DuggaSys/diagram/classes/element.js
+++ b/DuggaSys/diagram/classes/element.js
@@ -31,6 +31,8 @@ class Element {
         this.id = id;
         this.x = x;
         this.y = y;
+        this.anchorX;
+        this.anchorY;
         this.width = width;
         this.height = height;
         this.minWidth = minWidth;

--- a/DuggaSys/diagram/classes/stateChange.js
+++ b/DuggaSys/diagram/classes/stateChange.js
@@ -44,22 +44,49 @@ class StateChange {
         return values;
     }
 
-    /**
+   /**
      * @description Keeps the appropriate values for when a line is added.
-     * @param {Object} line New line that has been created.
+     * @param {Object} id ID of the newly created line.
      * @returns {object} A new object with the needed values.
      */
     static LineAdded(id) {
         const line = lines.find(line => line.id == id);
         const values = {};
-        // Get the keys of the values that is unique from default
+
+        // Get the keys of the values that are unique from the default
         const uniqueKeysArr = Object.keys(line).filter(key => {
-            return (Object.keys(defaultLine).filter(value => defaultLine[value] == line[key]).length == 0);
+            return defaultLine[key] !== line[key];
         });
-        // For every unique value set it into the change
+
+        // Store those unique values in the result
         uniqueKeysArr.forEach(key => {
             values[key] = line[key];
         });
+
+        // Optionally include offset(s) related to this line
+        const fromId = line.from;
+        const toId = line.to;
+        if (offsetMap.has(fromId)) {
+            const fromOffsets = offsetMap.get(fromId);
+            for (let [key, val] of fromOffsets.entries()) {
+                if (key.includes(`${fromId}->${toId}`)) {
+                    if (!values.offsets) values.offsets = {};
+                    values.offsets[fromId] = values.offsets[fromId] || {};
+                    values.offsets[fromId][key] = val;
+                }
+            }
+        }
+        if (offsetMap.has(toId)) {
+            const toOffsets = offsetMap.get(toId);
+            for (let [key, val] of toOffsets.entries()) {
+                if (key.includes(`${toId}<-${fromId}`)) {
+                    if (!values.offsets) values.offsets = {};
+                    values.offsets[toId] = values.offsets[toId] || {};
+                    values.offsets[toId][key] = val;
+                }
+            }
+        }
+
         return values;
     }
 

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -733,7 +733,7 @@ function drawElementSequenceActor(element, textWidth, boxw, boxh, linew, texth) 
                             m${-boxw / 4},0
                             h${boxw / 2}
                             m${-boxw / 4},0
-                            v${boxw / 3}
+                            v${boxw / 4}
                             l${boxw / 4},${boxw / 4}
                             m${-boxw / 4},${-boxw / 4}
                             l${-boxw / 4},${boxw / 4}"

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -46,7 +46,7 @@ function drawLine(line, targetGhost = false) {
     // Sets the to-coordinates to the same as the from-coordinates after getting line attributes
     // if the line is recursive
     if (line.recursive) {
-        [fx, fy, tx, ty, offset] = getLineAttributes(felem, felem, line.ctype, fromElemMouseY, toElemMouseY);
+        [fx, fy, tx, ty, offset] = getLineAttributes(line, felem, felem, line.ctype, fromElemMouseY, toElemMouseY);
         //Setting start position for the recursive line, to originate from the top.
         fx = felem.cx;
         fy = felem.y1;
@@ -55,7 +55,7 @@ function drawLine(line, targetGhost = false) {
         tx = fx;
         ty = fy;
     } else {
-        [fx, fy, tx, ty, offset] = getLineAttributes(felem, telem, line.ctype, fromElemMouseY, toElemMouseY);
+        [fx, fy, tx, ty, offset] = getLineAttributes(line, felem, telem, line.ctype, fromElemMouseY, toElemMouseY);
     }
 
     // Follows the cursor while drawing the line
@@ -89,7 +89,7 @@ function drawLine(line, targetGhost = false) {
 
     if (targetGhost && line.type == entityType.SD) line.endIcon = SDLineIcons.ARROW;
     if (line.type == entityType.ER) {
-        [fx, fy, tx, ty, offset] = getLineAttributes(felem, telem, line.ctype, fromElemMouseY, toElemMouseY);
+        [fx, fy, tx, ty, offset] = getLineAttributes(line, felem, telem, line.ctype, fromElemMouseY, toElemMouseY);
         if (line.kind == lineKind.NORMAL) {
             lineStr += `<line 
                         id='${line.id}' 
@@ -452,7 +452,7 @@ function recursiveERRelation(felem, telem, line, fromElemMouseY, toElemMouseY) {
     return [fx, fy, tx ?? telem.cx, ty ?? telem.cy];
 }
 
-function getLineAttributes(f, t, ctype, fromElemMouseY, toElemMouseY) {
+function getLineAttributes(line, f, t, ctype, fromElemMouseY, toElemMouseY) {
     let px = -1; // Don't touch
 
     let fWidth = f.width;
@@ -556,18 +556,19 @@ function getLineAttributes(f, t, ctype, fromElemMouseY, toElemMouseY) {
         }
     }
     
+    // Special case to handle sequence activation lines
     if (f.kind === elementTypesNames.sequenceActivation) {
-        const fromKey = `from:${f.id}->${t.id}`;
-        const toKey = `to:${t.id}<-${f.id}`;
+        const fromKey = `from:${line.id}`;
+        const toKey = `to:${line.id}`;
     
         if (!hasOffset(offsetMap, f.id, fromKey)) {
             setOffset(offsetMap, f.id, fromKey, (fromElemMouseY ?? lastMousePos.y) - f.cy);
         }
-    
+
         if (!hasOffset(offsetMap, t.id, toKey)) {
             setOffset(offsetMap, t.id, toKey, (toElemMouseY ?? lastMousePos.y) - t.cy);
         }
-    
+
         fy = f.cy + getOffset(offsetMap, f.id, fromKey) * zoomfact;
         ty = t.cy + getOffset(offsetMap, t.id, toKey) * zoomfact;
     }

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -557,8 +557,11 @@ function getLineAttributes(f, t, ctype, fromElemMouseY, toElemMouseY) {
     }
     
     if(f.kind === elementTypesNames.sequenceActivation){
-        fy = fromElemMouseY ?? lastMousePos.y;
-        ty = toElemMouseY ?? lastMousePos.y;
+        f.anchorY = fromElemMouseY ?? lastMousePos.y;
+        t.anchorY = toElemMouseY ?? lastMousePos.y;
+        fy = f.anchorY;
+        ty = t.anchorY;
+        console.log(f.anchorX, ' + ',  f.anchorY);
     }
 
     return [fx, fy, tx, ty, offset];
@@ -1059,6 +1062,7 @@ function redrawArrows() {
     }
     //Going through all elements and checking for adjacent lines
     for (let i = 0; i < data.length; i++) {
+        if (data[i].kind === elementTypesNames.sequenceActivation) continue;
         checkAdjacentLines(data[i]);
     }
     // Draw each line using sorted line ends when applicable

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -9,17 +9,32 @@ function drawLine(line, targetGhost = false) {
 
     let lineStr = ""; // only the lines, polylines, arrows etc
     let labelStr = ""; // labels and label backgrounds
+    let fromElemMouseY;
+    let toElemMouseY;
 
     // Element line is drawn from/to
     let felem = data[findIndex(data, line.fromID)];
+    if (!line.fromY) {
+        line.fromY = lastMousePos.y;
+    }
+    fromElemMouseY = line.fromY;
+
     let telem;
     if (targetGhost) {
         telem = ghostElement;
+        toElemMouseY = lastMousePos.y;
         isCurrentlyDrawing = true;
     } else {
         telem = data[findIndex(data, line.toID)];
         isCurrentlyDrawing = false;
+
+        // Cache toY only if not already set
+        if (!line.toY) {
+            line.toY = lastMousePos.y;
+        }
+        toElemMouseY = line.toY;
     }
+
     if (!felem || !telem) return { lineStr: "", labelStr: "" };
     line.type = (telem.type == entityType.note) ? telem.type : felem.type;
     let strokeDash = (line.kind == lineKind.DASHED || line.type == entityType.note) ? "10" : "0";
@@ -31,7 +46,7 @@ function drawLine(line, targetGhost = false) {
     // Sets the to-coordinates to the same as the from-coordinates after getting line attributes
     // if the line is recursive
     if (line.recursive) {
-        [fx, fy, tx, ty, offset] = getLineAttributes(felem, felem, line.ctype);
+        [fx, fy, tx, ty, offset] = getLineAttributes(felem, felem, line.ctype, fromElemMouseY, toElemMouseY);
         //Setting start position for the recursive line, to originate from the top.
         fx = felem.cx;
         fy = felem.y1;
@@ -40,7 +55,7 @@ function drawLine(line, targetGhost = false) {
         tx = fx;
         ty = fy;
     } else {
-        [fx, fy, tx, ty, offset] = getLineAttributes(felem, telem, line.ctype);
+        [fx, fy, tx, ty, offset] = getLineAttributes(felem, telem, line.ctype, fromElemMouseY, toElemMouseY);
     }
 
     // Follows the cursor while drawing the line
@@ -74,7 +89,7 @@ function drawLine(line, targetGhost = false) {
 
     if (targetGhost && line.type == entityType.SD) line.endIcon = SDLineIcons.ARROW;
     if (line.type == entityType.ER) {
-        [fx, fy, tx, ty, offset] = getLineAttributes(felem, telem, line.ctype);
+        [fx, fy, tx, ty, offset] = getLineAttributes(felem, telem, line.ctype, fromElemMouseY, toElemMouseY);
         if (line.kind == lineKind.NORMAL) {
             lineStr += `<line 
                         id='${line.id}' 
@@ -241,7 +256,7 @@ function drawLine(line, targetGhost = false) {
             labelStr += drawLineCardinality(line, lineColor, fx, fy, tx, ty, felem, telem);
         }
     }
-        
+
     if (isSelected) {
         labelStr += `<rect 
                     x='${((fx + tx) / 2) - (2 * zoomfact)}' 
@@ -423,7 +438,7 @@ function recursiveERCalc(ax, ay, bx, by, elem, isFirst, line) {
  * @param {object} line The line being dragged.
  * @returns {number[]} Returns the new coordinates
  */
-function recursiveERRelation(felem, telem, line) {
+function recursiveERRelation(felem, telem, line, fromElemMouseY, toElemMouseY) {
     const connections = felem.neighbours[telem.id].length;
     let fx = felem.cx, fy = felem.cy, tx = telem.cx, ty = telem.cy;
     if (connections != 2) return [fx, fy, tx, ty];
@@ -437,7 +452,7 @@ function recursiveERRelation(felem, telem, line) {
     return [fx, fy, tx ?? telem.cx, ty ?? telem.cy];
 }
 
-function getLineAttributes(f, t, ctype) {
+function getLineAttributes(f, t, ctype, fromElemMouseY, toElemMouseY) {
     let px = -1; // Don't touch
 
     let fWidth = f.width;
@@ -539,6 +554,11 @@ function getLineAttributes(f, t, ctype) {
             offset.y1 += (ctype === lineDirection.UP ? shrink : -shrink);
             offset.y2 += (ctype === lineDirection.UP ? -shrink : shrink);
         }
+    }
+    
+    if(f.kind === elementTypesNames.sequenceActivation){
+        fy = fromElemMouseY ?? lastMousePos.y;
+        ty = toElemMouseY ?? lastMousePos.y;
     }
 
     return [fx, fy, tx, ty, offset];

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -556,12 +556,20 @@ function getLineAttributes(f, t, ctype, fromElemMouseY, toElemMouseY) {
         }
     }
     
-    if(f.kind === elementTypesNames.sequenceActivation){
-        f.anchorY = fromElemMouseY ?? lastMousePos.y;
-        t.anchorY = toElemMouseY ?? lastMousePos.y;
-        fy = f.anchorY;
-        ty = t.anchorY;
-        console.log(f.anchorX, ' + ',  f.anchorY);
+    if (f.kind === elementTypesNames.sequenceActivation) {
+        const fromKey = `from:${f.id}->${t.id}`;
+        const toKey = `to:${t.id}<-${f.id}`;
+    
+        if (!hasOffset(offsetMap, f.id, fromKey)) {
+            setOffset(offsetMap, f.id, fromKey, (fromElemMouseY ?? lastMousePos.y) - f.cy);
+        }
+    
+        if (!hasOffset(offsetMap, t.id, toKey)) {
+            setOffset(offsetMap, t.id, toKey, (toElemMouseY ?? lastMousePos.y) - t.cy);
+        }
+    
+        fy = f.cy + getOffset(offsetMap, f.id, fromKey) * zoomfact;
+        ty = t.cy + getOffset(offsetMap, t.id, toKey) * zoomfact;
     }
 
     return [fx, fy, tx, ty, offset];

--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -284,32 +284,29 @@ function sameObjects(obj1, obj2, ignore = []) {
     return JSON.stringify(obj1) == JSON.stringify(obj2);
 }
 
+// Map<elementId, Map<connectionKey, offsetValue>>
 const offsetMap = new Map();
 
-const offsetCounters = {
-    from: new Map(), 
-    to: new Map()    
-};
-
-function getNextOffsetKey(counterMap, direction, elemId) {
-    let count = counterMap.get(elemId) ?? 0;
-    let key = `${direction}:${elemId}:${count}`;
-    counterMap.set(elemId, count + 1);
-    return key;
+// Generate an ID for a line
+function generateLineKey(fId, tId, index) {
+    return `from:${fId}->${tId}#${index}`;
 }
 
-function getNextLineIndex(fId, tId, offsetMap) {
+// Increment the map index position
+function getNextLineIndex(fId, tId, map) {
     let i = 0;
-    while (offsetMap.has(`from:${fId}->${tId}#${i}`)) {
+    while (map.has(generateLineKey(fId, tId, i))) {
         i++;
     }
     return i;
 }
 
+// Return offset key for a specified element
 function hasOffset(map, elemId, key) {
     return map.has(elemId) && map.get(elemId).has(key);
 }
 
+// Set the offset (value) for a specific key
 function setOffset(map, elemId, key, value) {
     if (!map.has(elemId)) {
         map.set(elemId, new Map());
@@ -317,6 +314,19 @@ function setOffset(map, elemId, key, value) {
     map.get(elemId).set(key, value);
 }
 
+// Retrieve the offset for a specific key
 function getOffset(map, elemId, key) {
-    return map.get(elemId)?.get(key);
+    return map.get(elemId)?.get(key) ?? null;
 }
+
+// Remove the offset for a specific key, and if map is empty remove that too.
+function removeOffset(map, elemId, key) {
+    if (map.has(elemId)) {
+        const innerMap = map.get(elemId);
+        innerMap.delete(key);
+        if (innerMap.size === 0) {
+            map.delete(elemId); 
+        }
+    }
+}
+

--- a/DuggaSys/diagram/helper.js
+++ b/DuggaSys/diagram/helper.js
@@ -225,7 +225,7 @@ function isDarkTheme() {
  */
 function makeRandomID() {
     let str = "";
-    const characters = 'ABCDEF0123456789';
+    const characters = 'ABCDEFGIJK0123456789';
     const charactersLength = characters.length;
     while (true) {
         for (let i = 0; i < 6; i++) {
@@ -282,4 +282,41 @@ function sameObjects(obj1, obj2, ignore = []) {
 
     // JSON.stringify() is needed to compare the values
     return JSON.stringify(obj1) == JSON.stringify(obj2);
+}
+
+const offsetMap = new Map();
+
+const offsetCounters = {
+    from: new Map(), 
+    to: new Map()    
+};
+
+function getNextOffsetKey(counterMap, direction, elemId) {
+    let count = counterMap.get(elemId) ?? 0;
+    let key = `${direction}:${elemId}:${count}`;
+    counterMap.set(elemId, count + 1);
+    return key;
+}
+
+function getNextLineIndex(fId, tId, offsetMap) {
+    let i = 0;
+    while (offsetMap.has(`from:${fId}->${tId}#${i}`)) {
+        i++;
+    }
+    return i;
+}
+
+function hasOffset(map, elemId, key) {
+    return map.has(elemId) && map.get(elemId).has(key);
+}
+
+function setOffset(map, elemId, key, value) {
+    if (!map.has(elemId)) {
+        map.set(elemId, new Map());
+    }
+    map.get(elemId).set(key, value);
+}
+
+function getOffset(map, elemId, key) {
+    return map.get(elemId)?.get(key);
 }


### PR DESCRIPTION
The issue( #17272) was that the sequence diagram functionality was borderline useless in terms of how sequence diagrams are supposed to look and be used. Lines would automatically connect to the center of the sequence activation elements, just as they do with other elements. This would however defeat the purpose of a UML-diagram type that is meant to have clear, distinguishable and customizable transitions between activations along a timeline. 

The implemented fix has resolved the main parts of the original problem. Lines can now be drawn to user-specified anchoring points on the activations. Lines won't be rearranged by removal of other lines and the arrowheads are correctly placed on the line ends instead of being misaligned etc. However, repetitively using the undo/ctrl+z as well as redo/ctrl+y operations will result in strange behavior. But this issue was present prior to these implemented fixes. Given the major improvement of the sequence diagram behavior I suggest merging this now and opening up a new issue for fixing the potentially faulty undo-stack later. 

Pictures of using the sequence diagram before and after. 

Before: 
![image](https://github.com/user-attachments/assets/4b620ffd-2eb8-425d-b610-5a2cecaf2e15)
Note that the arrowheads for the lines are all attached to the center of the middle line and is in the wrong direction. The line anchoring points are centered to the middle of the each activation, regardless of user input. The lines will crease if the elements aren't placed at the exact same Y-coordinates etc.

After:
![image](https://github.com/user-attachments/assets/d77a62d6-eec6-4f8a-bf73-8ae42f343823)
Exact same settings applied here, with the absence of the issues mentioned above.
  