### PR TITLE
added media query check for fab button margin

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8000,6 +8000,7 @@ only screen and (max-device-width: 568px) {
     transform: rotate(90deg);
     transform-origin: top left;
   }
+  
 
   .fab-btn-list2 li {
     transform: rotate(225deg);
@@ -8362,6 +8363,9 @@ only screen and (max-device-width: 568px) {
 @media only screen and (max-width: 601px) {
   .fileView{
     width: 75%;
+  }
+  .fixed-action-button.extra-margin{
+    right:20px;
   }
 
 


### PR DESCRIPTION
**Rebased PR**
Previously the fab button had an extensive right margin causing it to almost become centered on smaller width resolutions. This has been adjusted for smaller devices to have a more subtle margin.

Previously
![image](https://media.discordapp.net/attachments/1358723894244282409/1367075165975871539/chrome_hOnfeNatNF.gif?ex=682709f6&is=6825b876&hm=e1dc02531a8a11d0e0130dd37fa2b7c6b21caef771e0a02c13d355b778726b60&=&width=1648&height=813)


Now
![image](https://github.com/user-attachments/assets/38bd1c0e-1c5a-4c3f-a159-843b67696114)

This solution however may not be the best, may be worth looking into making the fab movable by the user, as it may be in the way depending on what page you are on.