### PR TITLE
COMPLEMENTS PR #17654: Convert JQuery in \DuggaSys\templates\dugga5.js - #17534 

### DIFF
--- a/DuggaSys/templates/dugga5.js
+++ b/DuggaSys/templates/dugga5.js
@@ -157,7 +157,7 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 
 		// Parse student answer and dugga answer
 		var studentPreviousAnswer = "";
-		var p = jQuery.parseJSON(param);
+		var p = JSON.parse(param);
 		if (uanswer !== null && uanswer !== "UNK"){
 			var previous = uanswer.split(' ');
 			var prevRaw = previous[3];


### PR DESCRIPTION
This PR complements PR [#17654](https://github.com/HGustavs/LenaSYS/pull/17654#event-17716343158) (which I reviewed), as I realized there were some remaining jQuery I initially missed since it was not the usual `$` sign syntax. I noticed this while working on PR #17527, which involves converting jQuery to JS in the `dugga1.js ` file - a file with a similar structure to dugga4.js.

Additionally, I noticed the use of jQuery's `$.getScript()` which I forgot to address in the review of  PR [#17654](https://github.com/HGustavs/LenaSYS/pull/17654#event-17716343158). Since there is no direct equivalent for this in JavaScript, replacing it would require a custom implementation. This is too big part this issue and should therefore be addressed in a separate issue.