### PR TITLE
Fix boxmodell dugga buttons layout on mobile devices

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -10915,5 +10915,54 @@ button:disabled {
 .feedback-content.slide-visible {
   max-height: 500px; /* Justera efter behov */
 }
+@media only screen and (max-width: 768px) {
+  
+  /* Fix för submitButtonTable containern */
+  #submitButtonTable.submitButtonTable-center {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 5px !important;
+    padding: 8px !important;
+    background-color: rgba(255, 255, 255, 0.9) !important;
+    border-radius: 5px !important;
+    margin-top: 10px !important;
+    margin-left: 0 !important; /* Flytta till vänster */
+    margin-right: auto !important;
+    width: auto !important; /* Låt bredden anpassa sig */
+    align-self: flex-start !important; /* Justera till vänster */
+  }
+  
+  /* Fix för alla knappar i submitButtonTable */
+  #submitButtonTable input[type="button"] {
+    width: 200px !important; /* Fast bredd istället för 100% */
+    height: 44px !important;
+    margin: 0 !important;
+    padding: 12px !important;
+    font-size: 14px !important;
+    border-radius: 4px !important;
+    box-sizing: border-box !important;
+    display: block !important;
+  }
+  
+  /* Specifika fixes för varje knapp */
+  input[value="Save"] {
+    order: 1 !important;
+  }
+  
+  input[value="Reset"] {
+    order: 2 !important;
+  }
+  
+  input[value="Load Dugga"] {
+    order: 3 !important;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  #submitButtonTable.submitButtonTable-center {
+    width: 45% !important; 
+    margin: 45px !important; 
+  }
+}
 
 /* END */


### PR DESCRIPTION
Fix boxmodell dugga buttons layout on mobile devices


Problem:
On mobile devices, the boxmodell dugga buttons (Save, Reset, Load Dugga) overlapped content and were poorly positioned, making it difficult for users to interact with them.
Solution:

Fixed button container positioning from absolute to flexbox layout
Stacked buttons vertically with consistent spacing on mobile screens
Aligned button container with main content area
Ensured all buttons have uniform width and height
Added responsive design that works on screens under 768px

Result:

* Buttons no longer overlap content
* Consistent vertical layout on mobile
* Better alignment with content area
* Improved mobile user experience


How it looked before: 
<img width="581" height="1107" alt="image" src="https://github.com/user-attachments/assets/87ed96cd-fad0-48ed-a2a1-73790887b81e" />


How it looks now: 
<img width="610" height="847" alt="image" src="https://github.com/user-attachments/assets/1d3ee22e-86ad-4333-b7e3-cc2481dee155" />

