### PR TITLE
Fixed clearGitFiles and refreshGithubRepo

### DIFF
--- a/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php
+++ b/DuggaSys/microservices/gitCommitService/clearGitFiles_ms.php
@@ -6,19 +6,25 @@ include_once "../../../Shared/sessions.php";
 
 global $pdo;
 
+header("Content-Type: application/json");
+
 //--------------------------------------------------------------------------------------------------
 // clearGitFiles: Clear the gitFiles table in SQLite db when a course has been updated with a new github repo. This function is used by other github microservices.
 //--------------------------------------------------------------------------------------------------
 
-function clearGitFiles($cid) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['cid'])) {
+    $cid = $_POST['cid'];
+    
     $pdolite = new PDO('sqlite:../../githubMetadata/metadata2.db');
     $query = $pdolite->prepare("DELETE FROM gitFiles WHERE cid = :cid"); 
     $query->bindParam(':cid', $cid);
+    
     if (!$query->execute()) {
         $error = $query->errorInfo();
-        echo "Error updating file entries" . $error[2];
-        $errorvar = $error[2];
-        print_r($error);
-        echo $errorvar;
+        echo json_encode(["success" => false, "error" => $error[2]]);
+        exit;
     }
 }
+
+// Returns JSON
+echo json_encode(["success" => true]);

--- a/DuggaSys/microservices/gitCommitService/refreshGithubRepo_ms.php
+++ b/DuggaSys/microservices/gitCommitService/refreshGithubRepo_ms.php
@@ -15,7 +15,7 @@ include_once "../../../Shared/basic.php";
 include_once "../../../Shared/sessions.php";
 include_once "../../gitfetchService.php";
 include_once "./refreshCheck_ms.php";
-include_once "./clearGitFiles_ms.php";
+include_once "../../../DuggaSys/microservices/curlService.php";
 
 //Get data from AJAX call in courseed.js and then runs the function getCourseID, refreshGithubRepo or updateGithubRepo depending on the action
 if (isset($_POST['action'])) {
@@ -24,7 +24,7 @@ if (isset($_POST['action'])) {
         // refreshGithubRepo: Updates the metadata from the github repo if there's been a new commit
         //--------------------------------------------------------------------------------------------------
         $cid = $_POST['cid'];
-        clearGitFiles($cid);
+        callMicroservicePOST("gitCommitService/clearGitFiles_ms.php", ['cid' => $cid]);
     }
 
     // Get old commit and URL from Sqlite 


### PR DESCRIPTION
Fixed clearGitFiles and refreshGithubRepo for issue #16861

I tried testing it or looking up how to test it, maybe im dumb and its easy to test but as I understood it there iss this file "metadata2.db" that has tables on its own. Tried to download extensions as sqlite to add a row so I could delete it but I could not add one. The extension sqlite viewer worked good to view the tables but they are empty. With this said I am not 100% certain howw to test this properly.