### PR TITLE
Fixed: G1 2025 v7 #17431 implement mockup for the option panel

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -423,10 +423,6 @@
     .hide-options-pane {
         right: -500px;
     }
-    
-    #options-pane-button {
-        visibility: hidden !important;
-    }
 }
 
 .diagramIcons:hover,

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -151,6 +151,22 @@
     z-index: 5001;
 }
 
+#fab-options {
+    position: fixed;
+    top: 10vh;
+    right: 7vw;
+    width: 56px;
+    height: 56px;
+    font-size: 36px;
+    line-height: 80px;
+    text-align: center;
+    border-radius: 40px;
+    background-color: #eb4;
+    user-select: none;
+    cursor: pointer;
+    z-index: 5000;
+}
+
 #options-pane {
     position: fixed;
     top: 0px;
@@ -175,6 +191,12 @@
     cursor: pointer;
     width: 780px;
     padding: 6px;
+}
+
+#options-fab {
+    display: grid;
+    align-items: center;
+    font-size: 40px;
 }
 
 #options-pane-content {
@@ -395,6 +417,14 @@
     }
 
     #zoom-container{
+        visibility: hidden !important;
+    }
+
+    .hide-options-pane {
+        right: -500px;
+    }
+    
+    #options-pane-button {
         visibility: hidden !important;
     }
 }

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -518,6 +518,7 @@ function getData() {
     document.getElementById("fab-localSaveAs").addEventListener("click", showSavePopout);
     document.getElementById("fab-localSave").addEventListener("click", quickSaveDiagram);
     document.getElementById("fab-load").addEventListener("click", showModal);
+    document.getElementById("fab-options").addEventListener("click", toggleOptionsPane);
 
     //Main mobile FAB-button
     document.getElementById("diagram-fab").addEventListener("click", () =>{

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -27,6 +27,7 @@
     <link type="text/css" href="../Shared/css/mobile-diagram.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link id="themeBlack" type="text/css" href="../Shared/css/blackTheme.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=design_services" />
     <script src="darkmodeToggle.js"></script>
     <script src="../Shared/js/jquery-1.11.0.min.js"></script>
     <script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
@@ -122,7 +123,14 @@
             <button id="diagram-fab"class="fab-btn-lg btn-floating diagram-btn-fab">+</button>
         </div>
         <!-- FAB-btn ENDS HERE! -->
-
+        <!-- The FAB-btn for the optionmenu, STARTS HERE!-->
+        <div class="fixed-option-button tooltip-fab">
+                
+            <button id="fab-options"class="fab-btn-lg btn-floating option-btn-fab"><span id="options-fab" class="material-symbols-outlined">
+                design_services</span>
+            </button>
+        </div>
+        <!-- FAB-btn for optionmenu ENDS HERE! -->
 
     <!-- TOOLBAR STARTS HERE!! -->
     <!-- Holds all buttons in the left-hand toolbar of the diagram-page -->

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -818,6 +818,8 @@
             <span id='optmarker'>&#9660;Options</span>
         </div>
 
+        <span class="close-btn" onclick="toggleOptionsPane();">&times;</span>
+
         <!-- FIELD FOR SMALLER FIELDS CONTAING THE OPTIONS -->
         <div id ="fieldsetBox">
             <fieldset id='propertyFieldset' class='options-fieldset options-fieldset-hidden'></fieldset>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8087,7 +8087,32 @@ only screen and (max-device-width: 568px) {
   .diagram-fab{
     display: block;
   }
+
+  #options-pane-button {
+    visibility: hidden !important;
+  }
+
+  .close-btn {
+    color: black;
+    cursor: pointer;
+    display: block;
+    position: absolute;
+    right: 10px;
+    top: -12px;
+    font-size: 60px;
+  }
 }
+
+@media (min-width: 415px){
+  .close-btn {
+    visibility: hidden;
+  }
+  
+  #fab-options {
+    visibility: hidden;
+  }
+}
+
 /*===============================*/
 
 /* FAB action buttons background */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8074,7 +8074,7 @@ only screen and (max-device-width: 568px) {
 *********************************/
 .diagram-fab{
   bottom: 10vh;
-  right: 15vw;
+  right: 7vw;
   display: none;
 }
 .diagram-btn-fab{


### PR DESCRIPTION
Made a working fab-button for the options menu that is only visible at mobile version.

Added a close-button to the options
menu. Also only visible when user is on mobile version.

https://github.com/user-attachments/assets/ab271a48-5ab5-4385-a5a6-a532d3868f13