### PR TITLE
Fixed remove option panel double click on mobile

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -505,13 +505,13 @@ function getData() {
     DiagramResponse = fetchDiagram();
 
     //Add event listeners 
-    document.getElementById("diagram-toolbar").addEventListener("mousedown", mdown);
-    document.getElementById("diagram-toolbar").addEventListener("mouseup", tup);
-    document.getElementById("container").addEventListener("mousedown", mdown);
-    document.getElementById("container").addEventListener("mouseup", mup);
-    document.getElementById("container").addEventListener("mousemove", mmoving);
+    document.getElementById("diagram-toolbar").addEventListener("pointerdown", mdown);
+    document.getElementById("diagram-toolbar").addEventListener("pointerup", tup);
+    document.getElementById("container").addEventListener("pointerdown", mdown);
+    document.getElementById("container").addEventListener("pointerup", mup);
+    document.getElementById("container").addEventListener("pointermove", mmoving);
     document.getElementById("container").addEventListener("wheel", mwheel);
-    document.getElementById("options-pane").addEventListener("mousedown", mdown);
+    document.getElementById("options-pane").addEventListener("pointerdown", mdown);
 
     //Mobile FAB-buttons
     document.getElementById("fab-check").addEventListener("click", toggleErrorCheck);

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -114,9 +114,12 @@ function mdown(event) {
                         pointerState = pointerStates.CLICKED_CONTAINER;
                         containerStyle.cursor = "grabbing";
 
-                        if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
-                            wasDblClicked = true;
-                            toggleOptionsPane();
+                        // Only react to mouse pointer double click
+                        if (event.pointerType === "mouse") {
+                            if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
+                                wasDblClicked = true;
+                                toggleOptionsPane();
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
To make the code differentiate mouse clicks and phone touch, I had to change the eventListeners to pointer instead of mouse. I also had to add an if-statment to check if the pointerType is a mouse or not.

You can now only open the options panel by double clicking with the mouse and not with touch.

https://github.com/user-attachments/assets/fcef9ae0-c74b-4afd-966d-c05872e6c436

