### PR TITLE
create a test for profileService/retrieveProfileService_ms.php #17810

### DIFF
--- a/DuggaSys/microservices/profileService/retrieveProfileService_ms.php
+++ b/DuggaSys/microservices/profileService/retrieveProfileService_ms.php
@@ -8,3 +8,6 @@ function retrieveProfileService($debug, $success, $status){
 		);
     return $array;
 }
+
+header("Content-Type: application/json");
+echo json_encode($array);

--- a/DuggaSys/microservices/profileService/retrieveProfileService_ms.php
+++ b/DuggaSys/microservices/profileService/retrieveProfileService_ms.php
@@ -1,5 +1,14 @@
 <?php
 
+function pg($name, $default = null) {
+    return $_POST[$name] ?? $_GET[$name] ?? $default;
+}
+
+$successRaw = pg('success', false);                 
+$success     = filter_var($successRaw);
+$status      = pg('status', '');
+$debug       = pg('debug',  '');
+
 function retrieveProfileService($debug, $success, $status){
 	$array = array(
         "success" => $success,
@@ -9,5 +18,8 @@ function retrieveProfileService($debug, $success, $status){
     return $array;
 }
 
-header("Content-Type: application/json");
-echo json_encode($array);
+$response = retrieveProfileService($debug, $success, $status);
+
+header('Content-Type: application/json');
+echo json_encode($response);
+exit;

--- a/DuggaSys/microservices/profileService/retrieveProfileService_ms.php
+++ b/DuggaSys/microservices/profileService/retrieveProfileService_ms.php
@@ -1,14 +1,5 @@
 <?php
 
-function pg($name, $default = null) {
-    return $_POST[$name] ?? $_GET[$name] ?? $default;
-}
-
-$successRaw = pg('success', false);                 
-$success     = filter_var($successRaw);
-$status      = pg('status', '');
-$debug       = pg('debug',  '');
-
 function retrieveProfileService($debug, $success, $status){
 	$array = array(
         "success" => $success,
@@ -17,9 +8,3 @@ function retrieveProfileService($debug, $success, $status){
 		);
     return $array;
 }
-
-$response = retrieveProfileService($debug, $success, $status);
-
-header('Content-Type: application/json');
-echo json_encode($response);
-exit;

--- a/DuggaSys/tests/microservices/profileService/retrieveProfileService_ms_test.php
+++ b/DuggaSys/tests/microservices/profileService/retrieveProfileService_ms_test.php
@@ -1,0 +1,35 @@
+<?php
+
+include_once "../../../../Shared/test.php";
+
+$testsData = array(
+    'retrieveProfileService_ms' => array(
+        'expected-output' => '{"success":true,"status":"OK","debug":"NONE!"}',
+
+        // Microservice and the data (POST)
+        'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/profileService/retrieveProfileService_ms.php',
+        'service-data' => serialize(
+            array(
+                // Parameters consumed by the microservice
+                'success' => true,
+                'status'  => 'OK',
+                'debug'   => 'NONE!',
+
+                // Session / login 
+                'username' => 'brom',
+                'password' => 'password'
+            )
+        ),
+
+        'filter-output' => serialize(
+            array(
+                'success',
+                'status',
+                'debug'
+            )
+        ),
+    ),
+);
+
+testHandler($testsData, true);
+?>


### PR DESCRIPTION
The test is located at: tests/microservices/profileService/retrieveProfileService_ms_test.php. 

The third test case is currently failing, which is consistent with other existing tests since the database schema update last year. While it's possible to make the test pass by hardcoding values that match the current database, this approach is not sustainable. 