### PR TITLE
Changed the background color of burger drop down on mobile #17495

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -67,7 +67,6 @@
 	background-color: var(--color-background);
 }
 
-
 #picktemplate{
 	position: absolute;
 	top: 0px;

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -67,6 +67,7 @@
 	background-color: var(--color-background);
 }
 
+
 #picktemplate{
 	position: absolute;
 	top: 0px;
@@ -437,6 +438,10 @@
 	font-family: Arial, Sans-Serif !important;
 	cursor:default !important;
 	color: var(--color-text-light) !important;
+}
+
+#hamburgerBox{
+    background-color: var(--color-primary);
 }
 
 /* ========================

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -440,7 +440,7 @@
 }
 
 #hamburgerBox{
-    background-color: var(--color-primary);
+    background-color: var(--color-background);
 }
 
 /* ========================


### PR DESCRIPTION
I think this is what the issue wanted.
Only added the hamburgerBox tag to the dark mode file and gave it the correct color

pic of how the dropdown looks in dark mode now.
![image](https://github.com/user-attachments/assets/2de1ac29-36a5-492b-b956-c040b1edee39)

I personally think it looks worse but this is what the issue wanted (unless I have misunderstood something)