### PR TITLE
Fixed failed to open stream on Windows with Docker

### DIFF
--- a/dockerenv/setup.bat
+++ b/dockerenv/setup.bat
@@ -7,4 +7,15 @@ IF NOT EXIST coursesyspw.php (
 )
 
 REM start building Docker
-docker compose up --build
+docker compose up --build -d
+
+REM Make sure the containers are running
+echo Please wait a bit to make sure the containers are running
+timeout /t 10
+
+REM Run chown and chmod command in Apache container
+echo Beginning to change ownership and permissions of html folder
+docker exec -u root apache-php chown -R www-data:www-data /var/www/html/
+docker exec -u root apache-php chmod -R 777 /var/www/html/
+
+echo Now you can use the website!


### PR DESCRIPTION
Fixes #18017.

I implemented the code in `setup.bat` instead of add code in `init.sh`, because modify the script could cause problem on Linux and macOS. So, I decided to implement the `setup.bat` instead of `init.sh`.

 **How to test it?** 

Go to `LenaSYS/dockerenv/` and try to run `setup.bat`. The script will build Docker container and there is a timer which you need to wait for 10 second. After that the script will add permissions and ownerships for the Apache server. When everything is complete, then you will get a message from the terminal about all is done.

To turn off container type: `docker compose down`.

It should stop showing `Failed to open stream`. 

 