### PR TITLE
Replaced jQuery with JS in dugga1.js

### DIFF
--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -265,16 +265,16 @@ function closeFacit(){
 function bitClick(divid) {
 	if (typeof ClickCounter != 'undefined') ClickCounter.onClick();
 
-	const divid = document.getElementById(divid);
+	const el = document.getElementById(divid);
 
-	if (divid.innerHTML === "1") {
-		divid.innerHTML = "0";
-		divid.classList.remove("ett");
-		divid.classList.add("noll");
+	if (el.innerHTML === "1") {
+		el.innerHTML = "0";
+		el.classList.remove("ett");
+		el.classList.add("noll");
 	} else {
-		divid.innerHTML = "1";
-		divid.classList.add("ett");
-		divid.classList.remove("noll");
+		el.innerHTML = "1";
+		el.classList.add("ett");
+		el.classList.remove("noll");
 	}
 
 	document.querySelectorAll('.submit-button').forEach(function (button) {

--- a/DuggaSys/templates/dugga1.js
+++ b/DuggaSys/templates/dugga1.js
@@ -25,32 +25,32 @@ var activehex;
 // Setup
 //----------------------------------------------------------------------------------
 
-function setup()
-{
-		$('.bit').click(function(){
-				bitClick(this.id);
+function setup() {
+	document.querySelectorAll('.bit').forEach(function (element) {
+		element.addEventListener('click', function () {
+			bitClick(this.id);
 		});
+	});
 
-		$('.hexo').click(function(){
-				hexClick(this.id);
+	document.querySelectorAll('.hexo').forEach(function (element) {
+		element.addEventListener('click', function () {
+			hexClick(this.id);
 		});
+	});
 
-		AJAXService("GETPARAM",{ },"PDUGGA");
+	AJAXService("GETPARAM",{ },"PDUGGA");
 }
 
 //----------------------------------------------------------------------------------
 // returnedDugga: callback from ajax call in setup, data is json
 //----------------------------------------------------------------------------------
 
-function returnedDugga(data)
-{
+function returnedDugga(data) {
 	if(data['debug']!="NONE!") alert(data['debug']);
 
 	if(data['opt']=="SAVDU"){
-		//$('#submission-receipt').html(`${data['duggaTitle']}\n\nDirect link (to be submitted in canvas)\n${data['link']}\n\nHash\n${data['hash']}\n\nHash password\n${data['hashpwd']}`);
 		showReceiptPopup();
 	}
-
 
 	Timer.startTimer();
 	ClickCounter.initialize();
@@ -67,51 +67,54 @@ function returnedDugga(data)
 		ClickCounter.showClicker();
 	}
 
-	
 
-		if(data['param']=="UNK"){
+	if(data['param']=="UNK") {
 				alert("UNKNOWN DUGGA!");
-		}else{		
-			retdata=jQuery.parseJSON(data['param']);
-			$("#talet").html(retdata['tal']);
-			// Add our previous answer
-			if(data['answer'] != null && data['answer'] != "UNK"){
-				resetBitstring();
-				var previous = data['answer'].split(' ');
-				if (previous.length >= 4){
-					var bitstring = previous[3];
-					var hexvalue1 = previous[4];
-					var hexvalue2 = previous[5]; 
-				}			
-				// NB: LSB is now on the highest string index
-				for (var i=bitstring.length;i>=0;i--){
-					if (bitstring[i]==1){
-						bitClick("B"+(7-i));
-						//console.log("B"+(7-i)+":"+bitstring[i]);
-					}				
-				}
-				document.getElementById('H0').innerHTML=hexvalue1;
-				document.getElementById('H1').innerHTML=hexvalue2;
+	} else {		
+		retdata = JSON.parse(data['param']);
+		document.getElementById('talet').innerHTML = retdata['tal'];
+		// Add our previous answer
+		if(data['answer'] != null && data['answer'] != "UNK"){
+			resetBitstring();
+			var previous = data['answer'].split(' ');
+			if (previous.length >= 4){
+				var bitstring = previous[3];
+				var hexvalue1 = previous[4];
+				var hexvalue2 = previous[5]; 
+			}			
+			// NB: LSB is now on the highest string index
+			for (var i=bitstring.length;i>=0;i--){
+				if (bitstring[i]==1){
+					bitClick("B"+(7-i));
+					//console.log("B"+(7-i)+":"+bitstring[i]);
+				}				
 			}
-		}		
-		// Teacher feedback
-		if (data["feedback"] == null || data["feedback"] === "" || data["feedback"] === "UNK") {
-				// No feedback
-		} else {
-				var fb = "<table class='list feedback-list'><thead><tr><th>Date</th><th>Feedback</th></tr></thead><tbody>";
-				var feedbackArr = data["feedback"].split("||");
-				for (var k=feedbackArr.length-1;k>=0;k--){
-					var fb_tmp = feedbackArr[k].split("%%");
-					fb+="<tr><td>"+fb_tmp[0]+"</td><td>"+fb_tmp[1]+"</td></tr>";
-				} 		
-				fb += "</tbody></table>";
-				document.getElementById('feedbackTable').innerHTML = fb;		
-				document.getElementById('feedbackBox').style.display = "block";
-				$("#showFeedbackButton").css("display","block");
+			document.getElementById('H0').innerHTML=hexvalue1;
+			document.getElementById('H1').innerHTML=hexvalue2;
 		}
-		$("#submitButtonTable").appendTo("#content");
-		$("#lockedDuggaInfo").prependTo("#content");
-		displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
+	}		
+	// Teacher feedback
+	if (data["feedback"] == null || data["feedback"] === "" || data["feedback"] === "UNK") {
+			// No feedback
+	} else {
+		var fb = "<table class='list feedback-list'><thead><tr><th>Date</th><th>Feedback</th></tr></thead><tbody>";
+		var feedbackArr = data["feedback"].split("||");
+		for (var k=feedbackArr.length-1;k>=0;k--){
+			var fb_tmp = feedbackArr[k].split("%%");
+			fb+="<tr><td>"+fb_tmp[0]+"</td><td>"+fb_tmp[1]+"</td></tr>";
+		} 		
+		fb += "</tbody></table>";
+		document.getElementById('feedbackTable').innerHTML = fb;		
+		document.getElementById('feedbackBox').style.display = "block";
+		document.getElementById('showFeedbackButton').style.display = 'block';
+	}
+
+	document.getElementById('content').appendChild(document.getElementById('submitButtonTable'));
+	document.getElementById('content').insertBefore(
+		document.getElementById('lockedDuggaInfo'),
+		document.getElementById('content').firstChild
+	);
+	displayDuggaStatus(data["answer"],data["grade"],data["submitted"],data["marked"],data["duggaTitle"]);
 }
 
 //--------------------================############================--------------------
@@ -119,8 +122,7 @@ function returnedDugga(data)
 //--------------------================############================--------------------
 
 
-function saveClick()
-{
+function saveClick() {
 	Timer.stopTimer();
 
 	timeUsed = Timer.score;
@@ -133,26 +135,25 @@ function saveClick()
 	}
 
 	// Loop through all bits
-	bitstr="";
-	$(".bit").each(function( index ) {
-			bitstr=bitstr+this.innerHTML;
+	let bitstr = "";
+	document.querySelectorAll('.bit').forEach(function (element) {
+		bitstr += element.innerHTML;
 	});
-	
-	bitstr+=" "+$("#H0").html();
-	bitstr+=" "+$("#H1").html();
-	
-	bitstr+=" "+screen.width;
-	bitstr+=" "+screen.height;
-	
-	bitstr+=" "+$(window).width();
-	bitstr+=" "+$(window).height();
+
+	bitstr += " " + document.getElementById('H0').innerHTML;
+	bitstr += " " + document.getElementById('H1').innerHTML;
+
+	bitstr += " " + screen.width;
+	bitstr += " " + screen.height;
+
+	bitstr += " " + window.innerWidth;
+	bitstr += " " + window.innerHeight;
 	
 	// Duggastr includes only the local information, duggasys adds the dugga number and the rest of the information.
 	saveDuggaResult(bitstr);
 }
 
-function reset()
-{
+function reset() {
 	if(confirm("This will remove everything and reset timers and step counters. Giving you a new chance at the highscore.")){
 		Timer.stopTimer();
 		Timer.score=0;
@@ -167,22 +168,21 @@ function reset()
 	}
 }
 
-function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
-{
+function showFacit(param, uanswer, danswer, userStats, files, moment, feedback) {
 	if (userStats != null){
 		document.getElementById('duggaTime').innerHTML=userStats[0];
 		document.getElementById('duggaTotalTime').innerHTML=userStats[1];
 		document.getElementById('duggaClicks').innerHTML=userStats[2];
 		document.getElementById('duggaTotalClicks').innerHTML=userStats[3];
-		$("#duggaStats").css("display","block");
+		document.getElementById('duggaStats').style.display = 'block';
 	}
-	var p = jQuery.parseJSON(param);
-	var daJSON = jQuery.parseJSON(danswer);
+	var p = JSON.parse(param);
+	var daJSON = JSON.parse(danswer);
 	
 	var da = daJSON['danswer'];
 	var danswer = da.split(' ');
 	
-	$("#talet").html(p['tal']);
+	document.getElementById('talet').innerHTML = p['tal'];
 	
 	// Add student answer
 	if (uanswer === "UNK"){
@@ -212,14 +212,17 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 			document.getElementById("B"+(8-i)).style.border = "4px dotted black";
 		}								 
 
-		if (danswer[0][i-1] == $("#B"+(8-i)).html()){
-			$("#B"+(8-i)).css("background","green");
-			document.getElementById('B'+(8-i)).innerHTML+= " == " + danswer[0][i-1];
-			
+		const id = 'B' + (8 - i);
+		const el = document.getElementById(id);
+
+		if (danswer[0][i - 1] === el.innerHTML) {
+			el.style.background = 'green';
+			el.innerHTML += " == " + danswer[0][i - 1];
 		} else {
-			$("#B"+(8-i)).css("background","red");
-			document.getElementById('B'+(8-i)).innerHTML+= " != " + danswer[0][i-1];					
+			el.style.background = 'red';
+			el.innerHTML += " != " + danswer[0][i - 1];
 		}
+
 	}
 	
 	if (hexvalue1 == danswer[1]) {
@@ -249,7 +252,6 @@ function showFacit(param, uanswer, danswer, userStats, files, moment, feedback)
 	if (feedback !== undefined){
 			document.getElementById('teacherFeedbackTable').innerHTML = fb;
 	}
-
 }
 
 function closeFacit(){
@@ -260,30 +262,38 @@ function closeFacit(){
 //                                  Local Functions
 //--------------------================############================--------------------
 
-function bitClick(divid)
-{
-	 if (typeof ClickCounter != 'undefined') ClickCounter.onClick();
+function bitClick(divid) {
+	if (typeof ClickCounter != 'undefined') ClickCounter.onClick();
 
-	if($("#"+divid).html()=="1"){
-			$("#"+divid).html("0");
-			$("#"+divid).removeClass("ett");
-			$("#"+divid).addClass("noll" );
-	}else{
-			$("#"+divid).html("1");
-			$("#"+divid).addClass("ett" );
-			$("#"+divid).removeClass("noll");
+	const divid = document.getElementById(divid);
+
+	if (divid.innerHTML === "1") {
+		divid.innerHTML = "0";
+		divid.classList.remove("ett");
+		divid.classList.add("noll");
+	} else {
+		divid.innerHTML = "1";
+		divid.classList.add("ett");
+		divid.classList.remove("noll");
 	}
-	$(".submit-button").removeClass("btn-disable");
+
+	document.querySelectorAll('.submit-button').forEach(function (button) {
+		button.classList.remove('btn-disable');
+	});
+
 }
 
-function hexClick(divid)
-{
-	 if (typeof ClickCounter != 'undefined') ClickCounter.onClick();
+function hexClick(divid) {
+	if (typeof ClickCounter != 'undefined') ClickCounter.onClick();
 
-	dw=$(window).width();
-	dpos=$("#"+divid).position();
-	dwid=$("#"+divid).width();
-	dhei=$("#"+divid).height();
+	const el = document.getElementById(divid);
+	const rect = el.getBoundingClientRect();
+
+	const dw = window.innerWidth;
+	const dpos = { top: rect.top + window.scrollY, left: rect.left + window.scrollX };
+	const dwid = rect.width;
+	const dhei = rect.height;
+
 	bw=Math.round(dwid)*1.10;
 	if(bw<180) bw=180;	// Ensure minimum width of the HEX-box
 	
@@ -299,25 +309,32 @@ function hexClick(divid)
 	if(hh<160) hh=160;
 	hh+="px";
 	
-	$("#pop").css({top: (dpos.dhei+10), left:lpos, width:bw,height:hh})
-	$("#pop").removeClass("arrow-topr");
-	$("#pop").removeClass("arrow-top");
-	$("#pop").addClass(popclass);
-	
-	hc=divid;
-	$(".submit-button").removeClass("btn-disable");
+	const pop = document.getElementById('pop');
+
+	pop.style.cssText = `top:${dpos.dhei + 10}px; left:${lpos}px; width:${bw}px; height:${hh}px;`;
+	pop.classList.remove('arrow-topr');
+	pop.classList.remove('arrow-top');
+	pop.classList.add(popclass);
+
+	hc = divid;
+
+	document.querySelectorAll('.submit-button').forEach(button => {
+		button.classList.remove('btn-disable');
+	});
 }
 
-function setval(sval)
-{
-		if(hc!=null){
-				$("#"+hc).html(sval);		
+function setval(sval) {
+	if (hc !== null) {
+		const el = document.getElementById(hc);
+		if (el) {
+			el.innerHTML = sval;
 		}
-		$("#pop").css({display:"none"})
+	}
+	document.getElementById('pop').style.display = 'none';
 }
 
 //functionality for opening and closing hexcode input boxes
-document.addEventListener('click', function(e){
+document.addEventListener('click', function(e) {
 	var pop = document.getElementById('pop');
 	if(e.target.classList.contains("hexo")){ 
 		if(pop.style.display === "block" && e.target === activehex){
@@ -332,7 +349,7 @@ document.addEventListener('click', function(e){
 	}
 });
 
-function resetBitstring(){
+function resetBitstring() {
 	for (var i=0;i<8;i++){
 		document.getElementById("B"+i).innerHTML="0";
 		document.getElementById("B"+i).className="bit noll";		


### PR DESCRIPTION
Replaced jQuery with JS in `/DuggaSys/templates/dugga1.js`. 

Additionally, the toggle feedback and show/close facit features has not been introduced to the page yet, making it impossible to verify whether the JS conversion works as intended. Related functions: `toggleFeedback()`,  `showFacit()`, `closeFacit()`

The `toggleInstructions()` and `toggleFeedback()`  functions in the end of the file have not been converted as there is no direct JavaScript equivalent for jQuery's `slideToggle()`  function, replacing it would require a custom implementation. This is too big part this issue and should therefore be addressed in a separate issue.
