### PR TITLE
[#17787] Removed showDugga navigation header bar in mobile view

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -216,6 +216,20 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 		
 		?>
 	</div>
+
+	<script>
+		// Hides the navheader if the chosen dugga is the diagram dugga since it has its own "header"
+		const hideNavIfDiagramMobile = () => {
+			const temp = '<?php echo $duggafile; ?>';
+			let nav = document.getElementsByClassName("navheader")[0];
+
+			if (window.innerWidth < 414 && temp === 'diagram_dugga') nav.style.display = "none";
+			else nav.style.display = "flex"; // Mainly if the window is resized after having loaded in to get the bar back
+		}
+
+		window.addEventListener("DOMContentLoaded", hideNavIfDiagramMobile); // Activates when all content has loaded
+		window.addEventListener("resize", hideNavIfDiagramMobile); // Activates if the user actively resizes the window (mainly for developers testing mobile view)
+	</script>
 	
 	<!-- formBox (receipt&Feedback-box ) Start! -->
 	<div id='receiptBox' class="loginBoxContainer" style="display:none">


### PR DESCRIPTION
**For reviewer:** You need to be in showDugga.php for this (_/DuggaSys/courseed.php -> "Demo Course" -> "Diagram Dugga"_).

The navheader now gets hidden if the system detects that the chosen dugga is the Diagram Dugga and the user is in the mobile view. The current way this is implemented is in the same way the mobile view is implemented in diagram.js (checking if the innerWidth is less than 414), if this were to change it should probably be changed here as well.

**Mobile view:**

![image](https://github.com/user-attachments/assets/b0d87b1d-dd68-4b00-a559-d87338e8e211)

**Regular view:**

![image](https://github.com/user-attachments/assets/deffc862-0e9c-441c-9234-f9dd1c0b0a51)
