### PR TITLE
(desktop-view) BUG instructions in 3D dugga don't close #17497

### DIFF
--- a/DuggaSys/templates/3d-dugga.js
+++ b/DuggaSys/templates/3d-dugga.js
@@ -904,6 +904,19 @@ function startDuggaHighScore(){
 	}
 }
 
+//----------------------------------------------------------------------------------
+// show/hide dugga instructions
+//----------------------------------------------------------------------------------
+function toggleInstructions()
+{
+    if(document.querySelector(".instructions-content").style.display==="block"){
+        document.querySelector(".instructions-content").style.display="none";
+    }
+    else{
+        document.querySelector(".instructions-content").style.display="block"
+    }
+}
+
 function toggleFeedback()
 {
     $(".feedback-content").slideToggle("slow");


### PR DESCRIPTION
### Summary
The bug was that instructions button wouldn't work, this was caused by the toggleInstructions() function being missing from the js file. This PR simply added back the missing function which restored functionality.

### For testing
To test this, simply go into the dugga 3D Dugga in Demo-Course and test that the button labeled "Instructions" works (hides/re-displays instructions when pressed repeatedly.