### PR TITLE
Rectangular FAB menu in mobile view same as in desktop view

### DIFF
--- a/DuggaSys/sectioned.php
+++ b/DuggaSys/sectioned.php
@@ -218,7 +218,7 @@
 			</div>
 		</div>
 
-		<!-- + button --->
+		<!-- + button -->
 
 
 		<div id='Sectionlist'>

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7843,6 +7843,7 @@ only screen and (max-device-width: 568px) {
     text-align: center;
     flex-wrap: wrap; /* Allow wrapping of elements */
     height: auto;
+  }
 }
 
 .fixed-action-button {
@@ -7987,30 +7988,6 @@ only screen and (max-device-width: 568px) {
   z-index:2;
 }
 
-@media only screen and (max-width: 430px) {
-  .fab-btn-list2 {
-    left: 3.4rem;
-  }
-}
-
-@media screen and (max-height: 600px) {
-  .fab-btn-list2{
-    top: 30px;
-    left: 45px;
-    transform: rotate(90deg);
-    transform-origin: top left;
-  }
-
-  .fab-btn-list2 li {
-    transform: rotate(225deg);
-  }
-
-  [data-tooltip]:before {
-    right: 55%;
-    top: 10px;
-  }
-}
-
 .fab-btn-list li, .fab-btn-list2 li  {
   display: inline-block;
   margin-bottom: 15px;
@@ -8025,15 +8002,8 @@ only screen and (max-device-width: 568px) {
 }
 
 @media screen and (max-height: 600px) {
-  .fab-btn-list {
-    transform-origin: 0% bottom;
-    transform: rotate(270deg);
-  }
-  .fab-btn-sm {
-    transform: rotate(375deg);
-  }
-  [data-tooltip]:before {
-    bottom: 90%;
+  .fab-btn-list2 {
+    padding: 3rem 3rem 0rem 1rem;
   }
 }
 


### PR DESCRIPTION
The small (rectangular) FAB button menu in mobile view should now function and appear the same as in the desktop view.

To achieve this, the mobile version of the rectangular FAB menu was removed. Additionally, the round FAB button was also removed from the mobile view, as it caused item text to display incorrectly in the rectangular FAB menu.

The default window size for mobile testing is 320x600.
##
### Info about the round FAB menu
The round FAB button will be completely removed from the mobile version in a separate issue, as discussed with the group leader. Furthermore, not all menu items were visible when using the round FAB button.

