### PR TITLE
Fixed elements placed on the canvas is above the FAB

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -331,7 +331,7 @@
     .icon-wrapper{
         display: block !important;
         position: fixed;
-        z-index: 10;
+        z-index: 5000;
         bottom: 5%;
         left: 50%;
         transform: translateX(-50%);
@@ -341,7 +341,7 @@
      .icon-wrapper-sidebar{
         display: block !important;
         position: fixed;
-        z-index: 10;
+        z-index: 5000;
         right: 10%;
         top: 50%;
         transform: translateX(-50%);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7727,7 +7727,7 @@ only screen and (max-device-width: 568px) {
   position: fixed;
   bottom: 64px;
   right: 24px;
-  z-index: 1;
+  z-index: 5000;
   touch-action: none;
 }
 


### PR DESCRIPTION
This solution is not good but does the job. I changed the z-index from 10 to 5000 but the user can still make the object appear above the FAB and the menu-buttons if the "Bring to Front" is pressed enough times. I can try to implement a better solution for this but it has to be made next week (G1-2025-v8).

https://github.com/user-attachments/assets/7e0d2d47-d76d-4ad5-8c17-242c64fbed73

