### PR TITLE
Added funtionality for read existing configuration for new installer

### DIFF
--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -8,6 +8,8 @@
 	<link rel="stylesheet" type="text/css" href="style.css">
 	<?php include 'tools/components.php'; ?>
 	<?php include 'tools/modal.php'; ?>
+	<?php include 'tools/configuration_manager.php'; ?>
+	<?php include 'tools/permissions.php'; ?>
 	<script defer src="tools/modal.js"></script>
 	<script defer src="tools/components.js"></script>
 	<script defer src="tools/sse_receiver.js"></script>
@@ -95,12 +97,20 @@
 					<div class="inner-wrapper">
 						<div class="input-grid">
 							<?php
-								inputField("db_name", "Database name:", "text");
-								inputField("username", "MySQL user:", "text");
-								inputFieldWithTip('hostname', 'Hostname:', 'Tip: Usually set to "localhost"');
-								inputField("password", "MySQL user password:", "password");
+								$ConfigurationManager = new ConfigurationManager("../../coursesyspw.php");
+								$parameters = $ConfigurationManager->read_parameters();
 
-								checkbox("distributed_environment", "Use Distributed Environment", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#use-distributed-environment");
+								inputField("db_name", "Database name:", "text", $parameters["DB_NAME"]);
+								inputField("username", "MySQL user:", "text", $parameters["DB_USER"]);
+								inputFieldWithTip('hostname', 'Hostname:', 'Tip: Usually set to "localhost"', $parameters["DB_HOST"]);
+								inputField("password", "MySQL user password:", "password", $parameters["DB_PASSWORD"]);
+								
+								if (!empty($parameters["DB_USING_DOCKER"])) {
+									checkbox("distributed_environment", "Use Distributed Environment", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#use-distributed-environment", $parameters["DB_USING_DOCKER"]);
+								} else {
+									checkbox("distributed_environment", "Use Distributed Environment", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#use-distributed-environment");
+								}
+
 								checkbox("Verbose", "Verbose", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#verbose");
 								checkboxWithWarning("overwrite_db", "Overwrite existing database", "WARNING! Overwriting databases and users cannot be undone!", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#overwrite-existing-database-and-user-names");
 								checkbox("overwrite_user", "Overwrite existing user");

--- a/newinstaller/tools/components.php
+++ b/newinstaller/tools/components.php
@@ -73,10 +73,10 @@
 			</div>";
 	}
 
-	function inputFieldWithTip($inputId, $inputLabel, $tipText) {
+	function inputFieldWithTip($inputId, $inputLabel, $tipText, $inputValue='') {
 		echo "<div class='input-field'>
 					<label for='$inputId'>$inputLabel</label>
-					<input id='$inputId' type='text'>
+					<input id='$inputId' type='text' value='". htmlspecialchars($inputValue) ."'>
 					<p class='tip'>$tipText</p>
 			</div>";
 	}
@@ -101,9 +101,17 @@
 		echo "</div>";
 	}
 
-	function checkbox($checkboxId, $checkboxText, $helpLink = null) {
+	function checkbox($checkboxId, $checkboxText, $helpLink = null, $inputValue = '') {
+		// Check if the value is "on" or “1”. If true, then the checkbox will be checked, otherwise it will not be checked. 
+		// Note: "on" is used for the old coursesyspw, while "1" is used for the new coursesyspw.
+		if (strtolower($inputValue) === 'on' || $inputValue === '1') {
+			$checked = 'checked';
+		} else {
+			$checked = '';
+		}
+	
 		echo "<div class='checkbox'>";
-		echo "    <input id='$checkboxId' type='checkbox' value='$checkboxId'>";
+		echo "    <input id='$checkboxId' type='checkbox' value='$checkboxId' $checked>";
 		echo "    <label for='$checkboxId'>$checkboxText";
 	
 		if (isset($helpLink)) {

--- a/newinstaller/tools/configuration_manager.php
+++ b/newinstaller/tools/configuration_manager.php
@@ -17,8 +17,10 @@ class ConfigurationManager {
 		$this->callback = $callback;
 		$this->verbose = $verbose;
 		$this->parameters = [];
-		$this->write_config(); // Write or create config
-		$this->read_config(); // Load existing config
+		$read = $this->read_config(); // Load existing config
+		if($read["success"]) {
+			$this->write_config(); // Write or create config
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #16150.

When you run the new installer for the first time, then the configuration manager file going to read the default values from coursesyspw.php, which are:

• DB_USER = lenasys
• DB_PASSWORD = password
• DB_HOST = db
• DB_NAME = lenasysdb
• DB_USING_DOCKER = on

After the configuration manager finish reading the coursesyspw.php, then configuration manager going to assign all the values to each input, so that skipping rewrite them over again. 

When the installer begin to install the lenasys and complete the installation of lenasys, then the configuration manager will write or overwrite the coursesyspw.php. If you go back to the new installer, then all values will be updated.

Note: These values only assign the username, password, hostname, database name, and distributed environment .
