### PR TITLE
Updated diagram.css

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -604,7 +604,7 @@
 
 #diagram-message>div {
     pointer-events: auto;
-    margin: 5px;
+    margin: 20px;
     display: block;
     padding: 10px;
     box-shadow: 6px 6px 10px #888;


### PR DESCRIPTION
Increased the margin of the diagram message from 5px to 20px so that the alert now sits above the zoom buttons.

Before:
![image](https://github.com/user-attachments/assets/02f63ed0-39b3-4a15-ae81-31851ee33e73)

After:
![image](https://github.com/user-attachments/assets/10022909-0e5a-4e8c-86b2-4a468e53b7ad)
