### PR TITLE
Fixed G1-2025-v8-#17901 add a limit to characters in savefile

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -1271,7 +1271,10 @@ button.saveButton {
   font-size: 16px;
   margin-top:10px;
   padding-left: 5px;
-  width: 70px;
+}
+
+.deleteLocalDiagram {
+    width: 70px;
 }
 
 /*****************

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -613,7 +613,7 @@
 
 /* Diagram Messages */
 #diagram-message {
-    width: 300px;
+    min-width: 300px;
     left: 85px;
     bottom: 20px;
     position: absolute;

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -445,7 +445,6 @@
         position: absolute !important;
         top: 50px !important;
         left: 50px !important;
-        width: 60% !important;
         z-index: 5000 !important;
     }
 
@@ -642,14 +641,35 @@
 
 #diagram-message .error {
     background-color: #FFD2D2;
+    min-width: 250px;
+    max-width: 250px;
+    overflow: hidden;
+    >p{
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }
 
 #diagram-message .success {
     background-color: #DFF2BF;
+    min-width: 250px;
+    max-width: 250px;
+    overflow: hidden;
+    >p{
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }
 
 #diagram-message .warning {
     background-color: #FEEFB3;
+    min-width: 250px;
+    max-width: 250px;
+    overflow: hidden;
+    >p{
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }
 
 /*tooltip*/

--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -953,6 +953,8 @@
     background-color: #815e9d;
     color: white;
     padding: 5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 #loadContainer button:hover {
@@ -1269,6 +1271,7 @@ button.saveButton {
   font-size: 16px;
   margin-top:10px;
   padding-left: 5px;
+  width: 70px;
 }
 
 /*****************


### PR DESCRIPTION
Added an ellipsis on the popup so the text overflow doesn't get outside the box.

<img width="169" alt="image" src="https://github.com/user-attachments/assets/7818a70d-c1ee-4603-92e8-37755f3ae206" />

Added an ellipsis to the filenames too so they fit in the load container.

desktop:
<img width="537" alt="image" src="https://github.com/user-attachments/assets/4a9cf0ab-759e-4df4-bb8a-6a1775b92c1f" />

mobile:
(the arrow-chevron disturbs me because it's over the load container. It's not a part of this issue so I'm making a new issue about this)
<img width="155" alt="image" src="https://github.com/user-attachments/assets/0f02bc3f-dfd9-4dc3-b945-16012b75c9c0" />
