### PR TITLE
[#17616] Decreased sensitivity of the way the system determines line connection type

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -1244,13 +1244,18 @@ function determineLine(line, targetGhost = false) {
     if (felem.y1 > telem.y2 || felem.y2 < telem.y1) overlapY = false;
     let overlapX = true;
     if (felem.x1 > telem.x2 || felem.x2 < telem.x1) overlapX = false;
-    let majorX = true;
-    if (Math.abs(line.dy) > Math.abs(line.dx)) majorX = false;
+
+    if (Math.abs(line.dy) > Math.abs(line.dx * 1.5)) line.majorX = false; // Top/Bottom if middle point between the two elements crosses the border closer to x = 0
+    else if (Math.abs(line.dy) < Math.abs(line.dx / 3)) line.majorX = true; // Left/Right if middle point crosses the border closer to y = 0
+
+    if (line.majorX === undefined) line.majorX = true; // For when initially creating the line, so as to not cause any problems in the code
+
     // Determine connection type (top to bottom / left to right or reverse) - no top to side possible
-    if (overlapY || ((majorX) && (!overlapX))) {
+    // A deadzone exists that lets the current connection type remain as long as the middle point between the two elements doesnt cross the opposing border
+    if (overlapY || ((line.majorX) && (!overlapX))) {
         if (line.dx > 0) line.ctype = lineDirection.LEFT;
         else line.ctype = lineDirection.RIGHT;
-    } else {
+    } else if (overlapX || ((!line.majorX) && (!overlapY))){
         if (line.dy > 0) line.ctype = lineDirection.UP;
         else line.ctype = lineDirection.DOWN;
     }


### PR DESCRIPTION
With the way the entire system for drawing lines and determining the connection type between them, it is essentially impossible to implement logic to "fix" the line moving issue described. To do that a large amount of code would have to be rewritten to accommodate a better way of determining it, as it's currently determined by the middle point between two elements instead of the lines position relative to the elements. This code also affects all lines which could cause a lot of issues if all lines aren't accounted for.

In order to somewhat alleviate the problem presented, the leniency of the determining system has been increased. There is now a dead zone which retains the current connection type until the border of the opposite type is crossed. This is as mentioned not a complete fix to the issue and is admittedly more of a band-aid fix than anything, but it should be less eccentric when moving an element in a diagram. This has however made it so that if you manage to move it to the wrong side, it takes quite a bit more movement to get it back to the original connection type. It's an unfortunate side effect of this but all in all it should be easier to move elements and lines around now without accidentally changing what side the line connects to.


**How it works in the diagram shown in the issue description (still kinda janky, but a bit more flexible):**

https://github.com/user-attachments/assets/19e73787-99dd-432d-9a13-a63807ccfa78


**Demonstration between two SD elements:**

https://github.com/user-attachments/assets/4d1fea37-cbdc-4a99-b02f-7acd02d83c8f

