### PR TITLE
Implemented feature: Automatic options-panel toggle

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -810,7 +810,7 @@
     <!-- OPTIONS PANE -->
     <!-- Yellow panel on the right side of the screen -->
     <div id="options-pane" class="hide-options-pane"> 
-        <div id="options-pane-button" class="tooltip-target" onclick="toggleOptionsPane();" data-toolmode="Option_Panel" data-toolid="24">
+        <div id="options-pane-button" class="tooltip-target" onclick="toggleOptionsPane(true);" data-toolmode="Option_Panel" data-toolid="24">
             <span id='optmarker'>&#9660;Options</span>
         </div>
 

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -810,7 +810,7 @@
     <!-- OPTIONS PANE -->
     <!-- Yellow panel on the right side of the screen -->
     <div id="options-pane" class="hide-options-pane"> 
-        <div id="options-pane-button" class="tooltip-target" onclick="toggleOptionsPane(true);" data-toolmode="Option_Panel" data-toolid="24">
+        <div id="options-pane-button" class="tooltip-target" onclick="toggleOptionsPane();" data-toolmode="Option_Panel" data-toolid="24">
             <span id='optmarker'>&#9660;Options</span>
         </div>
 

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -474,16 +474,26 @@ function setLineLabel() {
  * @description Toggles the option menu being open or closed.
  */
 function toggleOptionsPane() {
-    if (document.getElementById("options-pane").className == "show-options-pane") {
-        document.getElementById('optmarker').innerHTML = "&#9660;Options";
-        if (document.getElementById("BGColorMenu") != null) {
-            document.getElementById("BGColorMenu").style.visibility = "hidden";
-        }
-        document.getElementById("options-pane").className = "hide-options-pane";
-    } else {
-        document.getElementById('optmarker').innerHTML = "&#9650;Options";
-        document.getElementById("options-pane").className = "show-options-pane";
+    if (!optionsToggled){
+        optionsToggled = true;
+        userLock = true;
+        showOptionsPane();
     }
+    else if (optionsToggled) {
+        optionsToggled = false;
+        userLock = false;
+        hideOptionsPane();
+    } 
+}
+
+function showOptionsPane(){
+    document.getElementById('optmarker').innerHTML = "&#9650;Options";
+    document.getElementById("options-pane").className = "show-options-pane"; // Toggle optionspanel.
+}
+
+function hideOptionsPane(){
+    document.getElementById('optmarker').innerHTML = "&#9660;Options";
+    document.getElementById("options-pane").className = "hide-options-pane";
 }
 
 /**

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -475,13 +475,13 @@ function setLineLabel() {
  */
 function toggleOptionsPane() {
     if (!optionsToggled){
-        optionsToggled = true;
-        userLock = true;
+        optionsToggled = !optionsToggled;
+        userLock = !userLock;
         showOptionsPane();
     }
     else if (optionsToggled) {
-        optionsToggled = false;
-        userLock = false;
+        optionsToggled = !optionsToggled;
+        userLock = !userLock;
         hideOptionsPane();
     } 
 }

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -110,7 +110,16 @@ function mdown(event) {
                             }
                         }
                         break;
-                    } 
+                    } else {
+                        pointerState = pointerStates.CLICKED_CONTAINER;
+                        containerStyle.cursor = "grabbing";
+
+                        if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
+                            wasDblClicked = true;
+                            toggleOptionsPane();
+                        }
+                        break;
+                    }
                 case mouseModes.BOX_SELECTION:
                     // If pressed down in selection box
                     if (context.length > 0) {

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -24,6 +24,13 @@ function mwheel(event) {
 function mdown(event) {
     mouseButtonDown = true;
 
+    //If anything but an element was clicked, toggle options panel.
+    if (event.target.id == "container" && optionsToggled && !userLock) {
+        console.log(event.target.id);
+        optionsToggled = false;
+        hideOptionsPane();
+    }
+
     // Mouse pressed over delete button for multiple elements
     if (event.button == 0) {
         if (context.length > 0 || contextLine.length > 0) {
@@ -165,6 +172,13 @@ function mdown(event) {
  * @param {MouseEvent} event Triggered mouse event.
  */
 function ddown(event) {
+    
+    //If element was clicked, open options panel.
+    if (!optionsToggled && !userLock) {
+        optionsToggled = true;
+        showOptionsPane();
+    }
+    
     // Mouse pressed over delete button for a single line over a element
     if (event.button == 0 && (contextLine.length > 0 || context.length > 0)) {
         canPressDeleteBtn = true;
@@ -183,8 +197,6 @@ function ddown(event) {
                 input.focus();
                 input.setSelectionRange(0, input.value.length); // Select the whole text.
             }
-            document.getElementById('optmarker').innerHTML = "&#9650;Options";
-            document.getElementById("options-pane").className = "show-options-pane"; // Toggle optionspanel.
         }
     }
 
@@ -342,6 +354,10 @@ function tup() {
     mouseButtonDown = false;
     pointerState = pointerStates.DEFAULT;
     deltaExceeded = false;
+    if (optionsToggled && !userLock) {
+        optionsToggled = false;
+        hideOptionsPane();
+    }
 }
 
 /**

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -100,20 +100,10 @@ function mdown(event) {
                             containerStyle.cursor = "grabbing";
                             if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
                                 wasDblClicked = true;
-                                document.getElementById("options-pane").className = "hide-options-pane";
                             }
                         }
                         break;
-                    } else {
-                        pointerState = pointerStates.CLICKED_CONTAINER;
-                        containerStyle.cursor = "grabbing";
-
-                        if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
-                            wasDblClicked = true;
-                            toggleOptionsPane();
-                        }
-                        break;
-                    }
+                    } 
                 case mouseModes.BOX_SELECTION:
                     // If pressed down in selection box
                     if (context.length > 0) {

--- a/DuggaSys/diagram/globals.js
+++ b/DuggaSys/diagram/globals.js
@@ -373,6 +373,13 @@ var lastMousePosCoords = new Point(0, 0);
 //#region OPTIONS
 
 /**
+ * @description Flag indicating how options panel was opened.
+ * @see toggleOptionsPane
+ * @type {boolean}
+ */
+let userToggled = false;
+
+/**
  * @description If the ER table should be shown over the the options pane.
  * @see toggleErTable
  * @see generateContextProperties

--- a/DuggaSys/diagram/globals.js
+++ b/DuggaSys/diagram/globals.js
@@ -373,11 +373,18 @@ var lastMousePosCoords = new Point(0, 0);
 //#region OPTIONS
 
 /**
- * @description Flag indicating how options panel was opened.
+ * @description Flag indicating opened/closed options panel.
  * @see toggleOptionsPane
  * @type {boolean}
  */
-let userToggled = false;
+let optionsToggled = false;
+
+/**
+ * @description Flag indicating a locked options panel, (user opened).
+ * @see toggleOptionsPane
+ * @type {boolean}
+ */
+let userLock = false;
 
 /**
  * @description If the ER table should be shown over the the options pane.


### PR DESCRIPTION
This is an implementation of the feature mentioned in the following issue: (#17731). It allows for the options panel to toggle automatically upon selecting elements, which allows for a smoother interface and a faster and easier UX. 

**It works as follows:** 
By default the options panel will open when selecting an element to edit, and it will hide as soon as either the canvas or the toolbar is clicked. 

The user can also lock the toolbar into a desired position i.e. they can open the toolbar before placing any elements and it will remain open until the user closes it. During this state it stays unaffected by any automatic toggle-attempts following selection and de-selection of elements.

Similarly, the user can close the toolbar if they wish to keep it closed while editing elements, and it will remain closed until the user opens it again. Same here, not being affected by any automatic toggle-attempts.

 To reset the toolbar behavior the default behavior, manually opening/closing the toolbar again will reset it, depending on what position it was locked in.

**View this as a partially complete solution, that can be extended upon if deemed suitable for merging.**

Additional notes: 
* This is implemented for single-selection of elements, but can easily be extended to account for box-selection as well if needed to. 
* The locking of whatever toolbar behavior is in use (staying closed or remaining open) isn't inherently clear to the user right now. But a lock icon or a message dialog or similar can be implemented with ease to clearly signal this status to the user. Similarly, the locking can be attributed to a designated button instead of resulting from operating the toolbar manually, which might not be inherently obvious.

