### PR TITLE
Fixed G1-2025-v8-#17695-real-time-typing-in-elements

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1497,7 +1497,6 @@ function saveProperties() {
         addToLine("functions", "+");
     }
     // Saves the changes and updates relevant graphics
-    stateMachine.save(element.id, StateChange.ChangeTypes.ELEMENT_ATTRIBUTE_CHANGED);
     showdata();
     updatepos();
 }

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -63,9 +63,15 @@ function generateContextProperties() {
     }
     propSet.innerHTML = str;
     
+    // Real-time typing
+    var inputs = propSet.querySelectorAll('input, textarea');
+    for (var i = 0; i < inputs.length; i++) {
+        inputs[i].addEventListener('input', function() {
+            saveProperties();
+        });
+    }
 
     // Add a blur event to handle undo/redo when the user finishes editing (i.e clicks away or presses Enter) for better undo/redo functionality.
-
     const nameInput = propSet.querySelector('#elementProperty_name');
     if (nameInput) {
         nameInput.addEventListener('blur', () => {


### PR DESCRIPTION
The real-time typing for the elements is back, AND the undo/redo works. In other words; the undo/redo doesn't remove one letter at the time, it removes the latest save or when the user presses "enter". Also the user can se the typing directly in the element. I had to remove the stateMachine.save in the function saveProperties() and only have it in the blur event.

https://github.com/user-attachments/assets/a6813a5c-93d7-4236-bd62-1a531035c0f6