### PR TITLE
Fixed: Diagram-toolbar is not completely visible in showDugga

### DIFF
--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -7,7 +7,7 @@
     <style>
         .container {
             display: flex;
-            height: 50.1rem;
+            height: 100dvh;
             width: 100%;
             justify-content: space-between;
             position: relative;
@@ -28,7 +28,7 @@
         .assignment_left {
             background-color: #fffcfc;
             width: 300px;
-            height: 800px;
+            height: inherit;
             overflow: auto;
             margin-left: 0px;
             border: 1px solid #ccc;
@@ -40,12 +40,19 @@
             display: flex;
             justify-content: space-around;
             margin-left:0px;
+            height: inherit;
         }
         
         #assignment_discrb {
             visibility: visible;
             padding: 5px;
             padding-left: 25px;
+        }
+        #close_open_border{
+            height: 100dvh;
+        }
+        #diagram-iframe{
+            height: inherit;
         }
 
     </style>


### PR DESCRIPTION
The solution was to replace the containers height from 50.1rem to 100dvh and then have other elements inside it inherit that height. And the ifram inherits from .canvas_right and needed to explicit set the height of #close_open_border to 100dvh.  see figure 1. 

I fixed the issue #17639

figure 1 
![image](https://github.com/user-attachments/assets/64c7a1e6-cdf5-49cb-911b-cefc454e158c)
