### PR TITLE
Fixed chevron overlapping load save

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -2156,6 +2156,9 @@ function showModal() {
     let diagramKeys;
     let localDiagrams;
 
+    let chevron = document.querySelector('.icon-wrapper-sidebar');
+    chevron.style.setProperty('display', 'none', 'important');
+
     let local = localStorage.getItem("diagrams");
 
 
@@ -2232,6 +2235,12 @@ function closeModal() {
     const modal = document.querySelector('.loadModal');
     const overlay = document.querySelector('.loadModalOverlay');
 
+    let chevron = document.querySelector('.icon-wrapper-sidebar');
+    if(chevron.style.display === "none"){
+        chevron.style.setProperty('display', 'block', 'important');
+    }
+    
+    
     modal.classList.add('hiddenLoad');
     overlay.classList.add('hiddenLoad');
 }


### PR DESCRIPTION
## What I did
Made the chevron have display none when showModal is opened and be set back to display block when its closed

## Demo
![2025-05-27_15-59-06-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/5328a363-225f-4310-ac0f-7551dc84ad7f)
