### PR TITLE
[#17567] Fixed issue where app breaks when centering camera on example diagrams

### DIFF
--- a/DuggaSys/diagram/camera.js
+++ b/DuggaSys/diagram/camera.js
@@ -24,11 +24,31 @@ function centerCamera() {
             y: window.innerHeight / 2
         };
 
-        if(emptyDiagram == true){
+        if (emptyDiagram == true){
+            elementHeights = []; // Special array for height of elements since not all elements have a default height assigned to them
+
+            // Get smallest/largest x-value in the diagram (leftmost point and rightmost point), as well as smallest y-value
             const minX = Math.min.apply(null, data.map(i => i.x));
-            const maxX = Math.max.apply(null, data.map(i => i.x + i.width));
+            const maxX = Math.max.apply(null, data.map(i => i.x + i.width)); // Get rightmost point by taking the largest sum of x-position + element width
             const minY = Math.min.apply(null, data.map(i => i.y));
-            const maxY = Math.max.apply(null, data.map(i => i.y + i.height));
+
+            // Look through each element in the diagram and retrieve the sum of y-position and element height for all of them
+            data.forEach(element => {
+                if (element.kind == elementTypesNames.UMLEntity){ // UML Entities don't have a default height assigned to them, meaning that it needs to be retrieved from the UMLHeight array instead
+                    let temp = UMLHeight.find(item => item.id === element.id);
+                    elementHeights.push(element.y + temp.height);
+
+                } else if (element.kind == elementTypesNames.SDEntity) { // Same for SD Entities, but from SDHeight instead 
+                    let temp = SDHeight.find(item => item.id === element.id);
+                    elementHeights.push(element.y + temp.height);
+
+                } else { // Other elements get the height directly from the element
+                    elementHeights.push(element.y + element.height);
+                }
+            });
+
+            const maxY = Math.max.apply(null, elementHeights); // Get largest y-value from the predefined array
+
             determineZoomfact(maxX, maxY, minX, minY);
 
             // Center of diagram in coordinates


### PR DESCRIPTION
**TLDR:** Implemented special handling for certain elements when getting largest y-value since some elements don't have default height values.

The problem was caused by the _centerCamera()_ function in camera.js. It turns out that certain elements (_UML Entities and SD Entities_) don't have a default height value assigned to them, which clashed with how the function got the positional values for centering the camera (_This basically just means that the element objects have no height value to retrieve_).

The function works by getting the smallest and largest values of the entire diagram, which it then uses to determine zoom level and where to position the ruler bars. Since UML- and SD-entity elements don't have heights, the largest y-value became **NaN** (_Apparently, y-pos (which had a value) + element height (which was NaN) = NaN_). This is what caused the all elements to clump up at the top of the screen, and why the y-axis ruler disappeared. Unsure what exactly caused the scrolling to lock as well but it had something to do with this too.

The fix to this was to implement special handling for these two elements. They have their own arrays in globals.js called **UMLHeight** and **SDHeight**, which stores the total height of the elements whenever they are drawn. You can retrieve the height of these elements by searching the array using the ID of the element. The heights are retrieved from those arrays and added together with the element's y-position and put into a separate array. The largest value is then taken from that array instead of from an array created with the _.map()_ function like the other values. Also added some comments to explain the code.

The previously affected example diagrams now behave like the others when centering the camera, not clumping up at the top or locking the scroll function.


https://github.com/user-attachments/assets/71bd9489-edc1-4988-a57f-57e6fc93daeb

Note: The UML-diagram zooms so far out due to the way the system decides what zoom level to be at when centering the camera on a diagram. It just barely **doesn't** fit inside the viewport at 0.5x zoom, so it zooms all the way out to 0.25x instead, which makes it very small. Probably able to be changed and improved on, but it isn't a part of this issue, nor is it that big of a problem realistically.