### PR TITLE
G3-2025-V7-#17457-fix header-dropdown-codeviewer

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -316,15 +316,15 @@ $js = array(
                         <legend>Markdown</legend>
                         <div id='markdownEditor'>
                             <div class="markdown-icon-div">
-                                <span class="markdown-icons" onclick="boldText()" title="Bold"><b>B</b></span>
-                                <span class="markdown-icons" onclick="cursiveText()" title="Italic"><i>i</i></span>
-                                <span class="markdown-icons" onclick="codeBlockText()" title="CodeBlock">&#10065;</span>
-                                <span class="markdown-icons" onclick="lists()" title="lists"><img src="../Shared/icons/list-symbol.svg"></span>
-                                <span class="markdown-icons" onclick="linkYoutube()" title="link Youtube"><b>Yt</b></span>
-                                <span class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</span>
-                                <span class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></span>
-                                <span class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></span>
-                                <span class="markdown-icons headerType" id="headerIcon" title="Header" onclick="showDropdown('show');" onmouseleave="showDropdown('hide');">aA&#9663;
+                                <button class="markdown-icons" onclick="boldText()" title="Bold"><b>B</b></button>
+                                <button class="markdown-icons" onclick="cursiveText()" title="Italic"><i>i</i></button>
+                                <button class="markdown-icons" onclick="codeBlockText()" title="CodeBlock">&#10065;</button>
+                                <button class="markdown-icons" onclick="lists()" title="lists"><img src="../Shared/icons/list-symbol.svg"></button>
+                                <button class="markdown-icons" onclick="linkYoutube()" title="link Youtube"><b>Yt</b></button>
+                                <button class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</button>
+                                <button class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></button>
+                                <button class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></button>
+                                <button class="markdown-icons headerType" id="headerIcon" title="Header" onclick="showDropdown('show');" onmouseleave="showDropdown('hide');">aA&#9663;
                                     <div class="selectHeader" id="select-header">
                                         <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>
                                         <span id="headerType2" onclick="selected();headerVal2()" value="H2">Header 2</span>
@@ -333,7 +333,7 @@ $js = array(
                                         <span id="headerType5" onclick="selected();headerVal5()" value="H5">Header 5</span>
                                         <span id="headerType6" onclick="selected();headerVal6()" value="H6">Header 6</span>
                                     </div> 
-                                </span>
+                                </button>
 
                                 <select name=";" onchange="chooseFile(this.options[this.selectedIndex].value);" >
                                 <option value='defaultOption'>Choose file</option>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -324,7 +324,16 @@ $js = array(
                                 <span class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</span>
                                 <span class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></span>
                                 <span class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></span>
-                                <span class="markdown-icons headerType" id="headerIcon" title="Header" onmouseover="console.log('testing'); showDropdown('show');" onmouseout="showDropdown('hide');">aA&#9663;
+                                <span class="markdown-icons headerType" id="headerIcon" title="Header" onmouseover="console.log('testing'); 
+                                showDropdown('show');" onmouseleave="showDropdown('hide');">aA&#9663;
+                                    <div class="selectHeader" id="select-header" style="display: none;">
+                                        <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>
+                                        <span id="headerType2" onclick="selected();headerVal2()" value="H2">Header 2</span>
+                                        <span id="headerType3" onclick="selected();headerVal3()" value="H3">Header 3</span>
+                                        <span id="headerType4" onclick="selected();headerVal4()" value="H4">Header 4</span>
+                                        <span id="headerType5" onclick="selected();headerVal5()" value="H5">Header 5</span>
+                                        <span id="headerType6" onclick="selected();headerVal6()" value="H6">Header 6</span>
+                                    </div> 
                                 </span>
 
                                 <select name=";" onchange="chooseFile(this.options[this.selectedIndex].value);" >
@@ -355,14 +364,6 @@ $js = array(
                                     }
                                 ?>
                                 </select>
-                                <div class="selectHeader" id="select-header" style="display: none;">
-                                    <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>
-                                    <span id="headerType2" onclick="selected();headerVal2()" value="H2">Header 2</span>
-                                    <span id="headerType3" onclick="selected();headerVal3()" value="H3">Header 3</span>
-                                    <span id="headerType4" onclick="selected();headerVal4()" value="H4">Header 4</span>
-                                    <span id="headerType5" onclick="selected();headerVal5()" value="H5">Header 5</span>
-                                    <span id="headerType6" onclick="selected();headerVal6()" value="H6">Header 6</span>
-                                </div> 
                             </div>
 
                             <div class="markText" style="flex-grow:1;">

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -324,15 +324,15 @@ $js = array(
                                 <button class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</button>
                                 <button class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></button>
                                 <button class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></button>
-                                <div onmouseleave="showDropdown('hide');"> 
-                                    <button class="markdown-icons headerType" id="headerIcon" title="Header" onclick="showDropdown('show');">aA&#9663; </button>
+                                <div class="markdown-icons header-dropdown-div" onmouseleave="showDropdown('hide');"> 
+                                    <button id="headerIcon" title="Header" onclick="showDropdown('show');">aA&#9663; </button>
                                     <div class="selectHeader" id="select-header">
-                                        <button id="headerType1" onclick="selected();headerVal1();" value="H1">Header 1</button>
-                                        <button id="headerType2" onclick="selected();headerVal2();" value="H2">Header 2</button>
-                                        <button id="headerType3" onclick="selected();headerVal3();" value="H3">Header 3</button>
-                                        <button id="headerType4" onclick="selected();headerVal4();" value="H4">Header 4</button>
-                                        <button id="headerType5" onclick="selected();headerVal5();" value="H5">Header 5</button>
-                                        <button id="headerType6" onclick="selected();headerVal6();" value="H6">Header 6</button>
+                                        <button id="headerType1" onclick="selected(); headerVal1();" value="H1">Header 1</button>
+                                        <button id="headerType2" onclick="selected(); headerVal2();" value="H2">Header 2</button>
+                                        <button id="headerType3" onclick="selected(); headerVal3();" value="H3">Header 3</button>
+                                        <button id="headerType4" onclick="selected(); headerVal4();" value="H4">Header 4</button>
+                                        <button id="headerType5" onclick="selected(); headerVal5();" value="H5">Header 5</button>
+                                        <button id="headerType6" onclick="selected(); headerVal6();" value="H6">Header 6</button>
                                     </div> 
                                 </div>
 

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -324,7 +324,8 @@ $js = array(
                                 <span class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</span>
                                 <span class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></span>
                                 <span class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></span>
-                                <span class="markdown-icons headerType" id="headerIcon" title="Header">aA&#9663;</span>
+                                <span class="markdown-icons headerType" id="headerIcon" title="Header" onmouseover="console.log('testing'); showDropdown('show');" onmouseout="showDropdown('hide');">aA&#9663;
+                                </span>
 
                                 <select name=";" onchange="chooseFile(this.options[this.selectedIndex].value);" >
                                 <option value='defaultOption'>Choose file</option>
@@ -354,14 +355,14 @@ $js = array(
                                     }
                                 ?>
                                 </select>
-                                <div class="selectHeader" id="select-header">
+                                <div class="selectHeader" id="select-header" style="display: none;">
                                     <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>
                                     <span id="headerType2" onclick="selected();headerVal2()" value="H2">Header 2</span>
                                     <span id="headerType3" onclick="selected();headerVal3()" value="H3">Header 3</span>
                                     <span id="headerType4" onclick="selected();headerVal4()" value="H4">Header 4</span>
                                     <span id="headerType5" onclick="selected();headerVal5()" value="H5">Header 5</span>
                                     <span id="headerType6" onclick="selected();headerVal6()" value="H6">Header 6</span>
-                                </div>
+                                </div> 
                             </div>
 
                             <div class="markText" style="flex-grow:1;">

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -324,16 +324,17 @@ $js = array(
                                 <button class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</button>
                                 <button class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></button>
                                 <button class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></button>
-                                <button class="markdown-icons headerType" id="headerIcon" title="Header" onclick="showDropdown('show');" onmouseleave="showDropdown('hide');">aA&#9663;
+                                <div onmouseleave="showDropdown('hide');"> 
+                                    <button class="markdown-icons headerType" id="headerIcon" title="Header" onclick="showDropdown('show');">aA&#9663; </button>
                                     <div class="selectHeader" id="select-header">
-                                        <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>
-                                        <span id="headerType2" onclick="selected();headerVal2()" value="H2">Header 2</span>
-                                        <span id="headerType3" onclick="selected();headerVal3()" value="H3">Header 3</span>
-                                        <span id="headerType4" onclick="selected();headerVal4()" value="H4">Header 4</span>
-                                        <span id="headerType5" onclick="selected();headerVal5()" value="H5">Header 5</span>
-                                        <span id="headerType6" onclick="selected();headerVal6()" value="H6">Header 6</span>
+                                        <button id="headerType1" onclick="selected();headerVal1();" value="H1">Header 1</button>
+                                        <button id="headerType2" onclick="selected();headerVal2();" value="H2">Header 2</button>
+                                        <button id="headerType3" onclick="selected();headerVal3();" value="H3">Header 3</button>
+                                        <button id="headerType4" onclick="selected();headerVal4();" value="H4">Header 4</button>
+                                        <button id="headerType5" onclick="selected();headerVal5();" value="H5">Header 5</button>
+                                        <button id="headerType6" onclick="selected();headerVal6();" value="H6">Header 6</button>
                                     </div> 
-                                </button>
+                                </div>
 
                                 <select name=";" onchange="chooseFile(this.options[this.selectedIndex].value);" >
                                 <option value='defaultOption'>Choose file</option>

--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -324,9 +324,8 @@ $js = array(
                                 <span class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</span>
                                 <span class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></span>
                                 <span class="markdown-icons" id="imgIcon" onclick="externalImg()" title="Img"><img src="../Shared/icons/insert-photo.svg"></span>
-                                <span class="markdown-icons headerType" id="headerIcon" title="Header" onmouseover="console.log('testing'); 
-                                showDropdown('show');" onmouseleave="showDropdown('hide');">aA&#9663;
-                                    <div class="selectHeader" id="select-header" style="display: none;">
+                                <span class="markdown-icons headerType" id="headerIcon" title="Header" onclick="showDropdown('show');" onmouseleave="showDropdown('hide');">aA&#9663;
+                                    <div class="selectHeader" id="select-header">
                                         <span id="headerType1" onclick="selected();headerVal1()" value="H1">Header 1</span>
                                         <span id="headerType2" onclick="selected();headerVal2()" value="H2">Header 2</span>
                                         <span id="headerType3" onclick="selected();headerVal3()" value="H3">Header 3</span>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8394,7 +8394,7 @@ only screen and (max-device-width: 568px) {
   border: solid var(--color-border-4);
   background-color: var(--color-background-4);
   flex-grow:1;
-  max-width: 50%;
+  max-width: 55%;
   /*
   width: 38%;
   height: 80%;
@@ -8410,6 +8410,7 @@ only screen and (max-device-width: 568px) {
   */
   height: 100%;
   width: 100%;
+  padding-bottom: 15px;
   box-sizing: border-box;
 }
 
@@ -8506,7 +8507,7 @@ legend {
 
 .prevSpan {
   max-width: 100%;
-  padding: 10px;
+  padding: 10px 0px 0px;
   /*height: 85%;*/
   height: 100%;
   box-sizing: border-box;
@@ -9029,7 +9030,7 @@ div > div > .shortcut-keys:hover {
  * --------------================################================-------------- */
 .markdown-icons {
   cursor: pointer;
-  width: 20%;
+  width: 100%;
   height: 24px;
   text-align: center;
   line-height: 24px;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8695,9 +8695,10 @@ textarea#mrkdwntxt {
 
 #select-header {
   display: none;
-  margin: 0 auto;
   width: 63px;
-  position: relative;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 2000;
   background-color: rgba(255, 255, 255, 255);
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);
@@ -9041,6 +9042,7 @@ div > div > .shortcut-keys:hover {
 
 #imgIcon,
 #headerIcon {
+  position:relative;
   margin-left: 2px;
   margin-right: 10px;
 }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8694,15 +8694,12 @@ textarea#mrkdwntxt {
 }
 
 #select-header {
-  top: 82px;
-  left: 30%;
   max-width: 63px;
   position: absolute;
   z-index: 2000;
   background-color: rgba(255, 255, 255, 255);
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);
 }
-
 
 /* --------------===============################================-------------- *
  *                                    courseed                                 *

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8644,59 +8644,69 @@ textarea#mrkdwntxt {
   transition: 0.2s;
 }
 
-.selectHeader>span {
+.selectHeader>button {
   display: block;
   cursor: pointer;
+  border: none;
   /*color: var(--color-text-list);*/
   background-color: var(--color-background);
 }
 
-.selectHeader>span:hover {
+.selectHeader>button:hover {
+  border: none;
   background-color: var(--color-background-4);
 }
 
-#headerType1 {
-  font-size: 13px;
-  padding: 5px 7px 0px 3px;
-}
-
-#headerType2 {
-  font-size: 12px;
-  padding: 5px 11px 5px 3px;
-}
-
-#headerType2:hover {
-  background-color: var(--color-background-4);
-}
-
-#headerType3 {
-  font-size: 11px;
-  padding: 5px 15px 5px 3px;
-}
-
-#headerType4 {
-  font-size: 10px;
-  padding: 5px 19px 5px 3px;
-}
-
-#headerType5 {
-  font-size: 9px;
-  padding: 5px 23px 5px 3px;
-}
-
-#headerType6 {
-  font-size: 8px;
-  padding: 5px 27px 6px 3px;
+.header-dropdown-div{
+  position: relative;
 }
 
 .show-dropdown-content {
   display: block;
 }
 
+#headerType1 {
+  font-size: 13px;
+  height: 25px;
+  width: inherit;
+}
+
+#headerType2 {
+  font-size: 12px;
+  height: 25px;
+  width: inherit;
+}
+
+#headerType3 {
+  font-size: 11px;
+  height: 25px;
+  width: inherit;
+}
+
+#headerType4 {
+  font-size: 10px;
+  height: 25px;
+  width: inherit;
+}
+
+#headerType5 {
+  font-size: 9px;
+  height:25px;
+  width: inherit;
+}
+
+#headerType6 {
+  font-size: 8px;  
+  height:25px;
+  width: inherit;
+}
+
 #select-header {
   display: none;
