### PR TITLE
Fixed pointer-tool on mobile (#17545)

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -940,7 +940,22 @@ function setupTouchAsMouseSupport() {
         if (event.touches.length === 1) {
             const touch = event.touches[0];
 
+            // If the Pointer-tool is used, a selection can be done on one element, and movement is possible
             if (mouseMode === mouseModes.POINTER) {
+                let touchedElement = document.elementFromPoint (touch.clientX, touch.clientY);
+
+                while (touchedElement && !touchedElement.classList.contains("element")) {
+                    touchedElement = touchedElement.parentElement;
+                }
+
+                if (touchedElement && touchedElement.classList.contains ("element")) {
+                    const elementId = touchedElement.id;
+                    const elData = data.find(el => el.id === elementId); 
+                    // Updates element based on movement
+                    if (elData) {
+                        updateSelection(elData);
+                    }
+                }
                 pointerTool_Start(touch.clientX, touch.clientY);
             }
 

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -938,6 +938,12 @@ function setupTouchAsMouseSupport() {
     // Handle touchstart: either simulates mousedown or prepare for pinch-zoom
     container.addEventListener("touchstart", function (event) {
         if (event.touches.length === 1) {
+            const touch = event.touches[0];
+
+            if (mouseMode === mouseModes.POINTER) {
+                pointerTool_Start(touch.clientX, touch.clientY);
+            }
+
             // Single touch, simulates a mouse down event
             const mouseEvent = convertTouchToMouse(event, "mousedown");
             container.dispatchEvent(mouseEvent);
@@ -953,6 +959,12 @@ function setupTouchAsMouseSupport() {
     container.addEventListener("touchmove", function (event) {
         event.preventDefault();
         if (event.touches.length === 1) {
+            const touch = event.touches[0];
+
+            if (mouseMode === mouseModes.POINTER && pointerState === pointerStates.CLICKED_ELEMENT) {
+                pointerTool_Update(touch.clientX, touch.clientY);
+            }
+
             // Singel touch, simulate mouse move event
             const mouseEvent = convertTouchToMouse(event, "mousemove");
             container.dispatchEvent(mouseEvent);
@@ -968,6 +980,7 @@ function setupTouchAsMouseSupport() {
             // No touches left, simulate mouse up event
             const mouseEvent = convertTouchToMouse(event, "mouseup");
             container.dispatchEvent(mouseEvent);
+            pointerTool_End();
             initialPinchDistance = null;
         }
     }, { passive: false });
@@ -1092,6 +1105,10 @@ function mouseMode_onMouseUp(event) {
  */
 function mmoving(event) {
     lastMousePos = new Point(event.clientX, event.clientY);
+
+    if (pointerState === pointerStates.CLICKED_ELEMENT && mouseMode === mouseModes.POINTER && 'ontouchstart' in window) {
+        return;
+    }
     switch (pointerState) {
         case pointerStates.CLICKED_CONTAINER:
             // Compute new scroll position

--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -59,6 +59,7 @@
     <script src="./diagram/helpers/context.js"></script>
     <script src="./diagram/helpers/element.js"></script>
     <script src="./diagram/helpers/boxSelect.js"></script>
+    <script src="./diagram/helpers/pointerTool.js"></script>
     <script src="./diagram/zoom.js"></script>
     <script src="./diagram/camera.js"></script>
     <script src="./diagram/tooltip_information.js"></script>

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -92,34 +92,12 @@ function mdown(event) {
         if (event.target.id == "container") {
             switch (mouseMode) {
                 case mouseModes.POINTER:
-                    sscrollx = scrollx;
-                    sscrolly = scrolly;
-                    startX = event.clientX;
-                    startY = event.clientY;
-
-                    // If pressed down in selection box
-                    if (context.length > 0) {
-                        if (startX > selectionBoxLowX && startX < selectionBoxHighX && startY > selectionBoxLowY && startY < selectionBoxHighY) {
-                            pointerState = pointerStates.CLICKED_ELEMENT;
-                            targetElement = context[0];
-                        } else {
-                            pointerState = pointerStates.CLICKED_CONTAINER;
-                            containerStyle.cursor = "grabbing";
-                            if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
-                                wasDblClicked = true;
-                            }
-                        }
-                        break;
-                    } else {
-                        pointerState = pointerStates.CLICKED_CONTAINER;
-                        containerStyle.cursor = "grabbing";
-
-                        if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
-                            wasDblClicked = true;
-                            toggleOptionsPane();
-                        }
-                        break;
+                    pointerTool_Start(event.clientX, event.clientY);
+                    containerStyle.cursor = "grabbing"; 
+                    if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
+                        wasDblClicked = true;
                     }
+                    break;
                 case mouseModes.BOX_SELECTION:
                     // If pressed down in selection box
                     if (context.length > 0) {

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -93,11 +93,7 @@ function mdown(event) {
             switch (mouseMode) {
                 case mouseModes.POINTER:
 
-                    pointerTool_Start(event.clientX, event.clientY);
-                    containerStyle.cursor = "grabbing"; 
-                    if ((new Date().getTime() - dblPreviousTime) < dblClickInterval) {
-                        wasDblClicked = true;
-                    }
+                    
 
                     sscrollx = scrollx;
                     sscrolly = scrolly;
@@ -109,6 +105,7 @@ function mdown(event) {
                         if (startX > selectionBoxLowX && startX < selectionBoxHighX && startY > selectionBoxLowY && startY < selectionBoxHighY) {
                             pointerState = pointerStates.CLICKED_ELEMENT;
                             targetElement = context[0];
+                            pointerTool_Start(event.clientX, event.clientY);
                         } else {
                             pointerState = pointerStates.CLICKED_CONTAINER;
                             containerStyle.cursor = "grabbing";
@@ -128,9 +125,11 @@ function mdown(event) {
                                 toggleOptionsPane();
                             }
                         }
-                        break;
+                        
 
                     }
+
+                    break;
                 case mouseModes.BOX_SELECTION:
                     // If pressed down in selection box
                     if (context.length > 0) {

--- a/DuggaSys/diagram/helpers/pointerTool.js
+++ b/DuggaSys/diagram/helpers/pointerTool.js
@@ -9,7 +9,7 @@ function pointerTool_Start(mouseX, mouseY) {
     deltaX = 0;
     deltaY = 0;
 
-    if (AudioContext.length > 0) {
+    if (context.length > 0) {
         const elId = context [0]?.id;
         if (!elId) {
             return;

--- a/DuggaSys/diagram/helpers/pointerTool.js
+++ b/DuggaSys/diagram/helpers/pointerTool.js
@@ -1,0 +1,86 @@
+// Pointer logic for touch/mouse interaction
+
+/**
+ * starts pointer interaction
+ */
+function pointerTool_Start(mouseX, mouseY) {
+    startX = mouseX;
+    startY = mouseY;
+    deltaX = 0;
+    deltaY = 0;
+
+    if (AudioContext.length > 0) {
+        const elId = context [0]?.id;
+        if (!elId) {
+            return;
+        }
+
+        const el = document.querySelector(`[id="${CSS.escape(elId)}"]`);
+
+        if (el) {
+            const rect = el.getBoundingClientRect();
+
+            // Using the screen-coordinates for a more reliable hit-test
+            if (mouseX >= rect.left && mouseX <= rect.right && mouseY >= rect.top && mouseY <= rect.bottom) {
+                pointerState = pointerStates.CLICKED_ELEMENT;
+                targetElement = context[0];
+                return;
+            }
+        }
+    }
+
+    // If clicking outside an element; treat as container-drag
+    pointerState = pointerStates.CLICKED_CONTAINER;
+    sscrollx = scrollX;
+    sscrolly = scrollY;
+}
+
+/**
+ * Ends pointer interaction
+ */
+function pointerTool_End() {
+    pointerState = pointerStates.DEFAULT;
+    targetElement = null;
+    deltaX = 0;
+    deltaY = 0;
+
+    updatepos();
+}
+
+/**
+ * Updates position continuously while pointer is active
+ */
+function pointerTool_Update(currentX, currentY) {
+    const dx = currentX -startX;
+    const dy = currentY - startY;
+
+    if (pointerState === pointerStates.CLICKED_ELEMENT && context.length > 0) {
+        movingObject = true;
+
+        context.forEach(el => {
+            el.x += dx / zoomfact;
+            el.y += dy / zoomfact;
+
+            // Convert to screen position for live drag-visuals
+            const screenPos = diagramToScreenCoordinates(el.x, el.y);
+            const domEl = document.getElementById(el.id);
+            if (domEl) {
+                domEl.style.left = `${screenPos.x}px`;
+                domEl.style.top = `${screenPos.y}px`;
+            }
+        });
+
+        startX = currentX;
+        startY = currentY;
+    }
+}
+
+/**
+ * Converting the diagram-coordinates to screen-coordinates
+ */
+function diagramToScreenCoordinates(diagramX, diagramY) {
+    return {
+        x:Math.round((diagramX - scrollx) * zoomfact),
+        y: Math.round((diagramY - scrolly) * zoomfact)
+    };
+}


### PR DESCRIPTION
Fixed the issue with being unable to select and move an element using the pointer-tool on the mobile version. The user is now able to select an element, and then move it around the grid-area. 

Is this the perfect solution? Honestly no. 
However, the main problem is solved - a user can select an element, drag it around, and can open options if they press the options-button while the element is selected. Sure, the element is not visible while dragging it around (like it is when using box-select), but at this point that feels like a minor problem that can be fixed later on (and should be it's own issue as I have not managed to fix that in the four days I've been trying to solve this). 

https://github.com/user-attachments/assets/a3bd75c1-705c-4ae4-892d-25d40bc8886e

