### PR TITLE
Fixed: Tool sidebar no longer showing up when hovering over toolbar #17927

### DIFF
--- a/DuggaSys/diagram.css
+++ b/DuggaSys/diagram.css
@@ -34,35 +34,13 @@
         top: 0;
         left: 0;
         bottom: 0;
-        width: 60px; 
+        width: 50px; 
         height: 100vh; 
         z-index: 1000;
-        overflow-y: auto; /* Scrollbar appears only when needed */
-         overflow-x: hidden;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
     }
-}
-/*scrollbar styling more adaptive to different environments or browsers*/
-#diagram-toolbar::-webkit-scrollbar {
-    width: 10px;
-}
-
-/*  Options-scrollbar track */
-#diagram-toolbar::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 10px;
-    box-shadow: inset 0 0 5px grey;
-}
-
-/*  Options-scrollbar handle */
-#diagram-toolbar::-webkit-scrollbar-thumb {
-    background: #eb4;
-    border-radius: 10px;
-}
-
-/*  Options-scrollbar handle on hover */
-#diagram-toolbar::-webkit-scrollbar-thumb:hover {
-    background: #eb4;
-    border-radius: 10px;
 }
 
 @media screen and (min-height: 1199px) {


### PR DESCRIPTION
Unfortunately, the scrollbar and popouts are both situated in the same targeted div, which made the css overflow code - that creates the scrollbar - override the popout's overflow on the x-axis. The only way I found to solve this would have been to rewrite a large chunk of the toolbar html-code inside the diagram.php-file to incorporate a specific div for the scrollbar. I had a talk to the group leader and he said that it was better to prioritize the popout menus rather than having a scrollbar for the toolbar. So while this solves the problem of the popouts not showing, it isn't really a complete solution. Hence the Issue #17756 for the scrollbar will probably get reopened for someone to try to implement in a better way that doesn't remove the popouts. 

https://github.com/user-attachments/assets/de22df4f-3298-4aae-b075-5f1c1422e94d