### PR TITLE
 COMPLEMENTS PR #17723: G3 2025 v7 #17532 convert jquery to js in dugga4.js

### DIFF
--- a/DuggaSys/templates/dugga4.js
+++ b/DuggaSys/templates/dugga4.js
@@ -76,7 +76,7 @@ function returnedDugga(data)
 			//showDuggaInfoPopup();
 			var studentPreviousAnswer = "";
 
-			retdata = jQuery.parseJSON(data['param']);
+			retdata = JSON.parse(data['param']);
 			variant = retdata["variant"];
 
 			if (data["answer"] !== null && data["answer"] !== "UNK") {
@@ -248,7 +248,7 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 	tickInterval = setInterval("tick();", 50);
 	var studentPreviousAnswer = "";
 
-	retdata = jQuery.parseJSON(param);
+	retdata = JSON.parse(param);
 	variant = retdata["variant"];
 
 	if (uanswer !== null || uanswer !== "UNK") {


### PR DESCRIPTION
This PR complements PR [#17723](https://github.com/HGustavs/LenaSYS/pull/17723#event-17737125675) (which I reviewed), as I realized there were some remaining jQuery I initially missed since it was not the usual `$` sign syntax. I noticed this while working on PR #17527, which involves converting jQuery to JS in the `dugga1.js ` file - a file with a similar structure to dugga4.js.
