### PR TITLE
Fixed page not updating properly

### DIFF
--- a/DuggaSys/microservices/sectionedService/readCourseVersions_ms.php
+++ b/DuggaSys/microservices/sectionedService/readCourseVersions_ms.php
@@ -24,4 +24,6 @@ try {
 } catch (PDOException $e) {
     error_log("Error reading versions: " . $e->getMessage());
 }
+
 echo json_encode($versions);
+exit;

--- a/DuggaSys/microservices/sectionedService/retrieveSectionedService_ms.php
+++ b/DuggaSys/microservices/sectionedService/retrieveSectionedService_ms.php
@@ -193,7 +193,9 @@ function retrieveSectionedService($debug, $opt, $pdo, $userid, $courseid, $cours
     $links = array();
 
     // Retrieve Course Versions from microservice 'readCourseVersions_ms.php'
-    $versions = callMicroserviceGET("sectionedService/readCourseVersions_ms.php");
+    $versions = callMicroservicePOST("sectionedService/readCourseVersions_ms.php",[],true);
+    $versions = json_decode($versions);
+
 
     $codeexamples = array();
 


### PR DESCRIPTION
Fixed the codeExample part of course pages not updating when adding a codeExample. 

Now if you add a codeExample or test or whatever in a course page it should update without needing a page refresh (you still get an error you have to click away but I think that is fine?, since the listEntry appears as soon as you click it away)