### PR TITLE
Editing a codeblock is not in darkmode #17455

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -565,7 +565,9 @@ body {
 
 .loginBox,
 .logoutBox,
-.formBox{
+.formBox,
+.markdown,
+#mrkdwntxt{
   background-color: var(--color-background);
   color: var(--color-text-light);
   border: 2px solid var(--color-border);


### PR DESCRIPTION
Fixed the darkmode of the codeblock when editing in codeviewer.

![image](https://github.com/user-attachments/assets/398e637d-8b78-4256-bf72-fdd2945a5562)
Before

![image](https://github.com/user-attachments/assets/ff228eb9-e123-4749-b529-541c57843e9e)
After

This did however add a new problem where some of the icons arent clearly visable in darkmode. Ive already made a new issue for that [here](https://github.com/HGustavs/LenaSYS/issues/17848)
