### PR TITLE
Fixed course page shows empty. Linux and macos only.

### DIFF
--- a/xampp/setup.sh
+++ b/xampp/setup.sh
@@ -23,7 +23,7 @@ else
     # Change htdocs folder owner and permissions
     echo "Found htdocs and beginning to change htdocs folder owner and permissions"
     sudo chown daemon:daemon "$HTDOCS_DIR"
-    sudo chmod 777 "$HTDOCS_DIR"
+    sudo chmod -R 777 "$HTDOCS_DIR"
 fi
 
 # Add this user to daemon group if not exists


### PR DESCRIPTION
Fixes #17984.

I found out why the page was empty, the problem was with the log folder, because it needs the correct permissions and inside this contains a database file.

To fix this, I needed to add permissions to 777 for the `htdocs/log` folder, but to prevent another permission errors, I chose to add the permissions recursively to the whole `htdocs` folder. To make sure not make any new error.