### PR TITLE
Fixed option menu does not show all options

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -165,6 +165,8 @@
     padding: 10px;
     transition: right .3s ease-in-out;
     user-select: none;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 #options-pane-button {
@@ -182,6 +184,17 @@
     vertical-align: top;
     display: inline-block;
 }
+
+ /* Hide scrollbar for Chrome, Safari and Opera */
+#options-pane::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+#options-pane {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+} 
 
 .show-options-pane {
     right: 0px;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -185,16 +185,29 @@
     display: inline-block;
 }
 
- /* Hide scrollbar for Chrome, Safari and Opera */
+/* Options-scrollbar width */
 #options-pane::-webkit-scrollbar {
-  display: none;
+    width: 10px;
 }
 
-/* Hide scrollbar for IE, Edge and Firefox */
-#options-pane {
-  -ms-overflow-style: none;  /* IE and Edge */
-  scrollbar-width: none;  /* Firefox */
-} 
+/*  Options-scrollbar track */
+#options-pane::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 10px;
+    box-shadow: inset 0 0 5px grey;
+}
+
+/*  Options-scrollbar handle */
+#options-pane::-webkit-scrollbar-thumb {
+    background: #64417A;
+    border-radius: 10px;
+}
+
+/*  Options-scrollbar handle on hover */
+#options-pane::-webkit-scrollbar-thumb:hover {
+    background: #64417A;
+    border-radius: 10px;
+}
 
 .show-options-pane {
     right: 0px;


### PR DESCRIPTION
The problem were not that the elements didn't show, because they are always "visible". The problem was that depending on the users screen size, they may had to scroll down in the whole browserwindow. This made some options "disappear" when they in reality only were outside of the screen. To fix this, I implemented a scrollbar in the options panel and styled it a bit to make it fit in more (it can still be a lot nicer).

**NOTE:** This scrollbar only works in web browsers that uses chromium. The other ones gets the default ugly looking gray scrollbar.

https://github.com/user-attachments/assets/06e32b75-9005-49f8-b4b8-ac401f651fa0

