### PR TITLE
Fixed G1-2025-v7-#17553-examine-options.js

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -282,7 +282,7 @@ function drawElementProperties(element) {
  * @param {Object} object What types of value the element have.
  * @return Returns a dropdown menu.
  */
-function option(object, icon) {
+function lineOption(object, icon) {
     let result = '';
     Object.values(object).forEach(i => {
         let selected = (i == icon) ? 'selected' : '';
@@ -371,13 +371,13 @@ function drawLineProperties(line) {
             break;
         case entityType.SD:
             if (!connectedToInitialOrFinal) {
-                let optSD = option(SDLineType, line.innerType);
+                let optSD = lineOption(SDLineType, line.innerType);
                 str += includeLabel(line);
                 str += iconSelection([SDLineIcons], line);
                 str += `<label style="display: block;">Line Type:</label>`;
                 str += selectLineIcons('lineType', optSD, false);
             } else {
-                let optSD = option(SDLineType, line.innerType);
+                let optSD = lineOption(SDLineType, line.innerType);
                 str += includeLabel(line);
                 str += `<label style="display: block;">Line Type:</label>`;
                 str += selectLineIcons('lineType', optSD, false);
@@ -411,10 +411,10 @@ function iconSelection(arr, line) {
     let sOptions = '';
     let eOptions = '';
     arr.forEach(object => {
-        sOptions += option(object, line.startIcon)
+        sOptions += lineOption(object, line.startIcon)
     });
     arr.forEach(object => {
-        eOptions += option(object, line.endIcon)
+        eOptions += lineOption(object, line.endIcon)
     });
     return `<label style="display: block;">Icons:</label>`
         + selectLineIcons('lineStartIcon', sOptions)

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -318,7 +318,7 @@ function lineMode(line, arr) {
  * @param {boolean} inclChange True if the function "changeLineProperties" should be called.
  * @return Returns a dropdown menu with the options as selectable items.
  */
-function select(id, options, inclNone = true, inclChange = true) {
+function selectLineIcons(id, options, inclNone = true, inclChange = true) {
     let none = (inclNone) ? `<option value=''>None</option>` : '';
     let change = (inclChange) ? `onChange="changeLineProperties();"` : '';
     return `<select id='${id}' ${change}>
@@ -356,7 +356,7 @@ function drawLineProperties(line) {
                 let selected = (line.cardinality == cardinality) ? 'selected' : '';
                 optER += `<option value='${cardinality}' ${selected}>${lineCardinalitys[cardinality]}</option>`;
             });
-            str += select('propertyCardinality', optER, true, false);
+            str += selectLineIcons('propertyCardinality', optER, true, false);
             str += `</label>`;
             break;
         case entityType.UML:
@@ -375,12 +375,12 @@ function drawLineProperties(line) {
                 str += includeLabel(line);
                 str += iconSelection([SDLineIcons], line);
                 str += `<label style="display: block;">Line Type:</label>`;
-                str += select('lineType', optSD, false);
+                str += selectLineIcons('lineType', optSD, false);
             } else {
                 let optSD = option(SDLineType, line.innerType);
                 str += includeLabel(line);
                 str += `<label style="display: block;">Line Type:</label>`;
-                str += select('lineType', optSD, false);
+                str += selectLineIcons('lineType', optSD, false);
             }
             break;
         case entityType.SE:
@@ -417,8 +417,8 @@ function iconSelection(arr, line) {
         eOptions += option(object, line.endIcon)
     });
     return `<label style="display: block;">Icons:</label>`
-        + select('lineStartIcon', sOptions)
-        + select('lineEndIcon', eOptions);
+        + selectLineIcons('lineStartIcon', sOptions)
+        + selectLineIcons('lineEndIcon', eOptions);
 }
 
 /**

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -298,7 +298,7 @@ function option(object, icon) {
  * @return Returns a header for the radio menu and returns the radio menu with the different options.
  */
 
-function radio(line, arr) {
+function lineMode(line, arr) {
     let result = "";
         result = `<h3 style="margin-bottom: 0; margin-top: 5px;">Kinds</h3>`;
         arr.forEach(lineKind => {
@@ -349,7 +349,7 @@ function drawLineProperties(line) {
 
     switch (line.type) {
         case entityType.ER:
-            str += radio(line, [lineKind.NORMAL, lineKind.DOUBLE]);
+            str += lineMode(line, [lineKind.NORMAL, lineKind.DOUBLE]);
             str += `<label style="display: block;">Cardinality:`;
             let optER;
             Object.keys(lineCardinalitys).forEach(cardinality => {
@@ -360,13 +360,13 @@ function drawLineProperties(line) {
             str += `</label>`;
             break;
         case entityType.UML:
-            str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);
+            str += lineMode(line, [lineKind.NORMAL, lineKind.DASHED]);
             str += includeLabel(line);
             str += cardinalityLabels(line);
             str += iconSelection([UMLLineIcons, IELineIcons], line);
             break;
         case entityType.IE:
-            str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);
+            str += lineMode(line, [lineKind.NORMAL, lineKind.DASHED]);
             str += iconSelection([UMLLineIcons, IELineIcons], line);
             break;
         case entityType.SD:
@@ -393,7 +393,7 @@ function drawLineProperties(line) {
             }
 
             str += includeSELabel(line);
-            str += radio(line, [lineKind.NORMAL, lineKind.DASHED]);
+            str += lineMode(line, [lineKind.NORMAL, lineKind.DASHED]);
             str += iconSelection([SELineIcons], line);
             break;
     }


### PR DESCRIPTION
As requested, I changed some functionnames, like "radio()" "select()" and "option()". I did not change the name of the function "lineLabel" becuase it had preferences to other files and my opinion is that it's unnecessary to do all that work for that function.

"setLineLabel()" sets the lines label to "< < include > >" via the include-button on the picture below so I left that function as it is.

<img width="158" alt="image" src="https://github.com/user-attachments/assets/c143d5f2-70f5-4ee1-8d37-f36b84e286c3" />
