### PR TITLE
mobile buttons overlap #17832

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7899,7 +7899,7 @@ only screen and (max-device-width: 568px) {
     bottom: 100px; /* Nudges the FAB 10px up from the bottom */
   }
 }
-}
+
 @media screen and (max-width: 350px) {
 
   input.submit-button-newitem {


### PR DESCRIPTION
This PR is connected to the relevant Issue #17832 
--
This PR also simply removed a "}" that broke the styling of the buttons relevant to the Issue