### PR TITLE
Changed to curlService in retrieveResultedService_ms #17416

### DIFF
--- a/DuggaSys/microservices/resultedService/getUserAnswer_ms.php
+++ b/DuggaSys/microservices/resultedService/getUserAnswer_ms.php
@@ -72,34 +72,14 @@ if(isSuperUser($userid) || hasAccess($userid, $cid, 'w')){
 
     	array_push($tableInfo, $tableSubmissionInfo);
 	}
-	/*
-    // Set up POST call to retrieveResultedService_ms.php
-    header("Content-Type: application/json");
-    $baseURL = "http://" . $_SERVER['HTTP_HOST'];  // use http when testing locally
-    $url = $baseURL . "/LenaSYS/DuggaSys/microservices/resultedService/retrieveResultedService_ms.php";
 
-    $ch = curl_init($url);
-
-    // cURL options
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_POST, true);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-        'tableInfo' => json_encode($tableInfo),
-        'duggaFilterOptions' => json_encode($duggaFilterOptions)
-    ]));
-
-    // Execute and get response
-    $response = curl_exec($ch);
-    curl_close($ch);
-	*/
 	//Use curlService to make HTTP POST call
 	 $postData = [
     'tableInfo' => json_encode($tableInfo),
     'duggaFilterOptions' => json_encode($duggaFilterOptions)
  	];
 	$response = callMicroservicePOST("resultedService/retrieveResultedService_ms.php", $postData, true );
-	$data = json_decode($response, true);
-
+	header("Content-Type: application/json");
     // Send the data to frontend
-    echo $data;
+    echo $response;
 }

--- a/DuggaSys/microservices/resultedService/getUserAnswer_ms.php
+++ b/DuggaSys/microservices/resultedService/getUserAnswer_ms.php
@@ -6,6 +6,7 @@ date_default_timezone_set("Europe/Stockholm");
 include_once "../../../Shared/basic.php";
 include_once "../../../Shared/sessions.php";
 include_once "../sharedMicroservices/getUid_ms.php";
+include_once "../curlService.php";
 
 
 // Connect to database and start session
@@ -71,7 +72,7 @@ if(isSuperUser($userid) || hasAccess($userid, $cid, 'w')){
 
     	array_push($tableInfo, $tableSubmissionInfo);
 	}
-
+	/*
     // Set up POST call to retrieveResultedService_ms.php
     header("Content-Type: application/json");
     $baseURL = "http://" . $_SERVER['HTTP_HOST'];  // use http when testing locally
@@ -90,7 +91,15 @@ if(isSuperUser($userid) || hasAccess($userid, $cid, 'w')){
     // Execute and get response
     $response = curl_exec($ch);
     curl_close($ch);
+	*/
+	//Use curlService to make HTTP POST call
+	 $postData = [
+    'tableInfo' => json_encode($tableInfo),
+    'duggaFilterOptions' => json_encode($duggaFilterOptions)
+ 	];
+	$response = callMicroservicePOST("resultedService/retrieveResultedService_ms.php", $postData, true );
+	$data = json_decode($response, true);
 
-    // Send the response to frontend
-    echo $response;
+    // Send the data to frontend
+    echo $data;
 }

--- a/DuggaSys/microservices/resultedService/retrieveResultedService_ms.php
+++ b/DuggaSys/microservices/resultedService/retrieveResultedService_ms.php
@@ -13,18 +13,9 @@ session_start();
 $tableInfo = [];
 $duggaFilterOptions = [];
 $data = recieveMicroservicePOST(['tableInfo', 'duggaFilterOptions']);
-$tableInfo = json_decode($data['tableInfo']);
-$duggaFilterOptions = json_decode($data['duggaFilterOptions']);
-/*
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (isset($_POST['tableInfo'])) {
-        $tableInfo = json_decode($_POST['tableInfo'], true);
-    }
-    if (isset($_POST['duggaFilterOptions'])) {
-        $duggaFilterOptions = json_decode($_POST['duggaFilterOptions'], true);
-    }
-}
-*/
+$tableInfo = json_decode($data['tableInfo'], true);
+$duggaFilterOptions = json_decode($data['duggaFilterOptions'], true);
+
 // Prepare return array
 $returnArray = array(
     'tableInfo' => $tableInfo,

--- a/DuggaSys/microservices/resultedService/retrieveResultedService_ms.php
+++ b/DuggaSys/microservices/resultedService/retrieveResultedService_ms.php
@@ -4,6 +4,7 @@ date_default_timezone_set("Europe/Stockholm");
 
 include_once "../../../Shared/basic.php";
 include_once "../../../Shared/sessions.php";
+include_once "../curlService.php";
 
 pdoConnect();
 session_start();

--- a/DuggaSys/microservices/resultedService/retrieveResultedService_ms.php
+++ b/DuggaSys/microservices/resultedService/retrieveResultedService_ms.php
@@ -12,7 +12,10 @@ session_start();
 // Receive data from POST
 $tableInfo = [];
 $duggaFilterOptions = [];
-
+$data = recieveMicroservicePOST(['tableInfo', 'duggaFilterOptions']);
+$tableInfo = json_decode($data['tableInfo']);
+$duggaFilterOptions = json_decode($data['duggaFilterOptions']);
+/*
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['tableInfo'])) {
         $tableInfo = json_decode($_POST['tableInfo'], true);
@@ -21,7 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $duggaFilterOptions = json_decode($_POST['duggaFilterOptions'], true);
     }
 }
-
+*/
 // Prepare return array
 $returnArray = array(
     'tableInfo' => $tableInfo,


### PR DESCRIPTION
Fixes #17416 . I've changed to curlService in retrieveResultedService_ms and its inverse dependency microservice getUserAnswer_ms. At the moment these files are not used and it's the old resultedservice.php being used when you go to "Edit student results". Also, retrieveResultedService_ms just sends the same data back to getUserAnswer_ms as it received. To test that the communication works between these two files I created a testfile to send real values from the database for "cid" and "coursevers" to getUserAnswer_ms. I had to comment out the "isSuperUser().." line of code and change "(kind=3)"  to "(kind=2)" in the query in getUserAnswer_ms, then I was able to get a response with data of the two arrays.