### PR TITLE
got rid of the NONE alert in section.js #17620

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1585,7 +1585,6 @@ function toggleButtonClickHandler() {
 var itemKinds = [];
 function returnedSection(data) {
   retdata = data;
-  if (data['debug'] != "NONE!") alert(data['debug']);
 
   // Data variable is put in localStorage which is then used in Codeviewer
   // To get the right order when going backward and forward in code examples


### PR DESCRIPTION
I got rid of the NONE alert that appears when trying to create a element