### PR TITLE
Added check to course visiblity

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -699,9 +699,11 @@ function returnedCourse(data) {
 	if (data['entries'].length > 0) {
 		for (i = 0; i < data['entries'].length; i++) {
 			var item = data['entries'][i];
-			// Do not show courses the user does not have access to.
-			if (!data['writeaccess'] && !item['registered'] && uname != "Guest" && uname)
-				continue;
+			// Do not show courses the user does not have access to, unless they are Demo-Course or Testing-Course.
+			if(item['coursecode'] !== "G420" && item['coursecode'] !== "G1337"){
+				if (!data['writeaccess'] && !item['registered'] && uname != "Guest" && uname)
+					continue;
+			}
 
 			str += `<div class='bigg item nowrap' style='display: flex; align-items: center; justify-content: center;' id='C${item['cid']}' data-code='${item['coursecode']}'>`;
 


### PR DESCRIPTION
Added a check to exclude Demo-Course and Testing-Course from access filters and make them accessible to everyone, regardless of whether they are signed up or not.

(Alvik has no active courses)

Group:
<img width="900" alt="Screenshot 2025-05-23 at 11 14 32" src="https://github.com/user-attachments/assets/a3af2d8d-9cc4-4c8a-a2e6-61f51d9e6ef6" />

PR:
<img width="900" alt="Screenshot 2025-05-23 at 11 15 16" src="https://github.com/user-attachments/assets/0edc88cc-e86c-4d27-a705-bfccb5b43463" />