### PR TITLE
Relative positions of multiple elements are now maintained when dragged.

### DIFF
--- a/DuggaSys/diagram.js
+++ b/DuggaSys/diagram.js
@@ -1172,10 +1172,10 @@ function mmoving(event) {
                         const lLine = data.find(line => line.id === snapId);
                         el.x = lLine.x + (lLine.width / 2) - (el.width / 2); // Snap horizontally to lifeline cenetr 
                     } else {
-                        el.x = coords.x - (el.width / 2); //  Follow mouse normally (centered)
+                        el.x = coords.x - el.offsetX;
+                        el.y = coords.y - el.offsetY;  
                     }
 
-                    el.y = coords.y - (el.height / 2); // Update vertical position to center under mouse
                 });
 
                 //Flag as moving and update the diagram

--- a/DuggaSys/diagram/events/mouse.js
+++ b/DuggaSys/diagram/events/mouse.js
@@ -24,6 +24,11 @@ function mwheel(event) {
 function mdown(event) {
     mouseButtonDown = true;
 
+    context.forEach(el => {
+       el.offsetX = event.clientX - el.x;
+       el.offsetY = event.clientY - el.y;
+   })
+
     //If anything but an element was clicked, toggle options panel.
     if (event.target.id == "container" && optionsToggled && !userLock) {
         console.log(event.target.id);
@@ -101,7 +106,7 @@ function mdown(event) {
                     startY = event.clientY;
 
                     // If pressed down in selection box
-                    if (context.length > 0) {
+                    if (context.length > 0) { 
                         if (startX > selectionBoxLowX && startX < selectionBoxHighX && startY > selectionBoxLowY && startY < selectionBoxHighY) {
                             pointerState = pointerStates.CLICKED_ELEMENT;
                             targetElement = context[0];


### PR DESCRIPTION

You can test this by simply creating multiple elements in diagram.php, selecting them all with the box selection tool, and dragging them to a different location.
Solves issue #18141 