### PR TITLE
Problem when installing Lenasys with the new installer #16852

### DIFF
--- a/newinstaller/SQL/init_db.sql
+++ b/newinstaller/SQL/init_db.sql
@@ -260,7 +260,7 @@ CREATE TABLE template(
 	templateid				INTEGER UNSIGNED NOT NULL,
 	stylesheet 				VARCHAR(39) NOT NULL,
 	numbox					INTEGER NOT NULL,
-	PRIMARY KEY(templateid, stylesheet)
+	PRIMARY KEY(templateid)
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB;
 
 


### PR DESCRIPTION
I haven't encountered this issue myself (I use MariaDB and Mac), so I haven't been able to confirm that this fixes it. 
However, I did install with the new installer after I changed this, just to confirm that I didn't break anything. Fixes #16852 
 
From my understanding and from reading the comments from the previous developer that worked on this (https://github.com/HGustavs/LenaSYS/issues/16852#issuecomment-2858309050) there is problems with a foreign key. 

To be more specific, the error occurs when the installer tries to create a foreign key from the codeexample table referencing template.templateid. In the template table, templateid is currently not unique on its own, since it is only part of a composite primary key (templateid, stylesheet).

This breaks compatibility with MySQL (but not necessarily MariaDB), because MySQL requires that a foreign key references a column that is either a PRIMARY KEY or has a UNIQUE constraint.

To fix this, I changed the template table definition so that templateid is declared as the sole PRIMARY KEY instead. This ensures that codeexample.templateid can reference it without violating MySQL’s foreign key constraints.