### PR TITLE
G3-2025-V8-#18082-BUG MOTD not displayed correctly

### DIFF
--- a/DuggaSys/courseed.js
+++ b/DuggaSys/courseed.js
@@ -568,6 +568,8 @@ function updateSettings() {
 	if (window.bool9 === true) {
 		toast("success", 'Version updated', 5);
 		popupContainer.style.display = "none";
+		// Reset MOTD visibility state when updating
+		sessionStorage.setItem('show', 'true');
 		AJAXService("SETTINGS", { motd: messageElement.value, readonly: readonly }, "COURSE");
 	} else {
 		toast("error", "You have entered incorrect information", 7);

--- a/Shared/dugga.js
+++ b/Shared/dugga.js
@@ -2691,7 +2691,7 @@ function hideCookieMessage() {
 
 function showServerMessage(){
 	document.querySelector("#motdNav").style.display="none";
-	document.querySelector("#servermsgcontainer").style.display="inline-block";
+	document.querySelector("#servermsgcontainer").style.display="flex";
 	sessionStorage.setItem('show','true');
 }
 


### PR DESCRIPTION
Upon updating MOTD, it disappears for the user updating it. May cause an error for users also, has not been tested, however this issue has been fixed by updating the show value within sessionstorage upon submitting the form.

![chrome_kVh1G6OcJf](https://github.com/user-attachments/assets/2f9f97ca-cbdd-47fd-89a3-b0d7434e64ef)
