### PR TITLE
Converted jquery in the group-assignment.js

### DIFF
--- a/DuggaSys/templates/group-assignment.js
+++ b/DuggaSys/templates/group-assignment.js
@@ -168,7 +168,7 @@ function showFacit(param, uanswer, danswer, userStats, files, moment)
 				document.getElementById("snus").innerHTML="<embed src='showdoc.php?cid="+inParams["cid"]+"&fname="+duggaParams["filelink"]+"' width='100%' height='1000px' type='application/pdf'>";
 		}else if(duggaParams["type"]==="md" || duggaParams["type"]==="html"){
 			$.ajax({url: "showdoc.php?cid="+inParams["cid"]+"&fname="+duggaParams["filelink"]+"&headers=none", success: function(result){
-					document.getElementById("snus").innerHTML = result;
+        		$("#snus").html(result);
         		// Placeholder code
 				var pl = duggaParams.placeholders;
 				if (pl !== undefined) {


### PR DESCRIPTION
Converted all jquery(except AJAX) to javascript in the group-assignment.js.

Quick note:
The instructions for this dugga in only available in admin view and being able to send in the files is availble in all the other access except for admin, im not sure if this is on purpose or not but its noted that it was like this before the convertion.