### PR TITLE
Changed css for fab buttons

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -173,7 +173,6 @@
     line-height: 80px;
     text-align: center;
     border-radius: 40px;
-    background-color: #eb4;
     user-select: none;
     cursor: pointer;
     z-index: 5000;

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -77,7 +77,7 @@
                 flex-flow: column;
                 row-gap: .5rem;
                 z-index: 1;
-                margin-top: 10px;
+                margin-top: 1.5vh;
             }
             .dugga-btn{
                 background-color: var(--color-accent);

--- a/DuggaSys/templates/diagram_dugga.html
+++ b/DuggaSys/templates/diagram_dugga.html
@@ -77,6 +77,7 @@
                 flex-flow: column;
                 row-gap: .5rem;
                 z-index: 1;
+                margin-top: 10px;
             }
             .dugga-btn{
                 background-color: var(--color-accent);


### PR DESCRIPTION
The issue was to fix the spacing between the option-fab button and the dugga-button so they don't overlap. I added some more margin between them so that shouldn't be a problem. Although (at least for me) it wasn't the browser that was the problem. it was the size of the screen on the phone you used. When you are on a bigger phone, like Iphone XR (figure 2 below), the spacing is a little bit bigger than if you use an Iphone SE (figure 1). But I see this as a positive thing because the two dugga-buttons is a group and that should be visible, while the fab-option button is for it self.

Iphone SE:
<img width="191" alt="image" src="https://github.com/user-attachments/assets/80f8d566-23e8-42a9-8a14-a5e1639f0555" />
_figure 1_

Iphone XR:
<img width="158" alt="image" src="https://github.com/user-attachments/assets/63f2a976-3aa4-453d-a1b1-1ccbce40caf9" />
_figure 2_
