### PR TITLE
Removed visible icon when over the mobile width limit

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -19,6 +19,11 @@
     }
 }
 
+@media (min-width: 415px) and (max-width: 767px){
+    .icon-wrapper-sidebar{
+        display: none;
+    }
+}
 
 @media screen and (min-width: 768px) {
     #diagram-toolbar {
@@ -31,6 +36,7 @@
         z-index: 1000;
     }
 }
+
 @media screen and (min-height: 1199px) {
     #diagram-toolbar {
         width: 50px;

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -99,6 +99,7 @@
     and window.devicePixelRatio have to be included -->
     <div id="pixellength" style="width:1000mm;;padding:0px;visibility:hidden;"></div>
 
+    <!-- The chevron/arrows used for toggling the diagram-toolbar on the right of the mobile version-->
     <div class="icon-wrapper-sidebar" onclick="secondToolbarToggle()">
         <i class="material-icons toggle-chevron-sidebar">keyboard_arrow_up</i>
     </div>


### PR DESCRIPTION
Added a media query that had the width values inbetween mobile and desktop and displayed it as none to remove its existance. Make sure to check issue #17739 for reference.