### PR TITLE
Fixed hover effect in options panel

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -520,12 +520,12 @@
 }
 
 .saveButton:hover {
-    background: #815e9d;
-    color: #FFF;
+    background-color: #815e9d !important;
+    color: #FFF !important;
 }
 
 .saveButton:active {
-    background: #614875;
+    background-color: #614875;
     transition: 0.1s;
     color: #FFF;
 }


### PR DESCRIPTION
A function in toggle.js made inline styling which overrid diagram.css. Resulting in the hover effect being useless. Added !important to the hover class to make sure it is always active. Make sure to check issue #17718 for a video of before this change as reference.
