### PR TITLE
Fixed: Fix so fab buttons doesn't disappears when loading file

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -74,12 +74,18 @@
 #diagramFileName {
     position: absolute;
     z-index: 1000;
-    margin-left: 50vw;
-    margin-top: 6vh;
+    inset: 6vh 0 auto 0; /*Shorthand, top right bottom left*/
+    max-width: 245px;
+    margin-inline: auto; /*Centers the box*/
     padding: 2px;
     background-color: #fff;
     border: #775886 1px solid;
     text-align: center;
+
+    >p{
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }
 
 #svgbacklayer {


### PR DESCRIPTION
The buttons did not disappear, they were out of the screen because the diagramFileName created overflow. The solution was to set a max-width on it and then place a overflow hidden and text-overflow ellipsis on the p-tag. This creates an ellipsis implying that the file name is longer only when the name is longer than the width of the diagramFileName. see video 1 for illustration. 

Fixed the issue #17703 

video 1

https://github.com/user-attachments/assets/2fe3ca35-899f-4b61-83ed-457eb11e715b

