### PR TITLE
fixed motd in dark mode #17701

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1096,16 +1096,20 @@ input{
 	background-color: #212121;
 }
 
+.alertmsg{
+    background-color: var(--color-border);
+}
+
 #motdArea {
-    background-color: var(--color-accent);
+    background-color: var(--color-border);
 }
 
 #motdArea #motdContent {
-    background-color: var(--color-accent);
+    background-color: var(--color-border);
 }
 
 #motdArea .motdBoxheader {
-    background-color: var(--color-accent);
+    background-color: var(--color-border);
 }
 
 .arrow {
@@ -1348,8 +1352,8 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 }
 
 #motd {
-  background-color: #000!important;
-  color: #fff;
+  background-color: --color-border !important;
+  color: #614875;
 }
 
 #darkmodeToggle {


### PR DESCRIPTION
Motd is now a bit darker gray in darkmode.

pictures of how it used to look
![image](https://github.com/user-attachments/assets/e74c7ea1-a25e-4474-aa73-24552cdcff67)
![image](https://github.com/user-attachments/assets/39285071-0a67-46ee-927c-993b8bdf8ef2)


pictures of how it looks now
![image](https://github.com/user-attachments/assets/2bb940ee-824f-4389-a00c-a585def9367f)
![image](https://github.com/user-attachments/assets/8d230203-8971-4f3a-aa03-a40568373b83)

Closes #17701 