### PR TITLE
G3-2025-v7-bugfix-(mobile view)-bug-darkmode-text-hard-to-read-when-editing-course-visibility-17576#

### DIFF
--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -158,7 +158,7 @@ if(isset($_SESSION['uid'])){
 				</div>			
 				<div class='inputwrapper'>
 					<span>Visibility:</span>
-					<select class='selectinput margin-right_0px' id='visib'></select>
+					<select class="selectDarkModeText margin-right_0px" id='visib'></select>
 				</div>
     		</div>
 			<div class="formFooter" id='editCourseButtonPlacement' >

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -898,8 +898,8 @@ option:checked{
 /* END */
 
 select{
-    background-color: var(--color-background-light-surface);
-    color: var(--color-text-list);
+    
+    color: var(--color-text-light);
     border-radius: 5px;
 }
 

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -9,6 +9,7 @@
         --color-text-label: #000;
         --color-text-dark: #000;
         --color-text-light: #fff;
+        --color-text-unset: #aaaaaa;
       
         --color-logo1: #775886;
         --color-logo2: #573866;
@@ -903,7 +904,7 @@ select{
     border-radius: 5px;
 }
 
-select.selectDarkmodeText{
+select.selectDarkModeText{
     color: var(--color-text-light);
 }
 
@@ -1299,6 +1300,11 @@ border-left: 14px solid var(--color-sectioned-table-hi);
   
  .textinput {
     color:white;
+    background-color: var(--color-background);
+}
+
+ .textinput::placeholder {
+    color: var(--color-text-unset);
     background-color: var(--color-background);
 }
 

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -898,9 +898,13 @@ option:checked{
 /* END */
 
 select{
-    
-    color: var(--color-text-light);
+    background-color: var(--color-background-light-surface);
+    color: var(--color-text-list);
     border-radius: 5px;
+}
+
+select.selectDarkmodeText{
+    color: var(--color-text-light);
 }
 
 input{

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2407,6 +2407,7 @@ Dialog Box END
   width: 195px;
   height: 30px;
   line-height: 18px;
+  color: #6f6f6f;
   background-color: var(--color-background);
   border: 1px solid var(--color-border-2);
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -2407,7 +2407,6 @@ Dialog Box END
   width: 195px;
   height: 30px;
   line-height: 18px;
-  color: #6f6f6f;
   background-color: var(--color-background);
   border: 1px solid var(--color-border-2);
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);


### PR DESCRIPTION
### Changes made:
- Added styling regarding placeholders - making sure that github URL and Key text doesn't fall back to default (lightmode)
- Added specialized styling for the dropdown menu, since other files (like the contribution files from what I've gathered) might use the general select-styling within blackTheme.css.
  - Made sure that the dropdown menu selected item is the same color as other inserted items 
  _(such as course name and course code within image1 below.)_

Note that these change has affected the desktop dark mode view as well.

![image](https://github.com/user-attachments/assets/b4b507ab-ddba-4aa7-a08b-b4742809e995)
_(image1, displaying old (left) and updated (right) edit menu)_

---

### Possible errors present within both groupbranch and this PR:
There seems to appear a white background behind the Github URL when inserted (and valid) when testing on chrome _(image2.)_ I'm unsure if this is a me-problem, since I seem to have the same issue on the group-branch. 
- If possible, please confirm if the issue exists.

![image](https://github.com/user-attachments/assets/613965bb-be64-4fe8-9031-8805cc932ed3)
_(image2)_

---
### How to get to the functionality:

enter courseed.php (main menu) -> login as brom -> click the cogwheel _(image3)_ to edit course of your choice (ex. Datorns grunder) and press the visibility dropdown. 
![image](https://github.com/user-attachments/assets/317266ab-f083-4409-972f-c5790f18f715)
_(image3)_

-> This will lead you to one of the edit menus in _image1_