### PR TITLE
change word to use capital letter

### DIFF
--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -226,7 +226,7 @@
 					<div class="inner-wrapper">
 						<div class="input-flex">
 							<?php
-							checkbox("generate_SSL", "generate local SSL certificate");
+							checkbox("generate_SSL", "Generate local SSL certificate");
 							?>
 						</div>
 					</div>


### PR DESCRIPTION
Fixes issue #17885. 
In the new installer, step 6, "generate local SSL certificate" now starts with a capital letter.