### PR TITLE
G1 2025 v7 17559 arrows are wrong in state diagram

### DIFF
--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -227,9 +227,8 @@ function drawLine(line, targetGhost = false) {
             let felem, telem;
             felem = data[findIndex(data, line.fromID)];
             telem = data[findIndex(data, line.toID)];
-            angleDeg = findRotation(felem,telem,line);
             const arrowStartPos = calculateArrowPosition(fx, fy, tx, ty, "start", line.innerType);
-            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,angleDeg);
+            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(felem,telem,line.ctype));
         }
 
         // Handle end arrow
@@ -237,9 +236,8 @@ function drawLine(line, targetGhost = false) {
             let felem, telem;
             felem = data[findIndex(data, line.fromID)];
             telem = data[findIndex(data, line.toID)];
-            let angleDeg = findRotation(felem,telem,line);
             const arrowEndPos = calculateArrowPosition(fx, fy, tx, ty, "end", line.innerType);
-            lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,angleDeg);
+            lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,findRotation(felem,telem,line.ctype));
         }
     }    
         
@@ -422,9 +420,9 @@ function calculateArrowPosition(fx, fy, tx, ty, position, lineType, targetWidth 
     }
 }
 
-function findRotation(felem,telem,line){
+function findRotation(felem,telem,ctype){
     let angleRad;
-    switch(line.ctype){
+    switch(ctype){
         case "RL":
             angleRad = Math.atan2((telem.y - (felem.height/2)) - (felem.y - (felem.height/2)), telem.x - felem.x - felem.width); // in radians     
             break;
@@ -441,7 +439,6 @@ function findRotation(felem,telem,line){
             angleRad = 0;
             break;
     }
-        
     return angleRad * (180 / Math.PI);   // convert to degrees
 }
 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -246,7 +246,7 @@ function drawLine(line, targetGhost = false) {
             felem = data[findIndex(data, line.fromID)];
             telem = data[findIndex(data, line.toID)];
             const arrowStartPos = calculateArrowPosition(fx+(iconXModifier*zoomfact), fy+(iconYModifier*zoomfact), tx+(iconXModifier*zoomfact), ty+(iconYModifier*zoomfact), "start", line.innerType);
-            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(felem,telem,line.ctype));
+            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(felem,telem));
         }
 
         // Handle end arrow
@@ -255,7 +255,7 @@ function drawLine(line, targetGhost = false) {
             felem = data[findIndex(data, line.fromID)];
             telem = data[findIndex(data, line.toID)];
             const arrowEndPos = calculateArrowPosition(fx-(iconXModifier*zoomfact), fy-(iconYModifier*zoomfact), tx-(iconXModifier*zoomfact), ty-(iconYModifier*zoomfact), "end", line.innerType);
-            lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,findRotation(felem,telem,line.ctype));
+            lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,findRotation(felem,telem));
         }
     }    
         
@@ -438,25 +438,8 @@ function calculateArrowPosition(fx, fy, tx, ty, position, lineType, targetWidth 
     }
 }
 
