### PR TITLE
Acceptance Test Script for Connecting Course Element to Github

### DIFF
--- a/DuggaSys/tests/testGithubLinkCodeExample.php
+++ b/DuggaSys/tests/testGithubLinkCodeExample.php
@@ -1,0 +1,38 @@
+<?php
+include_once $_SERVER['DOCUMENT_ROOT'] . '/LenaSYS/Shared/basic.php';
+include_once $_SERVER['DOCUMENT_ROOT'] . '/LenaSYS/Shared/sessions.php';
+pdoConnect();
+
+// Setting up the titles
+$testExampleName = 'GitHub Link Test';
+$testSectionName = 'Test Section';
+$expectedGitHubURL = 'https://github.com/LenaSYS/Webbprogrammering-Examples/blob/master/Examples%20Html/HTML%20CSS%20Background.html';
+$cid = 1885;
+
+// Inserts to table
+$insert = $pdo->prepare("INSERT INTO codeexample (cid, examplename, sectionname, runlink, cversion, uid, templateid) 
+                         VALUES (:cid, :examplename, :sectionname, :runlink, 99999, 1, 1)");
+$insert->bindParam(':cid', $cid);
+$insert->bindParam(':examplename', $testExampleName);
+$insert->bindParam(':sectionname', $testSectionName);
+$insert->bindParam(':runlink', $expectedGitHubURL);
+$insert->execute(); 
+
+// Retrieve it 
+$select = $pdo->prepare("SELECT runlink FROM codeexample WHERE examplename = :examplename");
+$select->bindParam(':examplename', $testExampleName);
+$select->execute();
+$result = $select->fetch(PDO::FETCH_ASSOC);
+
+// Output result
+if ($result && $result['runlink'] === $expectedGitHubURL) {
+    echo " Test passed: GitHub link saved correctly.\n";
+} else {
+    echo " Test failed: GitHub link not saved correctly.\n";
+}
+
+// Cleanup/Deleting
+$delete = $pdo->prepare("DELETE FROM codeexample WHERE examplename = :examplename");
+$delete->bindParam(':examplename', $testExampleName);
+$delete->execute();
+?>


### PR DESCRIPTION
Acceptance Test Script for Connecting Course Element to Github #16513 
The file was bugging locally so it got 3 commits for 1 so just ignore it.
I am not 100% sure if I understod the issue or solved it.

The file created is test "testGithubLinkCodeExample.php" and it is located at: C:\xampp\htdocs\LenaSYS\DuggaSys\tests\testGithubLinkCodeExample.php

How to test it: 

Locate the file in browser at:
 http://localhost/LenaSYS/DuggaSys/tests/ 

Click the file: 
testGithubLinkCodeExample.php

It should say Test passed, and if failed: Test failed.

Now go in to the file but in vs code at path:
DuggaSys\tests\testGithubLinkCodeExample.php

Put "//" (comment out) the three rows of "Deleting/Cleanup" so it looks like this:
// Cleanup/Deleting
// $delete = $pdo->prepare("DELETE FROM codeexample WHERE examplename = :examplename");
// $delete->bindParam(':examplename', $testExampleName);
// $delete->execute();

Save and do the earlier step again, run the file in browser and it should again say test passed.

Go to phpMyAdmin, click "Admin" on mySQL on the xampp app. Go to the database, it is usually called something like "lena".
Click on tables, then click on "codeexamples", locate the newly created test. You can search for: "GitHub Link Test" because that is its name. See that it exists and with its own titles such as runlink as the link to github. 

Delete it manually by clicking "delete" or the trashbin symbol on it. Becase it should be deleted due to it only being a test(?), as it does when you have not put "//" before the cleanup/delete part of the script.
