### PR TITLE
Fixed and reduced whitespace in UML Class, IE and SD elements

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -389,7 +389,7 @@ function drawElementUMLEntity(element, boxw, boxh, linew, texth) {
 
     // Content, Attributes
     const textBox = (s, css) => {
-        let height = texth * (s.length + 1) * lineHeight + boxh / 2;
+        let height = texth * s.length * lineHeight + texth * 1;
         let text = "";
         for (let i = 0; i < s.length; i++) {
             text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i]);
@@ -443,7 +443,7 @@ function drawElementIEEntity(element, boxw, boxh, linew, texth) {
 
     // Content, Attributes
     const textBox = (s, css) => {
-        let height = texth * (s.length + 1) * lineHeight + boxh;
+        let height = texth * s.length * lineHeight + texth * 1;
         let text = "";
         for (let i = 0; i < s.length; i++) {
             if (i < newPrimaryKeys.length) {
@@ -517,7 +517,7 @@ function drawElementSDEntity(element, boxw, boxh, linew, texth) {
 
     // Attributes box with lower rounded corners
     const drawBox = (s, css) => {
-        let height = texth * (s.length + 1) * lineHeight + boxh;
+        let height = texth * s.length * lineHeight + texth * 1;
         let text = "";
         for (let i = 0; i < s.length; i++) {
             text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i]);


### PR DESCRIPTION
Reduced the whitespace in the bottom section under "Attribute" and "Function", to make the UML class element more compact. The same proccess was implemented to the IE ("Primary" and "Attribute") and SD ("do: func") elements. The changes made were done in the element.js file. 