### PR TITLE
Removed the button for announcements on mobile view for issue #17501

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -3051,19 +3051,6 @@ window.addEventListener("DOMContentLoaded", function () {
 
   });
   document.addEventListener("click", function (e) {
-    const target = e.target.closest("#announcementBurger");
-    if(target){
-      sessionStorage.removeItem("closeUpdateForm");
-      if(document.getElementById("announcementBoxOverlay").style.display==="none" ||
-      window.getComputedStyle(document.getElementById("announcementBoxOverlay")).display === "none"){
-        document.getElementById("announcementBoxOverlay").style.display="block";
-      }
-      else{
-        document.getElementById("announcementBoxOverlay").style.display="none";
-      }
-    }
-  });
-  document.addEventListener("click", function (e) {
     const target = e.target.closest(".createBtn");
     if(target){
       sessionStorage.setItem('closeUpdateForm', true);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6445,7 +6445,7 @@ only screen and (max-device-width: 568px) {
  
   #versionCogBurger, #versionPlusBurger, #editStudentBurger,
   #testsBTNBurger, #editFilesBurger, #courseIMGBurger,
-  #editCourseBurger, #announcementBurger, #refreshBurger{
+  #editCourseBurger, #refreshBurger{
     display: block;
   }
 
@@ -9588,7 +9588,7 @@ justify-content: center;
 @media only screen and (min-width: 861px) {
   #versionCogBurger, #versionPlusBurger, #editStudentBurger,
   #testsBTNBurger, #editFilesBurger, #courseIMGBurger,
-  #editCourseBurger, #announcementBurger, #refreshBurger{
+  #editCourseBurger, #refreshBurger{
     display: none;
   }
 

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -313,8 +313,7 @@
 
 							//Dropdown Menu For Teachers
 							echo "<div id='hamburgerBox'>";
-							echo "<div id='announcementBurger'><img alt='announcement icon'  class='burgerButt' src='../Shared/icons/new_announcement_iconShadow.svg'><p class='burgerHover'>Announcements</p></div>";
-
+							
 							echo "<div id='versionCogBurger' onclick=showEditVersion();><img alt='settings icon'  class='burgerButt' title='Edit the selected version'  src='../Shared/icons/CogwheelWhite.svg'><p  class='burgerHover'>Edit selected version</p></div>";
 
 							echo "<div id='versionPlusBurger' onclick='showCreateVersion();'><img alt='plus sign icon' value='New version' class='burgerButt' title='Create a new version of this course'  src='../Shared/icons/PlusS.svg'><p  class='burgerHover'>Create new courseversion</p></div>";


### PR DESCRIPTION
### Description
For mobile view, this PR removes the button for viewing announcements in the burger menu. Although I am unsure if the page displaying announcements is still accessible, it is probably outside the scope of this issue. This is what it looks like before/after changes:
### Before:
![image](https://github.com/user-attachments/assets/bf3d1e1b-2936-43d8-a2a0-349980fe2b6e)

## After:
![image](https://github.com/user-attachments/assets/843d33df-5cb1-480a-9b49-33a6509f7c65)

### Testing
For testing, simply navigate into any course, CTRL + SHIFT + I and enter mobile view. The previous "Announcements" button should not be visible anymore within the burger menu (three horizontal stripes) and presumably no related code should be remaining within the codebase.