### PR TITLE
Fixed: Make the showDugga buttons be behind ui elements in mobile

### DIFF
--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -320,22 +320,37 @@
             //Instead of using document, you use iframeDOM if you want to access elements from the iframe
             let sidebarToggleIcon = iframeDOM.querySelector(".icon-wrapper-sidebar");
             let diagramSidebar = iframeDOM.getElementById("mb-diagram-sidebar");
+            let optionPanel = iframeDOM.getElementById("options-pane");
+            let fabOption = iframeDOM.getElementById("fab-options");
             let buttonWrapper = document.querySelector(".button-wrapper");
+            let closeBtn = iframeDOM.querySelector(".close-btn");
             let timer = null;
 
             //Whenever the icon is clicked it hides and displays the buttons based on if the sidebar is open or not
-            sidebarToggleIcon.addEventListener("click", ()=>{
-                if(diagramSidebar.classList.contains("open")){
+            //The same goes for the fab for the option panel
+            sidebarToggleIcon.addEventListener("click", toggleButtonWrapper);
+            fabOption.addEventListener("click", toggleButtonWrapper);
+            closeBtn.addEventListener("click", toggleButtonWrapper);
+
+            //Function that hides and displays the buttons by checking if the sidebar or the option panel is currently active (meaning open)
+            function toggleButtonWrapper(){
+                let sidebarOpen = diagramSidebar.classList.contains("open");
+                let optionPanelOpen = optionPanel.classList.contains("show-options-pane");
+
+                if(sidebarOpen || optionPanelOpen){
                     buttonWrapper.style.display = 'none';
                 }
                 else{
+                    console.log("Display!");
                     clearTimeout(timer);
                     timer = setTimeout(()=>{
                         buttonWrapper.style.display = 'flex';
+                        console.log("display");
                     }, 150); //Displays it only after a delay to make it more smoothly
                 }
-            });
+            }
         }
+
     </script>
 </body>
 

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -341,11 +341,9 @@
                     buttonWrapper.style.display = 'none';
                 }
                 else{
-                    console.log("Display!");
                     clearTimeout(timer);
                     timer = setTimeout(()=>{
                         buttonWrapper.style.display = 'flex';
-                        console.log("display");
                     }, 150); //Displays it only after a delay to make it more smoothly
                 }
             }


### PR DESCRIPTION
I added a function so it can be reused in the click listeners. The function checks if either the sidebar or the option panel is open, if it true then it hides the buttons, if not then it displays the buttons after a delay. I needed to add this function to both the option fab and the close btn because otherwise the buttons would stay hidden because i could not press the option fab since it is under the option panel when it is active. see video 1 on how the solution works. 

video 1

https://github.com/user-attachments/assets/d2e519ef-2a29-4e33-8fbc-f6a6b5c64037

