### PR TITLE
G3 2025 v8 the logout button is not in view #17928

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -6473,7 +6473,11 @@ only screen and (max-device-width: 568px) {
 
   #versionCog, #versionPlus, #editStudent,
   #githubPopupWindow,#testsBTN, #editFiles, #courseIMG,
-  #editCourse, #announcement, #messagedialog, #refreshIMG, .editVers, .newVers, .results, .tests, .files, .access, .refresh, .coursePage{
+  #editCourse, #announcement, #messagedialog, #refreshIMG {   /*#editCourse behaves weirdly. Display:none; doesn't change correctly and if you force it with !important the cogwheel function on courseed breaks.*/
+    display: none;                                            /*TODO: Check if #editCourse can be safely deleted.*/
+  }
+
+  .editVers, .newVers, .results, .tests, .files, .access, .refresh, .coursePage {
     display: none !important; /*TODO: Make editVers..coursePage disappear from the DOM correctly without use of !important.*/
   }
 }


### PR DESCRIPTION
**This is a retread of [#18043](<https://github.com/HGustavs/LenaSYS/pull/18043>) due to a bug causing the cogwheel on courseed.php to stop working.**

## What's changed:
- Logout button is now visible on smaller screens while logged in as admin.
- Hamburger icon now uses a `<button>` element.
- Removed some inline styling
- Moved media query to a more suitable location
- Fixed issue with unused elements not disappearing from the DOM.

The fix for the unused elements uses `!important` which is not great. I will create an issue for another problem I encountered which will also remove the need to use `!important`.

### Before:
![image](https://github.com/user-attachments/assets/088ec257-66da-45c6-91f6-2bc94fc0fc21)

### New:
![image](https://github.com/user-attachments/assets/cc0607c7-00b3-43c8-ad60-a13242efdb49)

## How to test:
`Pick a course -> Login as admin (brom) -> Test different screen sizes`