### PR TITLE
Fixed: G1-2025-v8-#17844 refine the appearance of the save and save as buttons

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -658,11 +658,6 @@
     transition-delay: 700ms;
 }
 
-.disabledIcon:hover .toolTipText {
-    visibility: visible;
-    transition-delay: 700ms;
-}
-
 #tooltip-OPTIONS {
     left: 9.5%;
 }
@@ -1173,11 +1168,23 @@
 
 .disabledIcon {
     background-color: #8d68ab;
+    opacity: 0.5;
 }
 
-    .disabledIcon:hover .toolTipText {
-        visibility: visible;
-    }
+.disabledIcon .diagramIcons {
+    pointer-events: none;
+    border: none;
+    cursor: default;
+}
+
+.disabledIcon .diagramIcons:hover {
+    border: none;
+}
+
+.disabledIcon .diagramIcons:hover .toolTipText {
+    visibility: hidden;
+}
+
 #a4options {
     display: flex;
 }


### PR DESCRIPTION
Previously, users could hover over a disabled icon. This could give a misleading impression that the icon was clickable or active. With these changes; opacity and no hover, it is now clear that the icon is inactive and cannot be clicked. The message "You don't have anything to save!" still appears if the user presses Ctrl + S. Additionally, the border around the Save and Save As icons has been removed, making them more consistent with the rest of the icons.

<img width="32" alt="image" src="https://github.com/user-attachments/assets/a100e9ad-3885-45b1-988e-4fd27f062c75" />