### PR TITLE
Fixed the too light hover

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -592,6 +592,8 @@ body {
 .oddScheduleColumn{
     fill:#242729;
 }
+
+
 /* Course schedule styling END */
 
 .DateColorInDarkMode{
@@ -1103,6 +1105,13 @@ input.submit-button-newitem:hover {
 
 .arrowComp, .arrowRight,#sectionList_arrowStatisticsClosed, #sectionList_arrowStatisticsOpen {
     filter: brightness(0) saturate(100%) invert(99%) sepia(24%) saturate(91%) hue-rotate(298deg) brightness(112%) contrast(83%);
+}
+
+#Sectionlistc{
+    .courseRow:hover {
+    background-color: var(--color-primary-hover);
+    cursor: pointer;
+  }
 }
 
 /*/ Diagram.html style /*/


### PR DESCRIPTION
Added a courseRow hover in blackTheme as there was none and therefor used the lightmode hover. It now looks much better and readable when youre hovering over a listitem in sectioned.php.

![image](https://github.com/user-attachments/assets/c14ad5ef-5f20-40bc-b0e6-a999ba5de459)
Hover now

![image](https://github.com/user-attachments/assets/e5d20ae2-cd8e-4e21-ba26-65c0d2d6bee7)
Hover before