### PR TITLE
Remove save button when logged in as admin/teacher in showdugga #17604

### DIFF
--- a/DuggaSys/showDugga.php
+++ b/DuggaSys/showDugga.php
@@ -174,11 +174,11 @@ if(!isset($_SESSION["submission-$cid-$vers-$duggaid-$moment"])){
 						echo "</div>";
 						
 					}else if ($duggafile !== 'contribution') {						
-						echo "<div id='submitButtonTable'>";
-						echo "<input id='saveDuggaButton' class='btn-disable submit-button large-button' type='button' value='Save' onclick='uploadFile(); showReceiptPopup();' />";
+						echo "<div id='submitButtonTable' class='submitButtonTable-center'>";
+						echo "<input class='btn-disable submit-button large-button' type='button' value='Save' onclick='uploadFile(); showReceiptPopup();' />";
 						if ($duggafile !== 'generic_dugga_file_receive') {
 							echo "<input class='btn-disable submit-button large-button' type='button' value='Reset' onclick='reset();' />";
-							echo "<input id='loadDuggaButton' class='submit-button large-button' type='button' value='Load Dugga' onclick='showLoadDuggaPopup();' />";
+							echo "<input class='submit-button large-button' type='button' value='Load Dugga' onclick='showLoadDuggaPopup();' />";
 						}
 						echo "</div>";
 					}

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -3867,10 +3867,9 @@ div.submit-button:disabled {
   width: 100%;
 }
 
-#submitButtonTable{
-  position: relative;
-  z-index:500;
-  margin-top: 20px;
+.submitButtonTable-center{
+  display: flex;
+  justify-content: center;
 }
 
 #submitButtonTable input.large-button {


### PR DESCRIPTION
## What's changed:
- Restored functionality of `Edit instructions` button - `Save`, `Reset` and `Load Dugga` buttons no longer show up when logged in with admin rights.
- Changed the semantic structure of the button elements to a more modern approach.
- Revamped the positioning of the buttons.

The styling of the different buttons is subjective. I'm open to any suggestions/improvements!

# Old (Logged in/out appear the same):
![image](https://github.com/user-attachments/assets/aea614c9-b4dd-4442-9764-5ee389a7ef7f)

## New (Logged out/logged in as a student):
![image](https://github.com/user-attachments/assets/02d79130-8ae5-4998-88d8-7a01320272cd)

## New (Logged in with admin rights):
![image](https://github.com/user-attachments/assets/f3507363-c39d-4ed7-a511-ae1bb668b804)

## How to test:
A list of users with different access levels can be found [here](https://github.com/HGustavs/LenaSYS/wiki/Users-and-different-access-levels).
`Navigate to a course which contains duggas -> Select any dugga -> try different users`