### PR TITLE
Problem with variants of elements (#17511 and #17575)

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1396,14 +1396,19 @@ function changeState() {
 
     //Get new state of element from dropdown menu in options pane, save change if the new state is different from the old one
     const newRelation = document.getElementById("propertySelect")?.value || undefined;
-    if (newRelation && oldRelation != newRelation) {
-        if (element.type == entityType.ER || element.type == entityType.UML || element.type == entityType.IE) {
-            if (element.kind != elementTypesNames.UMLEntity && element.kind != elementTypesNames.IERelation) {
-                stateMachine.save(context[0].id, StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
-                displayMessage(messageTypes.SUCCESS, "Sucessfully saved");
-            }
+
+    if (!newRelation | oldRelation === newRelation) return;
+
+    element.state = newRelation;
+
+    if (element.type == entityType.ER || element.type == entityType.UML || element.type == entityType.IE) {
+        if (element.kind != elementTypesNames.UMLEntity && element.kind != elementTypesNames.IERelation) {
+            stateMachine.save(element.id, StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
+            displayMessage(messageTypes.SUCCESS, "Successfully saved");
         }
     }
+    // Re-draw the canvas
+    showdata();
 }
 
 /**


### PR DESCRIPTION
The changeState()-function has been fixed so that it can handle a name-change or color-change before changing the "variant" (state) of an element (see issues #17511 and #17575). 
Now it handles any change to the selected elements state, and then redraws the canvas to display the change, making it possible to change name or color and then change the state.

This should affect any elements/entities that utilize the "Variant"-option in the options-panel.

https://github.com/user-attachments/assets/34c2083c-e8a3-4ea4-b7e9-87a39113dc2d