### PR TITLE
Fixed the width of the load modal

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -773,7 +773,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 30%;
+    width: 70%;
     z-index: 999;
     background-color: white;
     color: black;


### PR DESCRIPTION
Change the width from 30% to 70% to fit better and show more of the saved files.

![bild](https://github.com/user-attachments/assets/0ff05099-bd45-46f1-9c01-32cd168caf2e)