### PR TITLE
[#17579] Fixed issue with app freezing after placing an UML Super State object

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -748,7 +748,7 @@ function drawElementSuperState(element, textWidth, boxw, boxh, linew) {
     let rectTwoWidth = Math.min(textWidth + 80 * zoomfact, boxw - 10);
 
     let rectOne = drawRect(boxw, boxh, linew, element, `fill='none' fill-opacity='0' rx='5'`);
-    let rectTwo = drawRect(rectTwoWidth, 50 * zoomfact, linew, element, `fill='${element.fill}' fill-opacity="1"`);
+    let rectTwo = drawRect(rectTwoWidth, 50 * zoomfact, linew, element, `fill='${element.fill}' fill-opacity="1" id="cornerLabel"`);
     // State name text inside header
     let text = drawText(20 * zoomfact, 30 * zoomfact, 'start', displayText, `font-size='${20 * zoomfact}px'`);
     
@@ -935,7 +935,7 @@ function drawElementSequenceLoopOrAlt(element, boxw, boxh, linew, texth) {
     }
     // SVG for the small label in top left corner
     content += `<path 
-                id="loopLabel"
+                id="cornerLabel"
                 d="M ${(7 * zoomfact) + linew},${linew}
                     h ${100 * zoomfact}
                     v ${25 * zoomfact}

--- a/DuggaSys/diagram/theme.js
+++ b/DuggaSys/diagram/theme.js
@@ -145,7 +145,7 @@ function updateCSSForAllElements() {
                         fillColor = elementDiv.querySelector("g > circle"); // Accessing the circular "head" element
                     }
                     else if (element.kind == elementTypesNames.sequenceLoopOrAlt || element.kind == elementTypesNames.UMLSuperState) {
-                        fillColor = elementDiv.querySelector("#loopLabel"); // Accessing the top left rectangle
+                        fillColor = elementDiv.querySelector("#cornerLabel"); // Accessing the top left rectangle
                     }
                     else {
                         fillColor = elementDiv.children[0].children[0]; // Accessing the whatever needs to be accessed


### PR DESCRIPTION
A recent change seems to have changed the way the _updateCSSForAllElements()_ function looked for elements in an entity that were supposed to be affected when changing the fill color of it. I assume this was related to the change where all selected objects now get a purple fill color. The sequence loop object and UML super state entity had the affected elements retrieved by finding the element with the ID "_loopLabel_". This ID had however not been added to the element in the UML super state object, so when the system tried to draw the super state entity the element to fill returned as null, which froze the app since the function for updating the CSS stopped working. 

The ID has now been added to the correct element in the super state object, in addition to changing the ID name from "_loopLabel_" to "_cornerLabel_" to better reflect both objects that use labels instead of just the loop object. The app should no longer freeze when placing out a super state object.

 
https://github.com/user-attachments/assets/524bf8bd-08f4-41e2-8a2e-f4e5abc467fe

