### PR TITLE
Tried to fix GitHub functionality #17702

### DIFF
--- a/DuggaSys/gitfetchService.php
+++ b/DuggaSys/gitfetchService.php
@@ -289,4 +289,18 @@ function bfs($url, $cid, $opt)
     }
 }
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $cid = $_POST['cid'] ?? null;
+    $url = $_POST['githubURL'] ?? null;
+
+    if ($cid && $url) {
+        // Call bfs to download files from GitHub
+        bfs($url, $cid, "DOWNLOAD");
+        echo json_encode(["status" => "ok", "message" => "GitHub repo downloaded."]);
+    } else {
+        echo json_encode(["status" => "error", "message" => "Missing 'cid' or 'githubURL'."]);
+    }
+}
+
 ?>
+

--- a/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
+++ b/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php
@@ -136,7 +136,6 @@ function NoCodeExampleFilesExist($exampleName, $groupedFiles)
     $url = $baseURL . "/LenaSYS/DuggaSys/microservices/sharedMicroservices/createNewCodeExample_ms.php";
 
     $dataToSend = [
-        'exampleid' => $exampleid,
         'courseid' => $courseid,
         'coursevers' => $coursevers,
         'sectname' => $sectionname,

--- a/DuggaSys/test_gitfetch.php
+++ b/DuggaSys/test_gitfetch.php
@@ -1,0 +1,23 @@
+<?php
+$url = "http://localhost/LenaSYS/DuggaSys/gitfetchService.php";
+
+$data = [
+    'cid' => 1902,
+    'githubURL' => 'https://github.com/LenaSYS/Webbprogrammering-Examples'
+];
+
+$ch = curl_init($url);
+
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+curl_setopt($ch, CURLOPT_POST, true);
+
+$response = curl_exec($ch);
+$err = curl_error($ch);
+curl_close($ch);
+
+if ($err) {
+    echo "Curl error: " . $err;
+} else {
+    echo $response;
+}


### PR DESCRIPTION
The problem I found was that when a new course is created, the files from the GitHub repo are not downloaded into the course folder (courses/"cid"/Github/) like they should be.

I’m committing the changes I’ve made so far related to the GitHub file download when a new course is created.

I don’t even know if this is the actual problem we’re supposed to fix, but I tried to make it so the files from the GitHub repo are downloaded automatically. I got it working through a separate test file, but couldn’t get it to work properly from the normal course creation automatically.

I’ll commit what I have anyway, just in case it helps or someone else knows how to continue from here. I’m a bit lost. 

#17702