### PR TITLE
Added missing inverse dependencies for retrieveSectionedService_ms.php in Microservices_inverse_dependencies.md #17694

### DIFF
--- a/DuggaSys/microservices/Microservices_inverse_dependencies.md
+++ b/DuggaSys/microservices/Microservices_inverse_dependencies.md
@@ -315,6 +315,8 @@ None
 - \sectionedService\updateListEntryOrder_ms.php
 - \sectionedService\updateQuizDeadline_ms.php
 - \sectionedService\updateVisibleListEntries_ms.php
+- \sectionedService\createGithubCodeExample_ms.php
+- \sectionedService\createListEntry_ms.php
 
 ### setVisibleListentries
 None


### PR DESCRIPTION
fixes #17694 . I found two more inverse dependencies for retrieveSectionedService_ms.php and added them in Microservices_inverse_dependencies.md. The documentation has to be correct before the re-engineering of this microservice can be done.