### PR TITLE
Dark mode now works for load dugga ##17630

### DIFF
--- a/DuggaSys/validateHash.php
+++ b/DuggaSys/validateHash.php
@@ -54,6 +54,13 @@
 	<link type="text/css" href="../Shared/css/markdown.css" rel="stylesheet">
 	<link type="text/css" href="../Shared/css/dugga.css" rel="stylesheet">
 
+    <!-- This is for dark mode -->
+    <link type="text/css" href="../Shared/css/jquery-ui-1.10.4.min.css" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+	<link id="themeBlack" type="text/css" href="../Shared/css/blackTheme.css" rel="stylesheet">
+
+    <script src="darkmodeToggle.js"></script>
 	<script src="../Shared/js/jquery-1.11.0.min.js"></script>
 	<script src="../Shared/js/jquery-ui-1.10.4.min.js"></script>
     <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
@@ -62,6 +69,8 @@
 	<script src="../Shared/dugga.js"></script>
 	<script src="../Shared/markdown.js"></script>
 	<script>var querystring=parseGet();</script>
+
+
 </head>
 <body>	
 <?php


### PR DESCRIPTION
Dark mode is now functional on validateHash.php 
You can't press the darkmode button in validateHash.php without closing the load window but it those work now.
It's easiest to test if you change to dark mode before trying to load a dugga.

picture of how it looks now
![image](https://github.com/user-attachments/assets/2ab67909-f28b-4e66-ad4d-553e616b3829)

