### PR TITLE
G3 2025 v8 #17599 fix course dropdown length

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -7878,7 +7878,7 @@ only screen and (max-device-width: 568px) {
     bottom: 100px; /* Nudges the FAB 10px up from the bottom */
   }
 }
-}
+
 @media screen and (max-width: 350px) {
 
   input.submit-button-newitem {


### PR DESCRIPTION
Fixes #17599. 

### What has been changed
- A `max-width` for the dropdown has been removed making it possible to see the entire text inside the dropdown window.
- Extra: An extra closing curly-bracket was spotted in the file and was removed. 

Before:
![image](https://github.com/user-attachments/assets/f7ac2ebd-576d-4858-b067-5c6860a1cf07)

After:
![image](https://github.com/user-attachments/assets/8ede3342-a22e-4133-b55a-3efa84fa9fb8)