### PR TITLE
Fixed: G1 2025 v6 #17437 fix so you can see all colors in mobile version

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -574,9 +574,7 @@
     border-radius: 5px;
     position: absolute;
     left: 0;
-    top: 0;
-    width: 230px;
-    height: 50px;
+    height: 110px;
     z-index: 5;
     float: left;
 }

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -455,13 +455,9 @@ function toggleColorMenu(buttonID) {
             }
         }
         // Menu position relative to button
-        menu.style.width = width + "px";
-        const buttonWidth = button.offsetWidth;
-        const offsetWidth = window.innerWidth - button.getBoundingClientRect().x - (buttonWidth);
-        const offsetHeight = button.getBoundingClientRect().y;
-        menu.style.top = (offsetHeight - 50) + "px";
-        const menuOffset = window.innerWidth - menu.getBoundingClientRect().x - (width);
-        menu.style.left = (menu.style.left + menuOffset) - (offsetWidth + buttonWidth) + "px";
+        menu.style.maxHeight = "600px";
+        menu.style.overflowY = "auto";
+        menu.style.overflowX = "hidden";
     } else {    // if the color menu's inner html is not empty, remove the content
         menu = button.children[0];
         menu.innerHTML = "";

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -456,8 +456,6 @@ function toggleColorMenu(buttonID) {
         }
         // Menu position relative to button
         menu.style.maxHeight = "600px";
-        menu.style.overflowY = "auto";
-        menu.style.overflowX = "hidden";
     } else {    // if the color menu's inner html is not empty, remove the content
         menu = button.children[0];
         menu.innerHTML = "";


### PR DESCRIPTION
This change simplifies the positioning logic and reduces unnecessary calculations. The whole color menu is now visible on both desktop version and mobile version. When the user clicks on a color, the color menu closes as it was before.

Desktop version:
<img width="959" alt="image" src="https://github.com/user-attachments/assets/13cc12dc-1bb6-408c-b6a0-0859513d92ba" />

Mobile version:
<img width="164" alt="image" src="https://github.com/user-attachments/assets/ce797c12-f0e1-4bf5-be60-b0c97ba7d73b" />
