### PR TITLE
G3 2025 v8 #17860 fix h3 styling fileed

### DIFF
--- a/Shared/css/markdown.css
+++ b/Shared/css/markdown.css
@@ -176,16 +176,6 @@
 	border: 1px solid #ddd;
 }
 
-#markdown h4, #markdown h5, #markdown h6 {
-	margin: 0;
-}
-
-#markdown h3{
-    font-size:16px;
-    margin: 2px 0px 2px 0px;
-    border-bottom: 2px solid #aaa;
-}
-
 #markdown hr {
     height:4px;  
     padding:0;

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -191,10 +191,17 @@ h3 {
 }
 
 h4 {
+  margin: 2px 0px 10px 0px;
+  padding: 0px;
+}
+
+h5 {
+  margin: 2px 0px 10px 0px;
   padding: 0px;
 }
 
 h6 {
+  margin: 2px 0px 10px 0px;
   padding: 0px;
 }
 

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -191,13 +191,10 @@ h3 {
 }
 
 h4 {
-  font-size: 16px;
-  margin: 1px 0px 8px 0px;
   padding: 0px;
 }
 
 h6 {
-  margin: 1px 0px 8px 0px;
   padding: 0px;
 }
 


### PR DESCRIPTION
Fixes #17860 

### What has been fixed
- Multiple CSS on the same element has been removed so only styling from `style.css` is now active 
- All styling about the headers in `markdown.css` has been removed
- Added styling for headers with no styling or different styling from the rest

Before:
![image](https://github.com/user-attachments/assets/1d6f1fd4-212f-42dc-b3e9-995d34acf8c6)

After:
![image](https://github.com/user-attachments/assets/22001c3f-5305-42cc-a2ae-9d598fecdf4a)