### PR TITLE
Fixed stereotype length issue#17565 stereotype

### DIFF
--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -363,7 +363,20 @@ function drawElementUMLEntity(element, boxw, boxh, linew, texth) {
 
     // Conditionally display stereotype above name if one is set
     if (element.stereotype != "" && element.stereotype != null) {
-        headStereotype = drawText(boxw / 2, texth * 0.8 * lineHeight, 'middle', `«${element.stereotype}»`);
+        // Shrinks the stereotype text but only if its long (over 20 chars)
+        //so it fits within the element width without overflowing/cutting off
+        let fullStereotype = `«${element.stereotype}»`;
+        if (fullStereotype.length > 20) {
+            headStereotype = `<text 
+        x="${boxw / 2}" 
+        y="${texth * 0.8 * lineHeight}" 
+        text-anchor="middle"
+        lengthAdjust="spacingAndGlyphs" 
+        textLength="${boxw - 10}"
+    >${fullStereotype}</text>`;
+        } else {
+            headStereotype = drawText(boxw / 2, texth * 0.8 * lineHeight, 'middle', fullStereotype);
+        }
         for (let i = 0; i < headerLines.length; i++) {
             const y = texth * (i + 1.5) * lineHeight;
             headText += drawText(boxw / 2, y, 'middle', headerLines[i]);

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -126,7 +126,7 @@ function textarea(name, property, element) {
         return `<div style='color:${color.WHITE};'>${name}</div>
             <input 
                 id='elementProperty_${property}' 
-                maxlength='10'
+                maxlength='30'
                 value='${shownProperty}'
             >${safeName}</input>`;
     }


### PR DESCRIPTION
Since a 10-character limit on stereotypes would feel too restrictive from the customer’s perspective the maximum length has now been extended to 30 characters. While it may be unlikely that such long stereotypes will be used frequently, it is still  beneficial to support them to ensure flexibility and avoid limitations for those cases that it may occur. The goal was to make this increase possible without breaking the layout such like cut offs, overflow or text continuing in a new row.


What has been done:

- Implemented logic to dynamically shrink stereotype text when it exceeds 20 characters

- Used lengthAdjust and textLength to fit long text within the box without unnatural behavior occuring.

- Preserved default size and readability for shorter texts (i.e ≤20 characters)

Down below you see images of different lengths and how they layout.

![image](https://github.com/user-attachments/assets/2de167a4-d914-417a-9c67-71dd486b3a7e)
![image](https://github.com/user-attachments/assets/f061ed24-1926-4aa1-8d6b-5cd2255b4b45)
![image](https://github.com/user-attachments/assets/3da922d4-b51e-42cc-88a3-05d08c620854)

