### PR TITLE
Fixed: Examine the tooltips for refactoring

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1204,6 +1204,9 @@
     background-color: #060606cb;
     z-index: 5000;
     text-align: center;
-    line-height: 1.6;
-    margin-block: .5rem;
+    line-height: 1.5;
+
+    >*{
+        margin: 0;
+    }
 }

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1192,3 +1192,18 @@
     border-radius: 50%;
     color: var(--color-text-secondary);
 }
+
+.diagram-tooltip{
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 250px;
+    padding: .3rem;
+    border-radius: 10px;
+    color: #f3f3f3;
+    background-color: #060606cb;
+    z-index: 5000;
+    text-align: center;
+    line-height: 1.6;
+    margin-block: .5rem;
+}

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2593,10 +2593,12 @@ function tooltipPosition(element){
     }
     else if(element.closest("#options-pane")){
         let optionPanelPosition = document.getElementById("options-pane").getBoundingClientRect();
+        console.log(optionPanelPosition);
+        console.log("Options Panel");
 
         return {
-            top: `${optionPanelPosition.top}px`,
-            left: `${optionPanelPosition.left + optionPanelPosition.width + 100}px`
+            top: `${optionPanelPosition.top + 50}px`,
+            left: `${optionPanelPosition.left - optionPanelPosition.width + 50}px`
         };
     }
     else if(element.closest("#zoom-container")){

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2506,4 +2506,128 @@ subMenuToolbarBoxs.forEach(subMenuBox=>{
     subMenuBox.addEventListener("click", changeActiveElement);
 });
 
+//Selects every element that has an tooltip
+const tooltipTargets = document.querySelectorAll(".tooltip-target");
+let timer = null;
+let currentTooltipElement = null;
+
+tooltipTargets.forEach((element)=>{
+    element.addEventListener("mouseenter", (e)=>{
+        if(e.target!==e.currentTarget) return;
+        const targetElement = e.currentTarget;
+
+        clearTimeout(timer);
+        timer = setTimeout(()=>{
+            showTooltip(targetElement);
+            currentTooltipElement = targetElement;
+        }, 400);
+    });
+
+    element.addEventListener("mouseleave", (e)=>{
+        if(!e.relatedTarget && !e.relatedTarget.closest("#diagramPopOut")) return;
+        clearTimeout(timer);
+        hideTooltip();
+        currentTooltipElement = null;
+    });
+});
+
+function showTooltip(element){
+    let tooltipContainer = document.querySelector(".diagram-tooltip");
+    let tooltipMode = element.dataset.toolmode;
+    let toolID = parseInt(element.dataset.toolid);
+    let tooltipInfo = tooltips[tooltipMode];
+
+    if(!tooltipInfo) return; 
+
+    tooltipContainer.innerHTML = `
+        <h3>${tooltipInfo.header}</h3>
+        <p>${tooltipInfo.description}</p>
+        <p id='tooltip-${tooltipID[toolID]}' class='key_tooltip'></p>
+    `;
+
+    const position = tooltipPosition(element);
+    if(!position) return;
+    
+    tooltipContainer.style.top = position.top;
+    tooltipContainer.style.left = position.left;
+    tooltipContainer.style.display = 'block';
+
+    updateKeybindSpan(toolID);
+}
+function hideTooltip(){
+    let tooltipContainer = document.querySelector(".diagram-tooltip");
+    tooltipContainer.style.display = 'none';
+    tooltipContainer.innerHTML = '';
+}
+function updateKeybindSpan(id){
+    const toolID = tooltipID[id];
+
+    const element = document.getElementById(`tooltip-${toolID}`);
+    console.log(element);
+    if(!element || !keybinds[toolID]) return;
+
+    let str = 'Keybinding: ';
+
+    if (keybinds[toolID].ctrl) str += "CTRL + ";
+    if (keybinds[toolID].shift) str += "SHIFT + ";
+    if (keybinds[toolID].alt) str += "ALT + ";
+
+    str += `"${keybinds[toolID].key.toUpperCase()}"`;
+
+    element.innerHTML = str;
+}
+function tooltipPosition(element){
+    let submenu = document.getElementById(`togglePlacementTypeBox${currentlyOpenSubmenu}`);
+    const isActive = submenu && submenu.classList.contains("activeTogglePlacementTypeBox");
+
+    if(element.closest("#diagramPopOut") && isActive){
+        const dropdownBox = element.closest(".togglePlacementTypeBox");
+
+        if(!dropdownBox) return;
+        let dropdownPosition = dropdownBox.getBoundingClientRect();
+
+        return{
+            top: `${dropdownPosition.top - dropdownPosition.height/2}px`,
+            left: `${dropdownPosition.left + dropdownPosition.right - 30}px`
+        };
+    }
+    else if(element.closest("#options-pane")){
+        let optionPanelPosition = document.getElementById("options-pane").getBoundingClientRect();
+
+        return {
+            top: `${optionPanelPosition.top}px`,
+            left: `${optionPanelPosition.left + optionPanelPosition.width + 100}px`
+        };
+    }
+    else if(element.closest("#zoom-container")){
+        let zoomContainerPosition = document.getElementById("zoom-container").getBoundingClientRect();
+
+        return{
+            top: `${zoomContainerPosition.top - 100}px`,
+            left: `${zoomContainerPosition.left}px`
+        };
+    }
+    else if(element.closest("#diagram-replay-box")){
+        let replayBoxPosition = document.getElementById("diagram-replay-box").getBoundingClientRect();
+
+        return {
+            top: `${replayBoxPosition.top - replayBoxPosition.height}px`,
+            left: `${replayBoxPosition.right/10 + 35}px`
+        };
+    }
+    else if(element.closest("#diagram-toolbar") && !element.closest("#diagramPopOut")){
+        let elementPosition = element.getBoundingClientRect();
+
+        return {
+            top: `${elementPosition.top - elementPosition.height/2}px`,
+            left: `${elementPosition.right + elementPosition.width/2+5}px`
+        };
+    }
+
+    return{
+        top: null,
+        left: null
+    };
+}
+
 //#endregion =====================================================================================

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -89,6 +89,7 @@
     <div id="markdownKeybinds" style="display: none">
 
     </div>
+    <div class="diagram-tooltip" style="display:none;"></div>
 
     <!-- Used for calculating pixels per millimeter using offsetWidth. Note that in offsetWidth system scaling is not included
     and window.devicePixelRatio have to be included -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -135,31 +135,16 @@
                 <!-- POINTER -->
                 <div id="mouseMode0" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode active tooltip-target" onclick='setMouseMode(0);' data-toolmode="Pointer" data-toolid="0">
                     <img src="../Shared/icons/diagram_pointer_white.svg" alt="Pointer"/>
-                    <span class="toolTipText" id="highestToolTip"><b>Pointer</b><br>
-                        <span>Allows you to select and move different elements as well as navigate the workspace</span><br><br>
-                        <span id="tooltip-POINTER" class="key_tooltip">Keybinding:</span>
-                    </span>
                 </div>
                 <!-- BOX SELECTION -->
                 <div id="mouseMode1" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick='setMouseMode(1); ' data-toolmode="Box_Selection" data-toolid="1">
                     <img src="../Shared/icons/diagram_box_selection2.svg" alt="Box Selection"/>
-                    <span class="toolTipText"><b>Box Selection</b><br>
-                        <p>Click and drag to select multiple elements within the selected area.</p><br>
-                        <p id="tooltip-BOX_SELECTION" class="key_tooltip">Keybinding:</p>
-                    </span>
                 </div>
                 <!-- ER, UML, IE, AND STATE ELEMENTS -->
                 <div>
                     <!-- ER-ENTITY (initial default, on pageload, choice) -->
                     <div id="elementPlacement0" class="ERButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseenter='hoverPlacementButton(0)' data-toolmode="ER_Entity" data-toolid="2"><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
-                        <span class="toolTipText"><b>ER entity</b><br>
-                            <p>Insert an ER entity to the diagram</p>
-                            <p>Each entity represents an object which is a representation of concepts or data.</p>
-                            <p>The entity only holds the name of the object and if it depends on another object.</p>
-                            <br>
-                            <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton0" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -170,44 +155,18 @@
                             <!-- ER-ENTITY (fist option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
-                                <span class="placementTypeToolTipText"><b>ER entity</b><br>
-                                    <p>Each entity represents an object which is a representation of concepts or data.</p>
-                                    <p>The entity only holds the name of the object and if it depends on another object.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML CLASS ("change to" - second option when hovering) -->
                             <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
-                                <span class="placementTypeToolTipText"><b>UML class</b><br>
-                                    <p>Change to UML class.</p>
-                                    <p>Each class entity represents its own class along with the attributes and operations held within the class.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- IE-ENTITY ("change to" - third option when hovering) -->
                             <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
-                                <span class="placementTypeToolTipText"><b>IE entity</b><br>
-                                    <p>Change to IE entity.</p>
-                                    <p>Each entity represents an object along with its attributes.</p>
-                                    <p>Each entity is represented by a table with a field that shows attributes.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("change to" - fourth option when hovering) -->
                             <div class="SDButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
-                                <span class="placementTypeToolTipText"><b>State diagram state</b><br>
-                                    <p>Change to state diagram state.</p>
-                                    <p>A state diagram state is a representation of a status a process can have.</p>
-                                    <p>Each state represents a unique status that a process can have.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                         </div>
                     </div>
@@ -217,12 +176,6 @@
                     <!-- UML CLASS (When chosen, takes up the "default" position in the toolbar) -->
                     <div id="elementPlacement4" class="UMLButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(4); setMouseMode(2); 'onmouseenter='hoverPlacementButton(4)' data-toolmode="UML_Class" data-toolid="2">
                         <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
-                        <span class="toolTipText"><b>UML class</b><br>
-                            <p>Create a UML class to the diagram</p>
-                            <p>Each class entity represents its own class along with the attributes and operations held within the class.</p>
-                            <br>
-                            <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton4" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -233,44 +186,18 @@
                             <!-- ER-ENTITY ("Change to" - first option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
-                                <span class="placementTypeToolTipText"><b>ER entity</b><br>
-                                    <p>Change to ER entity.</p>
-                                    <p>Each entity represents an object which is a representation of concepts or data.</p>
-                                    <p>The entity only holds the name of the object and if it depends on another object.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
                             <div class="UMLButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
-                                <span class="placementTypeToolTipText"><b>UML class</b><br>                      
-                                    <p>Each class entity represents its own class along with the attributes and operations held within the class.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
                             <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
-                                <span class="placementTypeToolTipText"><b>IE entity</b><br>
-                                    <p>Change to IE entity.</p>
-                                    <p>Each entity represents an object along with its attributes.</p>
-                                    <p>Each entity is represented by a table with a field that shows attributes.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
                             <div class="SDButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
-                                <span class="placementTypeToolTipText"><b>State diagram state</b><br>
-                                    <p>Change to state diagram state.</p>
-                                    <p>A state diagram state is a representation of a status a process can have.</p>
-                                    <p>Each state represents a unique status that a process can have.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                         </div>
                     </div>
@@ -280,13 +207,6 @@
                     <!-- IE-ENTITY (When chosen, takes up the "default" position in the toolbar) -->
                     <div id="elementPlacement6" class="IEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(6); setMouseMode(2);'onmouseenter='hoverPlacementButton(6)' data-toolmode="IE_Entity" data-toolid="2">
                         <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
-                        <span class="toolTipText"><b>IE entity</b><br>
-                            <p>Place an IE entity into the diagram</p>
-                            <p>Each entity represents an object along with its attributes.</p>
-                            <p>Each entity is represented by a table with a field that shows attributes.</p>
-                            <br>
-                            <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton6" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -297,44 +217,18 @@
                             <!-- ER-ENTITY ("Change to" - first option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
-                                <span class="placementTypeToolTipText"><b>ER entity</b><br>
-                                    <p>Change to ER entity.</p>
-                                    <p>Each entity represents an object which is a representation of concepts or data.</p>
-                                    <p>The entity only holds the name of the object and if it depends on another object.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
                             <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
-                                <span class="placementTypeToolTipText"><b>UML class</b><br>
-                                    <p>Change to UML class.</p>
-                                    <p>Each class entity represents its own class along with the attributes and operations held within the class.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
                             <div class="IEButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
-                                <span class="placementTypeToolTipText"><b>IE entity</b><br>
-                                    <p>Each entity represents an object along with its attributes.</p>
-                                    <p>Each entity is represented by a table with a field that shows attributes.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
                             <div class="SDButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
-                                <span class="placementTypeToolTipText"><b>State diagram state</b><br>
-                                    <p>Change to state diagram state.</p>
-                                    <p>A state diagram state is a representation of a status a process can have.</p>
-                                    <p>Each state represents a unique status that a process can have.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                         </div>
                     </div>
@@ -344,13 +238,6 @@
                     <!-- STATE DIAGRAM STATE (When chosen, takes up the "default" position in the toolbar) -->
                     <div id="elementPlacement8" class="SDButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(8); setMouseMode(2);'onmouseenter='hoverPlacementButton(8);' data-toolmode="SD_STATE" data-toolid="2">
                         <img src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
-                        <span class="toolTipText"><b>State diagram state</b><br>
-                            <p>Add a state diagram state to the diagram</p>
-                            <p>A state diagram state is a representation of a status a process can have.</p>
-                            <p>Each state represents a unique status that a process can have.</p>
-                            <br>
-                            <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton8" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -361,44 +248,18 @@
                             <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <!-- ER-ENTITY ("Change to" - first option when hovering) -->
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
-                                <span class="placementTypeToolTipText"><b>ER entity</b><br>
-                                    <p>Change to ER entity.</p>
-                                    <p>Each entity represents an object which is a representation of concepts or data.</p>
-                                    <p>The entity only holds the name of the object and if it depends on another object.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
                             <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
-                                <span class="placementTypeToolTipText"><b>UML class</b><br>
-                                    <p>Change to UML class.</p>
-                                    <p>Each class entity represents its own class along with the attributes and operations held within the class.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
                             <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
-                                <span class="placementTypeToolTipText"><b>IE entity</b><br>
-                                    <p>Change to IE entity.</p>
-                                    <p>Each entity represents an object along with its attributes.</p>
-                                    <p>Each entity is represented by a table with a field that shows attributes.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
                             <div class="SDButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="Statediagram state"/>
-                                <span class="placementTypeToolTipText"><b>State diagram state</b><br>
-                                    <p>A state diagram state is a representation of a status a process can have.</p>
-                                    <p>Each state represents a unique status that a process can have.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_ENTITY" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                         </div>
                     </div>        
@@ -410,12 +271,6 @@
                     <!-- ER RELATION (initial default choice) -->
                     <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseenter='hoverPlacementButton(1);' data-toolmode="ER_Relation" data-toolid="3"> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"  alt="ER relation"/>
-                        <span class="toolTipText"><b>ER relation</b><br>
-                            <p>Place an ER relation into the diagram</p>
-                            <p>Represents how entities are associated with each other.</p>
-                            <br>
-                            <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton1" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -426,43 +281,18 @@
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER relation"/>
-                                <span class="placementTypeToolTipText"><b>ER relation</b><br>
-                                    <p>Represents how entities are associated with each other.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
                             <div class="ERAttribute placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
-                                <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
-                                    <p>Change to ER attribute</p>
-                                    <p>Each attribute represents different characteristics of an entity.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
                             <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML Inheritance"/>
-                                <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
-                                    <p>Change to UML inheritance.</p>
-                                    <p>A relation between a superclass and subclasses.</p>
-                                    <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
                             <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
-                                <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
-                                    <p>Change to IE inheritance.</p>
-                                    <p>A relation between two or more entities.</p>
-                                    <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                         </div>
                     </div>
@@ -473,13 +303,6 @@
                     <!-- UML INHERITANCE (When chosen, takes up the "default" position in the toolbar) -->
                     <div id="elementPlacement5" class="UMLButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(5); setMouseMode(2);' onmouseenter='hoverPlacementButton(5)' data-toolmode="UML_Inheritance" data-toolid="3">
                         <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
-                        <span class="toolTipText"><b>UML inheritance</b><br>
-                            <p>Insert a UML inheritance to the diagram</p>
-                            <p>A relation between a superclass and subclasses.</p>
-                            <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                            <br>
-                            <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton5" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -490,43 +313,18 @@
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
-                                <span class="placementTypeToolTipText"><b>ER Relation</b><br>
-                                    <p>Change to ER relation.</p>
-                                    <p>Represents how entities are associated with each other.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
                             <div class="ERAttribute placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
-                                <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
-                                    <p>Change to ER attribute</p>
-                                    <p>Each attribute represents different characteristics of an entity.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
                             <div class="UMLButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
-                                <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
-                                    <p>A relation between a superclass and subclasses.</p>
-                                    <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
                             <div class="IEButton placementTypeBoxIcons tooltip-target " onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
-                                <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
-                                    <p>Change to IE inheritance.</p>
-                                    <p>A relation between two or more entities.</p>
-                                    <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                         </div>
                     </div>
@@ -537,13 +335,6 @@
                     <!-- IE INHERITANCE (When chosen, takes up the "default" position in the toolbar) -->
                     <div id="elementPlacement7" class="IEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(7); setMouseMode(2);' onmouseenter='hoverPlacementButton(7)' data-toolmode="IE_Inheritance" data-toolid="3">
                         <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
-                        <span class="toolTipText"><b>IE inheritance</b><br>
-                            <p>Create an IE inheritance to the diagram</p>
-                            <p>A relation between two or more entities.</p>
-                            <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                            <br>
-                            <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton7" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -554,43 +345,18 @@
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
-                                <span class="placementTypeToolTipText"><b>ER Relation</b><br>
-                                    <p>Change to ER relation.</p>
-                                    <p>Represents how entities are associated with each other.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
                             <div class="ERAttribute placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
-                                <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
-                                    <p>Change to ER attribute</p>
-                                    <p>Each attribute represents different characteristics of an entity.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
                             <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
-                                <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
-                                    <p>Change to UML inheritance.</p>
-                                    <p>A relation between a superclass and subclasses.</p>
-                                    <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
                             <div class="IEButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
-                                <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
-                                    <p>A relation between two or more entities.</p>
-                                    <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                         </div>
                     </div>
@@ -601,12 +367,6 @@
                     <!-- ER ATTRIBUTE (When chosen, takes up the "default" position in the toolbar) -->
                     <div id="elementPlacement2" class="ERAttribute diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(2); setMouseMode(2);' onmouseenter='hoverPlacementButton(2)' data-toolmode="ER_Attribute" data-toolid="3">
                         <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
-                        <span class="toolTipText"><b>ER Attribute</b><br>
-                            <p>Add a ER attribute to the diagram.</p>
-                            <p>Each attribute represents different characteristics of an entity.</p>
-                            <br>
-                            <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton2" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -617,44 +377,18 @@
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
-                                <span class="placementTypeToolTipText"><b>ER Relation</b><br>
-                                    <p>Change to ER relation.</p>
-                                    <p>Represents how entities are associated with each other.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
                             <div class="ERAttribute placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
-                                <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
-                                    <p>Add a ER attribute to the diagram.</p>
-                                    <p>Each attribute represents different characteristics of an entity.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
                             <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
-                                <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
-                                    <p>Change to UML inheritance.</p>
-                                    <p>A relation between a superclass and subclasses.</p>
-                                    <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
                             <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
-                                <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
-                                    <p>Change to IE inheritance</p>
-                                    <p>A relation between two or more entities.</p>
-                                    <p>The subclasses acquire all the properties and behaviors from the superclass.</p>
-                                    <br>
-                                    <p id="tooltip-PLACE_RELATION" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div> 
                         </div>
                     </div>
@@ -662,10 +396,6 @@
                 <!-- LINE -->
                 <div id="mouseMode3" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick='clearContext(); setMouseMode(3);' data-toolmode="Line" data-toolid="4">
                     <img src="../Shared/icons/diagram_line.svg" alt="Line"/>
-                    <span class="toolTipText"><b>Line</b><br>
-                        <p>Make a line between elements.</p><br>
-                        <p id="tooltip-EDGE_CREATION" class="key_tooltip">Keybinding:</p>
-                    </span>
                 </div>
 
                 <!-- OPTIONS FOR STATE ELEMENTS START HERE -->
@@ -673,12 +403,6 @@
                     <!-- UML INITIAL STATE (initial default choice) -->
                     <div id="elementPlacement9" class="SDButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(9); setMouseMode(2);' onmouseenter='hoverPlacementButton(9)' data-toolmode="UML_Initial_State" data-toolid="5"><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
-                        <span class="toolTipText"><b>UML initial state</b><br>
-                            <p>Insert an initial state for UML.</p>
-                            <p>The initial state represents the start of a process.</p>
-                            <br>
-                            <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton9" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -689,28 +413,14 @@
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
                             <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
-                                <span class="placementTypeToolTipText"><b>UML initial state</b><br>
-                                    <p>The initial state represents the start of a process.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- FINAL STATE ("Change to" - second option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
-                                <span class="placementTypeToolTipText"><b>UML final state</b><br>
-                                    <p>Change to UML final state</p>
-                                    <p>The final state represents where a process ends.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- UML SUPER STATE ("Change to" - third option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
-                                <span class="placementTypeToolTipText"><b>UML super state</b><br>
-                                    <p>Change to UML super state</p>
-                                    <p>A state that can contain substates.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>                           
                         </div>
                     </div>
@@ -720,11 +430,6 @@
                 <!-- UML FINAL STATE (When chosen, takes up the "default position in the toolbar) -->
                     <div id="elementPlacement10" class="SDButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(10); setMouseMode(2);' onmouseenter='hoverPlacementButton(10)' data-toolmode="UML_Final_State" data-toolid="5">
                         <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
-                        <span class="toolTipText"><b>UML final state</b><br>
-                            <p>Place a final state for UML.</p>
-                            <p>The final state represents where a process ends.</p><br>
-                            <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton10" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -735,28 +440,14 @@
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
-                                <span class="placementTypeToolTipText"><b>UML initial state</b><br>
-                                    <p>Change to UML initial state</p>
-                                    <p>The initial state represents the start of a process.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- FINAL STATE("Change to" - second option when hovering) -->
                             <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
-                                <span class="placementTypeToolTipText"><b>UML final state</b><br>
-                                    <p>The final state represents where a process ends.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SUPER STATE ("Chaange to" - third option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
-                                <span class="placementTypeToolTipText"><b>UML super state</b><br>
-                                    <p>Change to UML super state</p>
-                                    <p>A state that can contain substates.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>                           
                         </div>
                     </div>
@@ -766,11 +457,6 @@
                     <!-- UML SUPER STATE (When chosen, takes up the "default position in the toolbar)-->
                     <div id="elementPlacement11" class="SDButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(11); setMouseMode(2);' onmouseenter='hoverPlacementButton(11)' data-toolmode="UML_Super_State" data-toolid="5">
                         <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
-                        <span class="toolTipText"><b>UML super state</b><br>
-                            <p>Create a super state.</p>
-                            <p>A state that can contain substates.</p><br>
-                            <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton11" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -781,28 +467,14 @@
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
-                                <span class="placementTypeToolTipText"><b>UML initial state</b><br>
-                                    <p>Change to UML initial state</p>
-                                    <p>The initial state represents the start of a process.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>    
-                                </span>
                             </div>
                             <!-- FINAL STATE ("Change to" - second option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
-                                <span class="placementTypeToolTipText"><b>UML final state</b><br>
-                                    <p>Change to UML final state</p>
-                                    <p>The final state represents where a process ends.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SUPER STATE ("Change to" - third option when hovering) -->
                             <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
-                                <span class="placementTypeToolTipText"><b>UML super state</b><br>
-                                    <p>A state that can contain substates.</p><br>
-                                    <p id="tooltip-STATE_INITIAL" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>                           
                         </div>
                     </div>
@@ -813,12 +485,6 @@
                     <!-- SEQUENCE LIFELINE (initial default choice, and the same as the Sequence Lifeline (Actor)) -->
                     <div id="elementPlacement12" class="SEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(12); setMouseMode(2);' onmouseenter='hoverPlacementButton(12)' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6">
                         <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
-                        <span class="toolTipText"><b>Sequence lifeline</b><br>
-                            <p>Creates a lifeline for a sequnece diagram.</p>
-                            <p>Represents the passage of time.</p>
-                            <p>This version is used for human users, external hardware or other subjects</p><br>
-                            <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton12" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -829,36 +495,18 @@
                             <!-- SEQUENCE LIFELINE (ACTOR)(First option when hovering and the same as the initial option, as seen above this) -->
                             <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline object"/>
-                                <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
-                                    <p>Represents the passage of time.</p>
-                                    <p>This version is used for human users, external hardware or other subjects</p><br>
-                                    <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
-                                <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
-                                    <p>Represents the passage of time.</p>
-                                    <p>Shows events that occur to an object during the process.</p><br>
-                                    <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
-                                <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
-                                    <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
-                                    <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>  
                             <!-- SEQUENCE OBJECT (Fourth option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                                <span class="placementTypeToolTipText"><b>Sequence Object</b><br>
-                                    <p>Option loop or alternative.</p><br>
-                                    <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>                         
                         </div>
                     </div>
@@ -867,11 +515,6 @@
                 <div> <!-- SEQUENCE LIFELINE OBJECT (When chosen, takes up the "default position in the toolbar) -->
                     <div id="elementPlacement16" class="SEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(16); setMouseMode(2);' onmouseenter='hoverPlacementButton(16)' data-toolmode="Sequence_Lifeline_Object" data-toolid="6">
                         <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence activation"/>
-                        <span class="toolTipText"><b>Sequence activation</b><br>
-                            <p>Place an activation box.</p>
-                            <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
-                            <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton16" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -882,36 +525,18 @@
                             <!-- SEQUENCE LIFELINE (ACTOR) (First option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
-                                <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
-                                    <p>Represents the passage of time.</p>
-                                    <p>This version is used for human users, external hardware or other subjects</p><br>
-                                    <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
                             <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
-                                <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
-                                    <p>Represents the passage of time.</p>
-                                    <p>Shows events that occur to an object during the process.</p><br>
-                                    <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
-                                <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
-                                    <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
-                                    <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>  
                             <!-- SEQUENCE CONDITION (Fourth option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                                <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
-                                    <p>Option loop or alternative.</p><br>
-                                    <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>                         
                         </div>
                     </div>
@@ -920,12 +545,6 @@
                 <div> <!-- SEQUENCE ACTIVATION START (When chosen, takes up the "default position in the toolbar) -->
                     <div id="elementPlacement13" class="SEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(13); setMouseMode(2);' onmouseenter='hoverPlacementButton(13)' data-toolmode="Sequence_Activation" data-toolid="7">
                         <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
-                        <span class="toolTipText"><b>Sequence activation</b><br>
-                            <p>Place an activation box.</p>
-                            <p>Represents that an object is active during an interaction, with the length indicating the duration.</p>
-                            <br>
-                            <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                        </span>
                         <div id="togglePlacementTypeButton13" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -936,36 +555,18 @@
                             <!-- SEQUENCE LIFELINE (First option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
-                                <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
-                                    <p>Represents the passage of time.</p>
-                                    <p>This version is used for human users, external hardware or other subjects</p><br>
-                                    <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                             <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
-                                <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
-                                    <p>Represents the passage of time.</p>
-                                    <p>Shows events that occur to an object during the process.</p><br>
-                                    <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
                             <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
-                                <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
-                                    <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
-                                    <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>    
                             <!-- SEQUENCE CONDITION (Fourth option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                                <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
-                                    <p>Option loop or alternative.</p><br>
-                                    <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>                         
                         </div>
                     </div>
@@ -974,10 +575,6 @@
                 <div> <!-- SEQUENCE CONDITION/LOOP START (When chosen, takes up the "default position in the toolbar) -->
                     <div id="elementPlacement14" class="SEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(14); setMouseMode(2); ' onmouseenter='hoverPlacementButton(14)' data-toolmode="Sequence_Condition" data-toolid="8">
                         <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                            <span class="toolTipText"><b>Sequence Condition</b><br>
-                                <p>Add an option loop or alternative.</p><br>
-                                <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                            </span>
                         <div id="togglePlacementTypeButton14" class="placementTypeIcon togglePlacementTypeButton">
                             <img src="../Shared/icons/diagram_toolbar_arrow.svg" alt="An arrow for expanding this menu option"/>
                         </div>
@@ -988,36 +585,18 @@
                             <!-- SEQUENCE LIFELINE (ACTOR) (First option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
-                                <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
-                                    <p>Represents the passage of time.</p>
-                                    <p>This version is used for human users, external hardware, or other subjects</p><br>
-                                    <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
-                                <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
-                                    <p>Represents the passage of time.</p>
-                                    <p>Shows events that occur to an object during the process.</p><br>
-                                    <p id="tooltip-SQ_LIFELINE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>
                             <!-- SEQUENCE ACIVATION (Third option when hovering) -->
                             <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
-                                <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
-                                    <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
-                                    <p id="tooltip-STATE_SEQUENCE" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>  
                             <!-- EQUENCE CONDITION (Fourth option when hovering) -->
                             <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
-                                <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
-                                    <p>Option loop or alternative.</p><br>
-                                    <p id="tooltip-SEQUENCE_OBJECT" class="key_tooltip">Keybinding:</p>
-                                </span>
                             </div>                         
                         </div>
                     </div>
@@ -1027,10 +606,6 @@
                 <!-- NOTE ELEMENT -->
                 <div id="elementPlacement15" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(15); setMouseMode(2);' data-toolmode="Note" data-toolid="9">
                     <img src="../Shared/icons/diagram_note.svg"/>
-                    <span class="toolTipText"><b>Note</b><br>
-                        <p>Creates a note.</p><br>
-                        <p id="tooltip-NOTE_ENTITY" class="key_tooltip">Keybinding:</p>
-                    </span>
                 </div>
         </fieldset>
         <!-- MODES FIELD ENDS HERE!! -->
@@ -1040,10 +615,6 @@
             <legend aria-hidden="true">Camera</legend>
             <div id="camtoOrigo" data-single="true" class="diagramIcons tooltip-target" onclick="centerCamera();" data-toolmode="Camera" data-toolid="10">
                 <img src="../Shared/icons/fullscreen.svg" alt="Reset view">
-                <span class="toolTipText"><b>Reset view</b><br>
-                    <p>Reset view to show all elements.</p><br>
-                    <p id="tooltip-CENTER_CAMERA" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
         </fieldset>
         <!-- CAMERA FIELD IN TOOLBAR ENDS HERE!! -->
@@ -1054,34 +625,18 @@
             <!-- RESET DIAGRAM -->
             <div id="diagramReset" data-single="true" class="diagramIcons tooltip-target" onclick="resetDiagramAlert()" data-toolmode="Reset" data-toolid="11">
                 <img src="../Shared/icons/diagram_Refresh_Button.svg" alt="Reset diagram"/>
-                <span class="toolTipText"><b>Reset diagram</b><br>
-                    <p>Reset diagram to default state.</p><br>
-                    <p id="tooltip-RESET_DIAGRAM" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
             <!-- REDO -->
             <div id="stepForwardToggle" data-single="true" class="diagramIcons tooltip-target" onclick="toggleStepForward()" data-toolmode="Redo" data-toolid="12">
                 <img src="../Shared/icons/diagram_stepforward.svg" alt="Redo"/>
-                <span class="toolTipText"><b>Redo</b><br>
-                    <p>Redo last change.</p><br>
-                    <p id="tooltip-HISTORY_STEPFORWARD" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
             <!-- UNDO -->
             <div id="stepBackToggle" data-single="true" class="diagramIcons tooltip-target" onclick="toggleStepBack()" data-toolmode="Undo" data-toolid="13">
                 <img src="../Shared/icons/diagram_stepback.svg" alt="Undo"/>
-                <span class="toolTipText"><b>Undo</b><br>
-                    <p>Undo last change.</p><br>
-                    <p id="tooltip-HISTORY_STEPBACK" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
             <!-- REPLAY MODE -->
             <div id="replayToggle" data-single="true" class="diagramIcons tooltip-target" onclick="toggleReplay()" data-toolmode="Replay_Mode" data-toolid="14">
                 <img src="../Shared/icons/diagram_replay.svg" alt="Enter replay mode"/>
-                <span class="toolTipText"><b>Enter replay mode</b><br>
-                    <p>View history of changes made.</p><br>
-                    <p id="tooltip-TOGGLE_REPLAY_MODE" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
         </fieldset>
         <!-- HISTORY FIED IN TOOLBAR ENDS HERE!! -->
@@ -1092,10 +647,6 @@
             <legend aria-hidden="true">ER-Table</legend>
             <div id="erTableToggle" data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick="toggleErTable()" data-toolmode="ER_Table" data-toolid="15">
                 <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle ER-Table"/>
-                <span class="toolTipText"><b>Toggle ER-Table</b><br>
-                    <p>Click to toggle ER-Table in options.</p><br>
-                    <p id="tooltip-TOGGLE_ER_TABLE" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
         </fieldset>
         <!-- ER TABLE IN TOOLBAR ENDS HERE -->
@@ -1106,10 +657,6 @@
             <legend aria-hidden="true">Testcase</legend>
             <div id="testCaseToggle" data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick="toggleTestCase()" data-toolmode="Testcase" data-toolid="16"> <!--add func here later-->
                 <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle test-cases"/>
-                <span class="toolTipText"><b>Toggle test-cases</b><br>
-                    <p>Click to toggle test-cases in options.</p><br>
-                    <p id="tooltip-TOGGLE_TEST_CASE" class="key_tooltip">Keybinding: "CTRL + ALT + T"</p>
-                </span>
             </div>
         </fieldset> 
         <!-- TESTCASE FIELD IN TOOLBAR ENDS HERE!! -->
@@ -1120,12 +667,6 @@
         <legend aria-hidden="true">Check</legend>
             <div id="errorCheckToggle" data-single="true" class="diagramIcons tooltip-target" onclick="toggleErrorCheck()" data-toolmode="Error_Check" data-toolid="17">
                 <img src="../Shared/icons/diagram_errorCheck.svg" alt="Toggle error check"/>
-                <span class="toolTipText"><b>Toggle error check</b><br>
-                    <p>Click to toggle error checking on/off.</p>
-                    <p>Highlights errors inside a diagram.</p>
-                    <br>
-                    <p id="tooltip-TOGGLE_ERROR_CHECK" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
         </fieldset>
         <!-- CHECK FIELD IN TOOLBAR ENDS HERE -->
@@ -1135,12 +676,6 @@
             <legend aria-hidden="true">Save</legend>
             <div id="localSave" class="diagramIcons tooltip-target" onclick="quickSaveDiagram()" data-toolmode="Save" data-toolid="18">
                 <img src="../Shared/icons/diagram_save_icon.svg" alt="Save diagram"/>
-                <span class="toolTipText"><b>Save current diagram</b><br>
-                    <p>Click to save current diagram.</p>
-                    <p id="toolTipExtra">(Saves diagram to the last saved file. If no file has been saved to yet, it prompts to create new one.)</p>
-                    <br>
-                    <p id="tooltip-SAVE_DIAGRAM" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
         </fieldset>
         <!-- SAVE FIELD IN TOOLBAR ENDS HERE -->
@@ -1150,11 +685,6 @@
             <legend aria-hidden="true">Save As</legend>
             <div id="localSaveAs" class="diagramIcons tooltip-target" onclick="showSavePopout()" data-toolmode="Save_As" data-toolid="19">
                 <img src="../Shared/icons/diagram_save_as_icon.svg" alt="Save diagram as"/>
-                <span class="toolTipText"><b>Save current diagram to file</b><br>
-                    <p>Click to save current diagram <br> to a specific file.</p>
-                    <br>
-                    <p id="tooltip-SAVE_DIAGRAM_AS" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
         </fieldset>
         <!-- SAVE AS FIELD IN TOOLBAR ENDS HERE!! -->
@@ -1164,11 +694,6 @@
             <legend aria-hidden="true">Load</legend>
             <div id="localLoad" data-single="true" class="diagramIcons tooltip-target" onclick="showModal();" data-toolmode="Load" data-toolid="20">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
-                <span class="toolTipText"><b>Load diagram</b><br>
-                    <p>Click to load a diagram.</p>
-                    <br>
-                    <p id="tooltip-LOAD_DIAGRAM" class="key_tooltip">Keybinding:</p>
-                </span>
             </div>
         </fieldset>
         <!-- LOAD FIELD IN TOOLBAR ENDS HERE!! -->
@@ -1265,29 +790,14 @@
         <!-- ZOOM IN BUTTON -->
         <div class="diagramZoomIcons tooltip-target" onclick='zoomin();' data-toolmode="Zoom_In" data-toolid="21">
             <img src="../Shared/icons/diagram_zoomin.svg"/>
-            <span class="zoomToolTipText">
-                <b>Zoom IN</b><br>
-                <p>Zoom in on viewed area</p><br>
-                <p id="tooltip-ZOOM_IN" class="key_tooltip">Keybinding:</p>
-            </span>
         </div>
         <!-- ZOOM OUT BUTTON -->
         <div class="diagramZoomIcons tooltip-target" onclick='zoomout();' data-toolmode="Zoom_Out" data-toolid="22">
             <img src="../Shared/icons/diagram_zoomout.svg"/>
-            <span class="zoomToolTipText">
-                <b>Zoom OUT</b><br>
-                <p>Zoom out on viewed area</p><br>
-                <p id="tooltip-ZOOM_OUT" class="key_tooltip">Keybinding:</p>
-            </span>
         </div>
         <!-- RESET ZOOM BUTTON -->
         <div class="diagramZoomIcons tooltip-target" onclick="zoomreset()" data-toolmode="Zoom_Reset" data-toolid="23">
             <img src="../Shared/icons/diagram_zoomratio1to1.svg"/>
-            <span class="zoomToolTipText">
-                <b>Zoom RESET</b><br>
-                <p>Reset the zoom to 1x</p><br>
-                <p id="tooltip-ZOOM_RESET" class="key_tooltip">Keybinding:</p>
-            </span>
         </div>
     </div>
 
@@ -1296,10 +806,6 @@
     <div id="options-pane" class="hide-options-pane"> 
         <div id="options-pane-button" class="tooltip-target" onclick="toggleOptionsPane();" data-toolmode="Option_Panel" data-toolid="24">
             <span id='optmarker'>&#9660;Options</span>
-            <span id="tooltip-OPTIONS" class="toolTipText"><b>Show Option Panel</b><br>
-                <p>Enable/disable the Option Panel</p><br>
-                <p id="tooltip-OPTIONS" class="key_tooltip">Keybinding:</p>
-            </span>
         </div>
 
         <!-- FIELD FOR SMALLER FIELDS CONTAING THE OPTIONS -->
@@ -1361,23 +867,13 @@
                 <div id="diagram-replay-switch">
                     <div class="diagramIcons tooltip-target" onclick="stateMachine.replay()" data-toolmode="Replay_Play">
                         <img src="../Shared/icons/Play.svg" alt="Play">
-                        <span class="toolTipText" style="top: -80px"><b>Play</b><br>
-                            <p>Play history of changes made to the diagram</p><br>
-                        </span>
                     </div>
                 </div>
                 <div class="diagramIcons tooltip-target" onclick="stateMachine.replay(-1)" data-toolmode="Replay">
                     <img src="../Shared/icons/replay.svg" alt="Replay">
-                    <span class="toolTipText" style="top: -80px"><b>Replay</b><br>
-                        <p>Replay history of changes made to the diagram</p><br>
-                    </span>
                 </div>
                 <div class="diagramIcons tooltip-target" onclick="exitReplayMode()" data-toolmode="Replay_Exit" data-toolid="25">
                     <img src="../Shared/icons/exit.svg" alt="Exit">
-                    <span class="toolTipText" style="top: -95px"><b>Exit</b><br>
-                        <p>Exit the replay-mode</p><br>
-                        <p id="tooltip-ESCAPE" class="key_tooltip">Keybinding:</p>
-                    </span>
                 </div>
             </fieldset>
             <!-- PLAY/REPLAY/EXIT FIELD ENDS HERE!! -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -128,10 +128,12 @@
         <!-- MODES FIELD IN TOOLBAR -->
         <!-- Some of the modes have multiple options that show up when hovering over one of the buttons/options. -->
         <!-- When an option has been pressed, it shows up as the "default" in the toolbar, and so the options are written multiple times to mirror this behaviour -->
+        <!-- "data-toolmode", is used for mapping to the correct object in the tooltip_information.js (e.g. "Pointer"==="Pointer") -->
+        <!-- "data-toolid", is used for mapping to the correct ID for when creating the corresponding keybind.  -->
         <fieldset>
             <legend aria-hidden="true">Modes</legend>
                 <!-- POINTER -->
-                <div id="mouseMode0" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode active" onclick='setMouseMode(0);'>
+                <div id="mouseMode0" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode active" onclick='setMouseMode(0);' data-toolmode="Pointer" data-toolid="0">
                     <img src="../Shared/icons/diagram_pointer_white.svg" alt="Pointer"/>
                     <span class="toolTipText" id="highestToolTip"><b>Pointer</b><br>
                         <span>Allows you to select and move different elements as well as navigate the workspace</span><br><br>
@@ -139,7 +141,7 @@
                     </span>
                 </div>
                 <!-- BOX SELECTION -->
-                <div id="mouseMode1" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='setMouseMode(1);'>
+                <div id="mouseMode1" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='setMouseMode(1); ' data-toolmode="Box_Selection" data-toolid="1">
                     <img src="../Shared/icons/diagram_box_selection2.svg" alt="Box Selection"/>
                     <span class="toolTipText"><b>Box Selection</b><br>
                         <p>Click and drag to select multiple elements within the selected area.</p><br>
@@ -149,7 +151,7 @@
                 <!-- ER, UML, IE, AND STATE ELEMENTS -->
                 <div>
                     <!-- ER-ENTITY (initial default, on pageload, choice) -->
-                    <div id="elementPlacement0" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseenter='hoverPlacementButton(0)'><!--<-- UML functionality -->
+                    <div id="elementPlacement0" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseenter='hoverPlacementButton(0)' data-toolmode="ER_Entity" data-toolid="2"><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                         <span class="toolTipText"><b>ER entity</b><br>
                             <p>Insert an ER entity to the diagram</p>
@@ -166,7 +168,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(0), hidePlacementType()'>
                         <div id="togglePlacementTypeBox0" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <!-- ER-ENTITY (fist option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
+                            <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                                 <span class="placementTypeToolTipText"><b>ER entity</b><br>
                                     <p>Each entity represents an object which is a representation of concepts or data.</p>
@@ -176,7 +178,7 @@
                                 </span>
                             </div>
                             <!-- UML CLASS ("change to" - second option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);'>
+                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                                 <span class="placementTypeToolTipText"><b>UML class</b><br>
                                     <p>Change to UML class.</p>
@@ -186,7 +188,7 @@
                                 </span>
                             </div>
                             <!-- IE-ENTITY ("change to" - third option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' >
+                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                                 <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                     <p>Change to IE entity.</p>
@@ -197,7 +199,7 @@
                                 </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("change to" - fourth option when hovering) -->
-                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                                 <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                     <p>Change to state diagram state.</p>
@@ -213,7 +215,7 @@
                 <!-- If UML CLASS has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- UML CLASS (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement4" class="UMLButton diagramIcons toolbarMode" onclick='setElementPlacementType(4); setMouseMode(2); 'onmouseenter='hoverPlacementButton(4)'>
+                    <div id="elementPlacement4" class="UMLButton diagramIcons toolbarMode" onclick='setElementPlacementType(4); setMouseMode(2); 'onmouseenter='hoverPlacementButton(4)' data-toolmode="UML_Class" data-toolid="2">
                         <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                         <span class="toolTipText"><b>UML class</b><br>
                             <p>Create a UML class to the diagram</p>
@@ -227,7 +229,7 @@
                     </div>
                     <!-- Pop-out panel for element-options -->
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(4), hidePlacementType()'>
-                        <div id="togglePlacementTypeBox4" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
+                        <div id="togglePlacementTypeBox4" class="togglePlacementTypeBox togglePlacementTypeBoxEntity" data-toolmode="ER_Entity" data-toolid="2">
                             <!-- ER-ENTITY ("Change to" - first option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
@@ -240,7 +242,7 @@
                                 </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' >
+                            <div class="UMLButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                                 <span class="placementTypeToolTipText"><b>UML class</b><br>                      
                                     <p>Each class entity represents its own class along with the attributes and operations held within the class.</p>
@@ -249,7 +251,7 @@
                                 </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' >
+                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                                 <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                     <p>Change to IE entity.</p>
@@ -260,7 +262,7 @@
                                 </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
-                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                                 <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                     <p>Change to state diagram state.</p>
@@ -276,7 +278,7 @@
                 <!-- If IE-ENTITY has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- IE-ENTITY (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement6" class="IEButton diagramIcons toolbarMode" onclick='setElementPlacementType(6); setMouseMode(2);'onmouseenter='hoverPlacementButton(6)'>
+                    <div id="elementPlacement6" class="IEButton diagramIcons toolbarMode" onclick='setElementPlacementType(6); setMouseMode(2);'onmouseenter='hoverPlacementButton(6)' data-toolmode="IE_Entity" data-toolid="2">
                         <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                         <span class="toolTipText"><b>IE entity</b><br>
                             <p>Place an IE entity into the diagram</p>
@@ -291,9 +293,9 @@
                     </div>
                     <!-- Pop-out panel for element-options -->
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(6), hidePlacementType()'>
-                        <div id="togglePlacementTypeBox6" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
+                        <div id="togglePlacementTypeBox6" class="togglePlacementTypeBox togglePlacementTypeBoxEntity" >
                             <!-- ER-ENTITY ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
+                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                                 <span class="placementTypeToolTipText"><b>ER entity</b><br>
                                     <p>Change to ER entity.</p>
@@ -304,7 +306,7 @@
                                 </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' >
+                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                                 <span class="placementTypeToolTipText"><b>UML class</b><br>
                                     <p>Change to UML class.</p>
@@ -314,7 +316,7 @@
                                 </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' >
+                            <div class="IEButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                                 <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                     <p>Each entity represents an object along with its attributes.</p>
@@ -324,7 +326,7 @@
                                 </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
-                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_STATE" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                                 <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                     <p>Change to state diagram state.</p>
@@ -340,7 +342,7 @@
                 <!-- If STATE DIAGRAM STATE has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- STATE DIAGRAM STATE (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement8" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);'onmouseenter='hoverPlacementButton(8);'>
+                    <div id="elementPlacement8" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);'onmouseenter='hoverPlacementButton(8);' data-toolmode="SD_STATE" data-toolid="2">
                         <img src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                         <span class="toolTipText"><b>State diagram state</b><br>
                             <p>Add a state diagram state to the diagram</p>
@@ -356,7 +358,7 @@
                     <!-- Pop-out panel for element-options -->
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(8), hidePlacementType()'>
                         <div id="togglePlacementTypeBox8" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
+                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <!-- ER-ENTITY ("Change to" - first option when hovering) -->
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                                 <span class="placementTypeToolTipText"><b>ER entity</b><br>
@@ -368,7 +370,7 @@
                                 </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' >
+                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                                 <span class="placementTypeToolTipText"><b>UML class</b><br>
                                     <p>Change to UML class.</p>
@@ -378,7 +380,7 @@
                                 </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' >
+                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                                 <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                     <p>Change to IE entity.</p>
@@ -389,7 +391,7 @@
                                 </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
-                            <div class="SDButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' > <!-- Dummy button, functions like IE-button -->
+                            <div class="SDButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="Statediagram state"/>
                                 <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                     <p>A state diagram state is a representation of a status a process can have.</p>
@@ -406,7 +408,7 @@
                 <!-- RELATION, INHERITANCE, ATTRIBUTE -->
                 <div>
                     <!-- ER RELATION (initial default choice) -->
-                    <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseenter='hoverPlacementButton(1);'> <!--<-- UML functionality -->
+                    <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseenter='hoverPlacementButton(1);' data-toolmode="ER_Relation" data-toolid="3"> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"  alt="ER relation"/>
                         <span class="toolTipText"><b>ER relation</b><br>
                             <p>Place an ER relation into the diagram</p>
@@ -422,7 +424,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(1), hidePlacementType()'>
                         <div id="togglePlacementTypeBox1" class="togglePlacementTypeBox togglePlacementTypeBoxRI"><!--<-- UML functionality start-->
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
+                            <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER relation"/>
                                 <span class="placementTypeToolTipText"><b>ER relation</b><br>
                                     <p>Represents how entities are associated with each other.</p>
@@ -431,7 +433,7 @@
                                 </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
-                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);'>
+                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                                 <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
                                     <p>Change to ER attribute</p>
@@ -441,7 +443,7 @@
                                 </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);'>
+                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML Inheritance"/>
                                 <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
                                     <p>Change to UML inheritance.</p>
@@ -452,7 +454,7 @@
                                 </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);'>
+                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                                 <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
                                     <p>Change to IE inheritance.</p>
@@ -469,7 +471,7 @@
                 <!-- If UML INHERITANCE has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- UML INHERITANCE (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement5" class="UMLButton diagramIcons toolbarMode" onclick='setElementPlacementType(5); setMouseMode(2);' onmouseenter='hoverPlacementButton(5)'>
+                    <div id="elementPlacement5" class="UMLButton diagramIcons toolbarMode" onclick='setElementPlacementType(5); setMouseMode(2);' onmouseenter='hoverPlacementButton(5)' data-toolmode="UML_Inheritance" data-toolid="3">
                         <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                         <span class="toolTipText"><b>UML inheritance</b><br>
                             <p>Insert a UML inheritance to the diagram</p>
@@ -486,7 +488,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(5), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox5" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
+                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
                                 <span class="placementTypeToolTipText"><b>ER Relation</b><br>
                                     <p>Change to ER relation.</p>
@@ -496,7 +498,7 @@
                                 </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
-                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);'>
+                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                                 <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
                                     <p>Change to ER attribute</p>
@@ -506,7 +508,7 @@
                                 </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);'>
+                            <div class="UMLButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                                 <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
                                     <p>A relation between a superclass and subclasses.</p>
@@ -516,7 +518,7 @@
                                 </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons " onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);'>
+                            <div class="IEButton placementTypeBoxIcons " onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                                 <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
                                     <p>Change to IE inheritance.</p>
@@ -533,7 +535,7 @@
                 <!-- If IE INHERITANCE has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- IE INHERITANCE (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement7" class="IEButton diagramIcons toolbarMode" onclick='setElementPlacementType(7); setMouseMode(2);' onmouseenter='hoverPlacementButton(7)'>
+                    <div id="elementPlacement7" class="IEButton diagramIcons toolbarMode" onclick='setElementPlacementType(7); setMouseMode(2);' onmouseenter='hoverPlacementButton(7)' data-toolmode="IE_Inheritance" data-toolid="3">
                         <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                         <span class="toolTipText"><b>IE inheritance</b><br>
                             <p>Create an IE inheritance to the diagram</p>
@@ -550,7 +552,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(7), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox7" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
+                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
                                 <span class="placementTypeToolTipText"><b>ER Relation</b><br>
                                     <p>Change to ER relation.</p>
@@ -560,7 +562,7 @@
                                 </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
-                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);'>
+                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                                 <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
                                     <p>Change to ER attribute</p>
@@ -570,7 +572,7 @@
                                 </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);'>
+                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                                 <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
                                     <p>Change to UML inheritance.</p>
@@ -581,7 +583,7 @@
                                 </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);'>
+                            <div class="IEButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                                 <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
                                     <p>A relation between two or more entities.</p>
@@ -597,7 +599,7 @@
                 <!-- If ER ATTRIBUTE has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- ER ATTRIBUTE (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement2" class="ERAttribute diagramIcons toolbarMode" onclick='setElementPlacementType(2); setMouseMode(2);' onmouseenter='hoverPlacementButton(2)'>
+                    <div id="elementPlacement2" class="ERAttribute diagramIcons toolbarMode" onclick='setElementPlacementType(2); setMouseMode(2);' onmouseenter='hoverPlacementButton(2)' data-toolmode="ER_Attribute" data-toolid="3">
                         <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                         <span class="toolTipText"><b>ER Attribute</b><br>
                             <p>Add a ER attribute to the diagram.</p>
@@ -613,7 +615,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(2), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox2" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);'>
+                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
                                 <span class="placementTypeToolTipText"><b>ER Relation</b><br>
                                     <p>Change to ER relation.</p>
@@ -623,7 +625,7 @@
                                 </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
-                            <div class="ERAttribute placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);'>
+                            <div class="ERAttribute placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                                 <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
                                     <p>Add a ER attribute to the diagram.</p>
@@ -633,7 +635,7 @@
                                 </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);'>
+                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                                 <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
                                     <p>Change to UML inheritance.</p>
@@ -644,7 +646,7 @@
                                 </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);'>
+                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                                 <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
                                     <p>Change to IE inheritance</p>
@@ -658,7 +660,7 @@
                     </div>
                 </div>
                 <!-- LINE -->
-                <div id="mouseMode3" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='clearContext(); setMouseMode(3);'>
+                <div id="mouseMode3" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='clearContext(); setMouseMode(3);' data-toolmode="Line" data-toolid="4">
                     <img src="../Shared/icons/diagram_line.svg" alt="Line"/>
                     <span class="toolTipText"><b>Line</b><br>
                         <p>Make a line between elements.</p><br>
@@ -669,7 +671,7 @@
                 <!-- OPTIONS FOR STATE ELEMENTS START HERE -->
                 <div> 
                     <!-- UML INITIAL STATE (initial default choice) -->
-                    <div id="elementPlacement9" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(9); setMouseMode(2);' onmouseenter='hoverPlacementButton(9)'><!--<-- UML functionality -->
+                    <div id="elementPlacement9" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(9); setMouseMode(2);' onmouseenter='hoverPlacementButton(9)' data-toolmode="UML_Initial_State" data-toolid="5"><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                         <span class="toolTipText"><b>UML initial state</b><br>
                             <p>Insert an initial state for UML.</p>
@@ -685,7 +687,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(9), hidePlacementType()'><!--Initial state -->
                         <div id="togglePlacementTypeBox9" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);'>
+                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                                 <span class="placementTypeToolTipText"><b>UML initial state</b><br>
                                     <p>The initial state represents the start of a process.</p><br>
@@ -693,7 +695,7 @@
                                 </span>
                             </div>
                             <!-- FINAL STATE ("Change to" - second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);'>
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                                 <span class="placementTypeToolTipText"><b>UML final state</b><br>
                                     <p>Change to UML final state</p>
@@ -702,7 +704,7 @@
                                 </span>
                             </div>
                             <!-- UML SUPER STATE ("Change to" - third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' >
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                                 <span class="placementTypeToolTipText"><b>UML super state</b><br>
                                     <p>Change to UML super state</p>
@@ -716,7 +718,7 @@
                 <!-- If UML FINAL STATE has been chosen, the entity-options change position in the menu-->
                 <div>
                 <!-- UML FINAL STATE (When chosen, takes up the "default position in the toolbar) -->
-                    <div id="elementPlacement10" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(10); setMouseMode(2);' onmouseenter='hoverPlacementButton(10)'>
+                    <div id="elementPlacement10" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(10); setMouseMode(2);' onmouseenter='hoverPlacementButton(10)' data-toolmode="UML_Final_State" data-toolid="5">
                         <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                         <span class="toolTipText"><b>UML final state</b><br>
                             <p>Place a final state for UML.</p>
@@ -731,7 +733,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(10), hidePlacementType()'>
                         <div id="togglePlacementTypeBox10" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);'>
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                                 <span class="placementTypeToolTipText"><b>UML initial state</b><br>
                                     <p>Change to UML initial state</p>
@@ -740,7 +742,7 @@
                                 </span>
                             </div>
                             <!-- FINAL STATE("Change to" - second option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);'>
+                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                                 <span class="placementTypeToolTipText"><b>UML final state</b><br>
                                     <p>The final state represents where a process ends.</p><br>
@@ -748,7 +750,7 @@
                                 </span>
                             </div>
                             <!-- SUPER STATE ("Chaange to" - third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' >
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                                 <span class="placementTypeToolTipText"><b>UML super state</b><br>
                                     <p>Change to UML super state</p>
@@ -762,7 +764,7 @@
                 <!-- If UML SUPER STATE has been chosen, the entity-options change position in the menu  -->
                 <div>
                     <!-- UML SUPER STATE (When chosen, takes up the "default position in the toolbar)-->
-                    <div id="elementPlacement11" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(11); setMouseMode(2);' onmouseenter='hoverPlacementButton(11)'>
+                    <div id="elementPlacement11" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(11); setMouseMode(2);' onmouseenter='hoverPlacementButton(11)' data-toolmode="UML_Super_State" data-toolid="5">
                         <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                         <span class="toolTipText"><b>UML super state</b><br>
                             <p>Create a super state.</p>
@@ -777,7 +779,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(11), hidePlacementType()'>
                         <div id="togglePlacementTypeBox11" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);'>
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                                 <span class="placementTypeToolTipText"><b>UML initial state</b><br>
                                     <p>Change to UML initial state</p>
@@ -786,7 +788,7 @@
                                 </span>
                             </div>
                             <!-- FINAL STATE ("Change to" - second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);'>
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                                 <span class="placementTypeToolTipText"><b>UML final state</b><br>
                                     <p>Change to UML final state</p>
@@ -795,7 +797,7 @@
                                 </span>
                             </div>
                             <!-- SUPER STATE ("Change to" - third option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' >
+                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                                 <span class="placementTypeToolTipText"><b>UML super state</b><br>
                                     <p>A state that can contain substates.</p><br>
@@ -809,7 +811,7 @@
                 <!-- SEQUENCE POP-OUT START-->
                 <div> 
                     <!-- SEQUENCE LIFELINE (initial default choice, and the same as the Sequence Lifeline (Actor)) -->
-                    <div id="elementPlacement12" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(12); setMouseMode(2);' onmouseenter='hoverPlacementButton(12)'>
+                    <div id="elementPlacement12" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(12); setMouseMode(2);' onmouseenter='hoverPlacementButton(12)' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6">
                         <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                         <span class="toolTipText"><b>Sequence lifeline</b><br>
                             <p>Creates a lifeline for a sequnece diagram.</p>
@@ -825,7 +827,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(12), hidePlacementType()'>
                         <div id="togglePlacementTypeBox12" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- SEQUENCE LIFELINE (ACTOR)(First option when hovering and the same as the initial option, as seen above this) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline object"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -834,7 +836,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -843,7 +845,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                                 <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                     <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
@@ -851,7 +853,7 @@
                                 </span>
                             </div>  
                             <!-- SEQUENCE OBJECT (Fourth option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                                 <span class="placementTypeToolTipText"><b>Sequence Object</b><br>
                                     <p>Option loop or alternative.</p><br>
@@ -863,7 +865,7 @@
                 </div>
                 <!-- If SEQUENCE LIFELINE OBJECT has been chosen, the the entity-options change position in the menu -->
                 <div> <!-- SEQUENCE LIFELINE OBJECT (When chosen, takes up the "default position in the toolbar) -->
-                    <div id="elementPlacement16" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(16); setMouseMode(2);' onmouseenter='hoverPlacementButton(16)'>
+                    <div id="elementPlacement16" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(16); setMouseMode(2);' onmouseenter='hoverPlacementButton(16)' data-toolmode="Sequence_Lifeline_Object" data-toolid="6">
                         <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence activation"/>
                         <span class="toolTipText"><b>Sequence activation</b><br>
                             <p>Place an activation box.</p>
@@ -878,7 +880,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(16), hidePlacementType()'>
                         <div id="togglePlacementTypeBox16" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- SEQUENCE LIFELINE (ACTOR) (First option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -887,7 +889,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -896,7 +898,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                                 <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                     <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
@@ -904,7 +906,7 @@
                                 </span>
                             </div>  
                             <!-- SEQUENCE CONDITION (Fourth option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                                 <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                     <p>Option loop or alternative.</p><br>
@@ -916,7 +918,7 @@
                 </div> 
                 <!-- If SEQUENCE ACTIVATION START has been chosen, the element-options change position in menu -->
                 <div> <!-- SEQUENCE ACTIVATION START (When chosen, takes up the "default position in the toolbar) -->
-                    <div id="elementPlacement13" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(13); setMouseMode(2);' onmouseenter='hoverPlacementButton(13)'>
+                    <div id="elementPlacement13" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(13); setMouseMode(2);' onmouseenter='hoverPlacementButton(13)' data-toolmode="Sequence_Activation" data-toolid="7">
                         <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                         <span class="toolTipText"><b>Sequence activation</b><br>
                             <p>Place an activation box.</p>
@@ -932,7 +934,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(13), hidePlacementType()'>
                         <div id="togglePlacementTypeBox13" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- SEQUENCE LIFELINE (First option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -941,7 +943,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                             <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -950,7 +952,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                                 <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                     <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
@@ -958,7 +960,7 @@
                                 </span>
                             </div>    
                             <!-- SEQUENCE CONDITION (Fourth option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                                 <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                     <p>Option loop or alternative.</p><br>
@@ -970,7 +972,7 @@
                 </div> 
                 <!-- If SEQUENCE CONDITION/LOOP has been chosen, the element-options change position in the menu -->
                 <div> <!-- SEQUENCE CONDITION/LOOP START (When chosen, takes up the "default position in the toolbar) -->
-                    <div id="elementPlacement14" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(14); setMouseMode(2);' onmouseenter='hoverPlacementButton(14)'>
+                    <div id="elementPlacement14" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(14); setMouseMode(2); ' onmouseenter='hoverPlacementButton(14)' data-toolmode="Sequence_Condition" data-toolid="8">
                         <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="toolTipText"><b>Sequence Condition</b><br>
                                 <p>Add an option loop or alternative.</p><br>
@@ -984,7 +986,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(14), hidePlacementType()'>
                         <div id="togglePlacementTypeBox14" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- SEQUENCE LIFELINE (ACTOR) (First option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -993,7 +995,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -1002,7 +1004,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE ACIVATION (Third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);'> 
+                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                                 <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                     <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
@@ -1010,7 +1012,7 @@
                                 </span>
                             </div>  
                             <!-- EQUENCE CONDITION (Fourth option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' > 
+                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                                 <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                     <p>Option loop or alternative.</p><br>
@@ -1023,7 +1025,7 @@
                 <!-- SEQUENCE POP-OUT END -->
                 
                 <!-- NOTE ELEMENT -->
-                <div id="elementPlacement15" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='setElementPlacementType(15); setMouseMode(2);'>
+                <div id="elementPlacement15" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='setElementPlacementType(15); setMouseMode(2);' data-toolmode="Note" data-toolid="9">
                     <img src="../Shared/icons/diagram_note.svg"/>
                     <span class="toolTipText"><b>Note</b><br>
                         <p>Creates a note.</p><br>
@@ -1036,7 +1038,7 @@
         <!-- CAMERA FIELD IN TOOLBAR -->
         <fieldset>
             <legend aria-hidden="true">Camera</legend>
-            <div id="camtoOrigo" data-single="true" class="diagramIcons" onclick="centerCamera();">
+            <div id="camtoOrigo" data-single="true" class="diagramIcons" onclick="centerCamera();" data-toolmode="Camera" data-toolid="10">
                 <img src="../Shared/icons/fullscreen.svg" alt="Reset view">
                 <span class="toolTipText"><b>Reset view</b><br>
                     <p>Reset view to show all elements.</p><br>
@@ -1050,7 +1052,7 @@
         <fieldset>
             <legend aria-hidden="true">History</legend>
             <!-- RESET DIAGRAM -->
-            <div id="diagramReset" data-single="true" class="diagramIcons" onclick="resetDiagramAlert()">
+            <div id="diagramReset" data-single="true" class="diagramIcons" onclick="resetDiagramAlert()" data-toolmode="Reset" data-toolid="11">
                 <img src="../Shared/icons/diagram_Refresh_Button.svg" alt="Reset diagram"/>
                 <span class="toolTipText"><b>Reset diagram</b><br>
                     <p>Reset diagram to default state.</p><br>
@@ -1058,7 +1060,7 @@
                 </span>
             </div>
             <!-- REDO -->
-            <div id="stepForwardToggle" data-single="true" class="diagramIcons" onclick="toggleStepForward()">
+            <div id="stepForwardToggle" data-single="true" class="diagramIcons" onclick="toggleStepForward()" data-toolmode="Redo" data-toolid="12">
                 <img src="../Shared/icons/diagram_stepforward.svg" alt="Redo"/>
                 <span class="toolTipText"><b>Redo</b><br>
                     <p>Redo last change.</p><br>
@@ -1066,7 +1068,7 @@
                 </span>
             </div>
             <!-- UNDO -->
-            <div id="stepBackToggle" data-single="true" class="diagramIcons" onclick="toggleStepBack()">
+            <div id="stepBackToggle" data-single="true" class="diagramIcons" onclick="toggleStepBack()" data-toolmode="Undo" data-toolid="13">
                 <img src="../Shared/icons/diagram_stepback.svg" alt="Undo"/>
                 <span class="toolTipText"><b>Undo</b><br>
                     <p>Undo last change.</p><br>
@@ -1074,7 +1076,7 @@
                 </span>
             </div>
             <!-- REPLAY MODE -->
-            <div id="replayToggle" data-single="true" class="diagramIcons" onclick="toggleReplay()">
+            <div id="replayToggle" data-single="true" class="diagramIcons" onclick="toggleReplay()" data-toolmode="Replay_Mode" data-toolid="14">
                 <img src="../Shared/icons/diagram_replay.svg" alt="Enter replay mode"/>
                 <span class="toolTipText"><b>Enter replay mode</b><br>
                     <p>View history of changes made.</p><br>
@@ -1088,7 +1090,7 @@
         <!-- When an ER table is open, it allows user to edit properties in the options-panel -->
         <fieldset>
             <legend aria-hidden="true">ER-Table</legend>
-            <div id="erTableToggle" data-single="true" class="diagramIcons toolbarMode" onclick="toggleErTable()">
+            <div id="erTableToggle" data-single="true" class="diagramIcons toolbarMode" onclick="toggleErTable()" data-toolmode="ER_Table" data-toolid="15">
                 <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle ER-Table"/>
                 <span class="toolTipText"><b>Toggle ER-Table</b><br>
                     <p>Click to toggle ER-Table in options.</p><br>
@@ -1102,7 +1104,7 @@
         <!-- Allows user to see properties for a state diagram in the options-panel -->
         <fieldset>
             <legend aria-hidden="true">Testcase</legend>
-            <div id="testCaseToggle" data-single="true" class="diagramIcons toolbarMode" onclick="toggleTestCase()"> <!--add func here later-->
+            <div id="testCaseToggle" data-single="true" class="diagramIcons toolbarMode" onclick="toggleTestCase()" data-toolmode="Testcase" data-toolid="16"> <!--add func here later-->
                 <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle test-cases"/>
                 <span class="toolTipText"><b>Toggle test-cases</b><br>
                     <p>Click to toggle test-cases in options.</p><br>
@@ -1116,7 +1118,7 @@
         <!-- Toggle error-checking on/off -->
         <fieldset id = "errorCheckField">
         <legend aria-hidden="true">Check</legend>
-            <div id="errorCheckToggle" data-single="true" class="diagramIcons" onclick="toggleErrorCheck()">
+            <div id="errorCheckToggle" data-single="true" class="diagramIcons" onclick="toggleErrorCheck()" data-toolmode="Error_Check" data-toolid="17">
                 <img src="../Shared/icons/diagram_errorCheck.svg" alt="Toggle error check"/>
                 <span class="toolTipText"><b>Toggle error check</b><br>
                     <p>Click to toggle error checking on/off.</p>
@@ -1131,7 +1133,7 @@
         <!-- SAVE FIELD IN TOOLBAR (SAVE CURRENT FILE) -->
         <fieldset id="localSaveField" class="disabledIcon">
             <legend aria-hidden="true">Save</legend>
-            <div id="localSave" class="diagramIcons" onclick="quickSaveDiagram()">
+            <div id="localSave" class="diagramIcons" onclick="quickSaveDiagram()" data-toolmode="Save" data-toolid="18">
                 <img src="../Shared/icons/diagram_save_icon.svg" alt="Save diagram"/>
                 <span class="toolTipText"><b>Save current diagram</b><br>
                     <p>Click to save current diagram.</p>
@@ -1146,7 +1148,7 @@
         <!-- SAVE AS FIELD IN TOOLBAR (SAVE CURRENT DIAGRAM TO FILE) -->
         <fieldset id="localSaveAsField" class="disabledIcon">
             <legend aria-hidden="true">Save As</legend>
-            <div id="localSaveAs" class="diagramIcons" onclick="showSavePopout()">
+            <div id="localSaveAs" class="diagramIcons" onclick="showSavePopout()" data-toolmode="Save_As" data-toolid="19">
                 <img src="../Shared/icons/diagram_save_as_icon.svg" alt="Save diagram as"/>
                 <span class="toolTipText"><b>Save current diagram to file</b><br>
                     <p>Click to save current diagram <br> to a specific file.</p>
@@ -1160,7 +1162,7 @@
         <!-- LOAD FIELD IN TOOLBAR -->
         <fieldset id="localLoadField">
             <legend aria-hidden="true">Load</legend>
-            <div id="localLoad" data-single="true" class="diagramIcons" onclick="showModal();">
+            <div id="localLoad" data-single="true" class="diagramIcons" onclick="showModal();" data-toolmode="Load" data-toolid="20">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
                 <span class="toolTipText"><b>Load diagram</b><br>
                     <p>Click to load a diagram.</p>
@@ -1261,7 +1263,7 @@
             <text id ="zoom-message">1x</text>
         </div>
         <!-- ZOOM IN BUTTON -->
-        <div class="diagramZoomIcons" onclick='zoomin();'>
+        <div class="diagramZoomIcons" onclick='zoomin();' data-toolmode="Zoom_In" data-toolid="21">
             <img src="../Shared/icons/diagram_zoomin.svg"/>
             <span class="zoomToolTipText">
                 <b>Zoom IN</b><br>
@@ -1270,7 +1272,7 @@
             </span>
         </div>
         <!-- ZOOM OUT BUTTON -->
-        <div class="diagramZoomIcons" onclick='zoomout();'>
+        <div class="diagramZoomIcons" onclick='zoomout();' data-toolmode="Zoom_Out" data-toolid="22">
             <img src="../Shared/icons/diagram_zoomout.svg"/>
             <span class="zoomToolTipText">
                 <b>Zoom OUT</b><br>
@@ -1279,7 +1281,7 @@
             </span>
         </div>
         <!-- RESET ZOOM BUTTON -->
-        <div class="diagramZoomIcons" onclick="zoomreset()">
+        <div class="diagramZoomIcons" onclick="zoomreset()" data-toolmode="Zoom_Reset" data-toolid="23">
             <img src="../Shared/icons/diagram_zoomratio1to1.svg"/>
             <span class="zoomToolTipText">
                 <b>Zoom RESET</b><br>
@@ -1292,7 +1294,7 @@
     <!-- OPTIONS PANE -->
     <!-- Yellow panel on the right side of the screen -->
     <div id="options-pane" class="hide-options-pane"> 
-        <div id="options-pane-button" onclick="toggleOptionsPane();">
+        <div id="options-pane-button" onclick="toggleOptionsPane();" data-toolmode="Option_Panel" data-toolid="24">
             <span id='optmarker'>&#9660;Options</span>
             <span id="tooltip-OPTIONS" class="toolTipText"><b>Show Option Panel</b><br>
                 <p>Enable/disable the Option Panel</p><br>
@@ -1357,20 +1359,20 @@
             <!-- PLAY/REPLAY/EXIT FIELD -->
             <fieldset style="display: flex; justify-content: space-between">
                 <div id="diagram-replay-switch">
-                    <div class="diagramIcons" onclick="stateMachine.replay()">
+                    <div class="diagramIcons" onclick="stateMachine.replay()" data-toolmode="Replay_Play">
                         <img src="../Shared/icons/Play.svg" alt="Play">
                         <span class="toolTipText" style="top: -80px"><b>Play</b><br>
                             <p>Play history of changes made to the diagram</p><br>
                         </span>
                     </div>
                 </div>
-                <div class="diagramIcons" onclick="stateMachine.replay(-1)">
+                <div class="diagramIcons" onclick="stateMachine.replay(-1)" data-toolmode="Replay">
                     <img src="../Shared/icons/replay.svg" alt="Replay">
                     <span class="toolTipText" style="top: -80px"><b>Replay</b><br>
                         <p>Replay history of changes made to the diagram</p><br>
                     </span>
                 </div>
-                <div class="diagramIcons" onclick="exitReplayMode()">
+                <div class="diagramIcons" onclick="exitReplayMode()" data-toolmode="Replay_Exit" data-toolid="25">
                     <img src="../Shared/icons/exit.svg" alt="Exit">
                     <span class="toolTipText" style="top: -95px"><b>Exit</b><br>
                         <p>Exit the replay-mode</p><br>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -90,6 +90,8 @@
     <div id="markdownKeybinds" style="display: none">
 
     </div>
+    
+    <!-- The tooltip container that pops up with information based on where the user hovers -->
     <div class="diagram-tooltip" style="display:none;"></div>
 
     <!-- Used for calculating pixels per millimeter using offsetWidth. Note that in offsetWidth system scaling is not included

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -60,6 +60,7 @@
     <script src="./diagram/helpers/boxSelect.js"></script>
     <script src="./diagram/zoom.js"></script>
     <script src="./diagram/camera.js"></script>
+    <script src="./diagram/tooltip_information.js"></script>
     <script src="./diagram/helpers/line.js"></script>
     <script src="./diagram/helpers/mouse.js"></script>
     <script src="./diagram/helpers/mouseMode.js"></script>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -133,7 +133,7 @@
         <fieldset>
             <legend aria-hidden="true">Modes</legend>
                 <!-- POINTER -->
-                <div id="mouseMode0" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode active" onclick='setMouseMode(0);' data-toolmode="Pointer" data-toolid="0">
+                <div id="mouseMode0" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode active tooltip-target" onclick='setMouseMode(0);' data-toolmode="Pointer" data-toolid="0">
                     <img src="../Shared/icons/diagram_pointer_white.svg" alt="Pointer"/>
                     <span class="toolTipText" id="highestToolTip"><b>Pointer</b><br>
                         <span>Allows you to select and move different elements as well as navigate the workspace</span><br><br>
@@ -141,7 +141,7 @@
                     </span>
                 </div>
                 <!-- BOX SELECTION -->
-                <div id="mouseMode1" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='setMouseMode(1); ' data-toolmode="Box_Selection" data-toolid="1">
+                <div id="mouseMode1" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick='setMouseMode(1); ' data-toolmode="Box_Selection" data-toolid="1">
                     <img src="../Shared/icons/diagram_box_selection2.svg" alt="Box Selection"/>
                     <span class="toolTipText"><b>Box Selection</b><br>
                         <p>Click and drag to select multiple elements within the selected area.</p><br>
@@ -151,7 +151,7 @@
                 <!-- ER, UML, IE, AND STATE ELEMENTS -->
                 <div>
                     <!-- ER-ENTITY (initial default, on pageload, choice) -->
-                    <div id="elementPlacement0" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseenter='hoverPlacementButton(0)' data-toolmode="ER_Entity" data-toolid="2"><!--<-- UML functionality -->
+                    <div id="elementPlacement0" class="ERButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(0); setMouseMode(2);' onmouseenter='hoverPlacementButton(0)' data-toolmode="ER_Entity" data-toolid="2"><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                         <span class="toolTipText"><b>ER entity</b><br>
                             <p>Insert an ER entity to the diagram</p>
@@ -168,7 +168,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(0), hidePlacementType()'>
                         <div id="togglePlacementTypeBox0" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <!-- ER-ENTITY (fist option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
+                            <div class="ERButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                                 <span class="placementTypeToolTipText"><b>ER entity</b><br>
                                     <p>Each entity represents an object which is a representation of concepts or data.</p>
@@ -178,7 +178,7 @@
                                 </span>
                             </div>
                             <!-- UML CLASS ("change to" - second option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
+                            <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                                 <span class="placementTypeToolTipText"><b>UML class</b><br>
                                     <p>Change to UML class.</p>
@@ -188,7 +188,7 @@
                                 </span>
                             </div>
                             <!-- IE-ENTITY ("change to" - third option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
+                            <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                                 <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                     <p>Change to IE entity.</p>
@@ -199,7 +199,7 @@
                                 </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("change to" - fourth option when hovering) -->
-                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
+                            <div class="SDButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                                 <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                     <p>Change to state diagram state.</p>
@@ -215,7 +215,7 @@
                 <!-- If UML CLASS has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- UML CLASS (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement4" class="UMLButton diagramIcons toolbarMode" onclick='setElementPlacementType(4); setMouseMode(2); 'onmouseenter='hoverPlacementButton(4)' data-toolmode="UML_Class" data-toolid="2">
+                    <div id="elementPlacement4" class="UMLButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(4); setMouseMode(2); 'onmouseenter='hoverPlacementButton(4)' data-toolmode="UML_Class" data-toolid="2">
                         <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                         <span class="toolTipText"><b>UML class</b><br>
                             <p>Create a UML class to the diagram</p>
@@ -229,7 +229,7 @@
                     </div>
                     <!-- Pop-out panel for element-options -->
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(4), hidePlacementType()'>
-                        <div id="togglePlacementTypeBox4" class="togglePlacementTypeBox togglePlacementTypeBoxEntity" data-toolmode="ER_Entity" data-toolid="2">
+                        <div id="togglePlacementTypeBox4" class="togglePlacementTypeBox togglePlacementTypeBoxEntity tooltip-target" data-toolmode="ER_Entity" data-toolid="2">
                             <!-- ER-ENTITY ("Change to" - first option when hovering) -->
                             <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);'>
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
@@ -242,7 +242,7 @@
                                 </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
+                            <div class="UMLButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                                 <span class="placementTypeToolTipText"><b>UML class</b><br>                      
                                     <p>Each class entity represents its own class along with the attributes and operations held within the class.</p>
@@ -251,7 +251,7 @@
                                 </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
+                            <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                                 <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                     <p>Change to IE entity.</p>
@@ -262,7 +262,7 @@
                                 </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
-                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
+                            <div class="SDButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                                 <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                     <p>Change to state diagram state.</p>
@@ -278,7 +278,7 @@
                 <!-- If IE-ENTITY has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- IE-ENTITY (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement6" class="IEButton diagramIcons toolbarMode" onclick='setElementPlacementType(6); setMouseMode(2);'onmouseenter='hoverPlacementButton(6)' data-toolmode="IE_Entity" data-toolid="2">
+                    <div id="elementPlacement6" class="IEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(6); setMouseMode(2);'onmouseenter='hoverPlacementButton(6)' data-toolmode="IE_Entity" data-toolid="2">
                         <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                         <span class="toolTipText"><b>IE entity</b><br>
                             <p>Place an IE entity into the diagram</p>
@@ -295,7 +295,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(6), hidePlacementType()'>
                         <div id="togglePlacementTypeBox6" class="togglePlacementTypeBox togglePlacementTypeBoxEntity" >
                             <!-- ER-ENTITY ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
+                            <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                                 <span class="placementTypeToolTipText"><b>ER entity</b><br>
                                     <p>Change to ER entity.</p>
@@ -306,7 +306,7 @@
                                 </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
+                            <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                                 <span class="placementTypeToolTipText"><b>UML class</b><br>
                                     <p>Change to UML class.</p>
@@ -316,7 +316,7 @@
                                 </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
+                            <div class="IEButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                                 <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                     <p>Each entity represents an object along with its attributes.</p>
@@ -326,7 +326,7 @@
                                 </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
-                            <div class="SDButton placementTypeBoxIcons" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_STATE" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
+                            <div class="SDButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                                 <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                     <p>Change to state diagram state.</p>
@@ -342,7 +342,7 @@
                 <!-- If STATE DIAGRAM STATE has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- STATE DIAGRAM STATE (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement8" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(8); setMouseMode(2);'onmouseenter='hoverPlacementButton(8);' data-toolmode="SD_STATE" data-toolid="2">
+                    <div id="elementPlacement8" class="SDButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(8); setMouseMode(2);'onmouseenter='hoverPlacementButton(8);' data-toolmode="SD_STATE" data-toolid="2">
                         <img src="../Shared/icons/diagram_state.svg" alt="State diagram state"/>
                         <span class="toolTipText"><b>State diagram state</b><br>
                             <p>Add a state diagram state to the diagram</p>
@@ -358,7 +358,7 @@
                     <!-- Pop-out panel for element-options -->
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(8), hidePlacementType()'>
                         <div id="togglePlacementTypeBox8" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
+                            <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(0,0); setElementPlacementType(0); setMouseMode(2);' data-toolmode="ER_Entity" data-toolid="2">
                                 <!-- ER-ENTITY ("Change to" - first option when hovering) -->
                                 <img src="../Shared/icons/diagram_entity.svg" alt="ER entity"/>
                                 <span class="placementTypeToolTipText"><b>ER entity</b><br>
@@ -370,7 +370,7 @@
                                 </span>
                             </div>
                             <!-- UML CLASS ("Change to" - second option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
+                            <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(4,0); setElementPlacementType(4); setMouseMode(2);' data-toolmode="UML_Class" data-toolid="2">
                                 <img src="../Shared/icons/diagram_UML_entity.svg" alt="UML class"/>
                                 <span class="placementTypeToolTipText"><b>UML class</b><br>
                                     <p>Change to UML class.</p>
@@ -380,7 +380,7 @@
                                 </span>
                             </div>
                             <!-- IE-ENTITY ("Change to" - third option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
+                            <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(6,0); setElementPlacementType(6); setMouseMode(2);' data-toolmode="IE_Entity" data-toolid="2">
                                 <img src="../Shared/icons/diagram_IE_entity.svg" alt="IE entity"/>
                                 <span class="placementTypeToolTipText"><b>IE entity</b><br>
                                     <p>Change to IE entity.</p>
@@ -391,7 +391,7 @@
                                 </span>
                             </div>
                             <!-- STATE DIAGRAM STATE ("Change to" - fourth option when hovering) -->
-                            <div class="SDButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
+                            <div class="SDButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(8,0); setElementPlacementType(8); setMouseMode(2);' data-toolmode="SD_State" data-toolid="2"> <!-- Dummy button, functions like IE-button -->
                                 <img class="SDState-rounded" src="../Shared/icons/diagram_state.svg" alt="Statediagram state"/>
                                 <span class="placementTypeToolTipText"><b>State diagram state</b><br>
                                     <p>A state diagram state is a representation of a status a process can have.</p>
@@ -408,7 +408,7 @@
                 <!-- RELATION, INHERITANCE, ATTRIBUTE -->
                 <div>
                     <!-- ER RELATION (initial default choice) -->
-                    <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseenter='hoverPlacementButton(1);' data-toolmode="ER_Relation" data-toolid="3"> <!--<-- UML functionality -->
+                    <div id="elementPlacement1" class="ERButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(1); setMouseMode(2);' onmouseenter='hoverPlacementButton(1);' data-toolmode="ER_Relation" data-toolid="3"> <!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_relation.svg"  alt="ER relation"/>
                         <span class="toolTipText"><b>ER relation</b><br>
                             <p>Place an ER relation into the diagram</p>
@@ -424,7 +424,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(1), hidePlacementType()'>
                         <div id="togglePlacementTypeBox1" class="togglePlacementTypeBox togglePlacementTypeBoxRI"><!--<-- UML functionality start-->
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
+                            <div class="ERButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER relation"/>
                                 <span class="placementTypeToolTipText"><b>ER relation</b><br>
                                     <p>Represents how entities are associated with each other.</p>
@@ -433,7 +433,7 @@
                                 </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
-                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
+                            <div class="ERAttribute placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                                 <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
                                     <p>Change to ER attribute</p>
@@ -443,7 +443,7 @@
                                 </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
+                            <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML Inheritance"/>
                                 <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
                                     <p>Change to UML inheritance.</p>
@@ -454,7 +454,7 @@
                                 </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
+                            <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                                 <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
                                     <p>Change to IE inheritance.</p>
@@ -471,7 +471,7 @@
                 <!-- If UML INHERITANCE has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- UML INHERITANCE (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement5" class="UMLButton diagramIcons toolbarMode" onclick='setElementPlacementType(5); setMouseMode(2);' onmouseenter='hoverPlacementButton(5)' data-toolmode="UML_Inheritance" data-toolid="3">
+                    <div id="elementPlacement5" class="UMLButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(5); setMouseMode(2);' onmouseenter='hoverPlacementButton(5)' data-toolmode="UML_Inheritance" data-toolid="3">
                         <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                         <span class="toolTipText"><b>UML inheritance</b><br>
                             <p>Insert a UML inheritance to the diagram</p>
@@ -488,7 +488,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(5), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox5" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
+                            <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
                                 <span class="placementTypeToolTipText"><b>ER Relation</b><br>
                                     <p>Change to ER relation.</p>
@@ -498,7 +498,7 @@
                                 </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
-                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
+                            <div class="ERAttribute placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                                 <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
                                     <p>Change to ER attribute</p>
@@ -508,7 +508,7 @@
                                 </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
+                            <div class="UMLButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                                 <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
                                     <p>A relation between a superclass and subclasses.</p>
@@ -518,7 +518,7 @@
                                 </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons " onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
+                            <div class="IEButton placementTypeBoxIcons tooltip-target " onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                                 <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
                                     <p>Change to IE inheritance.</p>
@@ -535,7 +535,7 @@
                 <!-- If IE INHERITANCE has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- IE INHERITANCE (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement7" class="IEButton diagramIcons toolbarMode" onclick='setElementPlacementType(7); setMouseMode(2);' onmouseenter='hoverPlacementButton(7)' data-toolmode="IE_Inheritance" data-toolid="3">
+                    <div id="elementPlacement7" class="IEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(7); setMouseMode(2);' onmouseenter='hoverPlacementButton(7)' data-toolmode="IE_Inheritance" data-toolid="3">
                         <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                         <span class="toolTipText"><b>IE inheritance</b><br>
                             <p>Create an IE inheritance to the diagram</p>
@@ -552,7 +552,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(7), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox7" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
+                            <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
                                 <span class="placementTypeToolTipText"><b>ER Relation</b><br>
                                     <p>Change to ER relation.</p>
@@ -562,7 +562,7 @@
                                 </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
-                            <div class="ERAttribute placementTypeBoxIcons" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
+                            <div class="ERAttribute placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                                 <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
                                     <p>Change to ER attribute</p>
@@ -572,7 +572,7 @@
                                 </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
+                            <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                                 <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
                                     <p>Change to UML inheritance.</p>
@@ -583,7 +583,7 @@
                                 </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
+                            <div class="IEButton placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                                 <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
                                     <p>A relation between two or more entities.</p>
@@ -599,7 +599,7 @@
                 <!-- If ER ATTRIBUTE has been chosen, the entity-options change position in the menu -->
                 <div>
                     <!-- ER ATTRIBUTE (When chosen, takes up the "default" position in the toolbar) -->
-                    <div id="elementPlacement2" class="ERAttribute diagramIcons toolbarMode" onclick='setElementPlacementType(2); setMouseMode(2);' onmouseenter='hoverPlacementButton(2)' data-toolmode="ER_Attribute" data-toolid="3">
+                    <div id="elementPlacement2" class="ERAttribute diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(2); setMouseMode(2);' onmouseenter='hoverPlacementButton(2)' data-toolmode="ER_Attribute" data-toolid="3">
                         <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                         <span class="toolTipText"><b>ER Attribute</b><br>
                             <p>Add a ER attribute to the diagram.</p>
@@ -615,7 +615,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(2), hidePlacementType()'>  
                         <div id="togglePlacementTypeBox2" class="togglePlacementTypeBox togglePlacementTypeBoxRI">
                             <!-- ER RELATION ("Change to" - first option when hovering) -->
-                            <div class="ERButton placementTypeBoxIcons" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
+                            <div class="ERButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(1,1); setElementPlacementType(1); setMouseMode(2);' data-toolmode="ER_Relation" data-toolid="3">
                                 <img src="../Shared/icons/diagram_relation.svg" alt="ER Relation"/>
                                 <span class="placementTypeToolTipText"><b>ER Relation</b><br>
                                     <p>Change to ER relation.</p>
@@ -625,7 +625,7 @@
                                 </span>
                             </div>
                             <!-- ER ATTRIBUTE ("Change to" - second option when hovering) -->
-                            <div class="ERAttribute placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
+                            <div class="ERAttribute placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(2,1);setElementPlacementType(2); setMouseMode(2);' data-toolmode="ER_Attribute" data-toolid="3">
                                 <img src="../Shared/icons/diagram_attribute.svg" alt="ER Attribute"/>
                                 <span class="placementTypeToolTipText"><b>ER Attribute</b><br>
                                     <p>Add a ER attribute to the diagram.</p>
@@ -635,7 +635,7 @@
                                 </span>
                             </div>
                             <!-- UML INHERITANCE ("Change to" - third option when hovering) -->
-                            <div class="UMLButton placementTypeBoxIcons" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
+                            <div class="UMLButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(5,1); setElementPlacementType(5); setMouseMode(2);' data-toolmode="UML_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_inheritance.svg" alt="UML inheritance"/>
                                 <span class="placementTypeToolTipText"><b>UML Inheritance</b><br>
                                     <p>Change to UML inheritance.</p>
@@ -646,7 +646,7 @@
                                 </span>
                             </div>
                             <!-- IE INHERITANCE ("Change to" - fourth option when hovering) -->
-                            <div class="IEButton placementTypeBoxIcons" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
+                            <div class="IEButton placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(7,1); setElementPlacementType(7); setMouseMode(2);' data-toolmode="IE_Inheritance" data-toolid="3">
                                 <img src="../Shared/icons/diagram_IE_inheritance.svg" alt="IE inheritance"/>
                                 <span class="placementTypeToolTipText"><b>IE Inheritance</b><br>
                                     <p>Change to IE inheritance</p>
@@ -660,7 +660,7 @@
                     </div>
                 </div>
                 <!-- LINE -->
-                <div id="mouseMode3" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='clearContext(); setMouseMode(3);' data-toolmode="Line" data-toolid="4">
+                <div id="mouseMode3" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick='clearContext(); setMouseMode(3);' data-toolmode="Line" data-toolid="4">
                     <img src="../Shared/icons/diagram_line.svg" alt="Line"/>
                     <span class="toolTipText"><b>Line</b><br>
                         <p>Make a line between elements.</p><br>
@@ -671,7 +671,7 @@
                 <!-- OPTIONS FOR STATE ELEMENTS START HERE -->
                 <div> 
                     <!-- UML INITIAL STATE (initial default choice) -->
-                    <div id="elementPlacement9" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(9); setMouseMode(2);' onmouseenter='hoverPlacementButton(9)' data-toolmode="UML_Initial_State" data-toolid="5"><!--<-- UML functionality -->
+                    <div id="elementPlacement9" class="SDButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(9); setMouseMode(2);' onmouseenter='hoverPlacementButton(9)' data-toolmode="UML_Initial_State" data-toolid="5"><!--<-- UML functionality -->
                         <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                         <span class="toolTipText"><b>UML initial state</b><br>
                             <p>Insert an initial state for UML.</p>
@@ -687,7 +687,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(9), hidePlacementType()'><!--Initial state -->
                         <div id="togglePlacementTypeBox9" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                                 <span class="placementTypeToolTipText"><b>UML initial state</b><br>
                                     <p>The initial state represents the start of a process.</p><br>
@@ -695,7 +695,7 @@
                                 </span>
                             </div>
                             <!-- FINAL STATE ("Change to" - second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                                 <span class="placementTypeToolTipText"><b>UML final state</b><br>
                                     <p>Change to UML final state</p>
@@ -704,7 +704,7 @@
                                 </span>
                             </div>
                             <!-- UML SUPER STATE ("Change to" - third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                                 <span class="placementTypeToolTipText"><b>UML super state</b><br>
                                     <p>Change to UML super state</p>
@@ -718,7 +718,7 @@
                 <!-- If UML FINAL STATE has been chosen, the entity-options change position in the menu-->
                 <div>
                 <!-- UML FINAL STATE (When chosen, takes up the "default position in the toolbar) -->
-                    <div id="elementPlacement10" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(10); setMouseMode(2);' onmouseenter='hoverPlacementButton(10)' data-toolmode="UML_Final_State" data-toolid="5">
+                    <div id="elementPlacement10" class="SDButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(10); setMouseMode(2);' onmouseenter='hoverPlacementButton(10)' data-toolmode="UML_Final_State" data-toolid="5">
                         <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                         <span class="toolTipText"><b>UML final state</b><br>
                             <p>Place a final state for UML.</p>
@@ -733,7 +733,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(10), hidePlacementType()'>
                         <div id="togglePlacementTypeBox10" class="togglePlacementTypeBox togglePlacementTypeBoxEntity"><!--<-- UML functionality start-->
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                                 <span class="placementTypeToolTipText"><b>UML initial state</b><br>
                                     <p>Change to UML initial state</p>
@@ -742,7 +742,7 @@
                                 </span>
                             </div>
                             <!-- FINAL STATE("Change to" - second option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                                 <span class="placementTypeToolTipText"><b>UML final state</b><br>
                                     <p>The final state represents where a process ends.</p><br>
@@ -750,7 +750,7 @@
                                 </span>
                             </div>
                             <!-- SUPER STATE ("Chaange to" - third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                                 <span class="placementTypeToolTipText"><b>UML super state</b><br>
                                     <p>Change to UML super state</p>
@@ -764,7 +764,7 @@
                 <!-- If UML SUPER STATE has been chosen, the entity-options change position in the menu  -->
                 <div>
                     <!-- UML SUPER STATE (When chosen, takes up the "default position in the toolbar)-->
-                    <div id="elementPlacement11" class="SDButton diagramIcons toolbarMode" onclick='setElementPlacementType(11); setMouseMode(2);' onmouseenter='hoverPlacementButton(11)' data-toolmode="UML_Super_State" data-toolid="5">
+                    <div id="elementPlacement11" class="SDButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(11); setMouseMode(2);' onmouseenter='hoverPlacementButton(11)' data-toolmode="UML_Super_State" data-toolid="5">
                         <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                         <span class="toolTipText"><b>UML super state</b><br>
                             <p>Create a super state.</p>
@@ -779,7 +779,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(11), hidePlacementType()'>
                         <div id="togglePlacementTypeBox11" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- UML INITIAL STATE ("Change to" - first option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(9,9); setElementPlacementType(9); setMouseMode(2);' data-toolmode="UML_Initial_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_initial_state.svg" alt="UML initial state"/>
                                 <span class="placementTypeToolTipText"><b>UML initial state</b><br>
                                     <p>Change to UML initial state</p>
@@ -788,7 +788,7 @@
                                 </span>
                             </div>
                             <!-- FINAL STATE ("Change to" - second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(10,9); setElementPlacementType(10); setMouseMode(2);' data-toolmode="UML_Final_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_UML_final_state.svg" alt="UML final state"/>
                                 <span class="placementTypeToolTipText"><b>UML final state</b><br>
                                     <p>Change to UML final state</p>
@@ -797,7 +797,7 @@
                                 </span>
                             </div>
                             <!-- SUPER STATE ("Change to" - third option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
+                            <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(11,9); setElementPlacementType(11); setMouseMode(2);' data-toolmode="UML_Super_State" data-toolid="5">
                                 <img src="../Shared/icons/diagram_super_state.svg" alt="UML super state"/>
                                 <span class="placementTypeToolTipText"><b>UML super state</b><br>
                                     <p>A state that can contain substates.</p><br>
@@ -811,7 +811,7 @@
                 <!-- SEQUENCE POP-OUT START-->
                 <div> 
                     <!-- SEQUENCE LIFELINE (initial default choice, and the same as the Sequence Lifeline (Actor)) -->
-                    <div id="elementPlacement12" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(12); setMouseMode(2);' onmouseenter='hoverPlacementButton(12)' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6">
+                    <div id="elementPlacement12" class="SEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(12); setMouseMode(2);' onmouseenter='hoverPlacementButton(12)' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6">
                         <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                         <span class="toolTipText"><b>Sequence lifeline</b><br>
                             <p>Creates a lifeline for a sequnece diagram.</p>
@@ -827,7 +827,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(12), hidePlacementType()'>
                         <div id="togglePlacementTypeBox12" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- SEQUENCE LIFELINE (ACTOR)(First option when hovering and the same as the initial option, as seen above this) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
+                            <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);'data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline object"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -836,7 +836,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -845,7 +845,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                                 <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                     <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
@@ -853,7 +853,7 @@
                                 </span>
                             </div>  
                             <!-- SEQUENCE OBJECT (Fourth option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                                 <span class="placementTypeToolTipText"><b>Sequence Object</b><br>
                                     <p>Option loop or alternative.</p><br>
@@ -865,7 +865,7 @@
                 </div>
                 <!-- If SEQUENCE LIFELINE OBJECT has been chosen, the the entity-options change position in the menu -->
                 <div> <!-- SEQUENCE LIFELINE OBJECT (When chosen, takes up the "default position in the toolbar) -->
-                    <div id="elementPlacement16" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(16); setMouseMode(2);' onmouseenter='hoverPlacementButton(16)' data-toolmode="Sequence_Lifeline_Object" data-toolid="6">
+                    <div id="elementPlacement16" class="SEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(16); setMouseMode(2);' onmouseenter='hoverPlacementButton(16)' data-toolmode="Sequence_Lifeline_Object" data-toolid="6">
                         <img src="../Shared/icons/diagram_sequence_object.svg" alt="Sequence activation"/>
                         <span class="toolTipText"><b>Sequence activation</b><br>
                             <p>Place an activation box.</p>
@@ -880,7 +880,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(16), hidePlacementType()'>
                         <div id="togglePlacementTypeBox16" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- SEQUENCE LIFELINE (ACTOR) (First option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -889,7 +889,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
+                            <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -898,7 +898,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                                 <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                     <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
@@ -906,7 +906,7 @@
                                 </span>
                             </div>  
                             <!-- SEQUENCE CONDITION (Fourth option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                                 <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                     <p>Option loop or alternative.</p><br>
@@ -918,7 +918,7 @@
                 </div> 
                 <!-- If SEQUENCE ACTIVATION START has been chosen, the element-options change position in menu -->
                 <div> <!-- SEQUENCE ACTIVATION START (When chosen, takes up the "default position in the toolbar) -->
-                    <div id="elementPlacement13" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(13); setMouseMode(2);' onmouseenter='hoverPlacementButton(13)' data-toolmode="Sequence_Activation" data-toolid="7">
+                    <div id="elementPlacement13" class="SEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(13); setMouseMode(2);' onmouseenter='hoverPlacementButton(13)' data-toolmode="Sequence_Activation" data-toolid="7">
                         <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                         <span class="toolTipText"><b>Sequence activation</b><br>
                             <p>Place an activation box.</p>
@@ -934,7 +934,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(13), hidePlacementType()'>
                         <div id="togglePlacementTypeBox13" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- SEQUENCE LIFELINE (First option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -943,7 +943,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                             <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -952,7 +952,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE ACTIVATION (Third option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
+                            <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                                 <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                     <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
@@ -960,7 +960,7 @@
                                 </span>
                             </div>    
                             <!-- SEQUENCE CONDITION (Fourth option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                                 <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                     <p>Option loop or alternative.</p><br>
@@ -972,7 +972,7 @@
                 </div> 
                 <!-- If SEQUENCE CONDITION/LOOP has been chosen, the element-options change position in the menu -->
                 <div> <!-- SEQUENCE CONDITION/LOOP START (When chosen, takes up the "default position in the toolbar) -->
-                    <div id="elementPlacement14" class="SEButton diagramIcons toolbarMode" onclick='setElementPlacementType(14); setMouseMode(2); ' onmouseenter='hoverPlacementButton(14)' data-toolmode="Sequence_Condition" data-toolid="8">
+                    <div id="elementPlacement14" class="SEButton diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(14); setMouseMode(2); ' onmouseenter='hoverPlacementButton(14)' data-toolmode="Sequence_Condition" data-toolid="8">
                         <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                             <span class="toolTipText"><b>Sequence Condition</b><br>
                                 <p>Add an option loop or alternative.</p><br>
@@ -986,7 +986,7 @@
                     <div id="diagramPopOut" onmouseleave='hoverPlacementButton(14), hidePlacementType()'>
                         <div id="togglePlacementTypeBox14" class="togglePlacementTypeBox togglePlacementTypeBoxEntity">
                             <!-- SEQUENCE LIFELINE (ACTOR) (First option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(12,12); setElementPlacementType(12); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Actor" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_lifeline.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (actor)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -995,7 +995,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE LIFELINE (OBJECT) (Second option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(16,12); setElementPlacementType(16); setMouseMode(2);' data-toolmode="Sequence_Lifeline_Object" data-toolid="6"> 
                                 <img src="../Shared/icons/diagram_sequence_object.svg" alt="sequnece diagram lifeline"/>
                                 <span class="placementTypeToolTipText"><b>Sequence lifeline (object)</b><br>
                                     <p>Represents the passage of time.</p>
@@ -1004,7 +1004,7 @@
                                 </span>
                             </div>
                             <!-- SEQUENCE ACIVATION (Third option when hovering) -->
-                            <div class="placementTypeBoxIcons" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
+                            <div class="placementTypeBoxIcons tooltip-target" onclick='togglePlacementType(13,12); setElementPlacementType(13); setMouseMode(2);' data-toolmode="Sequence_Activation" data-toolid="7"> 
                                 <img src="../Shared/icons/diagram_activation.svg" alt="Sequence activation"/>
                                 <span class="placementTypeToolTipText"><b>Sequence activation</b><br>
                                     <p>Represents that an object is active during an interaction, with the length indicating the duration.</p><br>
@@ -1012,7 +1012,7 @@
                                 </span>
                             </div>  
                             <!-- EQUENCE CONDITION (Fourth option when hovering) -->
-                            <div class="placementTypeBoxIcons activePlacementType" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
+                            <div class="placementTypeBoxIcons activePlacementType tooltip-target" onclick='togglePlacementType(14,12); setElementPlacementType(14); setMouseMode(2);' data-toolmode="Sequence_Condition" data-toolid="8"> 
                                 <img src="../Shared/icons/diagram_optionLoop.svg" alt="Option loop"/>
                                 <span class="placementTypeToolTipText"><b>Sequence Condition</b><br>
                                     <p>Option loop or alternative.</p><br>
@@ -1025,7 +1025,7 @@
                 <!-- SEQUENCE POP-OUT END -->
                 
                 <!-- NOTE ELEMENT -->
-                <div id="elementPlacement15" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode" onclick='setElementPlacementType(15); setMouseMode(2);' data-toolmode="Note" data-toolid="9">
+                <div id="elementPlacement15" onmouseenter='hidePlacementType()' data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick='setElementPlacementType(15); setMouseMode(2);' data-toolmode="Note" data-toolid="9">
                     <img src="../Shared/icons/diagram_note.svg"/>
                     <span class="toolTipText"><b>Note</b><br>
                         <p>Creates a note.</p><br>
@@ -1038,7 +1038,7 @@
         <!-- CAMERA FIELD IN TOOLBAR -->
         <fieldset>
             <legend aria-hidden="true">Camera</legend>
-            <div id="camtoOrigo" data-single="true" class="diagramIcons" onclick="centerCamera();" data-toolmode="Camera" data-toolid="10">
+            <div id="camtoOrigo" data-single="true" class="diagramIcons tooltip-target" onclick="centerCamera();" data-toolmode="Camera" data-toolid="10">
                 <img src="../Shared/icons/fullscreen.svg" alt="Reset view">
                 <span class="toolTipText"><b>Reset view</b><br>
                     <p>Reset view to show all elements.</p><br>
@@ -1052,7 +1052,7 @@
         <fieldset>
             <legend aria-hidden="true">History</legend>
             <!-- RESET DIAGRAM -->
-            <div id="diagramReset" data-single="true" class="diagramIcons" onclick="resetDiagramAlert()" data-toolmode="Reset" data-toolid="11">
+            <div id="diagramReset" data-single="true" class="diagramIcons tooltip-target" onclick="resetDiagramAlert()" data-toolmode="Reset" data-toolid="11">
                 <img src="../Shared/icons/diagram_Refresh_Button.svg" alt="Reset diagram"/>
                 <span class="toolTipText"><b>Reset diagram</b><br>
                     <p>Reset diagram to default state.</p><br>
@@ -1060,7 +1060,7 @@
                 </span>
             </div>
             <!-- REDO -->
-            <div id="stepForwardToggle" data-single="true" class="diagramIcons" onclick="toggleStepForward()" data-toolmode="Redo" data-toolid="12">
+            <div id="stepForwardToggle" data-single="true" class="diagramIcons tooltip-target" onclick="toggleStepForward()" data-toolmode="Redo" data-toolid="12">
                 <img src="../Shared/icons/diagram_stepforward.svg" alt="Redo"/>
                 <span class="toolTipText"><b>Redo</b><br>
                     <p>Redo last change.</p><br>
@@ -1068,7 +1068,7 @@
                 </span>
             </div>
             <!-- UNDO -->
-            <div id="stepBackToggle" data-single="true" class="diagramIcons" onclick="toggleStepBack()" data-toolmode="Undo" data-toolid="13">
+            <div id="stepBackToggle" data-single="true" class="diagramIcons tooltip-target" onclick="toggleStepBack()" data-toolmode="Undo" data-toolid="13">
                 <img src="../Shared/icons/diagram_stepback.svg" alt="Undo"/>
                 <span class="toolTipText"><b>Undo</b><br>
                     <p>Undo last change.</p><br>
@@ -1076,7 +1076,7 @@
                 </span>
             </div>
             <!-- REPLAY MODE -->
-            <div id="replayToggle" data-single="true" class="diagramIcons" onclick="toggleReplay()" data-toolmode="Replay_Mode" data-toolid="14">
+            <div id="replayToggle" data-single="true" class="diagramIcons tooltip-target" onclick="toggleReplay()" data-toolmode="Replay_Mode" data-toolid="14">
                 <img src="../Shared/icons/diagram_replay.svg" alt="Enter replay mode"/>
                 <span class="toolTipText"><b>Enter replay mode</b><br>
                     <p>View history of changes made.</p><br>
@@ -1090,7 +1090,7 @@
         <!-- When an ER table is open, it allows user to edit properties in the options-panel -->
         <fieldset>
             <legend aria-hidden="true">ER-Table</legend>
-            <div id="erTableToggle" data-single="true" class="diagramIcons toolbarMode" onclick="toggleErTable()" data-toolmode="ER_Table" data-toolid="15">
+            <div id="erTableToggle" data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick="toggleErTable()" data-toolmode="ER_Table" data-toolid="15">
                 <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle ER-Table"/>
                 <span class="toolTipText"><b>Toggle ER-Table</b><br>
                     <p>Click to toggle ER-Table in options.</p><br>
@@ -1104,7 +1104,7 @@
         <!-- Allows user to see properties for a state diagram in the options-panel -->
         <fieldset>
             <legend aria-hidden="true">Testcase</legend>
-            <div id="testCaseToggle" data-single="true" class="diagramIcons toolbarMode" onclick="toggleTestCase()" data-toolmode="Testcase" data-toolid="16"> <!--add func here later-->
+            <div id="testCaseToggle" data-single="true" class="diagramIcons toolbarMode tooltip-target" onclick="toggleTestCase()" data-toolmode="Testcase" data-toolid="16"> <!--add func here later-->
                 <img src="../Shared/icons/diagram_ER_table_info.svg" alt="Toggle test-cases"/>
                 <span class="toolTipText"><b>Toggle test-cases</b><br>
                     <p>Click to toggle test-cases in options.</p><br>
@@ -1118,7 +1118,7 @@
         <!-- Toggle error-checking on/off -->
         <fieldset id = "errorCheckField">
         <legend aria-hidden="true">Check</legend>
-            <div id="errorCheckToggle" data-single="true" class="diagramIcons" onclick="toggleErrorCheck()" data-toolmode="Error_Check" data-toolid="17">
+            <div id="errorCheckToggle" data-single="true" class="diagramIcons tooltip-target" onclick="toggleErrorCheck()" data-toolmode="Error_Check" data-toolid="17">
                 <img src="../Shared/icons/diagram_errorCheck.svg" alt="Toggle error check"/>
                 <span class="toolTipText"><b>Toggle error check</b><br>
                     <p>Click to toggle error checking on/off.</p>
@@ -1133,7 +1133,7 @@
         <!-- SAVE FIELD IN TOOLBAR (SAVE CURRENT FILE) -->
         <fieldset id="localSaveField" class="disabledIcon">
             <legend aria-hidden="true">Save</legend>
-            <div id="localSave" class="diagramIcons" onclick="quickSaveDiagram()" data-toolmode="Save" data-toolid="18">
+            <div id="localSave" class="diagramIcons tooltip-target" onclick="quickSaveDiagram()" data-toolmode="Save" data-toolid="18">
                 <img src="../Shared/icons/diagram_save_icon.svg" alt="Save diagram"/>
                 <span class="toolTipText"><b>Save current diagram</b><br>
                     <p>Click to save current diagram.</p>
@@ -1148,7 +1148,7 @@
         <!-- SAVE AS FIELD IN TOOLBAR (SAVE CURRENT DIAGRAM TO FILE) -->
         <fieldset id="localSaveAsField" class="disabledIcon">
             <legend aria-hidden="true">Save As</legend>
-            <div id="localSaveAs" class="diagramIcons" onclick="showSavePopout()" data-toolmode="Save_As" data-toolid="19">
+            <div id="localSaveAs" class="diagramIcons tooltip-target" onclick="showSavePopout()" data-toolmode="Save_As" data-toolid="19">
                 <img src="../Shared/icons/diagram_save_as_icon.svg" alt="Save diagram as"/>
                 <span class="toolTipText"><b>Save current diagram to file</b><br>
                     <p>Click to save current diagram <br> to a specific file.</p>
@@ -1162,7 +1162,7 @@
         <!-- LOAD FIELD IN TOOLBAR -->
         <fieldset id="localLoadField">
             <legend aria-hidden="true">Load</legend>
-            <div id="localLoad" data-single="true" class="diagramIcons" onclick="showModal();" data-toolmode="Load" data-toolid="20">
+            <div id="localLoad" data-single="true" class="diagramIcons tooltip-target" onclick="showModal();" data-toolmode="Load" data-toolid="20">
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
                 <span class="toolTipText"><b>Load diagram</b><br>
                     <p>Click to load a diagram.</p>
@@ -1263,7 +1263,7 @@
             <text id ="zoom-message">1x</text>
         </div>
         <!-- ZOOM IN BUTTON -->
-        <div class="diagramZoomIcons" onclick='zoomin();' data-toolmode="Zoom_In" data-toolid="21">
+        <div class="diagramZoomIcons tooltip-target" onclick='zoomin();' data-toolmode="Zoom_In" data-toolid="21">
             <img src="../Shared/icons/diagram_zoomin.svg"/>
             <span class="zoomToolTipText">
                 <b>Zoom IN</b><br>
@@ -1272,7 +1272,7 @@
             </span>
         </div>
         <!-- ZOOM OUT BUTTON -->
-        <div class="diagramZoomIcons" onclick='zoomout();' data-toolmode="Zoom_Out" data-toolid="22">
+        <div class="diagramZoomIcons tooltip-target" onclick='zoomout();' data-toolmode="Zoom_Out" data-toolid="22">
             <img src="../Shared/icons/diagram_zoomout.svg"/>
             <span class="zoomToolTipText">
                 <b>Zoom OUT</b><br>
@@ -1281,7 +1281,7 @@
             </span>
         </div>
         <!-- RESET ZOOM BUTTON -->
-        <div class="diagramZoomIcons" onclick="zoomreset()" data-toolmode="Zoom_Reset" data-toolid="23">
+        <div class="diagramZoomIcons tooltip-target" onclick="zoomreset()" data-toolmode="Zoom_Reset" data-toolid="23">
             <img src="../Shared/icons/diagram_zoomratio1to1.svg"/>
             <span class="zoomToolTipText">
                 <b>Zoom RESET</b><br>
@@ -1294,7 +1294,7 @@
     <!-- OPTIONS PANE -->
     <!-- Yellow panel on the right side of the screen -->
     <div id="options-pane" class="hide-options-pane"> 
-        <div id="options-pane-button" onclick="toggleOptionsPane();" data-toolmode="Option_Panel" data-toolid="24">
+        <div id="options-pane-button" class="tooltip-target" onclick="toggleOptionsPane();" data-toolmode="Option_Panel" data-toolid="24">
             <span id='optmarker'>&#9660;Options</span>
             <span id="tooltip-OPTIONS" class="toolTipText"><b>Show Option Panel</b><br>
                 <p>Enable/disable the Option Panel</p><br>
@@ -1359,20 +1359,20 @@
             <!-- PLAY/REPLAY/EXIT FIELD -->
             <fieldset style="display: flex; justify-content: space-between">
                 <div id="diagram-replay-switch">
-                    <div class="diagramIcons" onclick="stateMachine.replay()" data-toolmode="Replay_Play">
+                    <div class="diagramIcons tooltip-target" onclick="stateMachine.replay()" data-toolmode="Replay_Play">
                         <img src="../Shared/icons/Play.svg" alt="Play">
                         <span class="toolTipText" style="top: -80px"><b>Play</b><br>
                             <p>Play history of changes made to the diagram</p><br>
                         </span>
                     </div>
                 </div>
-                <div class="diagramIcons" onclick="stateMachine.replay(-1)" data-toolmode="Replay">
+                <div class="diagramIcons tooltip-target" onclick="stateMachine.replay(-1)" data-toolmode="Replay">
                     <img src="../Shared/icons/replay.svg" alt="Replay">
                     <span class="toolTipText" style="top: -80px"><b>Replay</b><br>
                         <p>Replay history of changes made to the diagram</p><br>
                     </span>
                 </div>
-                <div class="diagramIcons" onclick="exitReplayMode()" data-toolmode="Replay_Exit" data-toolid="25">
+                <div class="diagramIcons tooltip-target" onclick="exitReplayMode()" data-toolmode="Replay_Exit" data-toolid="25">
                     <img src="../Shared/icons/exit.svg" alt="Exit">
                     <span class="toolTipText" style="top: -95px"><b>Exit</b><br>
                         <p>Exit the replay-mode</p><br>

--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -457,3 +457,36 @@ const backgroundElement = [
  * @type {number}
  */
 const maxDeltaBeforeExceeded = 2;
+
+/**
+ * Array that contains the necessary ID:s that is going to be used when you want to create the text for which keybind is used for that element in the tooltip (e.g. tooltip-"POINTER"). 
+ * "data-toolid", stores these indexes 
+ */
+const tooltipID = [
+    "POINTER", //0
+    "BOX_SELECTION", //1
+    "PLACE_ENTITY", //2
+    "PLACE_RELATION", //3
+    "EDGE_CREATION", //4
+    "STATE_INITIAL", //5
+    "SQ_LIFELINE", //6
+    "STATE_SEQUENCE", //7
+    "SEQUENCE_OBJECT", //8
+    "NOTE_ENTITY", //9
+    "CENTER_CAMERA", //10
+    "RESET_DIAGRAM", //11
+    "HISTORY_STEPFORWARD", //12
+    "HISTORY_STEPBACK", //13
+    "TOGGLE_REPLAY_MODE", //14
+    "TOGGLE_ER_TABLE", //15
+    "TOGGLE_TEST_CASE", //16
+    "TOGGLE_ERROR_CHECK", //17
+    "SAVE_DIAGRAM", //18
+    "SAVE_DIAGRAM_AS", //19
+    "LOAD_DIAGRAM", //20
+    "ZOOM_IN", //21
+    "ZOOM_OUT", //22
+    "ZOOM_RESET", //23
+    "OPTIONS", //24
+    "ESCAPE" //25
+];

--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -310,11 +310,7 @@ function togglePlacementTypeBox(num) {
         }
         document.getElementById("togglePlacementTypeButton" + num).classList.add("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox" + num).classList.add("activeTogglePlacementTypeBox");
-        document.getElementById("elementPlacement" + num).children.item(1).classList.remove("toolTipText");
-        document.getElementById("elementPlacement" + num).children.item(1).classList.add("hiddenToolTiptext");
     } else {
-        document.getElementById("elementPlacement" + num).children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement" + num).children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton" + num).classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox" + num).classList.remove("activeTogglePlacementTypeBox");
     }
@@ -328,85 +324,55 @@ function togglePlacementTypeBox(num) {
 function togglePlacementType(num, type) {
     if (type == 0) {
         document.getElementById("elementPlacement0").classList.add("hiddenPlacementType");// ER entity start
-        document.getElementById("elementPlacement0").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement0").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton0").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox0").classList.remove("activeTogglePlacementTypeBox");// ER entity end
         document.getElementById("elementPlacement4").classList.add("hiddenPlacementType");// UML entity start
-        document.getElementById("elementPlacement4").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement4").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton4").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox4").classList.remove("activeTogglePlacementTypeBox");// UML entity end
         document.getElementById("elementPlacement6").classList.add("hiddenPlacementType");// IE entity start
-        document.getElementById("elementPlacement6").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement6").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton6").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox6").classList.remove("activeTogglePlacementTypeBox");// IE entity end
         document.getElementById("elementPlacement8").classList.add("hiddenPlacementType");// SD state start
-        document.getElementById("elementPlacement8").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement8").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton8").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox8").classList.remove("activeTogglePlacementTypeBox");// SD state end
     } else if (type == 1) {
         document.getElementById("elementPlacement1").classList.add("hiddenPlacementType");// ER relation start
-        document.getElementById("elementPlacement1").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement1").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton1").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox1").classList.remove("activeTogglePlacementTypeBox");// ER relation end
         document.getElementById("elementPlacement5").classList.add("hiddenPlacementType"); // UML inheritance start
-        document.getElementById("elementPlacement5").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement5").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton5").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox5").classList.remove("activeTogglePlacementTypeBox");// UML inheritance end
         document.getElementById("elementPlacement7").classList.add("hiddenPlacementType"); //IE inheritance start
-        document.getElementById("elementPlacement7").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement7").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton7").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox7").classList.remove("activeTogglePlacementTypeBox"); // IE inheritance end
         document.getElementById("elementPlacement2").classList.add("hiddenPlacementType"); // ER ATTR START
-        document.getElementById("elementPlacement2").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement2").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton2").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox2").classList.remove("activeTogglePlacementTypeBox"); // ER ATTR END
     } else if (type == 9) {
         document.getElementById("elementPlacement9").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement9").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement9").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton9").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox9").classList.remove("activeTogglePlacementTypeBox");
         document.getElementById("elementPlacement10").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement10").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement10").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton10").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox10").classList.remove("activeTogglePlacementTypeBox");
         document.getElementById("elementPlacement11").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement11").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement11").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton11").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox11").classList.remove("activeTogglePlacementTypeBox");
     } else if (type == 12) {
         // Sequence lifeline (actor)
         document.getElementById("elementPlacement12").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement12").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement12").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton12").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox12").classList.remove("activeTogglePlacementTypeBox");
         // Sequence activation
         document.getElementById("elementPlacement13").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement13").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement13").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton13").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox13").classList.remove("activeTogglePlacementTypeBox");
         // Sequence condition/loop object
         document.getElementById("elementPlacement14").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement14").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement14").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton14").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox14").classList.remove("activeTogglePlacementTypeBox");
         // Sequence lifeline (object)
         document.getElementById("elementPlacement16").classList.add("hiddenPlacementType");
-        document.getElementById("elementPlacement16").children.item(1).classList.add("toolTipText");
-        document.getElementById("elementPlacement16").children.item(1).classList.remove("hiddenToolTiptext");
         document.getElementById("togglePlacementTypeButton16").classList.remove("activeTogglePlacementTypeButton");
         document.getElementById("togglePlacementTypeBox16").classList.remove("activeTogglePlacementTypeBox");
 

--- a/DuggaSys/diagram/tooltip_information.js
+++ b/DuggaSys/diagram/tooltip_information.js
@@ -1,3 +1,6 @@
+/**
+ * This is an object of object that is used to store information about the element in the tooltips.
+ */
 const tooltips = {
     "Pointer":{
         header: "Pointer",
@@ -79,7 +82,7 @@ const tooltips = {
         header: "Reset View",
         description: "Reset view to show all elements."
     },
-    "History":{
+    "Reset":{
         header: "Reset Diagram",
         description: "Reset diagram to default state."
     },

--- a/DuggaSys/diagram/tooltip_information.js
+++ b/DuggaSys/diagram/tooltip_information.js
@@ -1,0 +1,150 @@
+const tooltips = {
+    "Pointer":{
+        header: "Pointer",
+        description: "Allows you to select and move different elements as well as navigate the workspace."
+    },
+    "Box_Selection": {
+        header: "Box Selection",
+        description: "Click and drag to select multiple elements within the selected area."
+    },
+    "ER_Entity":{
+        header: "ER Entity",
+        description: "Insert an ER entity to the diagram. Each entity represents an object which is a representation of concepts or data. The entity only holds the name of the object and if it depends on another object."
+    },
+    "UML_Class":{
+        header: "UML Class",
+        description: "Create a UML class to the diagram. Each class entity represents its own class along with the attributes and operations held within the class."
+    },
+    "IE_Entity":{
+        header: "IE Entity",
+        description: "Place an IE entity into the diagram. Each entity represents an object along with its attributes. Each entity is represented by a table with a field that shows attributes."
+    },
+    "SD_State":{
+        header: "State diagram State",
+        description: "Add a state diagram state to the diagram. A state diagram state is a representation of a status a process can have. Each state represents a unique status that a process can have."
+    },
+    "ER_Relation":{
+        header: "ER Relation",
+        description: "Place an ER relation into the diagram. Represents how entities are associated with each other."
+    },
+    "ER_Attribute":{
+        header: "ER Attribute",
+        description: "Add a ER attribute to the diagram. Each attribute represents different characteristics of an entity."
+    },
+    "UML_Inheritance":{
+        header: "UML Inheritance",
+        description: "Insert a UML inheritance to the diagram. A relation between a superclass and subclasses. The subclasses acquire all the properties and behaviors from the superclass."
+    },
+    "IE_Inheritance":{
+        header: "IE Inheritance",
+        description: "Create an IE inheritance to the diagram. A relation between two or more entities. The subclasses acquire all the properties and behaviors from the superclass."
+    },
+    "Line":{
+        header: "Line",
+        description: "Make a line between elements."
+    },
+    "UML_Initial_State":{
+        header: "UML Initial State",
+        description: "Insert an initial state for UML. The initial state represents the start of a process."
+    },
+    "UML_Final_State":{
+        header: "UML Final State",
+        description: "Place a final state for UML. The final state represents where a process ends."
+    },
+    "UML_Super_State":{
+        header: "UML Super State",
+        description:"Create a super state. A state that can contain substates."
+    },
+    "Sequence_Lifeline_Actor":{
+        header: "Sequence lifeline (Actor)",
+        description: "Creates a lifeline for a sequnece diagram. Represents the passage of time. This version is used for human users, external hardware or other subjects. "
+    },
+    "Sequence_Lifeline_Object":{
+        header: "Sequence Lifeline (Object)",
+        description: "Represents the passage of time. Shows events that occur to an object during the process."
+    },
+    "Sequence_Activation":{
+        header: "Sequence Activation",
+        description: "Place an activation box. Represents that an object is active during an interaction, with the length indicating the duration."
+    },
+    "Sequence_Condition":{
+        header: "Sequence Condition",
+        description: "Add an option loop or alternative."
+    },
+    "Note":{
+        header: "Note",
+        description: "Creates a note."
+    },
+    "Camera":{
+        header: "Reset View",
+        description: "Reset view to show all elements."
+    },
+    "History":{
+        header: "Reset Diagram",
+        description: "Reset diagram to default state."
+    },
+    "Redo":{
+        header: "Redo",
+        description: "Redo last change."
+    },
+    "Undo":{
+        header: "Undo",
+        description: "Undo last change."
+    },
+    "Replay_Mode":{
+        header: "Enter Replay Mode",
+        description: "View history of changes made."
+    },
+    "ER_Table":{
+        header: "Toggle ER-Table",
+        description: "Click to toggle ER-Table in options."
+    },
+    "Testcase":{
+        header: "Toggle Test-Cases",
+        description: "Click to toggle test-cases in options."
+    },
+    "Error_Check":{
+        header: "Toggle Error Check",
+        description: "Click to toggle error checking on/off. Highlights errors inside a diagram."
+    },
+    "Save":{
+        header: "Save Current Diagram",
+        description: "Click to save current diagram. (Saves diagram to the last saved file. If no file has been saved to yet, it prompts to create new one)."
+    },
+    "Save_As":{
+        header: "Save Current Diagram To File",
+        description: "Click to save current diagram to a specific file."
+    },
+    "Load":{
+        header: "Load diagram",
+        description: "Click to load a diagram."
+    },
+    "Zoom_In":{
+        header: "Zoom In",
+        description: "Zoom in on viewed area. "
+    },
+    "Zoom_Out":{
+        header: "Zoom Out",
+        description: "Zoom out on viewed area. "
+    },
+    "Zoom_Reset":{
+        header: "Zoom Reset",
+        description: "Reset the zoom to 1x."
+    },
+    "Option_Panel":{
+        header: "Show Option Panel",
+        description: "Enable/disable the Option Panel."
+    },
+    "Replay_Play":{
+        header: "Play",
+        description: "Play history of changes made to the diagram."
+    },
+    "Replay":{
+        header:"Replay",
+        description: "Replay history of changes made to the diagram."
+    },
+    "Replay_Exit":{
+        header: "Exit",
+        description: "Exit the replay-mode. "
+    }
+};


### PR DESCRIPTION
My solution consists of having only one element used to contain information about the elements and act as a tooltip. When the user hovers on an element the tooltip's position is calculated based on where the hovered element are. For example the tooltips associated with the options panel gets a different position in contrast to tooltips on the toolbar. The tooltips information gets filled based on the hovered element. if the pointer element is being hovered then the tooltip gets filled with information about the pointer from the file that contains all information about the elements (tooltip_information.js). 

With this i have removed every old tooltip that existed for every element, this reduces the code especially for the toolbar. 

I think i have found a great refactoring solution to the tooltips #17486
