### PR TITLE
Darktheme fix for popupen #17944

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1436,4 +1436,27 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 .confirm { 
     background-color: #e9e9e9;
 }
-/*/ END /*/
+
+
+#pop {
+    background: var(--color-background) !important;
+    background-image: none !important;
+    box-shadow: none !important;
+    border: none !important;
+  }
+  
+  #pop table {
+    background: var(--color-background) !important;
+    background-image: none !important;
+  }
+  
+  #pop td {
+    background-image: none !important;
+  }
+  
+  #pop {
+    border: 2px solid white !important;
+    border-radius: 6px !important;
+    padding: 6px !important;
+  }
+  


### PR DESCRIPTION
updated popover for dark mode with black background and white border. 

before: 
<img width="423" alt="Skärmavbild 2025-05-27 kl  14 06 23" src="https://github.com/user-attachments/assets/b1a43495-d72e-4254-b7c2-b2b05b9bcfdb" />

after: 
<img width="421" alt="Skärmavbild 2025-05-27 kl  14 06 35" src="https://github.com/user-attachments/assets/b51cb10e-180f-4cd6-9ef7-0b22db188caa" />

