### PR TITLE
Fix undo/redo name issue #17185

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1216,7 +1216,7 @@ function mmoving(event) {
             }
 
             // Store the changes in the history
-            stateMachine.save(elementData.id, StateChange.ChangeTypes.ELEMENT_RESIZED);
+            if (!this.lastTypedTextMap) this.lastTypedTextMap = {}; (elementData.id, StateChange.ChangeTypes.ELEMENT_RESIZED);
 
             document.getElementById(context[0].id).remove();
             document.getElementById("container").innerHTML += drawElement(data[index]);

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -62,10 +62,15 @@ function generateContextProperties() {
         str += saveButton('toggleEntityLocked();', 'lockbtn', locked ? "Unlock" : "Lock");
     }
     propSet.innerHTML = str;
-    var inputs = propSet.querySelectorAll('input, textarea');
-    for (var i = 0; i < inputs.length; i++) {
-        inputs[i].addEventListener('input', function() {
-            saveProperties();
+    
+
+    // Add a blur event to handle undo/redo when the user finishes editing (i.e clicks away or presses Enter) for better undo/redo functionality.
+
+    const nameInput = propSet.querySelector('#elementProperty_name');
+    if (nameInput) {
+        nameInput.addEventListener('blur', () => {
+            const element = context[0];
+            stateMachine.save(element.id, StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
         });
     }
     multipleColorsTest();


### PR DESCRIPTION
Changed undo/redo behavior from character-by-character updates which felt unnatural, to using a blur event. Now when the user finishes input (e.g. clicks save or clicks away on the grid), pressing undo will remove the entire input (e.g. full name) instead of one character at a time. Redo behaves the same.