-  width: 63px;
+  width: 70px;
   position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 2000;
   background-color: rgba(255, 255, 255, 255);
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);
@@ -9041,13 +9051,18 @@ div > div > .shortcut-keys:hover {
   filter: invert(100%);
 }
 
-#imgIcon,
-#headerIcon {
-  position:relative;
+#imgIcon {
   margin-left: 2px;
-  margin-right: 10px;
 }
 
+#headerIcon {
+  margin-top: 2px;
+  margin-left: 4px;
+  margin-right: 6px;
+  background: none;
+  border: none;
+  font: inherit;
+}
 
 .editFileWindow {
   height: 80%;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9021,11 +9021,14 @@ div > div > .shortcut-keys:hover {
  * --------------================################================-------------- */
 .markdown-icons {
   cursor: pointer;
-  width: 100%;
+  width: 20%;
   height: 24px;
   text-align: center;
   line-height: 24px;
   vertical-align: middle;
+  background: none;
+  border: none;
+  font: inherit;
 }
 
 .markdown-icon-div {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8694,6 +8694,7 @@ textarea#mrkdwntxt {
 }
 
 #select-header {
+  display: none;
   max-width: 63px;
   position: absolute;
   z-index: 2000;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8426,7 +8426,7 @@ only screen and (max-device-width: 568px) {
 .markdownPrev {
   border: solid var(--color-border-4);
   flex-grow:1;
-  max-width: 50%;
+  max-width: 44%;
   /*
   width: 56%;
   height: 80%;
@@ -9058,8 +9058,6 @@ div > div > .shortcut-keys:hover {
 
 #headerIcon {
   margin-top: 2px;
-  margin-left: 4px;
-  margin-right: 6px;
   background: none;
   border: none;
   font: inherit;
@@ -9075,6 +9073,7 @@ div > div > .shortcut-keys:hover {
   right: 0;
   top: 10%;
   position: fixed;
+  padding: 0%;
 }
 
 .editFileCode {

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8697,8 +8697,6 @@ textarea#mrkdwntxt {
   display: none;
   width: 63px;
   position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
   z-index: 2000;
   background-color: rgba(255, 255, 255, 255);
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8695,8 +8695,9 @@ textarea#mrkdwntxt {
 
 #select-header {
   display: none;
-  max-width: 63px;
-  position: absolute;
+  margin: 0 auto;
+  width: 63px;
+  position: relative;
   z-index: 2000;
   background-color: rgba(255, 255, 255, 255);
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.19), 0px 6px 6px rgba(0, 0, 0, 0.3);

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -13,6 +13,7 @@
 // GLOBALS
 var tableAlignmentConf = [];
 var openedSublists = [];
+let displayed = false;
 
 //Functions for gif image
 //Fetches the picture and sets its properties
@@ -463,11 +464,16 @@ function cursiveText() {
 }
 
 function showDropdown(mode) {
-    if (mode == 'show'){
+    if (mode == 'show' && displayed == false){
         document.querySelector('#select-header').style.display="block";
+        displayed = true;
+    }
+    else if (displayed == true){
+        document.querySelector('#select-header').style.display="none";
+        displayed = false;
     }
     else{
-        document.querySelector('#select-header').style.display="none";
+    document.querySelector('#select-header').style.display="none";
     }
 }
 

--- a/Shared/markdown.js
+++ b/Shared/markdown.js
@@ -462,8 +462,13 @@ function cursiveText() {
     updatePreview(txtarea.value);
 }
 
-function showDropdown() {
-    document.querySelector('#select-header').style.display="block";
+function showDropdown(mode) {
+    if (mode == 'show'){
+        document.querySelector('#select-header').style.display="block";
+    }
+    else{
+        document.querySelector('#select-header').style.display="none";
+    }
 }
 
 function selected() {


### PR DESCRIPTION
**What's been changed:**
- Linked the dropdown to its corresponding "button" (parent-child).
- Changed so that the dropdown is displayed when clicked, and hidden when hover is outside menu.
- Positioned dropdown so that it's centered under its "button".
- To avoid menu-items being "warped", made the width a set number.

**How it should work:**
- Dropdown should only be displayed when its corresponding "button" is clicked.
- Dropdown should provide the functionality it was meant for, aka write text inside the markdown.
- Dropdown menu-items should be centered under the "button"
- Dropdown & menu-items should not be affected by different sized resolutions.

For additional information, see connected issue: https://github.com/HGustavs/LenaSYS/issues/17457

---
**How to get to functionality**
select course of your choice (which has code-duggor, ex. Testing Course) -> log in -> choose any code-dugga

-> click on the pencil, which brings up the markdown editor (seen within image1.) 
![image](https://github.com/user-attachments/assets/baed6bca-2643-4bd2-b184-e770b83cd4e2)
(image1)

Within the editor, you will find the icon/button & its dropdown, both seen in image2 which is affected by this PR.
![image](https://github.com/user-attachments/assets/2ae5eeb8-62e8-4acd-a9c9-c1f654ee29e9)
(image2)