### PR TITLE
Fixed: Elements overlap FAB buttons.

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -8129,7 +8129,7 @@ only screen and (max-device-width: 568px) {
   bottom: 10vh;
   right: 7vw;
   display: none;
-  z-index: 22;
+  z-index: 3;
 }
 .diagram-btn-fab{
   line-height: 0;


### PR DESCRIPTION
Using the mobile version, placed elements on the canvas overlaps the FAB buttons since they shared the same Z-index. See picture below.

Before: 
![localhost_LenaSYS_DuggaSys_diagram php(Samsung Galaxy A51_71) (1)](https://github.com/user-attachments/assets/f167c783-3f68-4e99-9989-429fada403f5)

This was fixed by incrementing the Z-index for the button. The value was changed from `2` to `22`, one step above the mobile side-bar that has Z-index of `21`. I changed it to this value because the expanded FAB-menu and mobile sidebar intersect with some screen sizes and I assumed the FAB-button/menu is supposed to sit above the mobile side bar. I'm unsure if this is correct however, and if not the Z-value can be adjusted to `3`  instead.  

**Update:** Apparently the mentioned buttons/bars aren't supposed to intersect, instead the button should disappear when the sidebar is opened. There's an issue for this: [#17921], so the z-index has been corrected to `3`.

After:
![localhost_LenaSYS_DuggaSys_diagram php(Samsung Galaxy A51_71)](https://github.com/user-attachments/assets/589aa10d-00f1-49bf-9add-f383b80a9d00)