### PR TITLE
G2 2025 v9 #17643

### DIFF
--- a/Shared/Documentation/newinstaller/documentation.md
+++ b/Shared/Documentation/newinstaller/documentation.md
@@ -175,8 +175,7 @@ To enable https on your system you need SSL on the apache server you are hosting
 If you are using [XAMPP](ssl-xampp.md)
 
 ## Use Distributed Environment
-Enabling this option will allow the created MySQL user to connect from anywhere. The default is for the created MySQL user t
-o only be allowed to connect from the same hostname as supplied in [step 3](#step-3). This option is useful if you have your database hosted on another machine, or you are using a containerized dev environment such as docker. 
+Enabling this option will allow the created MySQL user to connect from anywhere. The default is for the created MySQL user to only be allowed to connect from the same hostname as supplied in [step 3](#step-3). This option is useful if you have your database hosted on another machine, or you are using a containerized dev environment such as docker. 
 
 ## Verbose
 The verbose mode of the installer will print alot more information, such as the individual queries it runs to install the system, and all the files it copies during installation. This is useful for debugging, but should be left off in most cases. 

--- a/Shared/Documentation/newinstaller/documentation.md
+++ b/Shared/Documentation/newinstaller/documentation.md
@@ -167,8 +167,16 @@ This page also conatins the options:
 # Options
 This section covers the various options available in the installer.
 
+## Step 6 - SSL
+
+To enable https on your system you need SSL on the apache server you are hosting lenasys with.
+
+### Tutorials
+If you are using [XAMPP](ssl-xampp.md)
+
 ## Use Distributed Environment
-Enabling this option will allow the created MySQL user to connect from anywhere. The default is for the created MySQL user to only be allowed to connect from the same hostname as supplied in [step 3](#step-3). This option is useful if you have your database hosted on another machine, or you are using a containerized dev environment such as docker. 
+Enabling this option will allow the created MySQL user to connect from anywhere. The default is for the created MySQL user t
+o only be allowed to connect from the same hostname as supplied in [step 3](#step-3). This option is useful if you have your database hosted on another machine, or you are using a containerized dev environment such as docker. 
 
 ## Verbose
 The verbose mode of the installer will print alot more information, such as the individual queries it runs to install the system, and all the files it copies during installation. This is useful for debugging, but should be left off in most cases. 

--- a/Shared/Documentation/newinstaller/ssl-xampp.md
+++ b/Shared/Documentation/newinstaller/ssl-xampp.md
@@ -1,0 +1,59 @@
+# SSL for XAMPP
+
+## !IMPORTANT!
+this is only relevant if your XAMPP installation does not come with an SSL-ready config.
+
+to check, try to access __`https://localhost`__
+If you get __Warning: Potential Security Risk Ahead__, you have SSL configured and you can use LenaSYS with HTTPS. (you get a warning because it is a self-signed certificate, it is fine to continue).
+
+## Prerequisites
+
+To follow this tutorial you need to have successfully ran __newinstaller__, or have your own SSL-cert and key. You should have these two files at the following path:
+- _LenaSYS/newinstaller/tools/ssl/__localhost.crt___
+- _LenaSYS/newinstaller/tools/ssl/__localhost.key___
+These files are local to your system and are ignored by git.
+
+## Step 1: configure Apache (httpd.conf)
+In the XAMPP GUI, press the apache config button, and open _httpd.conf_:
+
+(_xampp/apache/conf/__httpd.conf___)
+
+locate and uncomment the following lines:
+``` 
+LoadModule ssl_module modules/mod_ssl.so
+Include conf/extra/httpd-ssl.conf
+```
+
+## Step 2: configure SSL (httpd-ssl.conf)
+Next, open _httpd-ssl.conf_ the same way as before:
+
+(_xampp/apache/conf/__httpd-ssl.conf___)
+
+The XAMPP conf will have a bunch of comments, so you will need to locate the lines. Some lines should not need to change, e.g __`SSLEngine on`__ but it is good to check. 
+
+Update the config to reflect the following:
+(NOTE: you can not just copy it into the file, it will break the config)
+
+```
+Listen 443
+
+<VirtualHost default:443>
+    DocumentRoot "C:/xampp/htdocs"
+    ServerName localhost:443
+    ServerAdmin admin@localhost
+
+    SSLEngine on
+
+    SSLCertificateFile "$PATH_TO_LENASYS/newinstaller/tools/ssl/localhost.crt"
+    SSLCertificateKeyFile "$PATH_TO_LENASYS/newinstaller/tools/ssl/localhost.key"
+
+</VirtualHost>
+```
+
+## Final step: Restart Apache
+
+restart apache and try to visit __`https://localhost`__
+if it does not work, double check that all relevant lines are present and that the correct path to the .crt and .key is given.
+
+
+

--- a/newinstaller/installer_ui.php
+++ b/newinstaller/installer_ui.php
@@ -103,23 +103,23 @@
 					<div class="inner-wrapper">
 						<div class="input-grid">
 							<?php
-								$ConfigurationManager = new ConfigurationManager("../../coursesyspw.php");
-								$parameters = $ConfigurationManager->read_parameters();
+							$ConfigurationManager = new ConfigurationManager("../../coursesyspw.php");
+							$parameters = $ConfigurationManager->read_parameters();
 
-								inputField("db_name", "Database name:", "text", $parameters["DB_NAME"]);
-								inputField("username", "MySQL user:", "text", $parameters["DB_USER"]);
-								inputFieldWithTip('hostname', 'Hostname:', 'Tip: Usually set to "localhost"', $parameters["DB_HOST"]);
-								inputField("password", "MySQL user password:", "password", $parameters["DB_PASSWORD"]);
-								
-								if (!empty($parameters["DB_USING_DOCKER"])) {
-									checkbox("distributed_environment", "Use Distributed Environment", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#use-distributed-environment", $parameters["DB_USING_DOCKER"]);
-								} else {
-									checkbox("distributed_environment", "Use Distributed Environment", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#use-distributed-environment");
-								}
+							inputField("db_name", "Database name:", "text", $parameters["DB_NAME"]);
+							inputField("username", "MySQL user:", "text", $parameters["DB_USER"]);
+							inputFieldWithTip('hostname', 'Hostname:', 'Tip: Usually set to "localhost"', $parameters["DB_HOST"]);
+							inputField("password", "MySQL user password:", "password", $parameters["DB_PASSWORD"]);
 
-								checkbox("Verbose", "Verbose", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#verbose");
-								checkboxWithWarning("overwrite_db", "Overwrite existing database", "WARNING! Overwriting databases and users cannot be undone!", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#overwrite-existing-database-and-user-names");
-								checkbox("overwrite_user", "Overwrite existing user");
+							if (!empty($parameters["DB_USING_DOCKER"])) {
+								checkbox("distributed_environment", "Use Distributed Environment", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#use-distributed-environment", $parameters["DB_USING_DOCKER"]);
+							} else {
+								checkbox("distributed_environment", "Use Distributed Environment", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#use-distributed-environment");
+							}
+
+							checkbox("Verbose", "Verbose", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#verbose");
+							checkboxWithWarning("overwrite_db", "Overwrite existing database", "WARNING! Overwriting databases and users cannot be undone!", "https://github.com/HGustavs/LenaSYS/blob/8be873ef4ccb3cdb2fc28e72b2a30a79aa52c2f9/Shared/Documentation/newinstaller/documentation.md#overwrite-existing-database-and-user-names");
+							checkbox("overwrite_user", "Overwrite existing user");
 							?>
 						</div>
 					</div>
@@ -221,15 +221,20 @@
 				<div class="content">
 					<?php
 					header2("SSL (HTTPS)");
-					bodyText("To allow for push notifications, you have to enable SSL on your webserver");
+					bodyText("Some features requires HTTPS");
 					?>
 					<div class="inner-wrapper">
 						<div class="input-flex">
 							<?php
-							checkbox("generate_SSL", "Generate local SSL certificate");
+							checkbox("generate_SSL", "generate local SSL certificate");
 							?>
 						</div>
 					</div>
+						<?php
+					
+					bodyText("To enable SSL on your system, follow this link:", "https://github.com/HGustavs/LenaSYS/Shared/Documentation/newinstaller/documentation.md#step-6");
+
+					?>
 				</div>
 				<?php
 				navigationButtons(5, 7);


### PR DESCRIPTION
This is a tutorial for integrating the keys into XAMPP.
To test, run newinstaller, then follow the link in the installer to the tutorial. I tested with the latest XAMPP version for Windows, 8.2.12. I noticed that the latest version already has SSL keys enabled. Some versions don't.

NOTE: the link wont work until it is merged into master