### PR TITLE
Fix initial page on newinstaller/installer.php  #18052

### DIFF
--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -20,7 +20,7 @@
 <body>
 
 	<form id="installer_form">
-		<div id="page1" class="page">
+		<div id="page1" class="page" style="display:flex;">
 			<div class="banner">
 				<h1 class="header-1">Welcome to <b>LenaSYS</b></h1>
 			</div>

--- a/newinstaller/style.css
+++ b/newinstaller/style.css
@@ -43,7 +43,7 @@ html, body {
 #page2, #page3, #page4, #page5, #page6, #installationPage { display: none; }
 
 .page {
-    display: flex;
+    display: none;
     flex-direction: column;
     height: calc(100vh - 4rem);
     width: calc(100% - 4rem);


### PR DESCRIPTION
The page class had `display: flex` when the page loaded which caused page 1 and 7 to be visible and didn't get display: none until the user changes page. Fixes #18052 
I replaced flex with none on the page class and gave page1 `display: flex`. 

Only page 1 should be visible now and the page navigation will still work. 