### PR TITLE
Empty white space on mobile version

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -1665,7 +1665,6 @@ function returnedSection(data) {
       document.getElementById("FABStatic").style.display = "None";
       document.getElementById("FABStatic2").style.display = "None";
       // remove course-label margin
-      document.getElementById("course-label").style.marginRight = "10px";
     }
 
     // Hide som elements if to narrow

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -282,7 +282,6 @@ p {
 
 #content {
   background: var(--color-background);
-  margin: 5px 0px 15px 0px;
 }
 
 #accessedcontent {
@@ -1520,14 +1519,12 @@ header {
   /*overflow: hidden;*/
   color: var(--color-text-header);
   height: 50px;
-  width: 100%;
   background: var(--color-primary);
   position: fixed;
   z-index: 5000;
   top: 0px;
   left: 0px;
   box-shadow: var(--standard-shadow);
-
 }
 
 header td {
@@ -2013,7 +2010,6 @@ div .navButt:hover {
 @media screen and (max-width: 600px) {
   .navheader {
     float: none;
-    width: 100%;
   }
   .logoutBox{
     width: 300px;
@@ -7898,7 +7894,7 @@ only screen and (max-device-width: 568px) {
     bottom: 100px; /* Nudges the FAB 10px up from the bottom */
   }
 }
-}
+
 @media screen and (max-width: 350px) {
 
   input.submit-button-newitem {


### PR DESCRIPTION
What's changed:
- Removed whitespace on devices bigger than 340px but smaller than 431px.
- Minor cleanup of unneeded CSS.
- Removed leftover curly brace, probably a merge conflict.

### Old:
![image](https://github.com/user-attachments/assets/e11e78c2-f6b9-42b3-b8ee-549ae074f7b8)

### New:
![image](https://github.com/user-attachments/assets/cf15c6f9-1a7d-4313-95ae-e4d2ee0c4ede)

## Knowns issues:
The positioning of elements in the courseheader on smaller screen. I believe that's a separate issue someone's working on.
