### PR TITLE
Hid the panels on mobile

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -315,7 +315,6 @@
     }
 }
 
-
 @media (max-width: 414px){
     .icon-wrapper{
         display: block !important;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -315,6 +315,7 @@
     }
 }
 
+
 @media (max-width: 414px){
     .icon-wrapper{
         display: block !important;

--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -204,14 +204,13 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 				}else{
 					echo "<div class='err'><span style='font-weight:bold;'>Bummer!</span> The link you asked for does not currently exist!</div>";
 				}
-        		echo "<div class='loginTransparent' id='lockedDuggaInfo' style='margin-bottom:5px;'>";
-        		echo "<img src='../Shared/icons/duggaLock.svg'>";
-        		echo "</div>";
+				echo "<div class='loginTransparent' id='lockedDuggaInfo' style='margin-bottom:5px;'>";
+				echo "<img src='../Shared/icons/duggaLock.svg'>";
+				echo "</div>";
 
 			}else{
 				echo "<div class='err'><span style='font-weight:bold;'>Bummer!</span> Something went wrong in loading the test. Contact LENASys-admin.</div>";
 			}
-
 		
 		?>
 	</div>

--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -386,6 +386,18 @@ svg text {
 		padding-right: 2px;
 		padding-left: 0px
 	}
+
+	.mobileNavRemover{
+		display: none;
+	}
+
+	.assignment_left{
+		display: none;
+	}
+
+	.instructions-container{
+		display: none;
+	}
 }
 
  /* --------------================################================-------------- *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1550,6 +1550,14 @@ header td {
   display: none;
 }
 
+@media (max-width: 414px){
+  #header {
+    display: none; /* Hides the header */
+    height: 0; /* Ensures no space is taken */
+    visibility: hidden; /* Optional: additional hide */
+  }
+}
+
 .navheader {
   height: 20px;
   margin-bottom: 10px;

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -1,8 +1,8 @@
 <?php
 			if (isset($_GET['embed'])){
-				echo "<header style='display:none;'>";
+				echo "<header id='header' style='display:none;'>";
 			}	else {
-				echo "<header>";
+				echo "<header id='header'>";
 			}		
 ?>
        <?php
@@ -538,7 +538,7 @@
 			if (isset($_GET['embed'])){
 				echo "<div style='display:none;'></div>";
 			}	else {
-				echo "<div style='height:50px;'></div>";
+				echo "<div class='mobileNavRemover' style='height:50px;'></div>";
 			}		
 ?>
 <div id="overlay" style="display: none;"></div>


### PR DESCRIPTION
Hid the Instructions, General information and the whole header with all its funtionality. To do this, I had to add an ID to the header to be able to use it in a media query. The other panels already had IDs so I just used them in already existing media queries.

_**This is how it looked before**_
![image](https://github.com/user-attachments/assets/7e24e289-67c6-48cf-af75-7decb3c0864f)

_**This is how it looks right now**_
![image](https://github.com/user-attachments/assets/1e024c75-7051-46d2-b143-16b22ef04ae8)
