### PR TITLE
Replace table based navigation with semantic nav and ul elements.

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -166,13 +166,13 @@
 		<!-- Scroll up END -->
 
 		<!-- MOTD dropdown -->
-		<div id="motdArea" style="display:none;">
-	<div class="motdLeftContainer">
-		<div class="motdBoxheader">
-			<h3>Message of the day</h3>
-		</div>
-		<div id="motdContent" style="text-align:center">
-			<p style="text-align:center" id="motd"><?php echo htmlspecialchars($motd ?? ''); ?></p>
+		<div id="motdArea">
+			<div class="motdLeftContainer">
+				<div class="motdBoxheader">
+					<h3>Message of the day</h3>
+				</div>
+				<div id="motdContent">
+					<p id="motd"><?php echo htmlspecialchars($motd ?? ''); ?></p>
 				</div>
 			</div>
 			<div class="motdRightContainer">

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9439,21 +9439,15 @@ textarea#filecont {
     display: none;
   }
 
-
-  .navheader {
-    height: 20px;
-    margin-bottom: 10px;
-    width: 100%;
-  }
-
-  .navheader div.menuButton{
-    margin-right: 0px;
-  }
 }
 
 #motdContent{
   background-color: rgba(254, 204, 86, 1);
   margin-left:5%;
+
+  > p {
+    text-align: center;
+  }
 }
 #motdArea{
   box-shadow: 1px 1px 6px grey;
@@ -9474,7 +9468,6 @@ textarea#filecont {
   flex-direction: column;
   width: 90%;
   justify-content: space-between; 
-
 }
 
 .motdRightContainer{
@@ -9493,8 +9486,8 @@ justify-content: center;
   justify-content: space-around;
   position: relative;
   margin-left:5%;
-
 }
+
 .motdBoxheader h3 {
   font-size: 20px;
   color: #614875;
@@ -9580,6 +9573,7 @@ justify-content: center;
   #hamburgerBox{
     display:none;
   }
