### PR TITLE
G3 Added dots and commas as legal names

### DIFF
--- a/DuggaSys/sectioned.js
+++ b/DuggaSys/sectioned.js
@@ -4230,7 +4230,7 @@ function validateDate2(ddate, dialogid) {
 function validateSectName(name) {
   var element = document.getElementById(name);
   var errorMsg = document.getElementById("dialog10");
-  if (element.value.match(/^[A-Za-zÅÄÖåäö\s\d():_-]+$/)) {
+  if (element.value.match(/^[A-Za-zÅÄÖåäö\s\d():_\-.,]+$/)) {
 
     if (errorMsg) {
       errorMsg.style.transition = "opacity 0.3s ease";


### PR DESCRIPTION
Added dots and commas as legal names when editing a section name.

![image](https://github.com/user-attachments/assets/96bae695-4981-4580-a668-40730370b98a)
Name can now contain . or , and still be valid.