-function findRotation(felem,telem,ctype){
-    let angleRad;
-    switch(ctype){
-        case "RL":
-            angleRad = Math.atan2((telem.y - (felem.height/2)) - (felem.y - (felem.height/2)), telem.x - felem.x - felem.width); // in radians     
-            break;
-        case "LR":
-            angleRad = Math.atan2((telem.y - (felem.height/2)) - (felem.y - (felem.height/2)), telem.x + telem.width - felem.x); // in radians
-            break;
-        case "TB":
-            angleRad = Math.atan2(telem.y - felem.y-felem.height, (telem.x - (felem.width/2)) - (felem.x - (felem.width/2))); // in radians     
-            break;
-        case "BT":
-            angleRad = Math.atan2(telem.y-telem.height - felem.y, (telem.x - (felem.width/2)) - (felem.x - (felem.width/2))); // in radians
-            break;
-        default: 
-            angleRad = 0;
-            break;
-    }
+function findRotation(felem,telem){
+    let angleRad = Math.atan2(telem.y - felem.y, telem.x - felem.x); // in radians     
     return angleRad * (180 / Math.PI);   // convert to degrees
 }
 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -230,15 +230,12 @@ function drawLine(line, targetGhost = false) {
 
     //Draws the Segmented version for arrow and not straight line
     if(line.recursive){
-
         if(line.startIcon === SDLineIcons.ARROW){
             lineStr += iconPoly(SD_ARROW[line.ctype], startX, startY, lineColor, color.BLACK);
         }
         if(line.endIcon === SDLineIcons.ARROW){
             lineStr += iconPoly(SD_ARROW[line.ctype], startX + length, startY +(10 * zoomfact), lineColor, color.BLACK);
         }
-        
-
     }else{
         const arrowStartPos = calculateArrowPosition(fx+(iconXModifier*zoomfact), fy+(iconYModifier*zoomfact), tx+(iconXModifier*zoomfact), ty+(iconYModifier*zoomfact), "start", line.innerType);
         const arrowEndPos = calculateArrowPosition(fx-(iconXModifier*zoomfact), fy-(iconYModifier*zoomfact), tx-(iconXModifier*zoomfact), ty-(iconYModifier*zoomfact), "end", line.innerType);
@@ -433,6 +430,14 @@ function calculateArrowPosition(fx, fy, tx, ty, position, lineType, targetWidth 
     }
 }
 
+/**
+ * @description By inputting the location of two points on the diagram into an atan2 formula (a formula i dont fully understand) we get the way degrees the two point would be tilted towards if they had a line between them in radians. Then we turn the radians to degrees
+ * @param {integer} x1 The x cordinate of the first point
+ * @param {integer} y1 The y cordinate of the first point
+ * @param {integer} x2 The x cordinate of the second point
+ * @param {integer} y2 The y cordinate of the second point
+ * @returns The angle the two point would point towards in degrees
+ */
 function findRotation(x1,y1,x2,y2){
     let angleRad = Math.atan2(y1 - y2, x1 - x2); // in radians     
     return angleRad * (180 / Math.PI);   // convert to degrees

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -132,6 +132,8 @@ function drawLine(line, targetGhost = false) {
                 offset.y2 = -15;
             } else { offset.y2 = 0; } //Aligning line with mouse coordinate before telem has been set
             offset.y1 = 15;
+            fy -= 15;
+            ty += 15;
 
         } else if ((fy < ty) && (line.ctype == lineDirection.DOWN)) {
             if (telem.kind === elementTypesNames.UMLFinalState) {
@@ -141,6 +143,8 @@ function drawLine(line, targetGhost = false) {
                 offset.y2 = 15;
             } else { offset.y2 = 0; }
             offset.y1 = -15;
+            fy += 15;
+            ty -= 15;
 
 
         } else if ((fx > tx) && (line.ctype == lineDirection.LEFT)) {
@@ -151,6 +155,8 @@ function drawLine(line, targetGhost = false) {
                 offset.x2 = -15;
             } else { offset.x2 = 0; }
             offset.x1 = 15;
+            fx -= 15;
+            tx += 15;
 
 
         } else if ((fx < tx) && (line.ctype == lineDirection.RIGHT)) {
@@ -161,7 +167,8 @@ function drawLine(line, targetGhost = false) {
                 offset.x2 = 15;
             } else { offset.x2 = 0; }
             offset.x1 = -15;
-
+            fx += 15;
+            tx -= 15;
         }
         lineStr += `<line 
                     id='${line.id}' 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -240,22 +240,16 @@ function drawLine(line, targetGhost = false) {
         
 
     }else{
+        const arrowStartPos = calculateArrowPosition(fx+(iconXModifier*zoomfact), fy+(iconYModifier*zoomfact), tx+(iconXModifier*zoomfact), ty+(iconYModifier*zoomfact), "start", line.innerType);
+                    const arrowEndPos = calculateArrowPosition(fx-(iconXModifier*zoomfact), fy-(iconYModifier*zoomfact), tx-(iconXModifier*zoomfact), ty-(iconYModifier*zoomfact), "end", line.innerType);
         // Handle start arrow
         if (line.startIcon === SDLineIcons.ARROW) {
-            let felem, telem;
-            felem = data[findIndex(data, line.fromID)];
-            telem = data[findIndex(data, line.toID)];
-            const arrowStartPos = calculateArrowPosition(fx+(iconXModifier*zoomfact), fy+(iconYModifier*zoomfact), tx+(iconXModifier*zoomfact), ty+(iconYModifier*zoomfact), "start", line.innerType);
-            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(felem,telem));
+            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(arrowStartPos.x,arrowStartPos.y,arrowEndPos.x,arrowEndPos.y));
         }
 
         // Handle end arrow
         if (line.endIcon === SDLineIcons.ARROW) {
-            let felem, telem;
-            felem = data[findIndex(data, line.fromID)];
-            telem = data[findIndex(data, line.toID)];
-            const arrowEndPos = calculateArrowPosition(fx-(iconXModifier*zoomfact), fy-(iconYModifier*zoomfact), tx-(iconXModifier*zoomfact), ty-(iconYModifier*zoomfact), "end", line.innerType);
-            lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,findRotation(felem,telem));
+            lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,findRotation(arrowEndPos.x,arrowEndPos.y,arrowStartPos.x,arrowStartPos.y));
         }
     }    
         
@@ -438,8 +432,8 @@ function calculateArrowPosition(fx, fy, tx, ty, position, lineType, targetWidth 
     }
 }
 
-function findRotation(felem,telem){
-    let angleRad = Math.atan2(telem.y - felem.y, telem.x - felem.x); // in radians     
+function findRotation(x1,y1,x2,y2){
+    let angleRad = Math.atan2(y1 - y2, x1 - x2); // in radians     
     return angleRad * (180 / Math.PI);   // convert to degrees
 }
 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -241,10 +241,11 @@ function drawLine(line, targetGhost = false) {
 
     }else{
         const arrowStartPos = calculateArrowPosition(fx+(iconXModifier*zoomfact), fy+(iconYModifier*zoomfact), tx+(iconXModifier*zoomfact), ty+(iconYModifier*zoomfact), "start", line.innerType);
-                    const arrowEndPos = calculateArrowPosition(fx-(iconXModifier*zoomfact), fy-(iconYModifier*zoomfact), tx-(iconXModifier*zoomfact), ty-(iconYModifier*zoomfact), "end", line.innerType);
+        const arrowEndPos = calculateArrowPosition(fx-(iconXModifier*zoomfact), fy-(iconYModifier*zoomfact), tx-(iconXModifier*zoomfact), ty-(iconYModifier*zoomfact), "end", line.innerType);
         // Handle start arrow
         if (line.startIcon === SDLineIcons.ARROW) {
-            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(arrowStartPos.x,arrowStartPos.y,arrowEndPos.x,arrowEndPos.y));
+            console.log("heyo");
+            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(arrowEndPos.x,arrowEndPos.y,arrowStartPos.x,arrowStartPos.y));
         }
 
         // Handle end arrow

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -12,6 +12,9 @@ function drawLine(line, targetGhost = false) {
     let fromElemMouseY;
     let toElemMouseY;
 
+    //For straight SD lines only
+    let iconXModifier, iconYModifier;
+
     // Element line is drawn from/to
     let felem = data[findIndex(data, line.fromID)];
     if (!line.fromY) {
@@ -134,6 +137,8 @@ function drawLine(line, targetGhost = false) {
             offset.y1 = 15;
             fy -= 15*zoomfact;
             ty += 15*zoomfact;
+            iconXModifier = 0;
+            iconYModifier = 15;
 
         } else if ((fy < ty) && (line.ctype == lineDirection.DOWN)) {
             if (telem.kind === elementTypesNames.UMLFinalState) {
@@ -145,6 +150,8 @@ function drawLine(line, targetGhost = false) {
             offset.y1 = -15;
             fy += 15*zoomfact;
             ty -= 15*zoomfact;
+            iconXModifier = 0;
+            iconYModifier = -15;
 
 
         } else if ((fx > tx) && (line.ctype == lineDirection.LEFT)) {
@@ -157,6 +164,8 @@ function drawLine(line, targetGhost = false) {
             offset.x1 = 15;
             fx -= 15*zoomfact;
             tx += 15*zoomfact;
+            iconXModifier = 15;
+            iconYModifier = 0;
 
 
         } else if ((fx < tx) && (line.ctype == lineDirection.RIGHT)) {
@@ -169,6 +178,8 @@ function drawLine(line, targetGhost = false) {
             offset.x1 = -15;
             fx += 15*zoomfact;
             tx -= 15*zoomfact;
+            iconXModifier = -15;
+            iconYModifier = 0;
         }
         lineStr += `<line 
                     id='${line.id}' 
@@ -234,7 +245,7 @@ function drawLine(line, targetGhost = false) {
             let felem, telem;
             felem = data[findIndex(data, line.fromID)];
             telem = data[findIndex(data, line.toID)];
-            const arrowStartPos = calculateArrowPosition(fx, fy, tx, ty, "start", line.innerType);
+            const arrowStartPos = calculateArrowPosition(fx+(iconXModifier*zoomfact), fy+(iconYModifier*zoomfact), tx+(iconXModifier*zoomfact), ty+(iconYModifier*zoomfact), "start", line.innerType);
             lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(felem,telem,line.ctype));
         }
 
@@ -243,7 +254,7 @@ function drawLine(line, targetGhost = false) {
             let felem, telem;
             felem = data[findIndex(data, line.fromID)];
             telem = data[findIndex(data, line.toID)];
-            const arrowEndPos = calculateArrowPosition(fx, fy, tx, ty, "end", line.innerType);
+            const arrowEndPos = calculateArrowPosition(fx-(iconXModifier*zoomfact), fy-(iconYModifier*zoomfact), tx-(iconXModifier*zoomfact), ty-(iconYModifier*zoomfact), "end", line.innerType);
             lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,findRotation(felem,telem,line.ctype));
         }
     }    

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -163,7 +163,6 @@ function drawLine(line, targetGhost = false) {
             offset.x1 = -15;
 
         }
