### PR TITLE
Add dependencies to microserviceUI #17721

### DIFF
--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -103,6 +103,12 @@ if (isset($_GET['id'])) {
         $stmt->execute([$_GET['id']]);
         $dependencies = $stmt->fetchAll();
     }
+
+    if ($microservice) {
+        $stmt = $db->prepare("SELECT * FROM dependencies WHERE dependency_id = ?");
+        $stmt->execute([$_GET['id']]);
+        $depending_on = $stmt->fetchAll();
+    }
 }
 
 } catch (PDOException $e) {

--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -252,9 +252,9 @@ if (isset($_GET['id'])) {
         <?php } ?>
         <?php 
         echo "<h3>Dependencies</h3>";
+        echo "Inverse dependencies - A list of microservices that depends on '<b>" . $microservice['ms_name'] . "</b>'";
         if (!empty($dependencies)) {
             echo "<table>";
-            echo "Inverse dependencies - A list of microservices that depends on '<b>" . $microservice['ms_name'] . "</b>'";
             echo "<tr><th>Microservice</th><th>Path</th></tr>";
             foreach ($dependencies as $dependency) {
                 echo '<tr>';
@@ -262,13 +262,14 @@ if (isset($_GET['id'])) {
                 echo '<td>' . $dependency['path'] . '</td>';
                 echo '</tr>';
             }
+            echo "</table>";
         } else {
             echo "<p>No inverse dependencies</p>";
         }
 
+        echo "Dependencies - A list of microservices that <b>'"  . $microservice['ms_name'] . "</b>' depends on";
         if (!empty($depending_on)) {
             echo "<table>";
-            echo "Dependencies - A list of microservices that <b>'"  . $microservice['ms_name'] . "</b>' depends on";
             echo "<tr><th>Microservice</th><th>Path</th></tr>";
             foreach ($depending_on as $depends) {
                 echo '<tr>';
@@ -276,6 +277,7 @@ if (isset($_GET['id'])) {
                 echo '<td>' . $depends['path'] . '</td>';
                 echo '</tr>';
             }
+            echo "</table>";
         } else {
             echo "<p>No dependencies</p>";
         }

--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -254,12 +254,26 @@ if (isset($_GET['id'])) {
         echo "<h3>Dependencies</h3>";
         if (!empty($dependencies)) {
             echo "<table>";
-            echo "List of microservices that depends on '<b>" . $microservice['ms_name'] . "</b>'";
+            echo "Inverse dependencies - A list of microservices that depends on '<b>" . $microservice['ms_name'] . "</b>'";
             echo "<tr><th>Microservice</th><th>Path</th></tr>";
             foreach ($dependencies as $dependency) {
                 echo '<tr>';
                 echo '<td>' . "<a href=?id=" . $dependency['depends_on_id'] . ">" . $dependency['depends_on'] . '</td>';
                 echo '<td>' . $dependency['path'] . '</td>';
+                echo '</tr>';
+            }
+        } else {
+            echo "<p>No inverse dependencies</p>";
+        }
+
+        if (!empty($depending_on)) {
+            echo "<table>";
+            echo "Dependencies - A list of microservices that <b>'"  . $microservice['ms_name'] . "</b>' depends on";
+            echo "<tr><th>Microservice</th><th>Path</th></tr>";
+            foreach ($depending_on as $depends) {
+                echo '<tr>';
+                echo '<td>' . "<a href=?id=" . $depends['depends_on_id'] . ">" . $depends['depends_on'] . '</td>';
+                echo '<td>' . $depends['path'] . '</td>';
                 echo '</tr>';
             }
         } else {

--- a/DuggaSys/microservices/endpointDirectory/microserviceUI.php
+++ b/DuggaSys/microservices/endpointDirectory/microserviceUI.php
@@ -105,7 +105,7 @@ if (isset($_GET['id'])) {
     }
 
     if ($microservice) {
-        $stmt = $db->prepare("SELECT * FROM dependencies WHERE dependency_id = ?");
+        $stmt = $db->prepare("SELECT * FROM dependencies WHERE depends_on_id = ?");
         $stmt->execute([$_GET['id']]);
         $depending_on = $stmt->fetchAll();
     }
@@ -272,7 +272,7 @@ if (isset($_GET['id'])) {
             echo "<tr><th>Microservice</th><th>Path</th></tr>";
             foreach ($depending_on as $depends) {
                 echo '<tr>';
-                echo '<td>' . "<a href=?id=" . $depends['depends_on_id'] . ">" . $depends['depends_on'] . '</td>';
+                echo '<td>' . "<a href=?id=" . $depends['microservice_id'] . ">" . $depends['ms_name'] . '</td>';
                 echo '<td>' . $depends['path'] . '</td>';
                 echo '</tr>';
             }


### PR DESCRIPTION
Added a query to get dependencies and added another table to the dependencies. Now both inverse dependencies and dependencies for a microservice are displayed. 
Only inverse dependencies was displayed before. Fixes #17721 

<img width="818" alt="image" src="https://github.com/user-attachments/assets/fad1511b-fc2e-42a1-88b5-13a23309a3b5" />
