### PR TITLE
Fixed-sequence-table-recursive-relation-labels

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -323,8 +323,15 @@ function drawLine(line, targetGhost = false) {
         if (line.recursive) {
             //Calculatin the lable possition based on element size, so it follows when resized.
 
-            const length = 20 * zoomfact;
-            const lift   = 80 * zoomfact; 
+            let length = 20 * zoomfact;
+            let lift   = 80 * zoomfact;
+                    
+                    // Calculations only for SE
+            if (line.type === entityType.SE) {
+                length = 70 * zoomfact; 
+                lift = 20 * zoomfact;   
+            }
+
             let {lineLength, elementLength, startX, startY } = recursiveParam(felem);
             startY -= lift;
             startX += length;

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -389,7 +389,6 @@ function drawLineProperties(line) {
             str += includeSELabel(line);
             str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);
             str += iconSelection([SELineIcons], line);
-            str += `<h3 style="margin-bottom: 0; margin-top: 5px;">Label</h3>`;
             break;
     }
     str += saveButton('changeLineProperties();');


### PR DESCRIPTION
Removed the redundant label from options.js. Added a condition statement in line.js to customize label positioning for SE recursive lines, also the label should now appear after saving. 