### PR TITLE
Fixed "Send to Back" elements placed behind the canvas

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -1949,11 +1949,18 @@ function sendToBack(id) {
     const elem = data.find(e => e.id === id);
     if (!elem) return;
 
-    const minZ = Math.min(...data.map(e => e.z ?? 2));
-    elem.z = minZ - 1;
+    const sortedZ = data.map(e => e.z ?? 2).sort((a, b) => a - b);
+    const uniqueZ = [...new Set(sortedZ)];
+
+    // Only set to the current minimum minus one if it's not already at bottom
+    if ((elem.z ?? 2) <= uniqueZ[0]) return;
+
+    elem.z = uniqueZ[0] - 1;
 
     showdata(); // Redraw everything
 }
+
+
 
 
 


### PR DESCRIPTION
Elements should now not dissappear behind the canvas no matter how many times "Send to Back" button is pressed. This solution has been implemented by setting a cap to the minimum "z" in the "sendtoBack" function. These changes were made in options.js file. 