### PR TITLE
Convert jquery in \DuggaSys\templates\generic_dugga_file_receive.js #17538

### DIFF
--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -53,7 +53,7 @@ function returnedDugga(data)
 				document.getElementById("snus").innerHTML="<embed src='showdoc.php?cid="+inParams["cid"]+"&fname="+duggaParams["filelink"]+"' width='100%' height='1000px' type='application/pdf'>";
 		}else if(duggaParams["type"]==="md" || duggaParams["type"]==="html"){
 			$.ajax({url: "showdoc.php?cid="+inParams["cid"]+"&fname="+duggaParams["filelink"]+"&headers=none", success: function(result){
-        		document.getElementById("snus").innerHTML=result;
+        		$("#snus").html(result);
 				// Placeholder code
 	        	var pl = duggaParams.placeholders;
 				if (pl !== undefined) {


### PR DESCRIPTION
Converted JQuery for 'generic_dugga_file_recieve.js', there should be none remaining except for AJAX related.