### PR TITLE
Fixed: Tooltip overlaps submenu

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2698,7 +2698,7 @@ function tooltipPosition(element){
 
         return{
             top: `${dropdownPosition.top - dropdownPosition.height/2}px`,
-            left: `${dropdownPosition.left + dropdownPosition.right - 30}px`
+            left: `${dropdownPosition.left + dropdownPosition.right - 44}px`
         };
     }
 
@@ -2736,10 +2736,19 @@ function tooltipPosition(element){
     else if(element.closest("#diagram-toolbar") && !element.closest("#diagramPopOut")){
         let elementPosition = element.getBoundingClientRect();
 
-        return {
-            top: `${elementPosition.top - elementPosition.height/2}px`,
-            left: `${elementPosition.right + elementPosition.width/2+5}px`
-        };
+        if (submenu && submenu.classList.contains("activeTogglePlacementTypeBox")) {
+            const submenuBox = submenu.getBoundingClientRect();
+            return  {
+                top: `${submenuBox.top - submenuBox.height/2}px`,
+                left: `${submenuBox.left + submenuBox.right - 44}px`
+            };
+        } 
+        else {
+            return {
+                top: `${elementPosition.top - elementPosition.height/2}px`,
+                left: `${elementPosition.right + elementPosition.width/2+5}px`
+            };
+        }
     }
 
     //Checks if the element is part of the mobile diagram toolbar


### PR DESCRIPTION
This PR fixes issue: #17842

Previously, hovering over a toolbar button with a submenu caused the tooltip to overlap the submenu, demonstrated below:

![image](https://github.com/user-attachments/assets/bfc6de35-557f-4c91-a950-8e0aac8c0f2a)
_Tool tip overlaps the sub menu._ 

An if-statement has been added that repositions the tooltip-box position if a submenu is present, eliminating the overlap. Additionally, the margin differences were also adjusted and the tool tip box now sits just as flush to the submenu as to the tool bar. This is what the behavior looks like now:

![image](https://github.com/user-attachments/assets/9ea2c0c9-c872-4ebb-949e-ba4f0de87a0a)
_Overlap eliminated by the repositioned tool tip. Margin between tool tip and sub menu reduced (compare this with weekly branch)._