### PR TITLE
Fixed home-screen instances on mobile (#17734)

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -529,7 +529,7 @@ function getData() {
     //Side navbar buttons. (save, load and reset are inside diagram_dugga)
     document.getElementById("mb-darkModeButton").addEventListener("click", burgerToggleDarkmode);
     document.getElementById("mb-Home").addEventListener("click", () => { //had to be in a function or it
-        window.location.assign('../DuggaSys/courseed.php');
+        window.top.location.assign('../DuggaSys/courseed.php');
     });
 
     const loginButton = document.getElementById("mb-loginButton");


### PR DESCRIPTION
When using the home-button on mobile, it would nestle the home-page inside the diagram-area rather than in the full window, see issue #17734 . Fixed the issue so it affects the full screen/window instead, and it no longer nestles the page within the diagram-area. 


https://github.com/user-attachments/assets/d0ea6726-27fe-46d7-9d28-73ddc817069c

