### PR TITLE
new css class

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1126,6 +1126,13 @@
     width: 100%;
 }
 
+button.saveButton {
+  border-radius: 4px;
+  font-size: 16px;
+  margin-top:10px;
+  padding-left: 5px;
+}
+
 /*****************
    Confirm buttons
 *****************/


### PR DESCRIPTION
Improved the design consistency by adding custom styles to .saveButton (for <button> elements):

CSS:
border-radius: 4px; — adds rounded corners to match the style of input buttons
font-size: 16px; — ensures consistent text sizing across all buttons
margin-top: 10px; — creates visual spacing between stacked buttons
padding-left: 5px; — adds inner spacing for a cleaner, more balanced look

![image](https://github.com/user-attachments/assets/c0a300ad-ebd6-4920-8746-1f9635f95068)

This update ensures the “Bring to Front” and “Send to Back” buttons visually align with the rest of the options panel.