### PR TITLE
Fixed: Cardinality labels do not scale correctly with Firefox

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -814,10 +814,11 @@ function drawLineCardinality(line, lineColor, fx, fy, tx, ty, f, t) {
                 height='${(textheight - 4) * zoomfact + zoomfact * 3}'
             /> 
             <text 
-                class='text cardinalityLabelText' 
+                class='cardinalityLabelText' 
                 dominant-baseline='middle' 
                 text-anchor='middle' 
-                style='fill:${lineColor}; font-size:${Math.round(zoomfact * textheight)};' 
+                fill='${lineColor}' 
+                font-size='${Math.round(zoomfact * textheight)}' 
                 x='${posX}' 
                 y='${posY}'
             > ${lineCardinalitys[line.cardinality]} </text>`;

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -365,7 +365,8 @@ function drawLine(line, targetGhost = false) {
                         text-anchor='middle'
                         x='${((startX))}'
                         y='${((startY)) + ((textheight / 4))}'
-                        style='fill:${lineColor}; font-size:${Math.round(zoomfact * textheight)}px;'>
+                        fill='${lineColor}' 
+                        font-size='${Math.round(zoomfact * textheight)}'>
                         ${labelValue}
                     </text>`;
         } else {
@@ -382,7 +383,8 @@ function drawLine(line, targetGhost = false) {
                         class='cardinalityLabelText'
                         dominant-baseline='middle'
                         text-anchor='middle'
-                        style='font-size:${Math.round(zoomfact * textheight)}px;'
+                        fill='${lineColor}' 
+                        font-size='${Math.round(zoomfact * textheight)}'
                         x='${labelCenterX}'
                         y='${labelCenterY}'>
                         ${labelValue}
@@ -645,7 +647,8 @@ function drawLineLabel(line, label, lineColor, labelStr, x, y, isStart, felem) {
                 class='text cardinalityLabelText' 
                 dominant-baseline='middle' 
                 text-anchor='middle' 
-                style='fill:${lineColor}; font-size:${Math.round(zoomfact * textheight)};' 
+                fill='${lineColor}' 
+                font-size='${Math.round(zoomfact * textheight)}' 
                 x='${x}' 
                 y='${y}'
             > ${label} </text>`;


### PR DESCRIPTION
This patches an issue for Firefox users where zooming didn't correctly scale the cardinality text labels. See the attached video in the issue for a problem demonstration (#17569).

The issue was that the cardinality text was styled using a CSS font-size property, and apparently Firefox does not consistently apply this styling to SVG <text> elements, causing the text to remain the same size regardless of zoom level. This was changed to dedicated font-size and fill SVG attributes being used for the cardinality texts. 

**This change should be tested specifically in Firefox to confirm the fix.**