### PR TITLE
G3-2025-V8-#17629 darkmode codeviewer hard to read

### DIFF
--- a/DuggaSys/codeviewer.js
+++ b/DuggaSys/codeviewer.js
@@ -2062,14 +2062,14 @@ function rendercode(codestring, boxid, wordlistid, boxfilename) {
 				switch(coloringcode) {
 					case "<html>":
 					case "</html":
-						fontcolor = "red";
+						fontcolor = "#fc2d2d";
 						break;
 					case "<link ":
 						fontcolor = "blue";
 						break;
 					case "<h1>":
 					case "</h1":
-						fontcolor = "darkorchid";
+						fontcolor = "#4f5aff";
 						break;
 					case "<title>":
 					case "</title":
@@ -2077,7 +2077,7 @@ function rendercode(codestring, boxid, wordlistid, boxfilename) {
 						break;
 					case "<body>":
 					case "</body":
-						fontcolor = "#941535";
+						fontcolor = "#bf1d46";
 						break;
 					case "<p>":
 					case "</p":
@@ -2092,7 +2092,7 @@ function rendercode(codestring, boxid, wordlistid, boxfilename) {
 						fontcolor = "#FF1493";
 						break;
 					default: 
-						fontcolor = "#00ff";
+						fontcolor = "#4f5aff";
 						break;
 				}
 

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -56,7 +56,11 @@
         --color-fileLink-table-1: #2d3133;
         --color-fileLink-table-2: #242729;
 
-        --color-codeviewer-tag: #CE9178;
+        --color-normtext-string: #CE9178;
+        --color-normtext-keywordfunction: #D7BA7D;
+        --color-normtext-oper: #D4D4D4;
+        --color-comment: #51a64a;
+        --color-normtext-number: #B5CEA8;
     }
 
     #dorf, #NewTabLink, .whiteIcon, .iconColorInDarkMode {
@@ -260,15 +264,15 @@
 }
 
 .comment {
-    color: #51a64a;
+    color: var(--color-comment);
 }
 
 .normtext .keywordfunction {
-    color: #D7BA7D;
+    color: var(--color-normtext-keywordfunction);
 }
 
 .normtext .oper {
-    color: #D4D4D4;
+    color: var(--color-normtext-oper);
     font-weight: bold;
     line-height: 15px;
 }
@@ -279,7 +283,7 @@
 }
 
 .normtext .string {
-    color: var( --color-codeviewer-tag);
+    color: var( --color-normtext-string);
     font-weight: bold;
 }
 
@@ -289,7 +293,7 @@
 }
 
 .normtext .number {
-    color: #B5CEA8;
+    color: var(--color-normtext-number);
     font-weight: bold;
 }
 

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -55,6 +55,8 @@
 
         --color-fileLink-table-1: #2d3133;
         --color-fileLink-table-2: #242729;
+
+        --color-codeviewer-tag: #CE9178;
     }
 
     #dorf, #NewTabLink, .whiteIcon, .iconColorInDarkMode {
@@ -258,11 +260,15 @@
 }
 
 .comment {
-    color: #888;
+    color: #51a64a;
+}
+
+.normtext .keywordfunction {
+    color: #D7BA7D;
 }
 
 .normtext .oper {
-    color: var(--color-text-light);
+    color: #D4D4D4;
     font-weight: bold;
     line-height: 15px;
 }
@@ -273,7 +279,7 @@
 }
 
 .normtext .string {
-    color: var(--color-text-light);
+    color: var( --color-codeviewer-tag);
     font-weight: bold;
 }
 
@@ -283,7 +289,7 @@
 }
 
 .normtext .number {
-    color: var(--color-text-light);
+    color: #B5CEA8;
     font-weight: bold;
 }
 

--- a/Shared/css/codeviewer.css
+++ b/Shared/css/codeviewer.css
@@ -407,7 +407,7 @@
 }
 
 .normtext .string {
-    color: #03b !important;
+    color: #03b;
 }
 
 .normtext .html, .hi {
@@ -463,8 +463,8 @@
 }
 
 .comment {
-    color: #50a750;
-	font-family: Hack,'Ubuntu Mono', "Andale Mono", AndaleMono, monospace;
+    color: #51a64a;
+    font-family: Hack,'Ubuntu Mono', "Andale Mono", AndaleMono, monospace;
 }
 
 /* TEXTWRAPPER STOP */

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -71,6 +71,7 @@ PLZ see "Handling and usage of Style.css" in the wiki before use
 
   --color-fileLink-table-1: #ccc;
   --color-fileLink-table-2: #eae8eb;
+  --color-comment: #3f8539;
 }
 
 /* --------------================################================-------------- *
@@ -9952,7 +9953,7 @@ span[id$="examples"]:hover{
 }
 
 .comment {
-    color: #3f8539;
+    color: var( --color-comment);
     font-family: Hack,'Ubuntu Mono', "Andale Mono", AndaleMono, monospace;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -9952,8 +9952,8 @@ span[id$="examples"]:hover{
 }
 
 .comment {
-  color: #50a750;
-  font-family: Hack,'Ubuntu Mono', "Andale Mono", AndaleMono, monospace;
+    color: #3f8539;
+    font-family: Hack,'Ubuntu Mono', "Andale Mono", AndaleMono, monospace;
 }
 
 .normtext .oper {


### PR DESCRIPTION
I have changed some of the colors for the darkmode codeviewer since it was hard to read before. Lightmode has been slightly affected as well since I could not find a darkmode option for HTML, so I changed the colors to work better in darkmode while also being readable in lightmode. The lightmode comment color has been slightly darkened for better readability. The colors used for darkmode are colors usually used in IDEs when darkmode theme is used.

JS Before:
![image](https://github.com/user-attachments/assets/4d8b8b85-0edc-4065-ad21-3a5ccee510b4)

JS After:
![image](https://github.com/user-attachments/assets/23e4f92f-bf61-435e-b8cc-b3aefd8badee)

HTML Before:
![image](https://github.com/user-attachments/assets/247600ee-f30b-4076-a176-a4de96d77865)

HTML After:
![image](https://github.com/user-attachments/assets/ff35b2ad-b319-4354-8fed-04fba5ff6fc9)
