### PR TITLE
(mobile-view) BUG Wrong darkmode contrast on dropdown text in accessed.php #17600

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -6,7 +6,7 @@
         --color-text-header: #fff;
         --color-text-list: #000;
         --color-text-logo: #fff;
-        --color-text-label: #000;
+        --color-text-label: #fff;
         --color-text-dark: #000;
         --color-text-light: #fff;
         --color-text-unset: #aaaaaa;
@@ -56,6 +56,13 @@
 
         --color-fileLink-table-1: #2d3133;
         --color-fileLink-table-2: #242729;
+
+        .checkbox-dugga:nth-child(odd)  {
+            background: var(--color-sectioned-table-hi); 
+        }
+        .checkbox-dugga:nth-child(even) {
+            background: var(--color-sectioned-table-lo); 
+        }
     }
 
     #dorf, #NewTabLink, .whiteIcon, .iconColorInDarkMode {


### PR DESCRIPTION
### Description
This PR addresses issue #17600 where a dropdown contrast issue made the text in dropdown difficult to see. I fixed this by adding a override for the dropdown inside of blackTheme.css and changing default text label color to white (#fff).

Here is what it looked like before:
![443670074-d79726eb-1868-4ed5-b663-58f6a1affb94](https://github.com/user-attachments/assets/d164895d-dde3-44cc-80fd-be2d5a1ac6e0)

Here is what it looks like now:
![image](https://github.com/user-attachments/assets/5de1e7c6-53de-4507-9028-e9b06ece59d3)
### How to test:
- Go into any course logged in as brom and tap the "edit course access" button. Then validate changes made for this PR actually work.
- Ensure changes don't break any other feature utilizing blackTheme.css.