### PR TITLE
All elements now work with bring/send to front/back

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -112,7 +112,6 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.sequenceActor:
             divContent = drawElementSequenceActor(element, textWidth, boxw, boxh, linew, texth);
             mouseEnter = 'mouseEnterSeq(event);';
-            zLevel = 2;
             break;
         case elementTypesNames.sequenceObject:
             divContent = drawElementSequenceObject(element, boxw, boxh, linew);

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -65,8 +65,8 @@ function drawElement(element, ghosted = false) {
             cssClass = 'ie-element';
             // Inheritance relations sit behind other IE elements
             style = element.name == "Inheritance" ?
-             `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:;` :
-             `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:1;`;
+             `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:${zLevel};`:
+             `left:0; top:0; width:${boxw}px; height:${boxh}px; z-index:${zLevel};`;
             break;
 
             //UML state‑diagram nodes
@@ -77,7 +77,7 @@ function drawElement(element, ghosted = false) {
                 </g>`;
             divContent = drawElementState(element, initVec);
             cssClass = 'uml-state';
-            style = `width:${boxw}px; height:${boxh}px; z-index:2;`;
+            style = `width:${boxw}px; height:${boxh}px; z-index:${zLevel};`;
             break;
         case elementTypesNames.UMLFinalState:
             let finalVec = `
@@ -100,7 +100,7 @@ function drawElement(element, ghosted = false) {
                 </g>`;
             divContent = drawElementState(element, finalVec);
             cssClass = 'uml-state';
-            style = `width:${boxw}px; height:${boxh}px; z-index:2;`;
+            style = `width:${boxw}px; height:${boxh}px; z-index:${zLevel};`;
             break;
         case elementTypesNames.UMLSuperState:
             divContent = drawElementSuperState(element, textWidth, boxw, boxh, linew);

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -105,7 +105,6 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.UMLSuperState:
             divContent = drawElementSuperState(element, textWidth, boxw, boxh, linew);
             cssClass = 'uml-Super';
-            zLevel = 1;    // Background layer for composite states
             break;
 
             //UML sequence‑diagram widgets

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -116,7 +116,6 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.sequenceObject:
             divContent = drawElementSequenceObject(element, boxw, boxh, linew);
             mouseEnter = 'mouseEnterSeq(event);';
-            zLevel = 2;
             break;
         case elementTypesNames.sequenceActivation:
             divContent = drawElementSequenceActivation(element, boxw, boxh, linew);

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -124,7 +124,6 @@ function drawElement(element, ghosted = false) {
             // Expand for each alternative block rendered below the header
             let height = boxh + (element.alternatives.length ?? 0) * zoomfact * 125;
             divContent = drawElementSequenceLoopOrAlt(element, boxw, height, linew, texth);
-            zLevel = 0;   // Below messages and activations
             break;
 
         //Legacy sticky note

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -119,7 +119,6 @@ function drawElement(element, ghosted = false) {
             break;
         case elementTypesNames.sequenceActivation:
             divContent = drawElementSequenceActivation(element, boxw, boxh, linew);
-            zLevel = 3;    // Always on top of actor/object boxes
             break;
         case elementTypesNames.sequenceLoopOrAlt:
             // Expand for each alternative block rendered below the header


### PR DESCRIPTION
It was discovered that certain elements did not respond to the bring/send to front/back operations via the buttons in the options panel. This was due to static zLevel values having been attributed to these elements, which would override any attempted z-ordering changes. By removing these static zLevel values, the elements now respond as expected.

The specific elements that were affected are: Sequence Actor, Sequence Object, Sequence Activation, Sequence Loop, UML Superstate, UML Initial State, and UML Final State. These have been modified to respond correctly in this patch.

An alternative approach could be to remove the relevant option buttons for these elements **IF** they are intended to remain locked at certain z-levels. One inherent issue with the implemented solution is that Sequence Activations can now get unintentionally buried under Sequence Lifelines, among other flaws. However, this patch resolves the immediate issue and can be merged if deemed necessary.

Check the attached video for issue demo: #17577 
