### PR TITLE
Fixed: Fix the toolbars z-value and position in mobile

### DIFF
--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -307,6 +307,35 @@
             if(!infoContainer) return; //Null check
             infoContainer.classList.remove("show");
         }
+
+        const iframe = document.getElementById("diagram-iframe");
+        //Waits for the whole iframe to load in
+        iframe.onload = ()=>{
+
+            //Returns the document object by the iframe element
+            //Enables you to access elements that belongs to the iframe
+            /*You can only access and manipulate the document elements in the iframe if the iframe and the parent (this page) are on the same domain and port, and other security reasons*/
+            const iframeDOM = iframe.contentDocument || iframe.contentWindow.document;
+
+            //Instead of using document, you use iframeDOM if you want to access elements from the iframe
+            let sidebarToggleIcon = iframeDOM.querySelector(".icon-wrapper-sidebar");
+            let diagramSidebar = iframeDOM.getElementById("mb-diagram-sidebar");
+            let buttonWrapper = document.querySelector(".button-wrapper");
+            let timer = null;
+
+            //Whenever the icon is clicked it hides and displays the buttons based on if the sidebar is open or not
+            sidebarToggleIcon.addEventListener("click", ()=>{
+                if(diagramSidebar.classList.contains("open")){
+                    buttonWrapper.style.display = 'none';
+                }
+                else{
+                    clearTimeout(timer);
+                    timer = setTimeout(()=>{
+                        buttonWrapper.style.display = 'flex';
+                    }, 150); //Displays it only after a delay to make it more smoothly
+                }
+            });
+        }
     </script>
 </body>
 

--- a/Shared/css/mobile-diagram.css
+++ b/Shared/css/mobile-diagram.css
@@ -19,7 +19,7 @@
         flex-direction: column;
     }
     #mb-diagram-sidebar.open {
-        transform: translateX(-33px);
+        transform: translateX(-1px);
     }
     #mb-diagram-toolbar.active {
         transform: translateY(0px);

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8129,6 +8129,7 @@ only screen and (max-device-width: 568px) {
   bottom: 10vh;
   right: 7vw;
   display: none;
+  z-index: 2;
 }
 .diagram-btn-fab{
   line-height: 0;


### PR DESCRIPTION
I have now made so the top menu sidebar has the highest priority when it is open. So, all the other elements are either placed under it or hidden. The fab button was easy to fix because you needed to change its z-index to something lower than the sidebar, however that solution didnt work with the other to buttons (general information and instructions). Because when you tried to lower the z-index on them it disappeared and was behind the iframe, then the solution was to access the elements from the iframe and make buttons disappear when the toggle icon sidebar was clicked, and for every click you check if the sidebar is open or not. If it is open then hide the buttons, and if not display them only after a delay to make it more smoothly and less snappy. 

see video 1 

video 1

https://github.com/user-attachments/assets/91f1a1c7-e3c2-4bf8-a7fd-5302140dbb8a

