### PR TITLE
Fixed: Multiple activation element snap bug

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1143,14 +1143,25 @@ function mmoving(event) {
 
                 // Check coordinates of moveable element and if they are within snap threshold
                 const moveableElementPos = screenToDiagramCoordinates(event.clientX, event.clientY);
+                // Lifeline coordinates to visualize snap for selected activation elements
                 const snapId = visualSnapToLifeline(moveableElementPos);
-
-                // Visualize the context snapping to lifeline (only a visual indication)
-                if (snapId && context[0]?.kind === elementTypesNames.sequenceActivation) {
+                
+                // Visualized snap to lifeline
+                if (snapId) {
                     const lLine = data.find(el => el.id === snapId);
-                    context[0].x = lLine.x + lLine.width / 2 - context[0].width / 2;
-                    startX = event.clientX;
-                    deltaX = 0;
+                    let anySnapped = false;
+
+                    context.forEach(el => {
+                        if (el.kind === elementTypesNames.sequenceActivation) {
+                            el.x = lLine.x + (lLine.width / 2) - (el.width / 2);
+                            anySnapped = true;
+                        }
+                    });
+
+                    if (anySnapped) {
+                        startX = event.clientX;
+                        deltaX = 0;
+                    }
                 }
                 updatepos();
                 calculateDeltaExceeded();


### PR DESCRIPTION
Now multiple sequenceActivations are allowed to snap, at the same time, to a lifeline when they are box selected. However if there are different elements within the box selection (in addition to sequenceActivations) the erratic behaviour still persists for these. This problem was there before this fix but at least sequenceActivations now behave correctly. The bug is a minor one as the user will seldom attempt to box select-snap a mixture of elements not belonging to a sequence diagram when that diagram type is the focus. This could be targeted in a future issue should it be deemed necessary.

https://github.com/user-attachments/assets/dc4c0083-72e8-4654-a61a-e6c2bc6f4418