### PR TITLE
SSL-generator #17644

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ gitErrorLog.txt
 log/gitErrorLog.txt
 DuggaSys/microservices/endpointDirectory/endpointDirectory_db.sqlite
 DuggaSys/microservices/endpointDirectory/newMDStructureTest.md
+
+*.key
+*.crt

--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -104,6 +104,7 @@
 								checkbox("Verbose", "Verbose", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#verbose");
 								checkboxWithWarning("overwrite_db", "Overwrite existing database", "WARNING! Overwriting databases and users cannot be undone!", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#overwrite-existing-database-and-user-names");
 								checkbox("overwrite_user", "Overwrite existing user");
+								checkbox("overwrite_user", "testbutton");
 							?>
 						</div>
 					</div>

--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -104,7 +104,6 @@
 								checkbox("Verbose", "Verbose", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#verbose");
 								checkboxWithWarning("overwrite_db", "Overwrite existing database", "WARNING! Overwriting databases and users cannot be undone!", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#overwrite-existing-database-and-user-names");
 								checkbox("overwrite_user", "Overwrite existing user");
-								checkbox("overwrite_user", "testbutton");
 							?>
 						</div>
 					</div>

--- a/newinstaller/tools/ssl/ssl_generator.php
+++ b/newinstaller/tools/ssl/ssl_generator.php
@@ -1,0 +1,44 @@
+<?php
+# create SSL for only local use( localhost )
+$hostname = "localhost";
+# a number is needed, so we pick:
+$validDays = 420;
+
+# generate a 2048 bit RSA private key
+$privateKey = openssl_pkey_new([
+	"private_key_bits" => 2048,
+	"private_key_type" => OPENSSL_KEYTYPE_RSA,
+]);
+
+# SSL keys requires some metadata, even though it is local
+$csr = openssl_csr_new([
+	"CN" => $hostname,
+	"O" => "dev",
+	"OU" => "dev",
+	"L" => "Locality",
+	"ST" => "State",
+	"C" => "SE",
+],$privateKey);
+
+# Sign the certificate!
+
+$certificate = openssl_csr_sign(
+	$csr,
+	null,
+	$privateKey,
+	$validDays,
+	["digest_alg" => "sha256"],
+);
+
+# export the key and certificate
+openssl_pkey_export($privateKey, $privateKeyOut);
+openssl_x509_export($certificate, $certificateOut);
+
+# write the output to files
+file_put_contents("localhost.key", $privateKeyOut);
+file_put_contents("localhost.crt", $certificateOut);
+
+
+
+
+


### PR DESCRIPTION
This is a SSL cert generator that generates localhost.key and localhost.crt.
These files will later be used for a tutorial that explains how to enable HTTPS on your local machine.
The .gitignore needs to be updated with _*.crt_ and _*.key_ since these files are supposed to be local, and not be pushed to remote.