### PR TITLE
Fixed unexpected behavior on ER-attribute text when weakKey

### DIFF
--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -151,11 +151,12 @@ function updateCSSForAllElements() {
                         fillColor = elementDiv.children[0].children[0]; // Accessing the whatever needs to be accessed
                     }
                     fontColor = elementDiv.children[0];
-                    weakKeyUnderline = elementDiv.children[0].children[2];
+                    weakKeyUnderline = elementDiv.querySelector("line");
                     if (contextLengthCheck()) {
                         fillColor.style.fill = color.LIGHT_PURPLE;
                         fontColor.style.fill = color.WHITE;
-                        // If its a weakKey attribute, update underline color
+                        
+                        // If the weakKey attribute is selected, update underline color
                         if (element.state == "weakKey") {
                             weakKeyUnderline.style.stroke = color.WHITE;
                         }
@@ -166,13 +167,16 @@ function updateCSSForAllElements() {
                             fontColor.style.fill = color.WHITE;
                         } else {
                             fillColor.style.fill = color.WHITE;
+                            weakKeyUnderline.style.stroke = color.BLACK;
                         }
                     } else {
                         fillColor.style.fill = `${element.fill}`;
                         fontContrast();
                         if (element.state == "weakKey") {
-                            if (element.fill == color.BLACK) {
+                            if (element.fill == color.BLACK || element.fill == color.PINK || element.fill == color.BLUE) { // If the weakKey attribute is set to the color black, pink or blue, update underline color
                                 weakKeyUnderline.style.stroke = color.WHITE;
+                            } else {
+                                weakKeyUnderline.style.stroke = color.BLACK;
                             }
                         }
                     }
@@ -255,7 +259,7 @@ function updateCSSForAllElements() {
 
     function fontContrast() {
         // Set text to white if background is black or pink, else black
-        if (element.fill == color.BLACK || element.fill == color.PINK) {
+        if (element.fill == color.BLACK || element.fill == color.PINK || element.fill == color.BLUE) {
             fontColor.style.fill = color.WHITE;
         } else {
             fontColor.style.fill = color.BLACK;
@@ -269,8 +273,6 @@ function updateCSSForAllElements() {
         
         return inContext && context.length > 0 || inContext && context.length > 0 && contextLine.length > 0;
     }
-
-
     toggleBorderOfElements();
 }
 


### PR DESCRIPTION
Fixed the unexpected behavior on ER-attribute text when weakKey is selected. This issue happened because the wrong child were selected and the colorchecks were not correct for the weakKey. I fixed this by removing the hardcoded childrens and instead used the "querySelector("line");". I also changed so the blue color has white text and underline because I found it more nice compared to the black text and line on the blue color.

https://github.com/user-attachments/assets/07936c43-4428-489e-89ab-d7afc34898ad