### PR TITLE
Fixed selection conflicts when using UML Superstate and Sequence Loop templates

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2748,5 +2748,4 @@ function tooltipPosition(element){
         left: null
     };
 }
-console.log(allToolbarBox);
 //#endregion =====================================================================================

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -1954,12 +1954,20 @@ function changeLineProperties() {
     showdata();
 }
 
-/* Enables bringing an element to the front or sending it to the back by adjusting its z-index and redrawing the canvas */
-
+/**
+ * @description Enables bringing an element to the front or sending it to the back by adjusting its z-index and redrawing the canvas 
+ */ 
 function bringToFront(id) {
     const elem = data.find(e => e.id === id);
     if (!elem) return;
 
+    // Loops through the entire list of elements placed on the canvas
+    // Disables the bring to front if the element is a Loop, Alt or Super State
+    for (let i = 0; i < data.length; i++){
+        if (data[i].name === "Loop or Alt" || data[i].name === "Super State"){
+            return;
+        }
+    }
     const maxZ = Math.max(...data.map(e => e.z ?? 2));
     elem.z = maxZ + 1;
 
@@ -1980,10 +1988,3 @@ function sendToBack(id) {
 
     showdata(); // Redraw everything
 }
-
-
-
-
-
-
-


### PR DESCRIPTION
Created a for loop that iterates through the elements placed on the canvas and if the bring to front button is pressed on a Loop, Alt or Super State, nothing happens and the code return nothing.

Also removed some unnecessary console logs in the code.