### PR TITLE
Updated diagram.css

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -569,6 +569,8 @@
     border-right: solid black 1px;
     background-color: var(--color-primary);
     z-index: 1000;
+    height: 100vh;
+    min-height: 100vh;
 }
 
 #diagram-toolbar>fieldset {


### PR DESCRIPTION
fixed the issue where the bottom toolbar icons would disappear when resizing.
https://github.com/user-attachments/assets/53d5e6c6-c30a-4166-bf95-3ec88c0dbeaf

