### PR TITLE
Added inverse dependencies for getUid_ms.php in Microservices_inverse_dependencies.md #17664

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -364,9 +364,10 @@ createListEntry_ms.php
 
 ##### sharedMicroservices
 - sharedMicroservices/createNewCodeExample_ms.php
-- sharedMicroservices/micupdateSecurityQuestion_ms.php
+- sharedMicroservices/updateSecurityQuestion_ms.php
 - sharedMicroservices/updateSecurityQuestion_ms.php
 - sharedMicroservices/updateUserPassword_ms.php
+- sharedMicroservices/retrieveUsername_ms.php
 
 ##### sectionedService
 - sectionedService/createGithubCodeExample_ms.php
@@ -385,6 +386,8 @@ createListEntry_ms.php
 - sectionedService/updateListEntriesTabs_ms.php
 - sectionedService/updateListEntryOrder_ms.php
 - sectionedService/updateVisibleListEntries_ms.php
+- sectionedService/readGroupValues_ms.php
+- sectionedService/removeListEntries_ms.php
 
 ##### resultedService
 - resultedService/getUserAnswer_ms.php
@@ -400,6 +403,7 @@ createListEntry_ms.php
 - fileedService/deleteFileLink_ms.php
 - fileedService/getFileedService_ms.php
 - fileedService/updateFileLink_ms.php
+- fileedService/retrieveFileedService_ms.php
 
 ##### duggaedService
 - duggaedService/createDugga_ms.php

--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -365,7 +365,6 @@ createListEntry_ms.php
 ##### sharedMicroservices
 - sharedMicroservices/createNewCodeExample_ms.php
 - sharedMicroservices/updateSecurityQuestion_ms.php
-- sharedMicroservices/updateSecurityQuestion_ms.php
 - sharedMicroservices/updateUserPassword_ms.php
 - sharedMicroservices/retrieveUsername_ms.php
 
@@ -413,7 +412,7 @@ createListEntry_ms.php
 - duggaedService/createDuggaVariant_ms.php
 - duggaedService/updateDuggaVariant_ms.php
 
-###### courseedService
+##### courseedService
 - courseedService/changeActiveCourseVersion_courseed_ms.php
 - courseedService/copyCourseVersion_ms.php
 - courseedService/createCourseVersion_ms.php
@@ -433,6 +432,7 @@ createListEntry_ms.php
 - codeviewerService/editCodeExample_ms.php
 - codeviewerService/editContentOfExample_ms.php
 - codeviewerService/updateCodeExampleTemplate_ms.php
+- codeviewerService/retrieveCodeviewerService_ms.php
 
 ##### accessedService
 

--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -410,6 +410,8 @@ createListEntry_ms.php
 - duggaedService/deleteDugga_ms.php
 - duggaedService/deleteDuggaVariant_ms.php
 - duggaedService/updateDugga_ms.php
+- duggaedService/createDuggaVariant_ms.php
+- duggaedService/updateDuggaVariant_ms.php
 
 ###### courseedService
 - courseedService/changeActiveCourseVersion_courseed_ms.php
@@ -422,6 +424,8 @@ createListEntry_ms.php
 - courseedService/retrieveCourseedService_ms.php
 - courseedService/updateCourse_ms.php
 - courseedService/updateCourseVersion_ms.php
+- courseedService/specialUpdate_ms.php
+- courseedService/updateActiveCourseVersion_courseed_ms.php
 
 ##### codeviewerService
 - codeviewerService/deleteCodeExample_ms.php
@@ -437,6 +441,7 @@ createListEntry_ms.php
 - accessedService/getAccessedService_ms.php
 - accessedService/updateUser_ms.php
 - accessedService/updateUserCourse_ms.php
+- accessedService/retrieveAccessedService_ms.php
 
 ### isSuperUser
 None


### PR DESCRIPTION
Fixes #17664 . Some inverse dependencies were missing for getUid_ms.php and have been added to Microservices_inverse_dependencies.md. It's important that all of them are correct before the re-engineering can be done for this microservice.