### PR TITLE
Added: overflow-y: auto;

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -26,6 +26,9 @@
 }
 
 @media screen and (min-width: 768px) {
+    /*
+    Make toolbar scrollable when content exceeds screen height.
+    */
     #diagram-toolbar {
         position: fixed;
         top: 0;
@@ -34,6 +37,11 @@
         width: 50px; 
         height: 100vh; 
         z-index: 1000;
+        overflow-y: auto; /* Scrollbar appears only when needed */
+
+        display: flex;
+        flex-direction: column;
+        align-items: center;
     }
 }
 

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -34,15 +34,35 @@
         top: 0;
         left: 0;
         bottom: 0;
-        width: 50px; 
+        width: 60px; 
         height: 100vh; 
         z-index: 1000;
         overflow-y: auto; /* Scrollbar appears only when needed */
-
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+         overflow-x: hidden;
     }
+}
+/*scrollbar styling more adaptive to different environments or browsers*/
+#diagram-toolbar::-webkit-scrollbar {
+    width: 10px;
+}
+
+/*  Options-scrollbar track */
+#diagram-toolbar::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 10px;
+    box-shadow: inset 0 0 5px grey;
+}
+
+/*  Options-scrollbar handle */
+#diagram-toolbar::-webkit-scrollbar-thumb {
+    background: #eb4;
+    border-radius: 10px;
+}
+
+/*  Options-scrollbar handle on hover */
+#diagram-toolbar::-webkit-scrollbar-thumb:hover {
+    background: #eb4;
+    border-radius: 10px;
 }
 
 @media screen and (min-height: 1199px) {


### PR DESCRIPTION
The #diagram-toolbar element already contained enough content to require scrolling on smaller screens.
However, without overflow-y: auto, the browser didn’t allow scrolling, which caused the layout to break or clip icons.

With overflow-y: auto and height: 100vh, the browser now detects when the content overflows and automatically shows a scrollbar as needed.

https://github.com/user-attachments/assets/71869b0c-4d0a-43e1-95a1-698a4ffd4627

As demonstrated in the video, when the screen height becomes too small to fit all toolbar icons, vertical scrolling is enabled