### PR TITLE
Display date of dugga in mobile-view

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1593,8 +1593,7 @@ function returnedSection(data) {
   var now = new Date();
   var startdate = new Date(retdata['startdate']);
   var enddate = new Date(retdata['enddate']);
-  let iconSize = window.innerWidth < 600 ? "18px" : "18px";
-  
+
   var numberOfParts = 0;
   for (var i = 0; i < retdata['entries'].length; i++) {
     var item = retdata['entries'][i];

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1951,7 +1951,8 @@ function returnedSection(data) {
 
         // Close Information
         str += " value='" + item['lid'] + "' onclick='duggaRowClick(this)' >";
-        // Content of Section Item
+
+        //=====CONTENT OF SECTION ITEM=====
         if (itemKind == 0) {
           // Header
           str += `<span style='margin-left:8px;' title='${item['entryname']}'>${item['entryname']}</span>`;
@@ -1998,6 +1999,11 @@ function returnedSection(data) {
 
           str += `<div class='ellipsis nowrap hide-on-mobile'><span>${makeanchor("showDugga.php", hideState,
             "", item['entryname'], false, param)}</span></div>`;
+
+          if (!(data['writeaccess'] || data['studentteacher'])) {
+            str += `<div class='ellipsis nowrap show-on-mobile'><span>${makeanchor("showDugga.php", hideState,
+              "", item['entryname'], false, param)}</span></div>`;
+          }
         } else if (itemKind == 5) {
           // Link
           if (item['link'] !== null && item['link'] !== undefined && item['link'].substring(0, 4) === "http") {

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1810,8 +1810,9 @@ function returnedSection(data) {
              comment: item['comments'],
              deadline: item['deadline'],
              'cid': querystring['courseid']
-          };
-          str += `<div style='display: flex; flex-direction: row; align-items: left; justify-content: space-between; width: 97%; margin-left: 5px;'>`;
+            };
+
+          str += `<div class='flex-row-container'>`;
 
           str += `<div class='ellipsis nowrap show-on-mobile'><span>${makeanchor("showDugga.php", hideState,
             "", item['entryname'], false, param)}</span></div>`;

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1593,7 +1593,8 @@ function returnedSection(data) {
   var now = new Date();
   var startdate = new Date(retdata['startdate']);
   var enddate = new Date(retdata['enddate']);
-
+  let iconSize = window.innerWidth < 600 ? "18px" : "18px";
+  
   var numberOfParts = 0;
   for (var i = 0; i < retdata['entries'].length; i++) {
     var item = retdata['entries'][i];
@@ -1784,9 +1785,13 @@ function returnedSection(data) {
 
           if (retdata['writeaccess']) {
             if (itemKind === 3) {
-              if (isLoggedIn) {
-                str += "<td class='LightBox" + hideState + "'>";
-                str += "<div class='dragbleArea'><img style='width: 53%; padding-left: 6px;padding-top: 5px;' title='Press and drag to arrange' alt='pen icon dugga' src='../Shared/icons/select.png'></div>";
+                if (isLoggedIn) {
+                    if (window.innerWidth < 600) {
+                        str += "<td class='LightBox" + hideState + "' style='position: relative; top: -11px;'>";
+                    } else {
+                        str += "<td class='LightBox" + hideState + "'>";
+                    }
+                  str += "<div class='dragbleArea'><img style='width: 53%; padding-left: 6px;padding-top: 5px;' title='Press and drag to arrange' alt='pen icon dugga' src='../Shared/icons/select.png'></div>";
               }
             } else if (itemKind === 4) {
               if (isLoggedIn) {
@@ -1797,6 +1802,38 @@ function returnedSection(data) {
             str += "</td>";
           }
         }
+            //==========MOBILE VIEW FOR TEST/DUGGA ITEMS===============
+          if (itemKind === 3 && (data['writeaccess'] || data['studentteacher'])) {             
+              var param = {
+                  'did': item['link'],
+                  'courseid': querystring['courseid'],
+                  'coursename': querystring['coursename'],
+                  'coursevers': querystring['coursevers'],
+                  'moment': item['lid'],
+                  'segment': momentexists,
+                  highscoremode: item['highscoremode'],
+                  comment: item['comments'],
+                  deadline: item['deadline'],
+                  'cid': querystring['courseid']
+              };
+              str += `<div style='display: flex; flex-direction: row; align-items: left; justify-content: space-between; width: 87%; margin-left: 34px;'>`;
+
+              str += `<div class='ellipsis nowrap show-on-mobile'><span>${makeanchor("showDugga.php", hideState,
+                  "", item['entryname'], false, param)}</span></div>`;
+             
+              if ((deadline !== null && deadline !== "undefined") && retdata['startdate'] !== null) {
+                  let formattedDeadline = convertDateToDeadline(new Date(deadline));
+                  let deadlineArr = formattedDeadline.split(" ");
+                  let deadlineText = deadlineArr[0];
+                  if (!/^[0:]+$/.test(deadlineArr[1])) {
+                      deadlineText += " " + deadlineArr[1].split(":")[0] + ":" + deadlineArr[1].split(":")[1];
+                  }
+                  str += `<div class='DateColorInDarkMode show-on-mobile' style='font-size: 0.8em; color: gray;'>${deadlineText}</div>`;
+              } else if (rDeadline !== null && rDeadline !== "undefined") {
+                  str += `<div class='DateColorInDarkMode  show-on-mobile' style='font-size: 0.8em; color: gray;'>${formatRelativeDeadlineToString(rDeadline)}</div>`;
+              }
+              str += `</div>`;
+          }
 
         if (retdata['writeaccess']) {
           if (itemKind === 2 || itemKind === 5 || itemKind === 6 || itemKind === 7) { // Draggable area with white background
@@ -1828,8 +1865,8 @@ function returnedSection(data) {
             str += addColorsToTabSections(itemKind, hideState, "E");
           } else if (itemGradesys == 7) {
             str += addColorsToTabSections(itemKind, hideState, "E");
-          }
         }
+          }
         // Collecting all the id:s from the different duggas on the page so that we can use the highest value to see the newest entry.
         collectedLid.push(item['lid']);
         // kind 0 == Header || 1 == Section || 2 == Code  || 3 == Test (Dugga)|| 4 == Moment || 5 == Link
@@ -1855,14 +1892,25 @@ function returnedSection(data) {
           kk++;
 
         } else if (itemKind === 3) {
-          if (retdata['writeaccess']) {
-            str += "<td class='LightBox" + hideState + "'>";
-            str += "<div ><img class='iconColorInDarkMode' alt='pen icon dugga' title='Quiz' src='../Shared/icons/PenT.svg'></div>";
-          }
+            if (retdata['writeaccess']) {
+                if (window.innerWidth < 600) {
+                    str += `<td class='LightBox${hideState}' style='width:${iconSize};'>`;
+
+                } else {
+                    str += "<td class='LightBox" + hideState + "'>";
+                } 
+                str += "<div ><img class='iconColorInDarkMode' alt='pen icon dugga' title='Quiz' src='../Shared/icons/PenT.svg'></div>";
+            }
+
 
           if (item['highscoremode'] != 0 && itemKind == 3) {
-            str += `<td style='width:20px;'><img class='iconColorInDarkMode' style=';' title='Highscore' src='../Shared/icons/top10.png'
-            onclick='showHighscore(\"${item['link']}\",\"${item['lid']}\")'/></td>`;
+              if (window.innerWidth < 600) {
+                 str += `<td style='width:${iconSize};'><img class='iconColorInDarkMode' style='width:${iconSize};'  title='Highscore' src='../Shared/icons/top10.png'
+                    onclick='showHighscore(\"${item['link']}\",\"${item['lid']}\")'/></td>`;
+              } else {
+                 str += `<td style='width:20px;'><img class='iconColorInDarkMode' style=';' title='Highscore' src='../Shared/icons/top10.png'
+                     onclick='showHighscore(\"${item['link']}\",\"${item['lid']}\")'/></td>`;
+              }
           }
           str += `<td class='example item${hideState}' placeholder='${momentexists}' id='I${item['lid']}' `;
           kk++;
@@ -1962,8 +2010,11 @@ function returnedSection(data) {
             deadline: item['deadline'],
             'cid': querystring['courseid']
           };
-          str += `<div class='ellipsis nowrap'><span>${makeanchor("showDugga.php", hideState,
-            "cursor:pointer;margin-left:8px;", item['entryname'], false, param)}</span></div>`;
+        
+          
+            str += `<div class='ellipsis nowrap hide-on-mobile'><span>${makeanchor("showDugga.php", hideState,
+                "", item['entryname'], false, param)}</span></div>`;
+
         } else if (itemKind == 5) {
           // Link
           if (item['link'] !== null && item['link'] !== undefined && item['link'].substring(0, 4) === "http") {
@@ -2002,9 +2053,9 @@ function returnedSection(data) {
 
         // If none of the deadlines are null or undefined we need to add it to the page
         if ((itemKind === 3) && ((deadline !== null || deadline !== "undefined") || (rDeadline !== null || rDeadline !== "undefined"))) {
-          // Both of them will need this html
-          str += "<td onclick='duggaRowClick(this)' class='dateSize' style='text-align:right;overflow:hidden;'>" +
-            "<div class='DateColorInDarkMode' style='white-space:nowrap;'>";
+            // Both of them will need this html
+            str += "<td onclick='duggaRowClick(this)' class='dateSize hide-on-mobile' style='text-align:right;overflow:hidden;'>" +
+                "<div class='DateColorInDarkMode' style='white-space:nowrap;'>";
 
           // We prioritize absolute deadline and we dont want absolute deadlines if there's no startdate for course
           if ((deadline !== null && deadline !== "undefined") && retdata['startdate'] !== null) {
@@ -2080,10 +2131,13 @@ function returnedSection(data) {
 
         // Userfeedback
         if (data['writeaccess'] && itemKind === 3 && item['feedbackenabled'] == 1) {
-          str += "<td style='width:32px;'>";
-          str += `<img id='dorf' src='../Shared/icons/FistV.svg' title='Feedback'
-          onclick='showUserFeedBack(\"${item['lid']}\",\"${item['feedbackquestion']}\");'>`;
-          str += "</td>";
+            if (window.innerWidth < 600) {
+                str += `<td style='width:${iconSize};'>`;
+            } else {
+                str += `<td style='width:32px;'>`;
+            }
+              str += `<img id='dorf' src='../Shared/icons/FistV.svg' title='Feedback' onclick='showUserFeedBack("${item['lid']}","${item['feedbackquestion']}");'>`;
+                str += `</td>`;
         }
 
         // Testing implementation
@@ -2097,32 +2151,48 @@ function returnedSection(data) {
           str += "</td>";
         }
         // Tab example button
-        if ((itemKind !== 4) && (itemKind !== 0) && (data['writeaccess'] || data['studentteacher'])) {
-          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<input style='filter: invert (1); border:none; background:transparent;' type='button' style='border:none; background:transparent;' value='&#8633' id='tabElement'
-            title='Tab example button' onclick='confirmBox("openTabConfirmBox",this);'>`
-          str += "</td>";
+          if ((itemKind !== 4) && (itemKind !== 0) && (data['writeaccess'] || data['studentteacher'])) {
+              if (window.innerWidth < 600) {
+                  str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind, ["header", "section",
+                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              } else {
+                  str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              }
+              str += `<input style='filter: invert (1); border:none; background:transparent;' type='button' style='border:none; background:transparent;' value='&#8633' id='tabElement'
+                     title='Tab example button' onclick='confirmBox("openTabConfirmBox",this);'>`
+              str += "</td>";
         }
-        if (itemKind != 4 && itemKind != 1 && itemKind != 0) { // dont create buttons for moments only for specific assignments
-          //Generate new tab link
-          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<img style='width:16px;' class="newTabCanvasLink" tabIndex="0" alt='canvasLink icon' id='NewTabLink' title='Open link in new tab' class=''
-            src='../Shared/icons/link-icon.svg' onclick='openCanvasLink(this);'>`;
-          str += "</td>";
+          if (itemKind != 4 && itemKind != 1 && itemKind != 0) { // dont create buttons for moments only for specific assignments
+              //Generate new tab link
+              if (window.innerWidth < 600) {
+                  str += `<td style='width:${iconSize};' class='${makeTextArray(itemKind, ["header", "section",
+                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              } else {
+                      str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+                          "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              }
+              str += `<img style='width:16px;' class="newTabCanvasLink" tabIndex="0" alt='canvasLink icon' id='NewTabLink' title='Open link in new tab' class=''
+                    src='../Shared/icons/link-icon.svg' onclick='openCanvasLink(this);'>`;
+              str += "</td>";
+          
 
-          // Generate Canvas Link Button
-          if (data['writeaccess'] || data['studentteacher']) {
-            str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-              "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-            str += `<div class="showCanvasLinkBoxTab" tabIndex="0">`;
-            str += `<img style='width:16px;' alt='canvasLink icon' id='dorf' title='Get Canvas Link' class=''
-            src='../Shared/icons/canvasduggalink.svg' onclick='showCanvasLinkBox(\"open\",this);'>`;
-            str += `</div>`;
-            str += "</td>";
+            // Generate Canvas Link Button
+             if (data['writeaccess'] || data['studentteacher']) {
+                if (window.innerWidth < 600) {
+                    str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind, ["header", "section",
+                        "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+                } else {
+                    str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+                        "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+            
+                }
+                 str += `<div class="showCanvasLinkBoxTab" tabIndex="0">`;
+                 str += `<img style='width:16px;' alt='canvasLink icon' id='dorf' title='Get Canvas Link' class='' src='../Shared/icons/canvasduggalink.svg' onclick='showCanvasLinkBox("open",this);'>`;
+                 str += `</div>`;
+                    str += "</td>";
+              }
           }
-        }
 
 
         // Tab element button for heading
@@ -2152,9 +2222,16 @@ function returnedSection(data) {
 
         // Cog Wheel
         if (itemKind !== 0 && data['writeaccess'] || data['studentteacher']) {
-          str += `<td style='width:32px;' class='${makeTextArray(itemKind,
-            ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-
+          //str += `<td style='width:32px;' class='${makeTextArray(itemKind,
+          //  ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState} hide-on-mobile'>`;
+            
+            if (window.innerWidth < 600) {
+                str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind,
+                    ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+            } else {
+                str += `<td style='width:32px;' class='${makeTextArray(itemKind,
+                    ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+            }
 
           str += "<img alt='settings icon'  tabIndex='0' id='dorf' title='Settings' class='settingIconTab' src='../Shared/icons/Cogwheel.svg' ";
           str += " onclick='setActiveLid(" + item['lid'] + ");selectItem(";
@@ -2170,8 +2247,6 @@ function returnedSection(data) {
             item['highscoremode'], item['comments'], item['grptype'], item['deadline'],item['relativedeadline'],
             item['tabs'], item['feedbackenabled'], item['feedbackquestion']]) + "), clearHideItemList();' />";
           }
-
-
           str += "</td>";
         }
 
@@ -2195,20 +2270,30 @@ function returnedSection(data) {
             str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
             src='../Shared/icons/Trashcan.svg' onclick='; if(selectedItemList.length == 0){markedItems(this, "trash")}; confirmBox(\"openConfirmBox\", this); '>`;
             str += "</td>";
-          }
-          else{
-          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-          str += `<img style='class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
-          src='../Shared/icons/Trashcan.svg' onclick=' markedItems(this, "trash"); confirmBox(\"openConfirmBox\", this); '>`;
-          str += "</td>";  
+          } else {
+              if (window.innerWidth < 600) {
+                  str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind, ["header", "section",
+                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              } else {
+                  str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              }
+   
+              str += `<img class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
+              src='../Shared/icons/Trashcan.svg' onclick=' markedItems(this, "trash"); confirmBox(\"openConfirmBox\", this); '>`;
+              str += "</td>";  
           } 
         }
 
         // Checkbox
         if (data['writeaccess'] || data['studentteacher']) {
-          str += `<td style='width:25px;' class='${makeTextArray(itemKind,
-            ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              if (window.innerWidth < 600) {
+                  str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind,
+                      ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              } else {
+                  str += `<td style='width:25px;' class='${makeTextArray(itemKind,
+                      ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+              }  
           str += "<input type='checkbox' id='" + item['lid'] + "-checkbox" + "' title='" + item['entryname'] + " - checkbox" + "' class='checkboxIconTab' onclick='markedItems(this)'>";
           str += "</td>";
         }

--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1785,13 +1785,9 @@ function returnedSection(data) {
 
           if (retdata['writeaccess']) {
             if (itemKind === 3) {
-                if (isLoggedIn) {
-                    if (window.innerWidth < 600) {
-                        str += "<td class='LightBox" + hideState + "' style='position: relative; top: -11px;'>";
-                    } else {
-                        str += "<td class='LightBox" + hideState + "'>";
-                    }
-                  str += "<div class='dragbleArea'><img style='width: 53%; padding-left: 6px;padding-top: 5px;' title='Press and drag to arrange' alt='pen icon dugga' src='../Shared/icons/select.png'></div>";
+              if (isLoggedIn) {
+                str += "<td class='LightBox" + hideState + "'>";
+                str += "<div class='dragbleArea'><img style='width: 53%; padding-left: 6px;padding-top: 5px;' title='Press and drag to arrange' alt='pen icon dugga' src='../Shared/icons/select.png'></div>";
               }
             } else if (itemKind === 4) {
               if (isLoggedIn) {
@@ -1802,38 +1798,38 @@ function returnedSection(data) {
             str += "</td>";
           }
         }
-            //==========MOBILE VIEW FOR TEST/DUGGA ITEMS===============
-          if (itemKind === 3 && (data['writeaccess'] || data['studentteacher'])) {             
-              var param = {
-                  'did': item['link'],
-                  'courseid': querystring['courseid'],
-                  'coursename': querystring['coursename'],
-                  'coursevers': querystring['coursevers'],
-                  'moment': item['lid'],
-                  'segment': momentexists,
-                  highscoremode: item['highscoremode'],
-                  comment: item['comments'],
-                  deadline: item['deadline'],
-                  'cid': querystring['courseid']
-              };
-              str += `<div style='display: flex; flex-direction: row; align-items: left; justify-content: space-between; width: 87%; margin-left: 34px;'>`;
+          //Mobile view of title and date for dugga/test items
+        if (itemKind === 3 && (data['writeaccess'] || data['studentteacher'])) {             
+          var param = {
+            'did': item['link'],
+            'courseid': querystring['courseid'],
+            'coursename': querystring['coursename'],
+            'coursevers': querystring['coursevers'],
+            'moment': item['lid'],
+            'segment': momentexists,
+             highscoremode: item['highscoremode'],
+             comment: item['comments'],
+             deadline: item['deadline'],
+             'cid': querystring['courseid']
+          };
+          str += `<div style='display: flex; flex-direction: row; align-items: left; justify-content: space-between; width: 97%; margin-left: 5px;'>`;
 
-              str += `<div class='ellipsis nowrap show-on-mobile'><span>${makeanchor("showDugga.php", hideState,
-                  "", item['entryname'], false, param)}</span></div>`;
-             
-              if ((deadline !== null && deadline !== "undefined") && retdata['startdate'] !== null) {
-                  let formattedDeadline = convertDateToDeadline(new Date(deadline));
-                  let deadlineArr = formattedDeadline.split(" ");
-                  let deadlineText = deadlineArr[0];
-                  if (!/^[0:]+$/.test(deadlineArr[1])) {
-                      deadlineText += " " + deadlineArr[1].split(":")[0] + ":" + deadlineArr[1].split(":")[1];
-                  }
-                  str += `<div class='DateColorInDarkMode show-on-mobile' style='font-size: 0.8em; color: gray;'>${deadlineText}</div>`;
-              } else if (rDeadline !== null && rDeadline !== "undefined") {
-                  str += `<div class='DateColorInDarkMode  show-on-mobile' style='font-size: 0.8em; color: gray;'>${formatRelativeDeadlineToString(rDeadline)}</div>`;
-              }
-              str += `</div>`;
+          str += `<div class='ellipsis nowrap show-on-mobile'><span>${makeanchor("showDugga.php", hideState,
+            "", item['entryname'], false, param)}</span></div>`;
+           
+          if ((deadline !== null && deadline !== "undefined") && retdata['startdate'] !== null) {
+            let formattedDeadline = convertDateToDeadline(new Date(deadline));
+            let deadlineArr = formattedDeadline.split(" ");
+            let deadlineText = deadlineArr[0];
+            if (!/^[0:]+$/.test(deadlineArr[1])) {
+              deadlineText += " " + deadlineArr[1].split(":")[0] + ":" + deadlineArr[1].split(":")[1];
+            }
+            str += `<div class='DateColorInDarkMode show-on-mobile' style='font-size: 0.8em; color: gray;'>${deadlineText}</div>`;
+          } else if (rDeadline !== null && rDeadline !== "undefined") {
+            str += `<div class='DateColorInDarkMode  show-on-mobile' style='font-size: 0.8em; color: gray;'>${formatRelativeDeadlineToString(rDeadline)}</div>`;
           }
+          str += `</div>`;
+        }
 
         if (retdata['writeaccess']) {
           if (itemKind === 2 || itemKind === 5 || itemKind === 6 || itemKind === 7) { // Draggable area with white background
@@ -1892,25 +1888,14 @@ function returnedSection(data) {
           kk++;
 
         } else if (itemKind === 3) {
-            if (retdata['writeaccess']) {
-                if (window.innerWidth < 600) {
-                    str += `<td class='LightBox${hideState}' style='width:${iconSize};'>`;
-
-                } else {
-                    str += "<td class='LightBox" + hideState + "'>";
-                } 
-                str += "<div ><img class='iconColorInDarkMode' alt='pen icon dugga' title='Quiz' src='../Shared/icons/PenT.svg'></div>";
-            }
-
+          if (retdata['writeaccess']) {
+            str += "<td class='LightBox" + hideState + "'>";
+            str += "<div ><img class='iconColorInDarkMode' alt='pen icon dugga' title='Quiz' src='../Shared/icons/PenT.svg'></div>";
+          }
 
           if (item['highscoremode'] != 0 && itemKind == 3) {
-              if (window.innerWidth < 600) {
-                 str += `<td style='width:${iconSize};'><img class='iconColorInDarkMode' style='width:${iconSize};'  title='Highscore' src='../Shared/icons/top10.png'
-                    onclick='showHighscore(\"${item['link']}\",\"${item['lid']}\")'/></td>`;
-              } else {
-                 str += `<td style='width:20px;'><img class='iconColorInDarkMode' style=';' title='Highscore' src='../Shared/icons/top10.png'
-                     onclick='showHighscore(\"${item['link']}\",\"${item['lid']}\")'/></td>`;
-              }
+            str += `<td style='width:20px;'><img class='iconColorInDarkMode' style=';' title='Highscore' src='../Shared/icons/top10.png'
+              onclick='showHighscore(\"${item['link']}\",\"${item['lid']}\")'/></td>`;
           }
           str += `<td class='example item${hideState}' placeholder='${momentexists}' id='I${item['lid']}' `;
           kk++;
@@ -2010,11 +1995,9 @@ function returnedSection(data) {
             deadline: item['deadline'],
             'cid': querystring['courseid']
           };
-        
-          
-            str += `<div class='ellipsis nowrap hide-on-mobile'><span>${makeanchor("showDugga.php", hideState,
-                "", item['entryname'], false, param)}</span></div>`;
 
+          str += `<div class='ellipsis nowrap hide-on-mobile'><span>${makeanchor("showDugga.php", hideState,
+            "", item['entryname'], false, param)}</span></div>`;
         } else if (itemKind == 5) {
           // Link
           if (item['link'] !== null && item['link'] !== undefined && item['link'].substring(0, 4) === "http") {
@@ -2053,9 +2036,9 @@ function returnedSection(data) {
 
         // If none of the deadlines are null or undefined we need to add it to the page
         if ((itemKind === 3) && ((deadline !== null || deadline !== "undefined") || (rDeadline !== null || rDeadline !== "undefined"))) {
-            // Both of them will need this html
-            str += "<td onclick='duggaRowClick(this)' class='dateSize hide-on-mobile' style='text-align:right;overflow:hidden;'>" +
-                "<div class='DateColorInDarkMode' style='white-space:nowrap;'>";
+          // Both of them will need this html
+          str += "<td onclick='duggaRowClick(this)' class='dateSize hide-on-mobile' style='text-align:right;overflow:hidden;'>" +
+            "<div class='DateColorInDarkMode' style='white-space:nowrap;'>";
 
           // We prioritize absolute deadline and we dont want absolute deadlines if there's no startdate for course
           if ((deadline !== null && deadline !== "undefined") && retdata['startdate'] !== null) {
@@ -2131,13 +2114,9 @@ function returnedSection(data) {
 
         // Userfeedback
         if (data['writeaccess'] && itemKind === 3 && item['feedbackenabled'] == 1) {
-            if (window.innerWidth < 600) {
-                str += `<td style='width:${iconSize};'>`;
-            } else {
-                str += `<td style='width:32px;'>`;
-            }
-              str += `<img id='dorf' src='../Shared/icons/FistV.svg' title='Feedback' onclick='showUserFeedBack("${item['lid']}","${item['feedbackquestion']}");'>`;
-                str += `</td>`;
+          str += `<td style='width:32px;'>`;
+          str += `<img id='dorf' src='../Shared/icons/FistV.svg' title='Feedback' onclick='showUserFeedBack("${item['lid']}","${item['feedbackquestion']}");'>`;
+          str += `</td>`;
         }
 
         // Testing implementation
@@ -2151,49 +2130,31 @@ function returnedSection(data) {
           str += "</td>";
         }
         // Tab example button
-          if ((itemKind !== 4) && (itemKind !== 0) && (data['writeaccess'] || data['studentteacher'])) {
-              if (window.innerWidth < 600) {
-                  str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind, ["header", "section",
-                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-              } else {
-                  str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-              }
-              str += `<input style='filter: invert (1); border:none; background:transparent;' type='button' style='border:none; background:transparent;' value='&#8633' id='tabElement'
-                     title='Tab example button' onclick='confirmBox("openTabConfirmBox",this);'>`
-              str += "</td>";
+        if ((itemKind !== 4) && (itemKind !== 0) && (data['writeaccess'] || data['studentteacher'])) {
+          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+          str += `<input style='filter: invert (1); border:none; background:transparent;' type='button' style='border:none; background:transparent;' value='&#8633' id='tabElement'
+            title='Tab example button' onclick='confirmBox("openTabConfirmBox",this);'>`
+          str += "</td>";
         }
-          if (itemKind != 4 && itemKind != 1 && itemKind != 0) { // dont create buttons for moments only for specific assignments
+        if (itemKind != 4 && itemKind != 1 && itemKind != 0) { // dont create buttons for moments only for specific assignments
               //Generate new tab link
-              if (window.innerWidth < 600) {
-                  str += `<td style='width:${iconSize};' class='${makeTextArray(itemKind, ["header", "section",
-                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-              } else {
-                      str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-                          "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-              }
-              str += `<img style='width:16px;' class="newTabCanvasLink" tabIndex="0" alt='canvasLink icon' id='NewTabLink' title='Open link in new tab' class=''
-                    src='../Shared/icons/link-icon.svg' onclick='openCanvasLink(this);'>`;
-              str += "</td>";
-          
+          str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+            "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+          str += `<img style='width:16px;' class="newTabCanvasLink" tabIndex="0" alt='canvasLink icon' id='NewTabLink' title='Open link in new tab' class=''
+            src='../Shared/icons/link-icon.svg' onclick='openCanvasLink(this);'>`;
+          str += "</td>";
 
             // Generate Canvas Link Button
-             if (data['writeaccess'] || data['studentteacher']) {
-                if (window.innerWidth < 600) {
-                    str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind, ["header", "section",
-                        "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-                } else {
-                    str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-                        "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-            
-                }
-                 str += `<div class="showCanvasLinkBoxTab" tabIndex="0">`;
-                 str += `<img style='width:16px;' alt='canvasLink icon' id='dorf' title='Get Canvas Link' class='' src='../Shared/icons/canvasduggalink.svg' onclick='showCanvasLinkBox("open",this);'>`;
-                 str += `</div>`;
-                    str += "</td>";
-              }
+          if (data['writeaccess'] || data['studentteacher']) {
+            str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+              "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+            str += `<div class="showCanvasLinkBoxTab" tabIndex="0">`;
+            str += `<img style='width:16px;' alt='canvasLink icon' id='dorf' title='Get Canvas Link' class='' src='../Shared/icons/canvasduggalink.svg' onclick='showCanvasLinkBox("open",this);'>`;
+            str += `</div>`;
+            str += "</td>";
           }
-
+        }
 
         // Tab element button for heading
         if (itemKind === 0 && (data['writeaccess'] || data['studentteacher'])) {
@@ -2221,17 +2182,9 @@ function returnedSection(data) {
         }
 
         // Cog Wheel
-        if (itemKind !== 0 && data['writeaccess'] || data['studentteacher']) {
-          //str += `<td style='width:32px;' class='${makeTextArray(itemKind,
-          //  ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState} hide-on-mobile'>`;
-            
-            if (window.innerWidth < 600) {
-                str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind,
-                    ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-            } else {
-                str += `<td style='width:32px;' class='${makeTextArray(itemKind,
-                    ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-            }
+        if (itemKind !== 0 && data['writeaccess'] || data['studentteacher']) { 
+          str += `<td style='width:32px;' class='${makeTextArray(itemKind,
+            ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
 
           str += "<img alt='settings icon'  tabIndex='0' id='dorf' title='Settings' class='settingIconTab' src='../Shared/icons/Cogwheel.svg' ";
           str += " onclick='setActiveLid(" + item['lid'] + ");selectItem(";
@@ -2240,8 +2193,7 @@ function returnedSection(data) {
             item['kind'], item['visible'], item['link'], momentexists, item['gradesys'],
             item['highscoremode'], item['comments'], item['grptype'], item['handindeadline'],item['relativedeadline'],
             item['tabs'], item['feedbackenabled'], item['feedbackquestion']]) + "), clearHideItemList();' />";
-          }
-          else {
+          } else {
             str +=makeparams([item['lid'], item['entryname'],
             item['kind'], item['visible'], item['link'], momentexists, item['gradesys'],
             item['highscoremode'], item['comments'], item['grptype'], item['deadline'],item['relativedeadline'],
@@ -2271,29 +2223,18 @@ function returnedSection(data) {
             src='../Shared/icons/Trashcan.svg' onclick='; if(selectedItemList.length == 0){markedItems(this, "trash")}; confirmBox(\"openConfirmBox\", this); '>`;
             str += "</td>";
           } else {
-              if (window.innerWidth < 600) {
-                  str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind, ["header", "section",
-                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-              } else {
-                  str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
-                      "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-              }
-   
-              str += `<img class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
+            str += `<td style='width:32px;' class='${makeTextArray(itemKind, ["header", "section",
+              "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
+            str += `<img class="traschcanDelItemTab" alt='trashcan icon' tabIndex="0" id='dorf' title='Delete item' class=''
               src='../Shared/icons/Trashcan.svg' onclick=' markedItems(this, "trash"); confirmBox(\"openConfirmBox\", this); '>`;
-              str += "</td>";  
+            str += "</td>";  
           } 
         }
 
         // Checkbox
         if (data['writeaccess'] || data['studentteacher']) {
-              if (window.innerWidth < 600) {
-                  str += `<td style='width:${iconSize};'  class='${makeTextArray(itemKind,
-                      ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-              } else {
-                  str += `<td style='width:25px;' class='${makeTextArray(itemKind,
-                      ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
-              }  
+          str += `<td style='width:25px;' class='${makeTextArray(itemKind,
+            ["header", "section", "code", "test", "moment", "link", "group", "message"])} ${hideState}'>`;
           str += "<input type='checkbox' id='" + item['lid'] + "-checkbox" + "' title='" + item['entryname'] + " - checkbox" + "' class='checkboxIconTab' onclick='markedItems(this)'>";
           str += "</td>";
         }

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -10826,24 +10826,32 @@ button:disabled {
 }
 
 .hide-on-mobile {
-    display: none !important;
+  display: none !important;
 }
 
 @media (min-width: 800px) {
-    .hide-on-mobile {
-        display: block !important;
-    }
+  .hide-on-mobile {
+     display: block !important;
+  }
 }
 
-
 .show-on-mobile {
-    display: none !important;
+  display: none !important;
 }
 
 @media (max-width: 800px) {
-    .show-on-mobile {
-        display: block !important;
-    }
+  .show-on-mobile {
+    display: block !important;
+  }
+}
+
+.flex-row-container {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start; 
+  justify-content: space-between;
+  width: 97%;
+  padding-left: 5px;
 }
 
 /* END */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -921,9 +921,9 @@ p {
   text-overflow: clip;
 }
 
-@media screen and (max-width : 570px) {
+@media screen and (max-width : 600px) {
 
-  & .view-label {
+  .view-label {
     display: none;
   }
   
@@ -941,7 +941,7 @@ p {
     display: none;
   }
 	.internal-link {
-        font-size: 10pt;
+        font-size: 12pt;
     }
 }
 
@@ -1480,11 +1480,12 @@ p {
   margin-bottom: 20px;
  }
 
- .sectionlistCWidth {
-  box-sizing: border-box;
-  width: 100%;
-  margin: 0;
- }
+.sectionlistCWidth {
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0;
+    height: auto !important;
+}
 
 
 #errorBox{
@@ -10822,6 +10823,27 @@ button:disabled {
 
 .displayBlock {
   display: block;
+}
+
+.hide-on-mobile {
+    display: none !important;
+}
+
+@media (min-width: 768px) {
+    .hide-on-mobile {
+        display: block !important;
+    }
+}
+
+
+.show-on-mobile {
+    display: none !important;
+}
+
+@media (max-width: 767px) {
+    .show-on-mobile {
+        display: block !important;
+    }
 }
 
 /* END */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -10829,7 +10829,7 @@ button:disabled {
     display: none !important;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 800px) {
     .hide-on-mobile {
         display: block !important;
     }
@@ -10840,7 +10840,7 @@ button:disabled {
     display: none !important;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 800px) {
     .show-on-mobile {
         display: block !important;
     }


### PR DESCRIPTION
The date for dugga items is now displayed. 

For testing: go to any course with duggas/tests, view the page in both the mobile and desktop view, switch between logged in/out.

Note that default window size of mobile-view for testing is 320x600(talked to group leader)
## 
I was about to give up on the issue with the solution burger menu containing buttons, but the group leader suggested an alternative approach: placing the title and date above the buttons. See PR [#17661](https://github.com/HGustavs/LenaSYS/pull/17661) for the burger menu.

While this(this PR) is not an ideal solution and requiring considerable changes, this temporary solution works for now. 

Initially, the dugga item had a different layout/design for its elements(the initial commit: [Mobile-view display of date](https://github.com/HGustavs/LenaSYS/commit/29faf0e893a1b82b94c6007d958ee534d4662e26)), which required a manual reload after resizing the window (e.g., switching between mobile and desktop views) - not a viable solution to reload every time. It featured dynamic icon resizing and allowed for a custom layout/design of each icon in mobile view. 

##
Files involved: 
/Shared/css/style.css
/DuggaSys/sectioned.js