### PR TITLE
Fixed failed to connect to the database. Test on Linux with docker and maybe macOS.

### DIFF
--- a/dockerenv/Dockerfile
+++ b/dockerenv/Dockerfile
@@ -43,8 +43,6 @@ RUN echo '<Directory /var/www/html>' > /etc/apache2/conf-available/custom-direct
     && echo '</Directory>' >> /etc/apache2/conf-available/custom-directory-listing.conf \
     && a2enconf custom-directory-listing
 
-RUN chown -R www-data:www-data /var/www/html/
-
 # Copy the initialization script
 COPY ./init.sh /usr/local/bin/init.sh
 
@@ -57,7 +55,15 @@ USER root
 # Set the script as the entrypoint
 ENTRYPOINT [ "/usr/local/bin/init.sh" ]
 
-USER www-data
+# Build arguments defines variables for the userID and username
+ARG USER_ID
+ARG USER_NAME
+
+# Create the user home, userID and login shell of the new account
+RUN useradd -m -u $USER_ID -s /bin/bash $USER_NAME || true
+
+# Set the user for running container
+USER $USER_NAME
 
 # Default command
 CMD [ "apache2-foreground" ]

--- a/dockerenv/Dockerfile
+++ b/dockerenv/Dockerfile
@@ -43,6 +43,8 @@ RUN echo '<Directory /var/www/html>' > /etc/apache2/conf-available/custom-direct
     && echo '</Directory>' >> /etc/apache2/conf-available/custom-directory-listing.conf \
     && a2enconf custom-directory-listing
 
+RUN chown -R www-data:www-data /var/www/html/
+
 # Copy the initialization script
 COPY ./init.sh /usr/local/bin/init.sh
 

--- a/dockerenv/init.sh
+++ b/dockerenv/init.sh
@@ -1,20 +1,4 @@
 #!/bin/bash
 
-# Add user and group if not exists
-if ! id "www-data" &>/dev/null; then
-    groupadd -g 33 www-data
-    useradd -u 33 -g www-data -s /bin/false www-data
-fi
-
-# Set appropriate user rights
-umask 000
-chown www-data:www-data /var/www/html/coursesyspw.php
-mkdir /var/www/html/githubMetadata
-chown www-data:www-data /var/www/html/LenaSYS
-chown -R www-data:www-data /var/www/html/githubMetadata
-chmod -R 777 /var/www/html
-
-git config core.fileMode false
-
-# Execute the main container command
+# Replace this script with the main Docker container command (passed as arguments)
 exec "$@"

--- a/dockerenv/setup.sh
+++ b/dockerenv/setup.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 
+mkdir -p ./githubMetadata
+
 # Make sure that coursesyspw.php exists before Docker mounts it
 if [ ! -f ./coursesyspw.php ]; then
   echo "Creating coursesyspw.php from template"
   cp ./coursesyspw.php.template ./coursesyspw.php
 fi
+
+# Add user and group if not exists
+if ! id "www-data" &>/dev/null; then
+  sudo groupadd -g 33 www-data
+  sudo useradd -u 33 -g www-data -s /bin/false www-data
+fi
+
+# Set appropriate user rights
+sudo chown -R www-data:www-data ./githubMetadata
+sudo chown www-data:www-data ./coursesyspw.php
+sudo chmod -R 777 ../../LenaSYS/
+
+# Prevent showing changing the file permissions recursively
+git config core.fileMode false
 
 # start building Docker
 docker compose up --build

--- a/dockerenv/setup.sh
+++ b/dockerenv/setup.sh
@@ -18,12 +18,15 @@ if ! id -nG "$USER" | grep -qw "www-data"; then
   sudo usermod -aG www-data "$USER"
 fi
 
-# Set appropriate user rights
-sudo chown -R www-data:www-data ./githubMetadata
-sudo chown www-data:www-data ./coursesyspw.php
+# Add LenaSYS folder to username and www-data group recursively
+echo "Beginning to add LenaSYS to your username and www-data group..."
+sudo chown -R "$USER":www-data ../../LenaSYS
+
+# Change permissions of LenaSYS to 777
+echo "Beginning to change permissions of LenaSYS to 777..."
 sudo chmod -R 777 ../../LenaSYS/
 
-# Prevent showing changing the file permissions recursively
+# Prevent Git from showing the file permission changes
 git config core.fileMode false
 
 # start building Docker

--- a/dockerenv/setup.sh
+++ b/dockerenv/setup.sh
@@ -29,5 +29,10 @@ sudo chmod -R 777 ../../LenaSYS/
 # Prevent Git from showing the file permission changes
 git config core.fileMode false
 
-# start building Docker
-docker compose up --build
+# Start building Docker
+echo "Beginning to build and start containers..."
+docker compose build \
+  --build-arg USER_ID=$(id -u) \
+  --build-arg USER_NAME=$USER
+
+docker compose up

--- a/dockerenv/setup.sh
+++ b/dockerenv/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Exit this script if an error ocuur
+set -e
+
+# Make sure metadata folder exists
 mkdir -p ./githubMetadata
 
 # Make sure that coursesyspw.php exists before Docker mounts it
@@ -8,10 +12,10 @@ if [ ! -f ./coursesyspw.php ]; then
   cp ./coursesyspw.php.template ./coursesyspw.php
 fi
 
-# Add user and group if not exists
-if ! id "www-data" &>/dev/null; then
-  sudo groupadd -g 33 www-data
-  sudo useradd -u 33 -g www-data -s /bin/false www-data
+# Add this user to www-data group if not exists
+if ! id -nG "$USER" | grep -qw "www-data"; then
+  echo "Beginning to add $USER to www-data group (you may need to logout/login)..."
+  sudo usermod -aG www-data "$USER"
 fi
 
 # Set appropriate user rights


### PR DESCRIPTION
Fixes #17870.

I removed the command from `init.sh` because Docker can’t change the owner and permissions on whole LenaSYS folder in an apache server. Instead, these need to change on a local computer. That’s why you see the error `chown: changing ownership of '/var/www/html/coursesyspw.php': Operation not permitted.` However, on Windows, this doesn’t matter, because Windows doesn’t have permissions and ownership, so it still works, but not on Linux. I have moved some commands from `init.sh` to `setup.sh` and refined some commands.

To test this, you to have a Linux with Docker, and run the file `./setup.sh` or `bash ./setup.sh` (if your first command doesn’t work). Also, you need to have Sudo command to run this file. This file is located at `LenaSYS/dockerenv/setup.sh`. 

When you run this file, you will see some outputs in the terminal showing about files and folders being created, ownership and permissions beginning to change all folders in the LenaSYS folder. Which looks like this: -rwxrwxrwx _username_:www-data in local computer and apache server.

Then, go to the [new installer](http://localhost/LenaSYS/newinstaller/installer.php) and follow all these steps and do not forget to check “Distributed environment”. When you have finished the setup with the new LenaSYS installer, then press the finish-button which lead to the course page and the error should not appear. 

Also check owner and permissions in dockerenv folder and type `ls -l` and there you can your username, group and permission has changed. This also change all folders in the LenaSYS folder. 
