### PR TITLE
Fixed G1-2025-v8-#17921 sidebar should cover fab button on mobile

### DIFF
--- a/DuggaSys/diagram/toggle.js
+++ b/DuggaSys/diagram/toggle.js
@@ -599,9 +599,11 @@ function secondToolbarToggle() {
 
     if (ChevronActive) {
         chevronIcon.style.transform = `rotate(180deg)`;
+        document.body.classList.add("sidebar-open");
     }
     else {
         chevronIcon.style.transform = `rotate(0deg)`;
+        document.body.classList.remove("sidebar-open");
     }
 
     toolbar.classList.toggle('open');

--- a/Shared/css/mobile-diagram.css
+++ b/Shared/css/mobile-diagram.css
@@ -21,6 +21,13 @@
     #mb-diagram-sidebar.open {
         transform: translateX(-1px);
     }
+
+    .sidebar-open .diagram-fab,
+    .sidebar-open .fixed-option-button,
+    .sidebar-open .button-wrapper {
+      display: none !important;
+    }
+    
     #mb-diagram-toolbar.active {
         transform: translateY(0px);
     }


### PR DESCRIPTION
Added logic to toggle the sidebar-open class on the <body> element when the mobile sidebar is opened or closed.
This class does so the fab buttons is invisible while the sidebar is active.

https://github.com/user-attachments/assets/64f8f9b1-d51c-4f15-817b-bb79859b4a51