### PR TITLE
Fixed the sequence diagram lines #17590

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -601,6 +601,13 @@ function getLineAttributes(line, f, t, ctype, fromElemMouseY, toElemMouseY) {
     
     // Special case to handle sequence activation lines
     if (f.kind === elementTypesNames.sequenceActivation) {
+        //console.log(f.y, f.height, t.y);
+        
+        if (f.y > t.y || f.y + f.height < t.y){
+            console.log("utanför");
+            
+        }
+
         const fromKey = `from:${line.id}`;
         const toKey = `to:${line.id}`;
     

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -190,10 +190,14 @@ function drawLine(line, targetGhost = false) {
                     fill='none' stroke='${lineColor}' stroke-width='${strokewidth * zoomfact}' stroke-dasharray='${strokeDash}'
                 />`;
     } else {
-        
+
         // Some drawing options for the remainder of line types (UML, IE or Sequence)
         if (line.recursive) {
             lineStr += drawRecursive(offset, line, lineColor, strokewidth, strokeDash, felem);
+        }
+        else if (line.type === entityType.SE){
+            
+            lineStr += drawSequenceLine(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
         }
         else {
             lineStr += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
@@ -601,12 +605,6 @@ function getLineAttributes(line, f, t, ctype, fromElemMouseY, toElemMouseY) {
     
     // Special case to handle sequence activation lines
     if (f.kind === elementTypesNames.sequenceActivation) {
-        //console.log(f.y, f.height, t.y);
-        
-        if (f.y > t.y || f.y + f.height < t.y){
-            console.log("utanför");
-            
-        }
 
         const fromKey = `from:${line.id}`;
         const toKey = `to:${line.id}`;
@@ -909,6 +907,34 @@ function drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash) 
 
 }
 
+/**
+ * @description Draws the line between two sequence activation elements, or the mouse
+ * @param {Number} fx The felem x coordinate
+ * @param {Number} fy The felem y coordinate, not used here
+ * @param {Number} tx The telem x coordinate
+ * @param {Number} ty The telem y coordinate
+ * @param {Object} offset Offset for the X and Y coordinate
+ * @param {Object} line The line object that is drawn
+ * @param {Object} lineColor Where the start and end label should be
+ * @param {Number} strokeDash A number for patterns of dashes and gaps
+ * @returns Returns the line as segmented
+ */
+function drawSequenceLine(fx, fy, tx, ty, offset, line, lineColor, strokeDash){
+    // Calculate the horizontal start and end points
+    const startX = Math.min(fx + offset.x1, tx + offset.x2);
+    const endX = Math.max(fx + offset.x1, tx + offset.x2);
+    const yPosition = ty + offset.y2;
+
+    // Create a horizontal polyline
+    return `<polyline 
+                id='${line.id}' 
+                points='${startX},${yPosition} ${endX},${yPosition}' 
+                fill='none' 
+                stroke='${lineColor}' 
+                stroke-width='${strokewidth * zoomfact}' 
+                stroke-dasharray='${strokeDash}' 
+            />`;
+}
 /**
  * @description Draw a segmented recursive loop
  * @param {Number} fx The felem x coordinate

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -55,7 +55,7 @@ function addLine(fromElement, toElement, kind, isRecursive = false, stateMachine
 
     //separe statement when more than 2 lines are created
     //Moastly the same from above but with a check for 3 lines
-    } else if(numOfExistingLines < 3 || (specialCase && numOfExistingLines < 4)){
+    } else if(fromElement.kind != elementTypesNames.sequenceActivation && numOfExistingLines < 3 || (specialCase && numOfExistingLines < 4)){
         let newLine = {
             id: makeRandomID(),
             fromID: fromElement.id,
@@ -101,7 +101,7 @@ function checkConnectionErrors(to, from) {
 }
 
 function sequenceDrawError(from, to) {
-    if (from.kind === elementTypesNames.sequenceObject)
+    if (from.kind === elementTypesNames.sequenceActivation)
     {
         const fromTop = from.y;
         const fromBottom = from.y + from.height;

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -103,15 +103,15 @@ function checkConnectionErrors(to, from) {
     return '';
 }
 
+
+// Checks that the lines are within bounds between two sequence activation elements
 function sequenceDrawError(from) {
     
     if (from.kind === elementTypesNames.sequenceActivation) {
-        const mouseY = lastMousePos.y - from.height;
+        const mouseY = screenToDiagramCoordinates(lastMousePos.x, lastMousePos.y).y;
         const elementTop = from.y;
         const elementBottom = from.y + from.height;
-        console.log(mouseY, elementTop, elementBottom, from.height);
-        // Return true if the mouse is outside the element's Y bounds
-        return mouseY < elementTop || mouseY > elementBottom;
+        return elementTop > mouseY|| elementBottom < mouseY;
     }
     return false;
 }

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -54,8 +54,10 @@ function addLine(fromElement, toElement, kind, isRecursive = false, stateMachine
         result = newLine;
 
     //separe statement when more than 2 lines are created
-    //Moastly the same from above but with a check for 3 lines
-    } else if(fromElement.kind != elementTypesNames.sequenceActivation && numOfExistingLines < 3 || (specialCase && numOfExistingLines < 4)){
+    //Mostly the same from above but with a check for 3 lines
+    } 
+    
+    else if(fromElement.kind === elementTypesNames.sequenceActivation || (numOfExistingLines < 3 || (specialCase && numOfExistingLines < 4))){
         let newLine = {
             id: makeRandomID(),
             fromID: fromElement.id,
@@ -94,23 +96,24 @@ function checkConnectionErrors(to, from) {
     if (sequenceTypeError(from, to)) {
         return `Lines in sequence diagram can only be drawn between sequence activations`;
     }
-    if (sequenceDrawError(from,to)) {
+    // Uses to as from elements since the implementation of activation lines is done this way
+    if (sequenceDrawError(to)) {
         return `Drawn line out of bounds`;
     }
     return '';
 }
 
-function sequenceDrawError(from, to) {
-    if (from.kind === elementTypesNames.sequenceActivation)
-    {
-        const fromTop = from.y;
-        const fromBottom = from.y + from.height;
-        const toTop = to.y;
-        const toBottom = to.y + to.height;
+function sequenceDrawError(from) {
     
-        // Check if the ranges are completely separate
-        return fromBottom < toTop || toBottom < fromTop;
+    if (from.kind === elementTypesNames.sequenceActivation) {
+        const mouseY = lastMousePos.y - from.height;
+        const elementTop = from.y;
+        const elementBottom = from.y + from.height;
+        console.log(mouseY, elementTop, elementBottom, from.height);
+        // Return true if the mouse is outside the element's Y bounds
+        return mouseY < elementTop || mouseY > elementBottom;
     }
+    return false;
 }
 
 function sequenceTypeError(from,to){

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -94,7 +94,23 @@ function checkConnectionErrors(to, from) {
     if (sequenceTypeError(from, to)) {
         return `Lines in sequence diagram can only be drawn between sequence activations`;
     }
+    if (sequenceDrawError(from,to)) {
+        return `Drawn line out of bounds`;
+    }
     return '';
+}
+
+function sequenceDrawError(from, to) {
+    if (from.kind === elementTypesNames.sequenceObject)
+    {
+        const fromTop = from.y;
+        const fromBottom = from.y + from.height;
+        const toTop = to.y;
+        const toBottom = to.y + to.height;
+    
+        // Check if the ranges are completely separate
+        return fromBottom < toTop || toBottom < fromTop;
+    }
 }
 
 function sequenceTypeError(from,to){

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -98,7 +98,7 @@ function checkConnectionErrors(to, from) {
     }
     // Uses to as from elements since the implementation of activation lines is done this way
     if (sequenceDrawError(to)) {
-        return `Drawn line out of bounds`;
+        return `Drawn line is out of bounds`;
     }
     return '';
 }


### PR DESCRIPTION
closes https://github.com/HGustavs/LenaSYS/issues/17590.

Added bounds detection so that the lines only can be drawn to a position in an element that is within the first clicked elements y-coordinates.
Implemented a way of visually showing how the lines will look while dragging it around. Also removed the 3 line limit on activation elements.

_Video of the implementations_
https://github.com/user-attachments/assets/95b7ce5c-5b66-41ef-8c78-66a27017b395

### Known issues that still exists are:
Resizing the activation element will move the lines to unwanted positions. Arrows will also stick around weird places when resizing.
Moving an activation element will only carry with it the lines that were drawn _to_ it.
Undo/redo still a bit broken in sequence diagram, the line might not be added to statemachine or something.
