### PR TITLE
Redo recursive relations into its own element

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -88,6 +88,17 @@
     }
 }
 
+
+.selfcallBox {
+  pointer-events: all;
+  cursor: pointer; /* if you want the hover cursor */
+  opacity: 0;
+}
+
+.selfcallBox:hover {
+  opacity: 1;
+}
+
 #svgbacklayer {
     position: absolute;
     left: 0;

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -624,6 +624,14 @@
         </fieldset>
         <!-- MODES FIELD ENDS HERE!! -->
 
+        <!-- Self Call -->
+        <fieldset id="localLoadField">
+            <legend aria-hidden="true">Self Call</legend>
+            <div class="placementTypeBoxIcons diagramIcons" id="elementPlacement17" onclick="togglePlacementType(17); setElementPlacementType(17); setMouseMode(mouseModes.PLACING_ELEMENT);">
+                <img src="../Shared/icons/diagram_entity.svg" alt="Self Call" />
+            </div>
+        </fieldset>
+
         <!-- CAMERA FIELD IN TOOLBAR -->
         <fieldset>
             <legend aria-hidden="true">Camera</legend>
@@ -631,6 +639,7 @@
                 <img src="../Shared/icons/fullscreen.svg" alt="Reset view">
             </div>
         </fieldset>
+
         <!-- CAMERA FIELD IN TOOLBAR ENDS HERE!! -->
 
         <!-- HISTORY FIELD IN TOOLBAR -->
@@ -710,16 +719,6 @@
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
             </div>
         </fieldset>
-        
-        <div class="UMLButton placementTypeBoxIcons"
-     id="elementPlacement17"
-     onclick="togglePlacementType(17); setElementPlacementType(17); setMouseMode(mouseModes.PLACING_ELEMENT);">
-  <img src="../Shared/icons/self_call_icon.svg" alt="Self Call" />
-  <span class="placementTypeToolTipText">
-    <b>Self Call</b><br>
-    <p>Draws a self-call element with a loopback arrow.</p>
-  </span>
-</div>
 
         <!-- LOAD FIELD IN TOOLBAR ENDS HERE!! -->
     </div>

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -710,6 +710,17 @@
                 <img src="../Shared/icons/diagram_load_icon.svg" alt="Load diagram"/>
             </div>
         </fieldset>
+        
+        <div class="UMLButton placementTypeBoxIcons"
+     id="elementPlacement17"
+     onclick="togglePlacementType(17); setElementPlacementType(17); setMouseMode(mouseModes.PLACING_ELEMENT);">
+  <img src="../Shared/icons/self_call_icon.svg" alt="Self Call" />
+  <span class="placementTypeToolTipText">
+    <b>Self Call</b><br>
+    <p>Draws a self-call element with a loopback arrow.</p>
+  </span>
+</div>
+
         <!-- LOAD FIELD IN TOOLBAR ENDS HERE!! -->
     </div>
     <!-- TOOLBAR ENDS HERE!! -->