+  
   #hamburgerIcon{
     display:none;
   }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6466,8 +6466,6 @@ only screen and (max-device-width: 568px) {
     color:white;
     font-size:24px;
     width: 29px;
-    vertical-align: middle;
-    margin-top: 15px;
     margin-left: 15px
   } 
  

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1560,6 +1560,13 @@ header td {
   width: 100%;
   position: fixed;
   z-index: 8000;
+  display: flex;
+  flex-direction: row;
+
+  & img {
+    height: 20px;
+    width: auto;
+  }
 }
 
 .trsize {
@@ -5880,7 +5887,7 @@ rect[class*="activitymarker"]:hover {
 
 /* The original state of the buttons */
 
-table.navheader td.menuButton {
+.navheader .menuButton {
   margin-right: 2px;
   width: 112px;
   transition: 0.5s;
@@ -5889,7 +5896,7 @@ table.navheader td.menuButton {
   -o-transition: 0.5s;
 }
 
-table.navheader div.menuButton {
+.navheader div.menuButton {
   margin-right: 8px;
   pointer-events: auto;
   display: inline-block;
@@ -5920,7 +5927,7 @@ table.navheader div.menuButton {
 
 /* Hamburger menu, hidden as default state */
 
-table.navheader td.hamburger {
+.navheader .hamburger {
   pointer-events: none;
   text-align: center;
   display: inline-block;
@@ -5935,12 +5942,12 @@ table.navheader td.hamburger {
   -o-transition: width 0.5s, opacity 0.5s, margin 0.5s;
 }
 
-table.navheader nav.package {
+.navheader nav.package {
   margin-left: 0px;
   width: 100%;
 }
 
-table.navheader div.hamburgerMenu {
+.navheader div.hamburgerMenu {
   padding: 2px 2px 2px 2px;
   pointer-events: none;
   position: absolute;
@@ -5953,7 +5960,7 @@ table.navheader div.hamburgerMenu {
   overflow-x: hidden;
 }
 
-table.navheader input.hamburger {
+.navheader input.hamburger {
   width: 30px;
   margin: 6px 0px 6px 4px;
   padding: 1px 6px 1px 6px;
@@ -6193,7 +6200,7 @@ only screen and (max-device-width: 568px) {
     height: 35px;
   }
 
-  table.navheader td.contribution {
+  .navheader .contribution {
     margin-right: 0px;
     width: 0px;
     -webkit-transition: margin-right 0.5s, width 0.5s;
@@ -6367,7 +6374,7 @@ only screen and (max-device-width: 568px) {
 
 @media only screen and (max-width: 860px),
 only screen and (max-device-width: 568px) {
-  table.navheader td.hamburger {
+  .navheader .hamburger {
     pointer-events: auto;
     width: 32px;
     opacity: 1.0;
@@ -6382,7 +6389,7 @@ only screen and (max-device-width: 568px) {
     height: 13px;
   }
 
-  table.navheader td.access {
+  .navheader .access {
     margin-right: 0px;
     width: 0px;
     -webkit-transition: margin-right 0.5s, width 0.5s;
@@ -6481,7 +6488,7 @@ only screen and (max-device-width: 568px) {
 
 @media only screen and (max-width: 790px),
 only screen and (max-device-width: 568px) {
-  table.navheader td.files {
+  .navheader td.files {
     margin-right: 0px;
     width: 0px;
     -webkit-transition: margin-right 0.5s, width 0.5s;
@@ -6489,7 +6496,7 @@ only screen and (max-device-width: 568px) {
     -o-transition: margin-right 0.5s, width 0.5s;
   }
 
-  table.navheader div.files {
+  .navheader div.files {
     pointer-events: none;
     opacity: 0;
     -webkit-transition: opacity 0.5s;
@@ -6509,8 +6516,8 @@ only screen and (max-device-width: 568px) {
 @media only screen and (max-width: 670px),
 only screen and (max-device-width: 568px) {
 
-  table.navheader td.results,
-  table.navheader td.tests {
+  .navheader .results,
+  .navheader .tests {
     margin-right: 0px;
     width: 0px;
     -webkit-transition: margin-right 0.5s, width 0.5s;
@@ -6518,8 +6525,8 @@ only screen and (max-device-width: 568px) {
     -o-transition: margin-right 0.5s, width 0.5s;
   }
 
-  table.navheader div.results,
-  table.navheader div.tests {
+  .navheader div.results,
+  .navheader div.tests {
     pointer-events: none;
     opacity: 0;
     -webkit-transition: opacity 0.5s;
@@ -6651,13 +6658,13 @@ only screen and (max-device-width: 568px) {
 @media only screen and (max-width: 520px),
 only screen and (max-device-width: 568px) {
 
-  table.navheader td.tests,
-  table.navheader td.results,
-  table.navheader td.editVers,
-  table.navheader td.newVers,
-  table.navheader td.files,
-  table.navheader td.coursePage,
-  table.navheader td.access {
+  .navheader .tests,
+  .navheader .results,
+  .navheader .editVers,
+  .navheader .newVers,
+  .navheader .files,
+  .navheader .coursePage,
+  .navheader .access {
     margin-right: 0px;
     padding: 0px;
     width: 0px;
@@ -6666,8 +6673,8 @@ only screen and (max-device-width: 568px) {
     -o-transition: margin-right 0.5s, width 0.5s;
   }
 
-  table.navheader div.tests,
-  table.navheader div.results {
+  .navheader div.tests,
+  .navheader div.results {
     pointer-events: none;
     opacity: 0;
     -webkit-transition: opacity 0.5s;
@@ -6683,19 +6690,19 @@ only screen and (max-device-width: 568px) {
     opacity: 1.0;
   }
 
-  table.navheader input.hamburger {
+  .navheader input.hamburger {
     position: absolute;
     top: 66px;
     right: 5px;
   }
 
-  table.navheader div.hamburger {
+  .navheader div.hamburger {
     position: absolute;
     top: 64px;
     right: 10px;
   }
 
-  table.navheader div.hamburgerMenu {
+  .navheader div.hamburgerMenu {
     right: 10px;
     top: 110px;
     margin-top: 0px;
@@ -9439,7 +9446,7 @@ textarea#filecont {
     width: 100%;
   }
 
-  table.navheader div.menuButton{
+  .navheader div.menuButton{
     margin-right: 0px;
   }
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1562,14 +1562,14 @@ header td {
   z-index: 8000;
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
 
   & .auth-box {
     height: fit-content;
     width: fit-content;
     display: flex;
-    justify-content: flex-end;
+    margin-left: auto;
   }
 
   & ul {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1575,9 +1575,7 @@ header td {
 }
 
 .navButt {
-  width: 29px;
   vertical-align: middle;
-  margin-top: 9px;
 }
 .filterButt{
   margin-top: 11px;
@@ -1627,7 +1625,6 @@ margin-block-end: 10px;
 }
 #hamburgerIcon{
   transform: scale(1.8);
-  margin-left: 10px;
   color: white;
 }
 #courseVersionDropDown{
@@ -1714,22 +1711,13 @@ div .navButt:hover {
   overflow: hidden;
 }
 
-@media screen and (max-width:480px) {
-  .loginbutton-nav {
-    height: 30px;
-    }
-  }
-
 @media screen and (max-width:400px){
     .hamburger{
         display: flex;
         flex-wrap: wrap;
         position: relative;
-
-
-        margin-top: 14px;
-
     }
+
     #GeneralStats, #CurrentlyOnline, #PasswordGuessing, #OSPercentage,#hamburgerBoxMSG{
         display:none;
     }
@@ -4374,8 +4362,6 @@ span.arrow {
   background: #fafafa url("../icons/desc_primary.svg") no-repeat 90% 50%;
   box-shadow: var(--standard-shadow);
   background-position: right;
-  margin-top: 7px;
-  margin-left: 3px;
   width: 90%;
 }
 
@@ -5888,8 +5874,8 @@ rect[class*="activitymarker"]:hover {
 /* The original state of the buttons */
 
 .navheader .menuButton {
-  margin-right: 2px;
-  width: 112px;
+  
+  width: fit-content;
   transition: 0.5s;
   -webkit-transition: 0.5s;
   -moz-transition: 0.5s;
@@ -5932,8 +5918,6 @@ rect[class*="activitymarker"]:hover {
   text-align: center;
   display: inline-block;
   cursor: pointer;
-  margin-right: 0px;
-  margin-bottom: 4px;
   width: 0px;
   opacity: 0.0;
   transition: width 0.5s, opacity 0.5s, margin 0.5s;
@@ -5948,11 +5932,8 @@ rect[class*="activitymarker"]:hover {
 }
 
 .navheader div.hamburgerMenu {
-  padding: 2px 2px 2px 2px;
   pointer-events: none;
   position: absolute;
-  margin-top: 40px;
-  margin-left: 5px;
   z-index: 1;
   background-color: var(--color-background-2);
   border: 2px solid var(--color-border);
@@ -6378,7 +6359,6 @@ only screen and (max-device-width: 568px) {
     pointer-events: auto;
     width: 32px;
     opacity: 1.0;
-    margin-right: 4px;
     -webkit-transition: opacity 0.5s, width 0.5s, margin 0.5s;
     -moz-transition: opacity 0.5s, width 0.5s, margin 0.5s;
     -o-transition: opacity 0.5s, width 0.5s, margin 0.5s;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1555,7 +1555,7 @@ header td {
 }
 
 .navheader {
-  height: 20px;
+  height: fit-content;
   margin-bottom: 10px;
   width: 100%;
   position: fixed;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1794,6 +1794,11 @@ div .navButt:hover {
   width: 50px;
   vertical-align: middle;
   text-align: center;
+
+  & #loginbuttonIcon {
+    height: 24px;
+    width: auto;
+  }
 }
 
 #div2 {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1555,17 +1555,48 @@ header td {
 }
 
 .navheader {
-  height: fit-content;
+  height: 50px;
   margin-bottom: 10px;
   width: 100%;
   position: fixed;
   z-index: 8000;
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  & .auth-box {
+    height: fit-content;
+    width: fit-content;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  & ul {
+    display: flex;
+    flex-direction: row;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    align-items: center;
+    gap: 0.5em;
+  }
+
+  & li {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 0.1em;
+  }
+
+  & nav {
+    margin: 0 0.5em;
+  }
 
   & img {
-    height: 20px;
-    width: auto;
+    height: 32px;
+    width: 32px;
+    padding: none;
   }
 }
 
@@ -6423,14 +6454,14 @@ only screen and (max-device-width: 568px) {
   margin-bottom: 10px;
 }
 
-header td.navBurgerIcon{ 
+.navheader .navBurgerIcon {
   display: none;
-  
 }
+
 @media only screen and (max-width: 380px),
 only screen and (max-device-width: 568px) {
 
-  header td.navBurgerIcon {
+  .navheader .navBurgerIcon {
     display: block;
     color:white;
     font-size:24px;

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -76,13 +76,13 @@
 				$updateTime = "No data found for the given course ID";
 			}
 
-			echo "<table><tr>";
+			echo "<nav><ul>";
 			//Burger menu that Contains the home, back and darkmode icons when window is small; Only shown if not superuser.
 			//Always on courseed.php ($noup is none). Contains only home and darkmode icons.
 			if(checklogin() == false|| $_SESSION['uid'] == 0 || (isStudentUser($_SESSION['uid'])) || $noup=='NONE'){
 				if (isset($courseed)) {
-					echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></td>";
-					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+					echo "<li class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></li>";
+					echo "<li class='navBurgerIcon' style='display: none;'> </li>";
 					echo "<div id='navBurgerBox' style='display: none;'>";
 					echo "	<div id='motdDiv' class='navButt' onclick='showServerMessage();' >";
 					echo "		<a id='motdBurger'>";
@@ -122,24 +122,24 @@
 				} 
 				else {
 					//Display default tools/buttons of burger dropdown menu, search(ctrl + f) for "Burger dropdown menu show dugga" 
-					echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></td>";
-					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+					echo "<li class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()'></li>";
+					echo "<li class='navBurgerIcon' style='display: none;'> </li>";
 				}
 			}
 			
 			// Always show home button which links to course homepage			
 			// Home button original code <a id='homeIcon' class='navButt'><img alt='home button icon' src='../Shared/icons/Home.svg'></a>
-			echo "<td class='navButt' id='home' title='Home' onclick='navigateToUrl(\"../DuggaSys/courseed.php\")'>
+			echo "<li class='navButt' id='home' title='Home' onclick='navigateToUrl(\"../DuggaSys/courseed.php\")'>
 					<div class='home-nav' tabindex='0'>
 						<img alt='home button icon' src='../Shared/icons/Home.svg'>
 					</div>
-				</td>";
+				</li>";
 			// Always show toggle button. When clicked it changes between dark and light mode.
-			echo "<td class='navButt' id='theme-toggle'>
+			echo "<li class='navButt' id='theme-toggle'>
 					<div class='theme-toggle-nav' tabindex='0'>
 						<img src='../Shared/icons/ThemeToggle.svg' title='Toggle between dark mode' alt='an icon on a moon, which indicates dark mode and light mood'>
 					</div>
-				</td>";
+				</li>";
 			
 				
 			// Generate different back buttons depending on which page is including
@@ -149,77 +149,77 @@
 			//---------------------------------------------------------------------
 
 			if($noup!='NONE') {
-				echo "<td class='navButt' id='back' title='Back'>";
+				echo "<li class='navButt' id='back' title='Back'>";
 			}
 			if($noup=='CONTRIBUTION'){
 				echo "<a id='upIcon' class='navButt' href='../DuggaSys/courseed.php'>";
-				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></td>";
+				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></li>";
 			}if($noup=='COURSE'){
 				echo "<div><a id='upIcon' class='navButt' href='../DuggaSys/courseed.php'>";
-				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></div></td>";
+				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></div></li>";
 			}if($noup=='COURSE' && checklogin() && (isTeacher($_SESSION['uid']))){
-				echo '<td class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" style="width: 29px; vertical-align: middle; margin-top: 15px;" onclick=hamburgerChange()>';
+				echo '<li class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" style="width: 29px; vertical-align: middle; margin-top: 15px;" onclick=hamburgerChange()>';
 			}else if($noup=='SECTION'){
 				echo "<a id='upIcon' href='";
 				echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
 				echo "'>";
-				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></td>";
+				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></li>";
 			}
 
-			echo "<td class='navButt' style='display:none;' id='motdNav' title='Message of the day 'onclick='showServerMessage();'>
+			echo "<li class='navButt' style='display:none;' id='motdNav' title='Message of the day 'onclick='showServerMessage();'>
 					<div class='motd-nav' tabindex='0'>
 						<img alt='motd icon' src='../Shared/icons/MOTD.svg'>
 					</div>
-				</td>";
+				</li>";
 			// Adding buttons for courses
 			if($noup=='COURSE'){
 					// Course specific navbar buttons moved from "static" to navheader
 					if(checklogin() && (isSuperUser($_SESSION['uid']) || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'st') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'w') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'sv'))) {
-						echo '<td class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" style="width: 29px; vertical-align: middle; margin-top: 15px;" onclick=hamburgerChange()>';
-						echo "</td>";
-						echo "<td id='courseVersionDropDown' title='Choose course version'>";
+						echo '<li class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" style="width: 29px; vertical-align: middle; margin-top: 15px;" onclick=hamburgerChange()>';
+						echo "</li>";
+						echo "<li id='courseVersionDropDown' title='Choose course version'>";
 							echo "    <div class='course-dropdown-div'>";
 							echo "      <select id='courseDropdownTop' class='course-dropdown' onchange='goToVersion(this)' ></select>";
 							echo "    </div>";
-							echo "</td>";
+							echo "</li>";
 
-							echo "<td class='editVers' style='display: inline-block;margin-left:8px;'>";
+							echo "<li class='editVers' style='display: inline-block;margin-left:8px;'>";
 							echo "    <div class='editVers menuButton' tabindex='0'>";
              				echo "      <img alt='settings icon' id='versionCog' class='navButt' title='Edit the selected version' onclick=showEditVersion(); src='../Shared/icons/CogwheelWhite.svg'>";
 							echo "    </div>";
-							echo "</td>";
+							echo "</li>";
 
 					if(checklogin() && (isSuperUser($_SESSION['uid']) )) {
 
-							echo "<td class='newVers' style='display: inline-block;'>";
+							echo "<li class='newVers' style='display: inline-block;'>";
 							echo "    <div class='newVers menuButton' tabindex='0'>";
               				echo "      <img alt='plus sign icon' id='versionPlus' value='New version' class='navButt' title='Create a new version of this course' onclick='showCreateVersion();' src='../Shared/icons/PlusS.svg'>";
 							echo "    </div>";
-							echo "</td>";
+							echo "</li>";
 					}
-							echo "<td class='results' style='display: inline-block;'>";
+							echo "<li class='results' style='display: inline-block;'>";
 							echo "    <div class='results menuButton'>";
 							echo "    <a id='resultsBTN' title='Edit student results' value='Results' href='resulted.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers']."' >";
 							echo "      <img alt='edit results icon' id='versionPlus' class='navButt' src='../Shared/icons/marking_icon.svg'>";
 							echo "    </a>";
 							echo "    </div>";
-							echo "</td>";
+							echo "</li>";
 
-							echo "<td class='tests' style='display: inline-block;'>";
+							echo "<li class='tests' style='display: inline-block;'>";
 							echo "    <div class='tests menuButton'>";
 							echo "      <a id='testsBTN' title='Show tests' value='Tests' href='duggaed.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers']."' >";
 							echo "        <img alt='show tests icon' id='testsBTN' class='navButt' src='../Shared/icons/test_icon.svg'>";
 							echo "      </a>";
 							echo "    </div>";
-							echo "</td>";
+							echo "</li>";
 
-							echo "<td class='files' style='display: inline-block;'>";
+							echo "<li class='files' style='display: inline-block;'>";
 							echo "    <div class='files menuButton'>";
              				echo "      <a id='filesBTN' title='Show files' value='Files' href='fileed.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers']."' >";
               				echo "        <img alt='files icon' id='editFiles' class='navButt' src='../Shared/icons/files_icon.svg'>";
 							echo "      </a>";
 							echo "    </div>";
-							echo "</td>";
+							echo "</li>";
 
 							include_once "../Shared/database.php";
 							pdoConnect();
@@ -249,26 +249,26 @@
 									$term = 1;
 								}
 
-								echo "<td class='coursePage' style='display: inline-block;'>";
+								echo "<li class='coursePage' style='display: inline-block;'>";
 								echo "    <div class='course menuButton'>";
 								echo " 		<a href='https://personal.his.se/utbildning/kurs/?semester=".$year.$term."&coursecode=".$result['coursecode']."' target='_blank'>";
 								echo "        <img alt='course page icon' id='courseIMG' value='Course' class='navButt' title='Course page for ".$result['coursecode']."' src='../Shared/icons/coursepage_button.svg'>";
 								echo "		</a>";
 								echo "    </div>";
-								echo "</td>";
+								echo "</li>";
 							}
 
-							echo "<td class='access' style='display: inline-block;'>";
+							echo "<li class='access' style='display: inline-block;'>";
 							echo "    <div class='access menuButton'>";
             			    echo "      <a id='accessBTN' title='Give students access to the selected version' value='Access' href='accessed.php?courseid=".$_SESSION['courseid']."&coursevers=".$_SESSION['coursevers']."' >";
              				echo "        <img alt='give access icon' id='editCourse' class='navButt' src='../Shared/icons/lock_symbol.svg'>";
 							echo "      </a>";
 							echo "    </div>";
-							echo "</td>";
+							echo "</li>";
 							echo "<input type='text' id='adminLoggedin' value='yes' style='display:none;'>";
 
 							// Refresh button for Github repo in nav
-							echo "<td class='refresh' style='display: inline-block; white-space: normal;'>";
+							echo "<li class='refresh' style='display: inline-block; white-space: normal;'>";
 							echo "<div class='refresh menuButton tooltip'>";
 								echo "<span id='refreshBTN' value='Refresh' href='#'>";
 									echo "<img alt='refresh icon' id='refreshIMG' title='Refresh github repo' class='navButt' onclick='refreshGithubRepo(".$_SESSION['courseid'].",".isSuperUser($_SESSION['uid']).");resetGitFetchTimer(".isSuperUser($_SESSION['uid']).")' src='../Shared/icons/gitrefresh.svg'>";
@@ -304,7 +304,7 @@
 
 								// echo "<span class='tooltiptext'><b>Last Fetch:</b> <br><b>Cooldown:</b> </span>";
 							echo "</div>";
-							echo "</td>";
+							echo "</li>";
 
 							//Dropdown Menu For Teachers
 							echo "<div id='hamburgerBox'>";
@@ -395,9 +395,9 @@
 			/*=====BURGER DROPDOWN MENU SHOWDUGGA=====*/
 			if ($noup == 'SECTION') {
 				if(checklogin() && (isSuperUser($_SESSION['uid']) || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'st') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'w') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'sv'))){
-					echo "<td class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()' ></td>";
-					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
-					echo "<td class='navBurgerIcon' style='display: none;'> </td>";
+					echo "<li class='navBurgerIcon fa fa-bars' onclick='navBurgerChange()' ></li>";
+					echo "<li class='navBurgerIcon' style='display: none;'> </li>";
+					echo "<li class='navBurgerIcon' style='display: none;'> </li>";
 				}
 			}
 			echo "<div id='navBurgerBox' class='navBurgerBox' style='display: none;'>";
@@ -440,7 +440,7 @@
 			//old search bar for resulted
 			// Handles onhover-text-examples (searchbar) based on what type of data can be requested.
       if($requestedService=="accessed.php" /*|| $requestedService=="resulted.php"*/ || $requestedService=="fileed.php" || $requestedService=="duggaed.php" ){
-					echo "<td id='testSearchContainer' class='navSearchWrapper'>";
+					echo "<li id='testSearchContainer' class='navSearchWrapper'>";
 
 					if ($requestedService == "fileed.php")
 						echo   "<form onsubmit='event.preventDefault()' autocomplete='off'><input id='searchinput' readonly type='text' onmouseover='hoverSearch();' onmouseleave='leaveSearch();' name='search' placeholder='Search..' onkeyup='searchterm=this.value;sortAndFilterTogether();myTable.reRender();'/></form>";
@@ -466,8 +466,8 @@
 					echo   "<div class='tooltipbackground'><div class='tooltipsearchbar'>";
 					echo 	"<input id='tooltipsearchinput' type='text' onmouseover='hoverSearch();' onmouseleave='leaveSearch();' name='search'  placeholder='Search..' onkeyup='searchterm=this.value;myTable.reRender()'/>";
 					echo 	"</div><div>";
-					echo "</td>";
-					echo "<td class='navButt' id='searchNavButt'>";
+					echo "</li>";
+					echo "<li class='navButt' id='searchNavButt'>";
 
 					if ($requestedService == "fileed.php")
 						echo   "<button id='searchbutton' class='switchContent' type='button'>";
@@ -476,22 +476,22 @@
 
 					echo     "<img alt='search icon' id='lookingGlassSVG' style='height:25px;' src='../Shared/icons/LookingGlass.svg'/>";
 					echo   "</button>";
-					echo "</td>";
+					echo "</li>";
 					if ($requestedService == "fileed.php" && (hasAccess($_SESSION["uid"], $_SESSION["courseid"], "w") || $_SESSION["superuser"] == 1)) {
 						//Adds the download files button to the toolbar
-						echo "<td class='navButt'>";
+						echo "<li class='navButt'>";
 						echo "    <div>";
 						echo "      <a id='downloadBTN' title='Download all content in a zip file' target='_blank' value='Download' href='downloadzip.php?courseid=".$_SESSION['courseid']."&coursevers=".$_SESSION['coursevers']."' >";
 						echo "        <img alt='download all icon' id='downloadButt' src='../Shared/icons/file_download_white.svg'>";
 						echo "      </a>";
 						echo "    </div>";
-						echo "</td>";
+						echo "</li>";
 					}
 			}
 
 			// Presents the filterButton and its connected dropdown menu.
       		if($requestedService=="accessed.php"){
-					echo "<td id='select' class='navFilterWrapper' onclick='pressFilter();' onmouseleave='leaveFilter()'; />";
+					echo "<li id='select' class='navFilterWrapper' onclick='pressFilter();' onmouseleave='leaveFilter()'; />";
 					echo   "<span id='filterButton'; ' name='filter'; >";
 					echo     "<img alt='filter icon' class='navButt filterButt' src='../Shared/icons/filter_icon.svg' style='pointer-events: none' />";
 					echo     "<div id='dropdownc' class='dropdown-list-container' style='z-index: 1' />";
@@ -500,46 +500,46 @@
 					echo       "<div id='customfilter'></div>";
 					echo     "</div>";
 					echo   "</span>";
-					echo "</td>";
+					echo "</li>";
 			}
 
 			// Either generate code viewer specific nav menu or a spacer
 			if(isset($codeviewer)){
-					echo "<td class='navButt' id='beforebutton' title='Previous example' onmousedown='Skip(\"bd\");' onmouseup='Skip(\"bu\");' onclick='Skip(\"b\");'ontouchstart='Skip(\"bd\");' ontouchend='Skip(\"bu\");'><img src='../Shared/icons/backward_button.svg'></td>";
-					echo "<td class='navButt' id='afterbutton' title='Next example' onmousedown='Skip(\"fd\");' onmouseup='Skip(\"fu\");' onclick='Skip(\"f\");' ontouchstart='Skip(\"fd\");' ontouchend='Skip(\"fu\");'><img src='../Shared/icons/forward_button.svg' /></td>";
-					echo "<td class='navButt' id='playbutton' title='Open demo' onclick='Play(event);'><img src='../Shared/icons/play_button.svg' /></td>";
+					echo "<li class='navButt' id='beforebutton' title='Previous example' onmousedown='Skip(\"bd\");' onmouseup='Skip(\"bu\");' onclick='Skip(\"b\");'ontouchstart='Skip(\"bd\");' ontouchend='Skip(\"bu\");'><img src='../Shared/icons/backward_button.svg'></li>";
+					echo "<li class='navButt' id='afterbutton' title='Next example' onmousedown='Skip(\"fd\");' onmouseup='Skip(\"fu\");' onclick='Skip(\"f\");' ontouchstart='Skip(\"fd\");' ontouchend='Skip(\"fu\");'><img src='../Shared/icons/forward_button.svg' /></li>";
+					echo "<li class='navButt' id='playbutton' title='Open demo' onclick='Play(event);'><img src='../Shared/icons/play_button.svg' /></li>";
 					if(checklogin() && (isSuperUser($_SESSION['uid']) || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'st') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'sv') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'w'))) {
-						echo "<td class='navButt' id='templatebutton' title='Choose Template' onclick='openTemplateWindow();'><img src='../Shared/icons/choose_template.svg'  /></td>";
-						echo "<td class='navButt' id='editbutton' onclick='displayEditExample();' title='Example Settings' ><img src='../Shared/icons/general_settings_button.svg' /></td>";
-					  echo "<td class='navButt' id='fileedButton' onclick='' style='display:none;' title='File Download/Upload' ><img src='../Shared/icons/files_icon.svg' /></td>";
+						echo "<li class='navButt' id='templatebutton' title='Choose Template' onclick='openTemplateWindow();'><img src='../Shared/icons/choose_template.svg'  /></li>";
+						echo "<li class='navButt' id='editbutton' onclick='displayEditExample();' title='Example Settings' ><img src='../Shared/icons/general_settings_button.svg' /></li>";
+					  echo "<li class='navButt' id='fileedButton' onclick='' style='display:none;' title='File Download/Upload' ><img src='../Shared/icons/files_icon.svg' /></li>";
 					}
-					echo "<td class='navButt' id='codeBurger' onclick='showBurgerMenu();' title='Show box' ><img src='../Shared/icons/hotdog_button.svg' /></td>";
-					echo "<td class='navButt showmobile' style='display:none;'><a href='courseed.php'><img src='../Shared/icons/hotdog_button.svg'></a></td>";
-					echo "<td id='navHeading' class='navHeading codeheader'>";
+					echo "<li class='navButt' id='codeBurger' onclick='showBurgerMenu();' title='Show box' ><img src='../Shared/icons/hotdog_button.svg' /></li>";
+					echo "<li class='navButt showmobile' style='display:none;'><a href='courseed.php'><img src='../Shared/icons/hotdog_button.svg'></a></li>";
+					echo "<li id='navHeading' class='navHeading codeheader'>";
 					echo "<span id='exampleSection'>Example Section : </span>";
 					echo "<span id='exampleName'> Example Name</span>";
-					echo "</td>";
+					echo "</li>";
 				}
 				
 				
 				else{
-					echo "<td id='select' style='display:none;' class='navButt'  onmouseover='hoverc();' onmouseleave='leavec();'>";
+					echo "<li id='select' style='display:none;' class='navButt'  onmouseover='hoverc();' onmouseleave='leavec();'>";
 					echo   "<span>";
 					echo     "<img class='navButt' src='../Shared/icons/tratt_white.svg'>";
 					echo     "<div id='dropdownc' class='dropdown-list-container' style='z-index: 1'>";
 					echo     "<div id='filterOptions'></div>";
 					echo     "</div>";
 					echo   "</span>";
-					echo "</td>";
-					echo "<td id='sort' style='display:none' class='navButt' onmouseover='hovers();' onmouseleave='leaves();'>";
+					echo "</li>";
+					echo "<li id='sort' style='display:none' class='navButt' onmouseover='hovers();' onmouseleave='leaves();'>";
 					echo   "<span>";
 					echo     "<img class='navButt' src='../Shared/icons/sort_white.svg'>";
 					echo     "<div id='dropdowns' class='dropdown-list-container' style='z-index: 1'>";
 					echo     "</div>";
 					echo   "</span>";
-					echo "</td>";
-					echo "</td>";
-					echo "<td id='menuHook' class='navSpacer' >";
+					echo "</li>";
+					echo "</li>";
+					echo "<li id='menuHook' class='navSpacer' >";
 					
 				}
 
@@ -547,31 +547,31 @@
 			{
 				if(checkLogin())
 				{
-					echo "<td class='navName' id='navName'><a id='userName' href='profile.php' title='".$_SESSION['loginname']."&#39;s profile'>".$_SESSION['loginname']."</a></td>";
+					echo "<li class='navName' id='navName'><a id='userName' href='profile.php' title='".$_SESSION['loginname']."&#39;s profile'>".$_SESSION['loginname']."</a></li>";
 				}
 				else if (git_checkLogin())
 				{
-					echo "<td class='navName' id='navName'><a id='userName' href='profile.php' title='".$_SESSION['git_loginname']."&#39;s profile'>".$_SESSION['git_loginname']."</a></td>";
+					echo "<li class='navName' id='navName'><a id='userName' href='profile.php' title='".$_SESSION['git_loginname']."&#39;s profile'>".$_SESSION['git_loginname']."</a></li>";
 				}
-				echo "<td id='loginbutton' class='loggedin' onclick='git_showLogoutPopup();'><img alt='logout icon' id='loginbuttonIcon' src='../Shared/icons/logout_button.svg' title='Logout'/></td>";
+				echo "<li id='loginbutton' class='loggedin' onclick='git_showLogoutPopup();'><img alt='logout icon' id='loginbuttonIcon' src='../Shared/icons/logout_button.svg' title='Logout'/></li>";
 			}
 			else if(checklogin()) 
 			{
-				echo "<td class='navName' id='navName'><a id='userName' href='profile.php' title='".$_SESSION['loginname']."&#39;s profile'>".$_SESSION['loginname']."</a></td>";
+				echo "<li class='navName' id='navName'><a id='userName' href='profile.php' title='".$_SESSION['loginname']."&#39;s profile'>".$_SESSION['loginname']."</a></li>";
 			
-					echo "<td id='loginbutton' class='loggedin' onclick='showLogoutPopup();'><div class='loginbutton-nav' tabindex='0'><img alt='logout icon' id='loginbuttonIcon' src='../Shared/icons/logout_button.svg' title='Logout'/></div></td>";
+					echo "<li id='loginbutton' class='loggedin' onclick='showLogoutPopup();'><div class='loginbutton-nav' tabindex='0'><img alt='logout icon' id='loginbuttonIcon' src='../Shared/icons/logout_button.svg' title='Logout'/></div></li>";
 				
 			}
 			else
 			{
 				//---  original --- echo "<td class='navName' id='navName'><label id='userName' title='Login to view your profile'>Guest</label></td>";
-				echo "<td class='navName' id='navName'><label id='userName' title='Login to view your profile'></label></td>";
+				echo "<li class='navName' id='navName'><label id='userName' title='Login to view your profile'></label></li>";
 				
 				// --- original --- echo "<td id='loginbutton' class='loggedout' onclick='showLoginPopup();'><img alt='login icon' id='loginbuttonIcon' src='../Shared/icons/login_button.svg' title='Login'/></td>";
-				echo "<td id='loginbutton' class='loggedout' onclick='showLoginPopup();'><div class='loginbutton-nav' tabindex='0'>Login</div></td>";
+				echo "<li id='loginbutton' class='loggedout' onclick='showLoginPopup();'><div class='loginbutton-nav' tabindex='0'>Login</div></li>";
 			}
 
-			echo "</tr></table>";
+			echo "</ul></nav>";
 			if(isset($codeviewer)){
 				echo "<div id='mobileNavHeading'><span id='mobileExampleSection'></span><span id='mobileExampleName'></span></div>";
 			}

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -76,7 +76,8 @@
 				$updateTime = "No data found for the given course ID";
 			}
 
-			echo "<nav><ul>";
+			echo "<nav>";
+			echo "<ul>";
 			//Burger menu that Contains the home, back and darkmode icons when window is small; Only shown if not superuser.
 			//Always on courseed.php ($noup is none). Contains only home and darkmode icons.
 			if(checklogin() == false|| $_SESSION['uid'] == 0 || (isStudentUser($_SESSION['uid'])) || $noup=='NONE'){
@@ -158,13 +159,17 @@
 				echo "<div><a id='upIcon' class='navButt' href='../DuggaSys/courseed.php'>";
 				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></div></li>";
 			}if($noup=='COURSE' && checklogin() && (isTeacher($_SESSION['uid']))){
-				echo '<li class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" style="width: 29px; vertical-align: middle; margin-top: 15px;" onclick=hamburgerChange()>';
+				echo '<li class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" onclick=hamburgerChange()>';
 			}else if($noup=='SECTION'){
 				echo "<a id='upIcon' href='";
 				echo ($_SESSION['courseid'] != (string)"UNK" ? "../DuggaSys/sectioned.php?courseid=".$_SESSION['courseid']."&coursename=".$_SESSION['coursename']."&coursevers=".$_SESSION['coursevers'] : "../DuggaSys/courseed.php");
 				echo "'>";
 				echo "<img alt='go back icon' src='../Shared/icons/Up.svg'></a></li>";
 			}
+
+			echo "</ul>";
+			echo "</nav>";
+			echo "<ul>";
 
 			echo "<li class='navButt' style='display:none;' id='motdNav' title='Message of the day 'onclick='showServerMessage();'>
 					<div class='motd-nav' tabindex='0'>
@@ -175,7 +180,7 @@
 			if($noup=='COURSE'){
 					// Course specific navbar buttons moved from "static" to navheader
 					if(checklogin() && (isSuperUser($_SESSION['uid']) || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'st') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'w') || hasAccess($_SESSION['uid'], $_SESSION['courseid'], 'sv'))) {
-						echo '<li class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" style="width: 29px; vertical-align: middle; margin-top: 15px;" onclick=hamburgerChange()>';
+						echo '<li class="hamburger fa fa-bars hamburgerMenu" id="hamburgerIcon" onclick=hamburgerChange()>';
 						echo "</li>";
 						echo "<li id='courseVersionDropDown' title='Choose course version'>";
 							echo "    <div class='course-dropdown-div'>";
@@ -543,6 +548,10 @@
 					
 				}
 
+			echo "</ul>";
+
+			echo "<div class='auth-box'><ul>";
+
 			if($noup=='CONTRIBUTION' && (checkLogin() || git_checkLogin()))
 			{
 				if(checkLogin())
@@ -571,7 +580,8 @@
 				echo "<li id='loginbutton' class='loggedout' onclick='showLoginPopup();'><div class='loginbutton-nav' tabindex='0'>Login</div></li>";
 			}
 
-			echo "</ul></nav>";
+			echo "</ul></div>";
+
 			if(isset($codeviewer)){
 				echo "<div id='mobileNavHeading'><span id='mobileExampleSection'></span><span id='mobileExampleName'></span></div>";
 			}

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -1,16 +1,14 @@
 <?php
 			if (isset($_GET['embed'])){
-				echo "<header style='display:none;'>";
+				echo "<header class='navheader' style='display:none;'>";
 			}	else {
-				echo "<header>";
+				echo "<header class='navheader'>";
 			}		
 ?>
        <?php
 			$requestedService = explode('?', $_SERVER['REQUEST_URI'], 2)[0];
 			$requestedService = substr($requestedService,strrpos ( $requestedService , "/")+1);
 			
-
-			echo "<table class='navheader' id='navheader'><tr id='navbar'>";
 			include_once "../Shared/basic.php";
 			pdoConnect();
 
@@ -78,7 +76,7 @@
 				$updateTime = "No data found for the given course ID";
 			}
 
-
+			echo "<table><tr>";
 			//Burger menu that Contains the home, back and darkmode icons when window is small; Only shown if not superuser.
 			//Always on courseed.php ($noup is none). Contains only home and darkmode icons.
 			if(checklogin() == false|| $_SESSION['uid'] == 0 || (isStudentUser($_SESSION['uid'])) || $noup=='NONE'){


### PR DESCRIPTION
## What's changed:
- Navheader is now semantically correct.
- Inline styling removed and moved to style.css.
- Removed excess margin/padding.2

Some elements are not placed inside of the <nav> element because it should only be used for actual site navigation. Functionality like editing/adding courses are instead grouped and placed in a separate unordered list. 

## How to test:
Everything should look mostly the same as before so please make sure to inspect the actual elements as well as checking desktop/mobile view to see that everything works as expected.  

![image](https://github.com/user-attachments/assets/02fefbf7-4ec2-4844-bb3a-4253dbd9c924)

