### PR TITLE
Fixed: G1 2025 v8 #17850 limited icon options on sequence lines

### DIFF
--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -263,7 +263,8 @@ const SDLineIcons = {//TODO: Replace with actual icons for the dropdown
  * @description Available options of icons to display at the end of lines connecting two SE elements.
  */
 const SELineIcons = {//TODO: Replace with actual icons for the dropdown
-    ARROW: "ARROW"
+    ARROW: "ARROW",
+    Arrow: "Arrow"
 };
 
 /**

--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -263,7 +263,7 @@ const SDLineIcons = {//TODO: Replace with actual icons for the dropdown
  * @description Available options of icons to display at the end of lines connecting two SE elements.
  */
 const SELineIcons = {//TODO: Replace with actual icons for the dropdown
-    ARROW: "ARROW",
+    ARROW: "Small_Triangle",
     Arrow: "Arrow"
 };
 


### PR DESCRIPTION
Line icon dropdown for Sequence Diagrams now has two alternatives: Arrow and Small_Triangle. I changed name from ARROW to Small_Triangle since ARROW and Arrow looked ugly and were confusing as dropdown options.

https://github.com/user-attachments/assets/6c53ff11-a590-479d-8eae-5aa708bff8ac