--- a/DuggaSys/diagram/constants.js
+++ b/DuggaSys/diagram/constants.js
@@ -81,6 +81,7 @@ const elementTypes = {
     sequenceLoopOrAlt: 14,
     note: 15,
     sequenceObject: 16,
+    SelfCall: 17,
 };
 
 /**
@@ -105,6 +106,7 @@ const elementTypesNames = {
     sequenceLoopOrAlt: "sequenceLoopOrAlt",
     note: "note",
     UMLRelation: "UMLRelation",
+    SelfCall: "SelfCall",
 };
 
 /**

--- a/DuggaSys/diagram/defaults.js
+++ b/DuggaSys/diagram/defaults.js
@@ -58,10 +58,10 @@ const defaults = {
         name: "Self Call",
         type: entityType.UML,
         kind: elementTypesNames.SelfCall,
-        width: 50,
-        height: 10,
+        width: 30,
+        height: 30,
         minWidth: 50,
-        maxHeight: 10,
+        maxHeight: 50,
     },
     IEEntity: {
         name: "IE Entity",

--- a/DuggaSys/diagram/defaults.js
+++ b/DuggaSys/diagram/defaults.js
@@ -54,6 +54,15 @@ const defaults = {
         minWidth: 60,
         minHeight: 60,
     },
+    SelfCall: {
+        name: "Self Call",
+        type: entityType.UML,
+        kind: elementTypesNames.SelfCall,
+        width: 50,
+        height: 10,
+        minWidth: 50,
+        maxHeight: 10,
+    },
     IEEntity: {
         name: "IE Entity",
         type: entityType.IE,

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -53,6 +53,9 @@ function drawElement(element, ghosted = false) {
         case elementTypesNames.ERRelation:
             divContent = drawElementERRelation(element, boxw, boxh, linew);
             break;
+        case elementTypesNames.SelfCall:
+            divContent = drawElementSelfCall(element, boxw, boxh, linew);
+            break;
         case elementTypesNames.ERAttr:
             divContent = drawElementERAttr(element, textWidth, boxw, boxh, linew, texth);
             break;
@@ -674,6 +677,23 @@ function drawElementUMLRelation(element, boxw, boxh, linew) {
             style='fill:${fill}; stroke:${strokeColor}; stroke-width:${linew};'
         />`;
     return drawSvg(boxw, boxh, poly);
+}
+
+//In progress 
+function drawElementSelfCall(element, boxw, boxh, linew) {
+    const strokeColor = "black";
+    const x1 = linew;
+    const x2 = boxw - linew;
+    const y = boxh / 2; 
+
+    const line = `
+        <line 
+            x1="${x1}" y1="${y}" 
+            x2="${x2}" y2="${y}" 
+            style="stroke:${strokeColor}; stroke-width:${linew};" 
+        />
+    `;
+    return drawSvg(boxw, boxh, line);
 }
 
 /**

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -681,19 +681,25 @@ function drawElementUMLRelation(element, boxw, boxh, linew) {
 
 //In progress 
 function drawElementSelfCall(element, boxw, boxh, linew) {
-    const strokeColor = "black";
-    const x1 = linew;
-    const x2 = boxw - linew;
-    const y = boxh / 2; 
+  const strokeColor = "black";
+  const fillColor   = "none";
+    console.log("hello from draw")
+  // Determine square size so it fits with a linew-wide margin
+  const size = Math.min(boxw, boxh) - 2 * linew;
+  // Center it
+  const x = (boxw  - size) / 2;
+  const y = (boxh  - size) / 2;
 
-    const line = `
-        <line 
-            x1="${x1}" y1="${y}" 
-            x2="${x2}" y2="${y}" 
-            style="stroke:${strokeColor}; stroke-width:${linew};" 
-        />
-    `;
-    return drawSvg(boxw, boxh, line);
+  const square = `
+    <rect 
+      class="selfcall"
+      x="${x}" y="${y}" 
+      width="${size}" height="${size}" 
+      style="fill:${fillColor}; stroke:${strokeColor}; stroke-width:${linew};" 
+    />
+  `;
+
+  return drawSvg(boxw, boxh, square);
 }
 
 /**

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -216,11 +216,17 @@ function drawLine(line, targetGhost = false) {
         }
         else if (line.type === entityType.SE){   
             lineStr += drawSequenceLine(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
-        }else if (telem.kind === elementTypesNames.SelfCall) {
-            console.log("things happend")
-            lineStr += selfcallthing(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
-            
         }
+        else if (telem.kind === elementTypesNames.SelfCall) {
+            lineStr += selfcallthing(fx, fy, tx, ty, offset.x1, offset.y1, line, lineColor, strokeDash);
+            const box = document.querySelector('.selfcall');
+            box.classList.add("selfcallBox");
+        }
+        else if (felem.kind === elementTypesNames.SelfCall) {
+            lineStr += selfcallthing(tx, ty, fx, fy, offset.x2, offset.y2, line, lineColor, strokeDash);
+            const box = document.querySelector('.selfcall');
+            box.classList.add("selfcallBox");
+        } 
         else {
             lineStr += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
         }
@@ -678,42 +684,41 @@ function getLineAttributes(line, f, t, ctype, fromElemMouseY, toElemMouseY) {
 }
 
 
-function selfcallthing(fx, fy, tx, ty, offset,  line, lineColor, strokeDash) {
+function selfcallthing(fx, fy, tx, ty, offsetX1, offsetY1,  line, lineColor, strokeDash) {
 
-    const startX = fx + offset.x1;
-    const startY = fy;
-
-    const targetX = tx + offset.x1;
+    const startX = fx + offsetX1;
+    const startY = fy + offsetY1;
+    const targetX = tx ;
     const targetY = ty;
+    const lineWidth = 30;   
 
-    const horizontalOffset = 30;
+    console.log(line);
 
-    // Determine if SelfCall is to the left or right
-    const bendDir = targetX >= startX ? 1 : -1;
-
-    const bendX = targetX + horizontalOffset * bendDir;
-    const exitX = startX + horizontalOffset * bendDir;
+    const bendX = targetX + lineWidth 
+    const bendY = targetY + lineWidth 
+    const exitX = startX  + lineWidth 
+    const exitY = startY  + lineWidth 
     let points = []
    
-    if(line.ctype == "LR" || line.ctype == "RL"){
+    if(line.ctype === "LR" || line.ctype === "RL"){
         points = [
-            `${startX},${startY}`,   // Down from Class
-            `${targetX},${targetY}`, // Down to SelfCall height
-            `${bendX},${targetY}`,   // Bend left or right
-            `${exitX},${startY}`     // Back up and out
-         ].join(" ");
+            `${startX},${startY}`,   
+            `${targetX},${targetY - 15}`, 
+            `${targetX},${bendY - 15}`,   
+            `${startX},${exitY}`, 
+        ].join(" ");
 
-    } else if(line.ctype == "BT" || line.ctype == "TB"){
+    } else if(line.ctype === "BT" || line.ctype === "TB"){
         points = [
-            `${startX},${startY}`,   // Down from Class
-            `${targetX},${targetY}`, // Down to SelfCall height
-            `${bendX},${targetY}`,   // Bend left or right
-            `${exitX},${startY}`     // Back up and out
+            `${startX},${startY}`,   
+            `${targetX - 15},${targetY}`, 
+            `${bendX - 15},${targetY}`,   
+            `${exitX},${startY}`     
         ].join(" ");
     }
- 
 
     return `
+
         <polyline 
             id="${line.id}" 
             points="${points}" 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -692,7 +692,6 @@ function selfcallthing(fx, fy, tx, ty, offsetX1, offsetY1,  line, lineColor, str
     const targetY = ty;
     const lineWidth = 30;   
 
-    console.log(line);
 
     const bendX = targetX + lineWidth 
     const bendY = targetY + lineWidth 
@@ -724,7 +723,7 @@ function selfcallthing(fx, fy, tx, ty, offsetX1, offsetY1,  line, lineColor, str
             points="${points}" 
             fill="none" 
             stroke="${lineColor}" 
-            stroke-width="${(line.width || 1) * zoomfact}" 
+            stroke-width="${(strokewidth) * zoomfact}" 
             stroke-dasharray="${strokeDash}" 
         />
     `;
@@ -1213,7 +1212,6 @@ function iconPoly(arr, x, y, lineColor, fill, rotation = 0) {
                 fill='${fill}' stroke='${lineColor}' stroke-width='${strokewidth}'
             />`;
     }
-    console.log("test");
     return `<polyline 
                 points='${s}' 
                 fill='${fill}' stroke='${lineColor}' stroke-width='${strokewidth}' transform='rotate(${rotation}, ${x},${y})'

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -301,20 +301,20 @@ function drawLine(line, targetGhost = false) {
     // Draws the cardinality start and end labels for Self Call
     if (felem.name === "Self Call" || telem.name === "Self Call") {
         if(felem.name === "Self Call"){
-                fx = tx + offset.x2 * 2; //If line is from self we want it to work same as if its the otwer way around
-                 fy = ty + offset.y2 * 2;
+                fx = tx + (offset.x2 * 2) * zoomfact ; //If line is from self we want it to work same as if its the otwer way around
+                fy = ty + (offset.y2 * 2) * zoomfact;
         }
          if (line.startLabel && line.startLabel != '') {
-            let fxCardinality = fx + (2* offset.x1);
-            let fyCardinality = fy + (2* offset.y1);
-            let txCardinality = fx + (2* offset.x1);
-            let tyCardinality = fy + (2* offset.y1);
+            let fxCardinality = fx + (2* offset.x1) * zoomfact;
+            let fyCardinality = fy + (2* offset.y1) * zoomfact;
+            let txCardinality = fx + (2* offset.x1) * zoomfact;
+            let tyCardinality = fy + (2* offset.y1) * zoomfact;
             
             if (line.ctype === lineDirection.UP  || line.ctype === lineDirection.DOWN ) { 
-                txCardinality += 40;
+                txCardinality += 40 * zoomfact;
             }
             else if (line.ctype === lineDirection.LEFT  || line.ctype === lineDirection.RIGHT ) { 
-                tyCardinality += 40;
+                tyCardinality += 40 * zoomfact;
             }
 
         labelStr += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fxCardinality, fyCardinality, true, felem, telem);
@@ -725,32 +725,33 @@ function getLineAttributes(line, f, t, ctype, fromElemMouseY, toElemMouseY) {
 function selfCall(fx, fy, tx, ty, offsetX1, offsetY1,  line, lineColor, strokeDash) {
     const startX = fx + offsetX1;
     const startY = fy + offsetY1;
-    const targetX = tx
-    const targetY = ty 
-    const lineWidth = 30;   
+    const targetX = tx;
+    const targetY = ty;
+    const lineWidth = 30 * zoomfact;   
+    console.log(" tx: "  + tx  + " ty: " + ty  + " fx: " + fx + " fy: " + fy)
 
     const bendX = targetX + lineWidth //Making the line curv and bend back
     const bendY = targetY + lineWidth //different bend dependant on Left/Right or Top/Bottom
     const endX = startX  + lineWidth 
-    const endY = startY  + lineWidth 
+    const endY = startY  + lineWidth
     let points = []
    
     if(line.ctype === "LR" || line.ctype === "RL"){ // Left/Right
         points = [
             `${startX},${startY + offsetY1}`,   
-            `${targetX},${targetY - 15 }`, 
-            `${targetX},${bendY - 15}`,   
+            `${targetX},${targetY - 15 * zoomfact}`, 
+            `${targetX},${bendY - 15 * zoomfact}`,   
             `${startX},${endY + offsetY1}`,
         ].join(" ");
     } else if(line.ctype === "BT" || line.ctype === "TB"){ // Top/Bottom
         points = [
             `${startX + offsetX1},${startY}`,   
-            `${(targetX - 15)},${targetY}`, 
-            `${bendX - 15 },${targetY}`,   
+            `${targetX - 15 * zoomfact},${targetY}`, 
+            `${bendX - 15 * zoomfact},${targetY}`,   
             `${endX + offsetX1 },${startY }`
         ].join(" ");
     }
-
+ 
     return `
         <polyline 
             id="${line.id}" 

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -218,14 +218,10 @@ function drawLine(line, targetGhost = false) {
             lineStr += drawSequenceLine(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
         }
         else if (telem.kind === elementTypesNames.SelfCall) {
-            lineStr += selfcallthing(fx, fy, tx, ty, offset.x1, offset.y1, line, lineColor, strokeDash);
-            /* const box = document.querySelector('.selfcall');
-            box.classList.add("selfcallBox");*/
+            lineStr += selfCall(fx, fy, tx, ty, offset.x1, offset.y1, line, lineColor, strokeDash);
         }
         else if (felem.kind === elementTypesNames.SelfCall) {
-            lineStr += selfcallthing(tx, ty, fx, fy, offset.x2, offset.y2, line, lineColor, strokeDash);
-           /* const box = document.querySelector('.selfcall');
-            box.classList.add("selfcallBox"); */
+            lineStr += selfCall(tx, ty, fx, fy, offset.x2, offset.y2, line, lineColor, strokeDash);
         } 
         else {
             lineStr += drawLineSegmented(fx, fy, tx, ty, offset, line, lineColor, strokeDash);
@@ -234,44 +230,25 @@ function drawLine(line, targetGhost = false) {
     }
         //Line icon for SeflCall
         if (felem.name === "Self Call" || telem.name === "Self Call") {
-            const isFrom = felem.name === "Self Call";
+            const isFrom = felem.name === "Self Call"; //used to know if line is felem or telem 
             let startX = isFrom ? tx : fx; //Different values dependant on line direction
             let startY = isFrom ? ty : fy;
-            const element = document.getElementById(isFrom ? felem.id : telem.id );
+            const selectOffsetX = (isFrom ? offset.x2 : offset.x1); //keeping track of which offset to use
+            const selectOffsetY = (isFrom ? offset.y2 : offset.y1);
+            const length = 30 * zoomfact; 
 
-            if(isFrom){  //if the line is from the source element reverse icon
+            if(isFrom){  //if the line is from the source element reverse icons
                 line.ctype = line.ctype.split('').reverse().join('');
             }
-
-            const dx = 2 * (isFrom ? offset.x2 : offset.x1); //keeping track of which offset to use
-            const dy = 2 * (isFrom ? offset.y2 : offset.y1);
-            const length = 30 * zoomfact;
             
-            if (line.ctype === lineDirection.UP) {
-                const currentValue = element.offsetLeft;  
-                element.style.left = (currentValue + dx) + "px"; //Givingthe div element the offset aswell, to follow the line
-                lineStr += drawLineIcon(line.startIcon, line.ctype, startX + dx, startY, lineColor, line);
-                lineStr += drawLineIcon(line.endIcon,   line.ctype, startX + dx + length, startY, lineColor, line);
+            if (line.ctype === lineDirection.UP || line.ctype === lineDirection.DOWN) {
+                lineStr += drawLineIcon(line.startIcon, line.ctype, startX + selectOffsetX, startY, lineColor, line);
+                lineStr += drawLineIcon(line.endIcon,   line.ctype, startX + selectOffsetX + length, startY, lineColor, line);
+            } else if (line.ctype === lineDirection.LEFT || line.ctype === lineDirection.RIGHT) {
+                lineStr += drawLineIcon(line.startIcon, line.ctype, startX, startY + selectOffsetY, lineColor, line);
+                lineStr += drawLineIcon(line.endIcon,   line.ctype, startX, startY + selectOffsetY + length, lineColor, line);
+            } 
 
-            } else if (line.ctype === lineDirection.DOWN) {
-                const currentValue = element.offsetLeft;
-                element.style.left = (currentValue + dx) + "px";
-                lineStr += drawLineIcon(line.startIcon, line.ctype, startX +dx, startY, lineColor, line);
-                lineStr += drawLineIcon(line.endIcon,   line.ctype, startX +dx + length, startY, lineColor, line);
-
-            } else if (line.ctype === lineDirection.LEFT) {
-                const currentValue = element.offsetTop;
-                element.style.top = (currentValue + dy) + "px";
-                lineStr += drawLineIcon(line.startIcon, line.ctype, startX, startY + dy, lineColor, line);
-                lineStr += drawLineIcon(line.endIcon,   line.ctype, startX, startY + dy + length, lineColor, line);
-
-            } else if (line.ctype === lineDirection.RIGHT) {
-                const currentValue = element.offsetTop;
-                element.style.top = (currentValue + dy) + "px";
-                lineStr += drawLineIcon(line.startIcon, line.ctype, startX, startY + dy, lineColor, line);
-                lineStr += drawLineIcon(line.endIcon,   line.ctype, startX, startY + dy + length, lineColor, line);
-            }
-        
     }else {
         lineStr += drawLineIcon(line.startIcon, line.ctype, fx + offset.x1, fy + offset.y1, lineColor, line);
         lineStr += drawLineIcon(line.endIcon, line.ctype.split('').reverse().join(''), tx + offset.x2, ty + offset.y2, lineColor, line);
@@ -324,14 +301,15 @@ function drawLine(line, targetGhost = false) {
     // Draws the cardinality start and end labels for Self Call
     if (felem.name === "Self Call" || telem.name === "Self Call") {
         if(felem.name === "Self Call"){
-             fx = tx + offset.x2 * 2; //If line is from self we want it to work same as if its the otwer way around
-             fy = ty + offset.y2 * 2;
+            fx = tx + offset.x2; //If line is from self we want it to work same as if its the otwer way around
+            fy = ty + offset.y2;
         }
-         if (line.startLabel && line.startLabel != '') {
-            let fxCardinality = fx + (2* offset.x1);
-            let fyCardinality = fy + (2* offset.y1);
-            let txCardinality = fx + (2* offset.x1);
-            let tyCardinality = fy + (2* offset.y1);
+        if (line.startLabel && line.startLabel != '') {
+            let fxCardinality = fx + offset.x1;
+            let fyCardinality = fy + offset.y1;
+            let txCardinality = fx + offset.x1;
+            let tyCardinality = fy + offset.y1;
+            
             if (line.ctype === lineDirection.UP  || line.ctype === lineDirection.DOWN ) { 
                 txCardinality += 40;
             }
@@ -339,8 +317,8 @@ function drawLine(line, targetGhost = false) {
                 tyCardinality += 40;
             }
 
-            labelStr += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fxCardinality, fyCardinality, true, felem, telem);
-            labelStr += drawLineLabel(line, line.endLabel, lineColor, 'startLabel', txCardinality, tyCardinality, true, felem, telem);
+        labelStr += drawLineLabel(line, line.startLabel, lineColor, 'startLabel', fxCardinality, fyCardinality, true, felem, telem);
+        labelStr += drawLineLabel(line, line.endLabel, lineColor, 'startLabel', txCardinality, tyCardinality, true, felem, telem);
     }
     }
     // Draws the cardinality start and end labels for the line for UML
@@ -731,39 +709,49 @@ function getLineAttributes(line, f, t, ctype, fromElemMouseY, toElemMouseY) {
 }
 
 
-function selfcallthing(fx, fy, tx, ty, offsetX1, offsetY1,  line, lineColor, strokeDash) {
-
+/**
+ * @description Draw a line that returns to the main element, representing a self association
+ * @param {Number} fx The X coordinate of the From element
+ * @param {Number} fy The Y coordinate of the From element
+ * @param {Number} tx The X coordinate of the To element
+ * @param {Number} ty The Y coordinate of the To element
+ * @param {Number} offsetX1 The X offset for the first point
+ * @param {Number} offsetY1 The Y offset for the first point
+ * @param {Object} line The line object
+ * @param {String} lineColor The color of the line
+ * @param {Number} strokeDash if its dashed or not
+ * @returns Returns the SVG polyline for the self call line
+ **/
+function selfCall(fx, fy, tx, ty, offsetX1, offsetY1,  line, lineColor, strokeDash) {
     const startX = fx + offsetX1;
     const startY = fy + offsetY1;
-    const targetX = tx + offsetX1;
-    const targetY = ty + offsetY1;
+    const targetX = tx
+    const targetY = ty 
     const lineWidth = 30;   
 
-    const bendX = targetX + lineWidth 
-    const bendY = targetY + lineWidth 
-    const exitX = startX  + lineWidth 
-    const exitY = startY  + lineWidth 
+    const bendX = targetX + lineWidth //Making the line curv and bend back
+    const bendY = targetY + lineWidth //different bend dependant on Left/Right or Top/Bottom
+    const endX = startX  + lineWidth 
+    const endY = startY  + lineWidth 
     let points = []
    
-    if(line.ctype === "LR" || line.ctype === "RL"){
+    if(line.ctype === "LR" || line.ctype === "RL"){ // Left/Right
         points = [
             `${startX},${startY + offsetY1}`,   
-            `${targetX},${targetY - 15 + offsetY1}`, 
-            `${targetX},${bendY - 15 + offsetY1}`,   
-            `${startX},${exitY + offsetY1}`, 
+            `${targetX},${targetY - 15 }`, 
+            `${targetX},${bendY - 15}`,   
+            `${startX},${endY + offsetY1}`,
         ].join(" ");
-
-    } else if(line.ctype === "BT" || line.ctype === "TB"){
+    } else if(line.ctype === "BT" || line.ctype === "TB"){ // Top/Bottom
         points = [
-            `${startX+ offsetX1},${startY}`,   
-            `${(targetX - 15) +offsetX1},${targetY}`, 
-            `${bendX - 15 + offsetX1},${targetY}`,   
-            `${exitX + offsetX1 },${startY }`     
+            `${startX + offsetX1},${startY}`,   
+            `${(targetX - 15)},${targetY}`, 
+            `${bendX - 15 },${targetY}`,   
+            `${endX + offsetX1 },${startY }`
         ].join(" ");
     }
 
     return `
-
         <polyline 
             id="${line.id}" 
             points="${points}" 
@@ -774,9 +762,6 @@ function selfcallthing(fx, fy, tx, ty, offsetX1, offsetY1,  line, lineColor, str
         />
     `;
 }
-
-
-
 
 
 /**

--- a/DuggaSys/diagram/draw/line.js
+++ b/DuggaSys/diagram/draw/line.js
@@ -233,8 +233,8 @@ function drawLine(line, targetGhost = false) {
             const isFrom = felem.name === "Self Call"; //used to know if line is felem or telem 
             let startX = isFrom ? tx : fx; //Different values dependant on line direction
             let startY = isFrom ? ty : fy;
-            const selectOffsetX = (isFrom ? offset.x2 : offset.x1); //keeping track of which offset to use
-            const selectOffsetY = (isFrom ? offset.y2 : offset.y1);
+            const selectOffsetX =  2 * (isFrom ? offset.x2 : offset.x1); //keeping track of which offset to use
+            const selectOffsetY =  2 * (isFrom ? offset.y2 : offset.y1);
             const length = 30 * zoomfact; 
 
             if(isFrom){  //if the line is from the source element reverse icons
@@ -301,14 +301,14 @@ function drawLine(line, targetGhost = false) {
     // Draws the cardinality start and end labels for Self Call
     if (felem.name === "Self Call" || telem.name === "Self Call") {
         if(felem.name === "Self Call"){
-            fx = tx + offset.x2; //If line is from self we want it to work same as if its the otwer way around
-            fy = ty + offset.y2;
+                fx = tx + offset.x2 * 2; //If line is from self we want it to work same as if its the otwer way around
+                 fy = ty + offset.y2 * 2;
         }
-        if (line.startLabel && line.startLabel != '') {
-            let fxCardinality = fx + offset.x1;
-            let fyCardinality = fy + offset.y1;
-            let txCardinality = fx + offset.x1;
-            let tyCardinality = fy + offset.y1;
+         if (line.startLabel && line.startLabel != '') {
+            let fxCardinality = fx + (2* offset.x1);
+            let fyCardinality = fy + (2* offset.y1);
+            let txCardinality = fx + (2* offset.x1);
+            let tyCardinality = fy + (2* offset.y1);
             
             if (line.ctype === lineDirection.UP  || line.ctype === lineDirection.DOWN ) { 
                 txCardinality += 40;

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -87,7 +87,7 @@ function checkConnectionErrors(to, from) {
     if (sameTypeError(from, to, sameConnectionForbidden)) {
         return `Not possible to draw a line between: ${from.name}- and ${to.name}-element`;
     }
-    if (diffrerentTypeError(from, to)) {
+    if (diffrerentTypeError(from, to) && (from.kind != elementTypesNames.SelfCall && to.kind != elementTypesNames.SelfCall)) {
         return `Not possible to draw lines between: ${from.type}- and ${to.type}-elements`;
     }
     if (limitEREntitiesToAttriutes(from, to)) {

--- a/DuggaSys/diagram/helpers/line.js
+++ b/DuggaSys/diagram/helpers/line.js
@@ -79,10 +79,9 @@ function addLine(fromElement, toElement, kind, isRecursive = false, stateMachine
     return result;
 }
 function checkConnectionErrors(to, from) {
-    if (from.id == to.id &&
-        (to.kind != elementTypesNames.SDEntity && to.kind != elementTypesNames.UMLEntity && to.kind != elementTypesNames.IEEntity && to.kind != "sequenceActivation")
+    if (from.id == to.id && ( to.kind != "sequenceActivation")
     ) {
-        return `Not possible to draw a line between: ${from.name} and ${to.name}, they are the same element`;
+        return `Not possible to draw a line between: ${from.name} and ${to.name}, they are the same element. Use Self Call object instead.`;
     }
     if (sameTypeError(from, to, sameConnectionForbidden)) {
         return `Not possible to draw a line between: ${from.name}- and ${to.name}-element`;


### PR DESCRIPTION
A recursive line (self call) is now no longer a function of each element but its own separate element to be placed.
Now the user gets a error when trying to draw a line to the same element and is advised to use Self call instead.
Its named Self Call and can be selected from the menu. 
At the moment its a cube shape, but this is very easy to change in the future.

* The main issue wanted the element to only be visible when selected or having no lines connected, i where unable to do this and a issue will have to be made for that functions specifically.

* Arrows(icons), cardinality and label are not optimally placed and might need to be looked into to in future issues.

* I removed much of the old recursive functions, but not all. This requires a deeper dive and i feel a separate issue would suit it better.

I feel that this works and solves the basic problems of the recursive, its not perfect or fully complete, but also makes it easier for new implementation and fixes as it is its own element.  Hopefully the next year they can continue evolving it.
I feel i could make it better and fix the smaller issues, but i have spent to much time already on this issue and feel it would be better to make problems there own separate issues instead. 

[Screencast from 2025-05-26 11-46-40.webm](https://github.com/user-attachments/assets/531a5b52-268e-45c8-bcf8-5c94ac529fbe)
