### PR TITLE
Fixed issue #17865 A4 template problem

### DIFF
--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -145,21 +145,24 @@ function toggleA4Template() {
         template.style.display = "none";
         vRect.style.display = "none";
         a4Rect.style.display = "none";
-        document.getElementById("a4OptionsDropdownContainer").style.display = "none";
-        
+
         document.getElementById("a4TemplateToggle").style.backgroundColor = "transparent";
         document.getElementById("a4TemplateToggle").style.color = color.PURPLE;
         document.getElementById("a4TemplateToggle").style.fontWeight = "bold";
     } else {
         template.style.display = "block";
-        document.getElementById("a4OptionsDropdownContainer").style.display = "block";
-        
+
+        // Apply the selected layout immediately
+        applyA4Option();
+
         document.getElementById("a4TemplateToggle").style.backgroundColor = color.PURPLE;
         document.getElementById("a4TemplateToggle").style.color = color.WHITE;
         document.getElementById("a4TemplateToggle").style.fontWeight = "normal";
     }
+
     document.getElementById("a4TemplateToggle").style.border = `3px solid ${color.PURPLE}`;
 }
+
 
 function toggleA4Dropdown() {
     const dropdown = document.getElementById("a4OptionsDropdown");
@@ -202,8 +205,13 @@ function toggleA4Vertical() {
     const vRect = document.getElementById("vRect");
     const a4Rect = document.getElementById("a4Rect");
 
-    vRect.style.display = "none";  // Hide horizontal
-    a4Rect.style.display = "block";  // Show vertical
+    vRect.style.display = "none";
+    a4Rect.style.display = "block";
+
+
+    // Set position to origin
+    a4Rect.style.left = "0px";
+    a4Rect.style.top = "0px";
 }
 
 /**
@@ -213,8 +221,12 @@ function toggleA4Horizontal() {
     const vRect = document.getElementById("vRect");
     const a4Rect = document.getElementById("a4Rect");
 
-    a4Rect.style.display = "none";  // Hide vertical
-    vRect.style.display = "block";  // Show horizontal
+    a4Rect.style.display = "none";
+    vRect.style.display = "block";
+
+    // Set position to origin
+    vRect.style.left = "0px";
+    vRect.style.top = "0px";
 }
 
 /**
@@ -223,12 +235,29 @@ function toggleA4Horizontal() {
 function applyA4Option() {
     const selectedOption = document.getElementById("a4OptionsDropdown").value;
 
+    // Always show the A4 template layer itself
+    const template = document.getElementById("a4Template");
+    template.style.display = "block";
+
+    const vRect = document.getElementById("vRect");
+    const a4Rect = document.getElementById("a4Rect");
+
+    // Reset both rectangles
+    vRect.style.display = "none";
+    a4Rect.style.display = "none";
+
+    // Apply the selected template shape
     if (selectedOption === "vertical") {
-        toggleA4Vertical();
+        a4Rect.style.display = "block";
+        a4Rect.style.left = "0px";
+        a4Rect.style.top = "0px";
     } else if (selectedOption === "horizontal") {
-        toggleA4Horizontal();
+        vRect.style.display = "block";
+        vRect.style.left = "0px";
+        vRect.style.top = "0px";
     }
 }
+
 
 /**
  * @description Toggles weither the snap-to-grid logic should be active or not. The GUI button will also be flipped.


### PR DESCRIPTION
The A4 templates was placed incorrectly and not from the origin, also when trying to load A4 templates the system displayed some incorrect behavior where it only loaded the A4 container and not the template and you had to toggle back and forth between horizontal and vertical until eventually something loaded up. These issues have been fixed

-  Updated toggleA4Vertical and toggleA4Horizontal to always reset both rectangles before showing the selected one.
-  Set explicit top/left to "0px" to guarantee origin positioning.
-  Removed duplicated calls between vertical and horizontal modes.

-  Moved logic to show a4Template into applyA4Option() so it's always visible when toggling.
-  Call to applyA4Option() added inside toggleA4Template() for immediate application of current layout.





**Fixed version**

https://github.com/user-attachments/assets/d56fd924-f636-40bb-b7c3-27e680e32854


**Idea for new issue:** The lines of the templates don't correctly align with the grid lines this is an issue from the master version and not something new, perhaps this can be resolved in a new issue. 
![image](https://github.com/user-attachments/assets/f385c22b-a6b3-4a57-9686-4a7a7f12b860)



