### PR TITLE
Securityquestion box now displays correctly while in dark mode.

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -574,6 +574,7 @@ body {
 .logoutBox,
 .formBox,
 .markdown,
+.showsecurityquestion,
 #mrkdwntxt{
   background-color: var(--color-background);
   color: var(--color-text-light);


### PR DESCRIPTION
## What's changed:
- Darkmode is now displayed correctly when trying to reset password.

### Old:
![image](https://github.com/user-attachments/assets/2010554e-85e0-4836-b38e-ccc5b2d9007c)

### New:
![image](https://github.com/user-attachments/assets/ed607e3b-fc4a-4e04-bc9d-0ce9fc6c6d29)

## How to test:
brom will not work, use keree for example instead.

`Login -> Forgot Password? -> enter <user>`