### PR TITLE
[#17561] Fixed IE relation getting cut of at max zoom

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -700,7 +700,7 @@ function drawElementIERelation(element, boxw, boxh, linew) {
         content += `<line x1="${boxw / 1.6}" y1="${boxw / 2.9}" x2="${boxw / 2.6}" y2="${boxw / 12.7}" stroke='black' />
                     <line x1="${boxw / 2.6}" y1="${boxw / 2.87}" x2="${boxw / 1.6}" y2="${boxw / 12.7}" stroke='black' />`;
     }
-    return drawSvg(boxw, boxh, content, `style='transform:rotate(180deg); stroke-width:${linew};'`);
+    return drawSvg(boxw, boxh, content, `style='transform:rotate(180deg); stroke-width:${linew}; display: block;'`);
 }
 
 /**


### PR DESCRIPTION
Fixed the issue where IE relation got cut of at max zoom. For some reason, only the IE relation had this problem while the other relations didn't.

_**Max zoom**_
![bild](https://github.com/user-attachments/assets/827394d1-576d-4e5c-a35c-ff96d69d13be)
