### PR TITLE
Change 'setupEndpointDirectory.php' to use delete script #17467

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/setupEndpointDirectory.php
+++ b/DuggaSys/microservices/endpointDirectory/setupEndpointDirectory.php
@@ -8,8 +8,7 @@ $dbFile = __DIR__ . '/endpointDirectory_db.sqlite';
 
 // remove old database if it exists
 if (file_exists($dbFile)) {
-    unlink($dbFile);
-    echo "Old database removed.<br>";
+    require_once __DIR__ . '/deleteEndpointDb.php';
 }
 
 // create a new database


### PR DESCRIPTION
Removed the old code that removes the database (if it exists) before reinstalling it. It does the same thing as before, but there was a delete script made for a different issue, so it might as well be used here too. Fixes #17467 

To test this you can run `'setupEndpointDirectory.php'` and check when the `'endpointDirectory_db.sqlite'` was created. If you didn't have the database before running `'setupEndpointDirectory.php'` you need to run it two times. 