### PR TITLE
Fixed: G1 2025 v7 #17555 fix the lines floating on er attributes

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -583,7 +583,8 @@ function getLineAttributes(line, f, t, ctype, fromElemMouseY, toElemMouseY) {
         } 
     } 
     
-    // Special case if line is connected to or from an ERRelation
+    // Special case if line is connected to or from an ER Relation, ER Entity or ER Attribute
+    // Extends (or "shrinks") line to suit oddly shaped elements where it would otherwise not connect
     if (f.kind === elementTypesNames.ERRelation || t.kind === elementTypesNames.ERRelation ||
         f.kind === elementTypesNames.EREntity || t.kind === elementTypesNames.EREntity ||
         f.kind === elementTypesNames.ERAttr || t.kind === elementTypesNames.ERAttr) {

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -585,8 +585,10 @@ function getLineAttributes(line, f, t, ctype, fromElemMouseY, toElemMouseY) {
     
     // Special case if line is connected to or from an ERRelation
     if (f.kind === elementTypesNames.ERRelation || t.kind === elementTypesNames.ERRelation ||
-        f.kind === elementTypesNames.EREntity || t.kind === elementTypesNames.EREntity) {
-        const shrink = 8 * zoomfact; 
+        f.kind === elementTypesNames.EREntity || t.kind === elementTypesNames.EREntity ||
+        f.kind === elementTypesNames.ERAttr || t.kind === elementTypesNames.ERAttr) {
+
+        const shrink = 8 * zoomfact;
 
         if (ctype === lineDirection.LEFT || ctype === lineDirection.RIGHT) {
             offset.x1 += (ctype === lineDirection.LEFT ? shrink : -shrink);


### PR DESCRIPTION
Lines will no longer stop short and create a gap when trying to attach them to an ER Attribute element. Instead the line should now run all the way to the ellipse regardless of its position.

https://github.com/user-attachments/assets/538fdd2a-e24b-4a15-bb7c-b141df541e8a

