### PR TITLE
Display message positioning fixed on mobile

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -337,6 +337,13 @@
         transition: var(--normal-transition);
     }
 
+    #diagram-message{
+        position: absolute !important;
+        top: 50px !important;
+        left: 50px !important;
+        width: 60% !important;
+    }
+
     .icon-wrapper.toolbar-active{
         margin-bottom: calc(var(--diagram-toolbar-height) - 2rem);
     }


### PR DESCRIPTION
Fixed diagram message positioning on mobile because it got cut off by the options-panel. I moved it to the top left corner instead and changed the width on the box. I think the top left corner is the best place because the toolbar and the FAB is at the bottom of the screen. 😄

https://github.com/user-attachments/assets/63f6d423-6ee1-4211-9c85-1ea80ea299fd

