### PR TITLE
[#17957] Changed visibility of buttons in options pane for UML SuperState and Sequence Condition elements

### DIFF
--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -40,7 +40,7 @@ function generateContextProperties() {
         showProperties(true, propSet, menuSet);
         str += drawElementProperties(element);
 
-        // Bring to front / send to back buttons, not shown for UML SuperState or Sequence Loop elements
+        // Bring to front / send to back buttons. Bring to front isn't displayed for UML SuperState or Sequence Loop elements
         if(element.kind != elementTypesNames.UMLSuperState && element.kind != elementTypesNames.sequenceLoopOrAlt){
             str += `
             <div style="margin-top: 10px; color: ${color.WHITE};">Layer</div>
@@ -48,7 +48,10 @@ function generateContextProperties() {
             <button class="saveButton" onclick="sendToBack('${element.id}')">Send to Back</button>
             `;
         } else {
-            str += `<div style="margin-top: 10px; margin-bottom: -30px; color: ${color.WHITE};">Layer</div>`;
+            str += `
+            <div style="margin-top: 10px; color: ${color.WHITE};">Layer</div>
+            <button class="saveButton" onclick="sendToBack('${element.id}')">Send to Back</button>
+            `;
         }
     }
     // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.

--- a/DuggaSys/diagram/draw/options.js
+++ b/DuggaSys/diagram/draw/options.js
@@ -39,12 +39,17 @@ function generateContextProperties() {
     if (context.length == 1 && contextLine.length == 0) {
         showProperties(true, propSet, menuSet);
         str += drawElementProperties(element);
-        // Bring to front / send to back buttons
-    str += `
-        <div style="margin-top: 10px; color: ${color.WHITE};">Layer</div>
-        <button class="saveButton" onclick="bringToFront('${element.id}')">Bring to Front</button>
-        <button class="saveButton" onclick="sendToBack('${element.id}')">Send to Back</button>
-    `;
+
+        // Bring to front / send to back buttons, not shown for UML SuperState or Sequence Loop elements
+        if(element.kind != elementTypesNames.UMLSuperState && element.kind != elementTypesNames.sequenceLoopOrAlt){
+            str += `
+            <div style="margin-top: 10px; color: ${color.WHITE};">Layer</div>
+            <button class="saveButton" onclick="bringToFront('${element.id}')">Bring to Front</button>
+            <button class="saveButton" onclick="sendToBack('${element.id}')">Send to Back</button>
+            `;
+        } else {
+            str += `<div style="margin-top: 10px; margin-bottom: -30px; color: ${color.WHITE};">Layer</div>`;
+        }
     }
     // Creates radio buttons and drop-down menu for changing the kind attribute on the selected line.
     if (context.length == 0 && contextLine.length == 1) {


### PR DESCRIPTION
The **Bring to Front** button is no longer displayed in the options pane for the UML SuperState and Sequence Condition elements. 

The description of the issue was to make it greyed out and unclickable, but that seemed a bit uneccessary, since it would've just made it so that the options pane included an "empty" button with no functionality. This felt like it would've been cluttered and a bit misleading so I chose to just remove the button displaying for those elements altogether. Readding the button with the greyed out style and unclickability isn't a difficult thing to do, _just add the button to the else statement with the proper modifications_.

**How the options pane looks now (The Sequence Condition element is identical from the save button down):**

![image](https://github.com/user-attachments/assets/a419c553-9071-48c9-8011-bfa839dd6889)

There is an issue with the bring to front/send to back buttons in general where it sometimes stops working after sending to back too many times, especially when sending behind a superstate/condition element. The affected element just stops being selectable and trying to send other elements behind it also prevents them from being selectable. 

Sometimes the buttons just don't work in general.

These bugs existed before the changes made in the pull request and weren't part of this issue, I just thought I'd mention them.