### PR TITLE
Fixed the pop up messages (er toggle, error message and m.m.) are hidden

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -412,6 +412,7 @@
         top: 50px !important;
         left: 50px !important;
         width: 60% !important;
+        z-index: 5000 !important;
     }
 
     .icon-wrapper.toolbar-active{


### PR DESCRIPTION
Increased the z-index to 5000 to make the pop up message appear above the filename box.

![image](https://github.com/user-attachments/assets/6ca2b172-0f24-4214-b580-1694fc9b7df3)