### PR TITLE
Fixed: G1-2025-v7-#17554-align-er-attribute-name-to-the-left

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -632,11 +632,32 @@ function drawElementERAttr(element, textWidth, boxw, boxh, linew, texth) {
             extra = `class='underline'`;
             break;
     }
+
+        const maxTextWidth = boxw - 10; // leave some margin
+        let displayName = element.name;
+        let estimatedTextWidth = displayName.length * 8;
+
+        let x;
+        let textAnchor;
+
+        if (estimatedTextWidth <= maxTextWidth) {
+            // Text fits – center it
+            x = boxw / 2;
+            textAnchor = "middle";
+        } else {
+            // Text is too long – show first part of text
+            x = 4;
+            textAnchor = "start";
+        }
+
      // Default text label centered
-    content += `<text 
-                    x='${boxw / 2}' y='${hboxh}' ${extra} 
-                    dominant-baseline='middle' text-anchor='middle'
-                > ${element.name} </text>`;
+        content += `<text 
+        x='${x}' 
+        y='${hboxh}' ${extra}
+        dominant-baseline='middle' 
+        text-anchor='${textAnchor}'
+        >${displayName}</text>`;
+    
     return drawSvg(boxw, boxh, content);
 }
 


### PR DESCRIPTION
This change makes the name of the attribute centered but if the name is too long, it shows the first part of the attributes name instead of the middle part of it.