### PR TITLE
Search dropdown not disappearing #17754

### DIFF
--- a/DuggaSys/accessed.js
+++ b/DuggaSys/accessed.js
@@ -73,7 +73,8 @@ function hoverSearch() {
 
 //stops displaying the dropdown when removing cursor from search bar
 function leaveSearch() {
-
+	document.querySelector('#dropdownSearch').style.display = 'none';
+	
 }
 
 // displays dropdown for the filter-button


### PR DESCRIPTION
So this was a silly issue. The problem was that that function that removes the dropdown was empty. It was an easy fix and should now work as intended.