### PR TITLE
Fix Lines move weirdly with recursive

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -1277,13 +1277,14 @@ function checkAdjacentLines(element) {
                 if (lineIdIndex === -1) { // Check if the line exists in the line's array
                     return false;
                 }
-                    const lineObject = lines[lineIdIndex];
-                if (lineObject.ghostLine || lineObject.targetGhost) { // To keep ghostlines active
-                    return lineObject.kind === lineKind.NORMAL;
+                
+                const lineObject = lines[lineIdIndex];
+                if (lineObject.ghostLine || lineObject.targetGhost) {
+                    return !lineObject.recursive;
                 }
-                    return lineObject.kind !== lineKind.RECURSIVE;
+                return !lineObject.recursive;
             });
-
+            
             if (filteredLines.length > 1) {
                 filteredLines.forEach((lineID, index) => {
                     const lineIndex = findIndex(lines, lineID);


### PR DESCRIPTION
Changed the part where to recursive lines should be sorted out of the offset.
The logic was broken and the recursive line where not excluded from the offset.
With this change the recursive line is now not part of the line offset and the lines behave as before and multiple recursive lines can not be stacked on each other.

[Screencast from 2025-05-19 11-59-21.webm](https://github.com/user-attachments/assets/3db9b40c-5f0a-4d07-9d4c-d21140a27a26)
