### PR TITLE
Fixed the typo. Only macOS and Linux

### DIFF
--- a/dockerenv/setup.sh
+++ b/dockerenv/setup.sh
@@ -8,12 +8,12 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   # macOS
   GROUP_CMD=(sudo dseditgroup -o edit -a "$USER" -t user _www)
   GROUP_NAME="_www"
-  CHMOD_CMD=(sudo chown -R "$USER":_www ../../LenaSYS)
+  CHOWN_CMD=(sudo chown -R "$USER":_www ../../LenaSYS)
 else
   # Linux  
   GROUP_CMD=(sudo usermod -aG www-data "$USER")
   GROUP_NAME="www-data"
-  CHMOD_CMD=(sudo chown -R "$USER":www-data ../../LenaSYS)
+  CHOWN_CMD=(sudo chown -R "$USER":www-data ../../LenaSYS)
 fi
 
 # Make sure metadata folder exists
@@ -33,7 +33,7 @@ fi
 
 # Add LenaSYS folder to username and group recursively
 echo "Changing ownership of LenaSYS to $USER:$GROUP_NAME..."
-"${CHMOD_CMD[@]}"
+"${CHOWN_CMD[@]}"
 
 # Change permissions of LenaSYS to 777
 echo "Beginning to change permissions of LenaSYS to 777..."


### PR DESCRIPTION
Fixed #18054. 

I renamed `CHMOD_CMD` to `CHOWN_CMD`.

**How to Test:**

1. Open the terminal and navigate to the `LenaSYS/dockerenv/` directory.
2. Run the script: `bash ./setup.sh` or  `./setup.sh`
3. Open `Docker Desktop`. 
4. Go to the `containers tab`. 
6. Click the three dots on the apache-php container and select the `Open in terminal`.


![image](https://github.com/user-attachments/assets/6629ae2f-62e5-45ef-86d5-698faff072c7)

8. In the terminal type: `ls -l`

You should now see your username and group:
macOS: _username_:_username_
Linux: _username_:_username_