### PR TITLE
Made markdown-icons white in darkmode - codeviewer

### DIFF
--- a/DuggaSys/fileed.php
+++ b/DuggaSys/fileed.php
@@ -319,7 +319,7 @@ $js = array(
                                 <button class="markdown-icons" onclick="boldText()" title="Bold"><b>B</b></button>
                                 <button class="markdown-icons" onclick="cursiveText()" title="Italic"><i>i</i></button>
                                 <button class="markdown-icons" onclick="codeBlockText()" title="CodeBlock">&#10065;</button>
-                                <button class="markdown-icons" onclick="lists()" title="lists"><img src="../Shared/icons/list-symbol.svg"></button>
+                                <button class="markdown-icons" id="listIcon" onclick="lists()" title="lists"><img src="../Shared/icons/list-symbol.svg"></button>
                                 <button class="markdown-icons" onclick="linkYoutube()" title="link Youtube"><b>Yt</b></button>
                                 <button class="markdown-icons" id="quoteIcon" onclick="quoteText()" title="quote">&#10078;</button>
                                 <button class="markdown-icons" id="linkIcon" onclick="linkText()" title="link"><img src="../Shared/icons/link-icon.svg"></button>

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -580,7 +580,14 @@ body {
   border: 2px solid var(--color-border);
 }
 
-.iconColorInDarkMode{
+.markdown-icons,
+#listIcon,
+#imgIcon,
+#headerIcon {
+    filter: brightness(0) invert(1); 
+}
+
+.iconColorInDarkMode {
     cursor: pointer;
     filter: invert(80%);
     -webkit-filter: invert(80%);


### PR DESCRIPTION
The markdown icons in codeviewer have been changed from black to white for better visibility in dark mode.
