### PR TITLE
Fixed $pdo error in createNewListEntry_ms.php #17954

### DIFF
--- a/DuggaSys/microservices/sharedMicroservices/createNewListEntry_ms.php
+++ b/DuggaSys/microservices/sharedMicroservices/createNewListEntry_ms.php
@@ -7,7 +7,6 @@ pdoConnect();
 session_start();
 
 
-global $pdo;
 $requiredKeys = [
 	'cid',
 	'cvs',


### PR DESCRIPTION
Fixes #17954 . I've simply removed "global  $pdo" from createNewListEntry_ms.php as this gave an error before and it should be enough with pdoConnect();. The error disappeared but I don't think it made any difference to the functionality when creating a new list entry in a course (for example a new section).

But I found another issue which I don't think is related to this issue and I'm not sure if it's our re-engineering of microservices that broke it or if the issue was there already (it's also in the master branch). When a new list entry is created you can see it in the UI but it's not inserted to the database. I will create a new issue for this if the reviewer confirms it as well. 