-
         lineStr += `<line 
                     id='${line.id}' 
                     x1='${fx + offset.x1 * zoomfact}' 
@@ -225,15 +224,22 @@ function drawLine(line, targetGhost = false) {
     }else{
         // Handle start arrow
         if (line.startIcon === SDLineIcons.ARROW) {
+            let felem, telem;
+            felem = data[findIndex(data, line.fromID)];
+            telem = data[findIndex(data, line.toID)];
+            angleDeg = findRotation(felem,telem,line);
             const arrowStartPos = calculateArrowPosition(fx, fy, tx, ty, "start", line.innerType);
-            lineStr += iconPoly(SD_ARROW[line.ctype], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK);
+            lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,angleDeg);
         }
 
         // Handle end arrow
         if (line.endIcon === SDLineIcons.ARROW) {
+            let felem, telem;
+            felem = data[findIndex(data, line.fromID)];
+            telem = data[findIndex(data, line.toID)];
+            let angleDeg = findRotation(felem,telem,line);
             const arrowEndPos = calculateArrowPosition(fx, fy, tx, ty, "end", line.innerType);
-            const reverseCtype = line.ctype.split('').reverse().join('');
-            lineStr += iconPoly(SD_ARROW[reverseCtype], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK);
+            lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,angleDeg);
         }
     }    
         
@@ -414,6 +420,29 @@ function calculateArrowPosition(fx, fy, tx, ty, position, lineType, targetWidth 
     } else if (position === "end") {
         return { x: tx - offsetX, y: ty - offsetY };
     }
+}
+
+function findRotation(felem,telem,line){
+    let angleRad;
+    switch(line.ctype){
+        case "RL":
+            angleRad = Math.atan2((telem.y - (felem.height/2)) - (felem.y - (felem.height/2)), telem.x - felem.x - felem.width); // in radians     
+            break;
+        case "LR":
+            angleRad = Math.atan2((telem.y - (felem.height/2)) - (felem.y - (felem.height/2)), telem.x + telem.width - felem.x); // in radians
+            break;
+        case "TB":
+            angleRad = Math.atan2(telem.y - felem.y-felem.height, (telem.x - (felem.width/2)) - (felem.x - (felem.width/2))); // in radians     
+            break;
+        case "BT":
+            angleRad = Math.atan2(telem.y-telem.height - felem.y, (telem.x - (felem.width/2)) - (felem.x - (felem.width/2))); // in radians
+            break;
+        default: 
+            angleRad = 0;
+            break;
+    }
+        
+    return angleRad * (180 / Math.PI);   // convert to degrees
 }
 
 /**
@@ -970,7 +999,7 @@ function iconCircle([a, b, c], x, y, lineColor,) {
  * @param {Object} fill Its the color to fill the icons.
  * @returns Returns the icons for the polyline.
  */
-function iconPoly(arr, x, y, lineColor, fill) {
+function iconPoly(arr, x, y, lineColor, fill, rotation = 0) {
     let s = "";
     for (let i = 0; i < arr.length; i++) {
         const [a, b] = arr[i];
@@ -978,7 +1007,7 @@ function iconPoly(arr, x, y, lineColor, fill) {
     }
     return `<polyline 
                 points='${s}' 
