### PR TITLE
Removal of whitespace under MOTD

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -39,6 +39,10 @@ function closeDeleteForm() {
 	document.getElementById("myForm").style.display = "none";
 }
 
+function removeMotdMargin() {
+	document.getElementById("Courselistc").style.margin = "0px auto";
+}
+
 function deleteCourse() {
 
 	let cid = document.getElementById("cid").value;

--- a/DuggaSys/courseed.php
+++ b/DuggaSys/courseed.php
@@ -73,7 +73,7 @@ if(isset($_SESSION['uid'])){
 	<div id="servermsgcontainer" class="alertmsg display_none">
 			<h3 id="servermsgtitle">Message of the day</h3>
 			<p id="servermsg"></p>
-			<input type='button' id="MOTDbutton" value='Close' class='submit-button' onclick='hideServerMessage()'/>
+			<input type='button' id="MOTDbutton" value='Close' class='submit-button' onclick='hideServerMessage(); removeMotdMargin();'/>
 	</div>
 	<!-- Server Msg END -->
 


### PR DESCRIPTION
Added a minimal javascript function that changes margin to adjust for the removal of the motd. 

A secondary approach to this would have been to rebuild the layout of the header and motd, to make them fall after each other in order. That way when motd closes the gap would close by itself.
Before
![image](https://github.com/user-attachments/assets/bdae62d0-6584-4a39-b9e4-d2f51fd5b9e1)

After
![SbQyx8TJVg](https://github.com/user-attachments/assets/1e4233bf-5aa8-4069-b2cf-981e8165b6c9)

