### PR TITLE
[#17508] Fixed wide load button issue on in mobile view

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2125,7 +2125,17 @@ function showModal() {
         for (let i = 0; i < diagramKeys.length; i++) {
             let wrapper = document.createElement('div');
             const btn = document.createElement('button');
-            const btnText = document.createTextNode(diagramKeys[i]);
+            let btnText;
+
+            if(isMobile){
+                if(diagramKeys[i].length > 12) {
+                    btnText = document.createTextNode(diagramKeys[i].slice(0, 12) + "...");
+                } else {
+                    btnText = document.createTextNode(diagramKeys[i]);
+                }
+            } else {
+                btnText = document.createTextNode(diagramKeys[i]);
+            }
 
             btn.setAttribute("onclick", `loadDiagramFromLocalStorage('${diagramKeys[i]}');closeModal();`);
             btn.appendChild(btnText);
@@ -2475,10 +2485,12 @@ window.addEventListener("resize", () => {
     if (!settings.ruler.isRulerActive) return;
 
     if (window.innerWidth > 414) {
+        isMobile = false;
         ruler.style.left = "50px";
         ruler.style.top = "0px";
     }
     else {
+        isMobile = true;
         ruler.style.left = "0px";
         ruler.style.top = "0px";
     }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2127,14 +2127,16 @@ function showModal() {
             const btn = document.createElement('button');
             let btnText;
 
+            // Special button text formatting for mobile so that the load and delete buttons fit within the modal
             if(isMobile){
+                // Limit the text content for the button to 12 characters (15 with the dots)
                 if(diagramKeys[i].length > 12) {
                     btnText = document.createTextNode(diagramKeys[i].slice(0, 12) + "...");
                 } else {
                     btnText = document.createTextNode(diagramKeys[i]);
                 }
             } else {
-                btnText = document.createTextNode(diagramKeys[i]);
+                btnText = document.createTextNode(diagramKeys[i]); // Regular formatting for bigger browsers
             }
 
             btn.setAttribute("onclick", `loadDiagramFromLocalStorage('${diagramKeys[i]}');closeModal();`);

--- a/DuggaSys/diagram/globals.js
+++ b/DuggaSys/diagram/globals.js
@@ -96,6 +96,13 @@ var ghostLine = null;
  */
 var UMLHeight = [], IEHeight = [], SDHeight = [], NOTEHeight = [];
 
+
+/**
+ * @description Global variable that checks if the browser window is sized for mobile screens (414px and less).
+ * @type {boolean}
+ */
+var isMobile = false;
+
 //#endregion
 //#region MOUSE
 


### PR DESCRIPTION
The load button didn't have special formatting to ensure that load buttons fit within the load modal window. This caused the button to extend outside of the window, bringing the delete button with it. The button was still accessible if you scrolled horizontally, but ideally it should just fit into the available window. 

A condition has been added so that the text in the buttons receive special formatting if the browser is in mobile view, limiting the displayed text to 12 characters of the file name. This, admittedly, isn't the most elegant solution to the problem, but it does its job.

A global variable called _isMobile_ has also been added for future mobile specific formatting.

**After fix - mobile view:** 
![image](https://github.com/user-attachments/assets/24d792fe-3b73-4933-8c72-c461246a6020)

**After fix - pc view:**
![image](https://github.com/user-attachments/assets/62026422-e6ff-4621-95c0-fbacacf17a00)

