### PR TITLE
Created test for createGithubCodeExample_ms_test.php

### DIFF
--- a/DuggaSys/tests/microservices/sectionedService/createGithubCodeExample_ms_test.php
+++ b/DuggaSys/tests/microservices/sectionedService/createGithubCodeExample_ms_test.php
@@ -1,0 +1,39 @@
+<?php
+include_once "../../../../Shared/test.php";
+
+$testsData = array(
+    'createGithubCodeExample_ms' => array(
+        'expected-output' => '{"debug":"Success","entries":[{"entryname":"GH-test-entry"}]}',
+
+        'query-before-test-1' => "INSERT INTO listentries(cid, entryname, visible, creator, vers) VALUES (1885, 'GH-test-entry', 1, 101, 1337);",
+        
+        'query-before-test-2' => "SELECT lid FROM listentries WHERE entryname = 'GH-test-entry';",
+        
+        'query-before-test-3' => "INSERT INTO userAnswer (cid, moment, useranswer, vers, hash, password) VALUES(1885, '2025-11-02 00:00:00', 'dummy', 1337, 'hash', 'password');",
+
+        'query-after-test-1' => "DELETE FROM userAnswer WHERE useranswer = 'dummy' AND cid = 1885;",
+        'query-after-test-2' => "DELETE FROM listentries WHERE entryname = 'GH-test-entry' AND cid = 1885;",
+
+        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/sectionedService/createGithubCodeExample_ms.php',
+        'service-data' => serialize(
+            array(
+                'opt' => 'CREGITEX',
+                'lid' => '<!query-before-test-2!><*[0]["lid"]*>',
+                'username' => 'brom',
+                'password' => 'password',
+                'courseid' => 1885,
+                'coursevers' => 1337
+            )
+        ),
+        'filter-output' => serialize(
+            array(
+                'debug',
+                'entries' => array(
+                    'entryname',
+                ),
+            )
+        ),
+    )
+);
+
+testHandler($testsData, true);


### PR DESCRIPTION
Fixes #17813 and adds a test file for createGithubCodeExample_ms. You'll find it in tests/microservices/sectionedService/createGithubCodeExample_ms_test.php. The third test case currently fails, consistent with other existing tests due to the new database schema since last year. The third test could be passed by hardcoding values that match the current database, but this would not be sustainable (as we notice happen with the old tests not passing the third test). This was mentioned in PR #17830.