### PR TITLE
17390 fix z index on latest interacted with element

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -11,7 +11,7 @@ function drawElement(element, ghosted = false) {
     let boxw = Math.round(element.width * zoomfact);
     let boxh = element.height ? 
     Math.round(element.height * zoomfact) : 0; // Only used for extra whitespace from resize
-    let zLevel = 2;
+    let zLevel = element.z ?? 2; /*nsures that elements without a defined z-index get a default value (2)*/
     let mouseEnter = '';
 
     canvas = document.getElementById('canvasOverlay');
@@ -350,7 +350,7 @@ function drawElementUMLEntity(element, boxw, boxh, linew, texth) {
             headText += drawText(boxw / 2, y, 'middle', headerLines[i]);
         }
         headSvg = drawSvg(boxw, height, headRect + headText + headStereotype);
-    }
+    }   
     else {
         height = texth * (headerLines.length + 0.5) * lineHeight;
         for (let i = 0; i < headerLines.length; i++) {

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -71,7 +71,6 @@ function generateContextProperties() {
     multipleColorsTest();
 }
 
-
 /**
  * @description Makes it show or hide the properties with class names.
  * @param {boolean} show Shows the properties if it's true, or hide if it's false.
@@ -1933,3 +1932,30 @@ function changeLineProperties() {
     stateMachine.save(contextLine[0].id, StateChange.ChangeTypes.LINE_ATTRIBUTE_CHANGED);
     showdata();
 }
+
+/* Enables bringing an element to the front or sending it to the back by adjusting its z-index and redrawing the canvas */
+
+function bringToFront(id) {
+    const elem = data.find(e => e.id === id);
+    if (!elem) return;
+
+    const maxZ = Math.max(...data.map(e => e.z ?? 2));
+    elem.z = maxZ + 1;
+
+    showdata(); // Redraw everything
+}
+
+function sendToBack(id) {
+    const elem = data.find(e => e.id === id);
+    if (!elem) return;
+
+    const minZ = Math.min(...data.map(e => e.z ?? 2));
+    elem.z = minZ - 1;
+
+    showdata(); // Redraw everything
+}
+
+
+
+
+

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -39,6 +39,12 @@ function generateContextProperties() {
     if (context.length == 1 && contextLine.length == 0) {
         showProperties(true, propSet, menuSet);
         str += drawElementProperties(element);
+        // Bring to front / send to back buttons
+    str += `
+        <div style="margin-top: 10px; color: ${color.WHITE};">Layer</div>
+        <button class="saveButton" onclick="bringToFront('${element.id}')">Bring to Front</button>
+        <button class="saveButton" onclick="sendToBack('${element.id}')">Send to Back</button>
+    `;
     }
     // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.
     if (context.length == 0 && contextLine.length == 1) {
@@ -64,6 +70,7 @@ function generateContextProperties() {
     }
     multipleColorsTest();
 }
+
 
 /**
  * @description Makes it show or hide the properties with class names.


### PR DESCRIPTION
!!(I should note that the original purpose of the issue has evolved—from automatically bringing an element to the front when selected, to giving users manual control over which elements should appear in front or behind. This gives users more flexibility when arranging their diagrams.)!!

This pull request, that has been given life by me, adds two buttons in the options panel that let you change the layer order of elements on the canvas. When one element overlaps another, you can now choose to move it forward or backward by adjusting its z-index.

The functions work by finding the current highest or lowest z value and updating the selected element accordingly. Then the entire canvas is redrawn to reflect the change.

I’ve tested this with different kinds of elements and it behaves as expected. This should make arranging elements much easier, without needing to delete and recreate them.

I have added comments that should give context to the code

https://github.com/user-attachments/assets/8266d829-5af5-4282-b1be-2becceb1fbee

The video shows that the objects are being pushed forward and backwards depending on what button is pressed.