### PR TITLE
Remove auto double line ER-element feature (#17529)

### DIFF
--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -13,13 +13,6 @@ function addLine(fromElement, toElement, kind, isRecursive = false, stateMachine
     ) {
         [toElement, fromElement] = [fromElement, toElement];
     }
-    //If line is comming to ERRelation from weak entity it adds double line, else it will be single
-    if (toElement.kind == elementTypesNames.ERRelation) {
-        if (fromElement.state == entityState.WEAK) {
-            kind = lineKind.DOUBLE;
-        }
-        [toElement, fromElement] = [fromElement, toElement];
-    }
     let errorMessage = checkConnectionErrors(fromElement, toElement);
     if (errorMessage) {
         displayMessage(messageTypes.ERROR, errorMessage);


### PR DESCRIPTION
Removed an if-statement from line.js which was responsible for automatically making the line double when connected to weak entities (only applies to the ER entities, all other ones are un-touched). 

The user now has to manually select "Double" for the line in the options-tab, see below. 


https://github.com/user-attachments/assets/2e32d8dd-8d39-47ad-8a11-2444a16edafc

