### PR TITLE
G2 2025 v8 #17814

### DIFF
--- a/DuggaSys/microservices/sectionedService/retrieveSectionedService_ms.php
+++ b/DuggaSys/microservices/sectionedService/retrieveSectionedService_ms.php
@@ -3,6 +3,7 @@
 
 // Include basic application services
 include_once "../../../Shared/basic.php";
+include_once "../curlService.php";
 
 //------------------------------------------------------------------------------------------------
 // Retrieve Information

--- a/DuggaSys/tests/microservices/sectionedService/removeListEntries_ms_test.php
+++ b/DuggaSys/tests/microservices/sectionedService/removeListEntries_ms_test.php
@@ -1,0 +1,36 @@
+<?php
+include_once "../../../../Shared/test.php";
+
+$testsData = array(
+
+  'removeListEntries_sectionedTest ' => array(
+
+    // Insert a test listentry row
+    'query-before-test-1' => "
+      INSERT INTO listentries (lid, cid, vers, entryname, visible, creator)
+      VALUES (9999, 1885, 950, 'Test', 1, 1);
+    ",
+
+    'expected-output' => '{"debug":"NONE!"}',
+
+    'service' => 'http://localhost/LenaSYS/DuggaSys/microservices/sectionedService/removeListEntries_ms.php',
+
+    'service-data' => serialize(array(
+      'courseid'   => 1885,
+      'coursevers' => 950,
+      'log_uuid'   => '',
+      'opt'        => 'updateListEntries',
+      'lid'        => 9999,
+      'creator'    => 1,
+      'username'   => 'brom',
+      'password'   => 'password'
+    )),
+
+    'filter-output' => serialize(array('debug')),
+
+    
+  )
+
+);
+
+testHandler($testsData, true);

--- a/DuggaSys/tests/microservices/sectionedService/removeListEntries_ms_test.php
+++ b/DuggaSys/tests/microservices/sectionedService/removeListEntries_ms_test.php
@@ -28,7 +28,9 @@ $testsData = array(
 
     'filter-output' => serialize(array('debug')),
 
-    
+    'query-after-test-1' => "
+      DELETE FROM listentries WHERE lid = 9999;
+    ",
   )
 
 );


### PR DESCRIPTION
Fixes issue https://github.com/HGustavs/LenaSYS/issues/17814

To test comment out the delete part:
`'query-after-test-1' => "
      DELETE FROM listentries WHERE lid = 9999;
    ",`
    
Check the database table "listentries".
A new row should appear and the value visible should change to "3".

Had to add "include_once "../curlService.php";" in updateCourseVersion_sectioned_ms.php because it uses the function callMicroservicePOST.
The file removeListEntries_ms.php has an include to updateCourseVersion so would get error without the new include.