-                fill='${fill}' stroke='${lineColor}' stroke-width='${strokewidth}'
+                fill='${fill}' stroke='${lineColor}' stroke-width='${strokewidth}' transform='rotate(${rotation}, ${x},${y})'
             />`;
 }
 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -132,8 +132,8 @@ function drawLine(line, targetGhost = false) {
                 offset.y2 = -15;
             } else { offset.y2 = 0; } //Aligning line with mouse coordinate before telem has been set
             offset.y1 = 15;
-            fy -= 15;
-            ty += 15;
+            fy -= 15*zoomfact;
+            ty += 15*zoomfact;
 
         } else if ((fy < ty) && (line.ctype == lineDirection.DOWN)) {
             if (telem.kind === elementTypesNames.UMLFinalState) {
@@ -143,8 +143,8 @@ function drawLine(line, targetGhost = false) {
                 offset.y2 = 15;
             } else { offset.y2 = 0; }
             offset.y1 = -15;
-            fy += 15;
-            ty -= 15;
+            fy += 15*zoomfact;
+            ty -= 15*zoomfact;
 
 
         } else if ((fx > tx) && (line.ctype == lineDirection.LEFT)) {
@@ -155,8 +155,8 @@ function drawLine(line, targetGhost = false) {
                 offset.x2 = -15;
             } else { offset.x2 = 0; }
             offset.x1 = 15;
-            fx -= 15;
-            tx += 15;
+            fx -= 15*zoomfact;
+            tx += 15*zoomfact;
 
 
         } else if ((fx < tx) && (line.ctype == lineDirection.RIGHT)) {
@@ -167,8 +167,8 @@ function drawLine(line, targetGhost = false) {
                 offset.x2 = 15;
             } else { offset.x2 = 0; }
             offset.x1 = -15;
-            fx += 15;
-            tx -= 15;
+            fx += 15*zoomfact;
+            tx -= 15*zoomfact;
         }
         lineStr += `<line 
                     id='${line.id}' 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -236,15 +236,24 @@ function drawLine(line, targetGhost = false) {
         if(line.endIcon === SDLineIcons.ARROW){
             lineStr += iconPoly(SD_ARROW[line.ctype], startX + length, startY +(10 * zoomfact), lineColor, color.BLACK);
         }
+    }else if(line.innerType == SDLineType.SEGMENT){
+        const arrowStartPos = calculateArrowPosition(fx, fy, tx, ty, "start", line.innerType);
+        const arrowEndPos = calculateArrowPosition(fx, fy, tx, ty, "end", line.innerType);
+        const reverseCtype = line.ctype.split('').reverse().join('');
+        if (line.startIcon === SDLineIcons.ARROW) {
+            lineStr += iconPoly(SD_ARROW[line.ctype], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK);
+        }
+        // Handle end arrow
+        if (line.endIcon === SDLineIcons.ARROW) {
+            lineStr += iconPoly(SD_ARROW[reverseCtype], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK);
+        }
     }else{
         const arrowStartPos = calculateArrowPosition(fx+(iconXModifier*zoomfact), fy+(iconYModifier*zoomfact), tx+(iconXModifier*zoomfact), ty+(iconYModifier*zoomfact), "start", line.innerType);
         const arrowEndPos = calculateArrowPosition(fx-(iconXModifier*zoomfact), fy-(iconYModifier*zoomfact), tx-(iconXModifier*zoomfact), ty-(iconYModifier*zoomfact), "end", line.innerType);
         // Handle start arrow
         if (line.startIcon === SDLineIcons.ARROW) {
-            console.log("heyo");
             lineStr += iconPoly(SD_ARROW["RL"], arrowStartPos.x, arrowStartPos.y, lineColor, color.BLACK,findRotation(arrowEndPos.x,arrowEndPos.y,arrowStartPos.x,arrowStartPos.y));
         }
-
         // Handle end arrow
         if (line.endIcon === SDLineIcons.ARROW) {
             lineStr += iconPoly(SD_ARROW["LR"], arrowEndPos.x, arrowEndPos.y, lineColor, color.BLACK,findRotation(arrowEndPos.x,arrowEndPos.y,arrowStartPos.x,arrowStartPos.y));
@@ -1003,6 +1012,13 @@ function iconPoly(arr, x, y, lineColor, fill, rotation = 0) {
         const [a, b] = arr[i];
         s += `${x + a * zoomfact} ${y + b * zoomfact} `;
     }
+    if(rotation === 0){
+        return `<polyline 
+                points='${s}' 
+                fill='${fill}' stroke='${lineColor}' stroke-width='${strokewidth}'
+            />`;
+    }
+    console.log("test");
     return `<polyline 
                 points='${s}' 
                 fill='${fill}' stroke='${lineColor}' stroke-width='${strokewidth}' transform='rotate(${rotation}, ${x},${y})'

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -391,8 +391,16 @@ function drawLine(line, targetGhost = false) {
     }
     return { lineStr, labelStr };
 }
-
-// Calculates the arrowhead position at the start or end of a line, adjusting for target size if needed.
+/** 
+ * @description Calculates the arrowhead position at the start or end of a line, adjusting for target size if needed.
+ * @param {integer} fx X-coordinate from the first element
+ * @param {integer} fy Y-coordinate from the first element
+ * @param {integer} tx X-coordinate from the target element
+ * @param {integer} ty Y-coordinate from the target element
+ * @param {string} position If it is the start or end position
+ * @param {string} lineType At the moment no idea
+ * @returns {number[]} Returns the coordinates for the icons position
+ */
 function calculateArrowPosition(fx, fy, tx, ty, position, lineType, targetWidth = 0, targetHeight = 0) {
     const dx = tx - fx;
     const dy = ty - fy;


### PR DESCRIPTION
You are now able to see the arrows properly and they align with the line

![image](https://github.com/user-attachments/assets/e9713562-8bb5-4241-aa87-b2448f5ce396)

### Known issue
This is a known issue that was here before i started and unfortunately has stayed I would love to try and fix it after the weekly merge
![image](https://github.com/user-attachments/assets/c7144dc1-3487-46ef-b6c8-b187ead827c2)
