### PR TITLE
[#17888] Fixed issue with certain elements not resizing properly

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1169,6 +1169,7 @@ function mmoving(event) {
             }
             break;
         case pointerStates.CLICKED_NODE:
+            console.log("hello");
             const index = findIndex(data, context[0].id);
             const elementData = data[index];
 
@@ -1231,6 +1232,8 @@ function mmoving(event) {
 
             } else { // Normal resize for the other elements
                 // Functionality Left/Right resize
+
+                //if (elementData.kind == elementTypesNames.UMLEntity) console.log(elementData.width, elementData.height, elementData.x, elementData.y);
                 if ((startNode.left || startNode.upLeft || startNode.downLeft) && (startWidth + (deltaX / zoomfact)) > minWidth) { // Leftmost nodes while above minWidth
                     let tmpW = elementData.width;
                     let tmpX = elementData.x;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1232,8 +1232,6 @@ function mmoving(event) {
 
             } else { // Normal resize for the other elements
                 // Functionality Left/Right resize
-
-                //if (elementData.kind == elementTypesNames.UMLEntity) console.log(elementData.width, elementData.height, elementData.x, elementData.y);
                 if ((startNode.left || startNode.upLeft || startNode.downLeft) && (startWidth + (deltaX / zoomfact)) > minWidth) { // Leftmost nodes while above minWidth
                     let tmpW = elementData.width;
                     let tmpX = elementData.x;

--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1169,7 +1169,6 @@ function mmoving(event) {
             }
             break;
         case pointerStates.CLICKED_NODE:
-            console.log("hello");
             const index = findIndex(data, context[0].id);
             const elementData = data[index];
 

--- a/DuggaSys/diagram/draw/element.js
+++ b/DuggaSys/diagram/draw/element.js
@@ -397,7 +397,7 @@ function drawElementUMLEntity(element, boxw, boxh, linew, texth) {
 
     // Content, Attributes
     const textBox = (s, css) => {
-        let height = texth * s.length * lineHeight + texth * 1;
+        let height = (texth * s.length * lineHeight) + boxh / 2 + texth;
         let text = "";
         for (let i = 0; i < s.length; i++) {
             text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i]);
@@ -451,7 +451,7 @@ function drawElementIEEntity(element, boxw, boxh, linew, texth) {
 
     // Content, Attributes
     const textBox = (s, css) => {
-        let height = texth * s.length * lineHeight + texth * 1;
+        let height = (texth * s.length * lineHeight) + boxh + texth;
         let text = "";
         for (let i = 0; i < s.length; i++) {
             if (i < newPrimaryKeys.length) {
@@ -525,7 +525,7 @@ function drawElementSDEntity(element, boxw, boxh, linew, texth) {
 
     // Attributes box with lower rounded corners
     const drawBox = (s, css) => {
-        let height = texth * s.length * lineHeight + texth * 1;
+        let height = (texth * s.length * lineHeight) + boxh + texth;
         let text = "";
         for (let i = 0; i < s.length; i++) {
             text += drawText('0.5em', texth * (i + 1) * lineHeight, 'start', s[i]);

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -145,6 +145,7 @@ function mdown(event) {
             // If node is clicked, determine start point for resize
         } else if (event.target.classList.contains("node")) {
             pointerState = pointerStates.CLICKED_NODE;
+            console.log("hi");
             const element = data[findIndex(data, context[0].id)];
 
             // Save the original properties

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -145,7 +145,6 @@ function mdown(event) {
             // If node is clicked, determine start point for resize
         } else if (event.target.classList.contains("node")) {
             pointerState = pointerStates.CLICKED_NODE;
-            console.log("hi");
             const element = data[findIndex(data, context[0].id)];
 
             // Save the original properties
@@ -225,7 +224,7 @@ function ddown(event) {
                 startX = event.clientX;
                 startY = event.clientY;
 
-                if (!altPressed) {
+                if (!altPressed && pointerState !== pointerStates.CLICKED_NODE) {
                     pointerState = pointerStates.CLICKED_ELEMENT;
                     targetElement = event.currentTarget;
                     canPressDeleteBtn = true;


### PR DESCRIPTION
Certain elements, the ones that consisted of multiple "layers", i.e. UML Class, SD State, and IE Entity elements, were behaving weird when trying to resize them.

The cause of the bug lied in the way the elements were drawn. The _boxh_ value had been removed from the function that drew each box "layer" in the element. Without this, the elements wouldn't resize properly since boxh is crucial for all elements to resize properly. Boxh has been readded to the affected elements, while trying to keep the box-layer height ratios as similar as possible to what they were during the bug.

**The affected elements now resize properly again:**
https://github.com/user-attachments/assets/aab2c62e-0ce0-42d3-b0e5-ae3df0d816d6

