### PR TITLE
Fix: BIT Dugga dropdown positioning on mobile view

### DIFF
--- a/Shared/css/dugga.css
+++ b/Shared/css/dugga.css
@@ -137,6 +137,19 @@ strong {font-weight: bold;}
 	border-radius:8px;
 }
 
+@media screen and (max-width: 768px) {
+	.popover {
+		position: absolute !important;
+		left: 50% !important;
+		top: 86% !important;
+		width: calc(100vw - 20px) !important;
+		max-width: 350px !important;
+		transform: translateX(-50%) !important;
+		z-index: 9999 !important;
+		margin: 0 !important;
+	}
+}
+
 .popover, .popover:before {
 	box-shadow: 2px 2px 2px rgba(0,0,0,0.5);
 }


### PR DESCRIPTION
Fixed the dropdown positioning in BIT dugga since it was only showing half of the pop up window, you had to scroll to view the entire window, now that is fixed and working.

Here is what i implemented to fix the issue
- Added responsive CSS for .popover element on mobile devices  
- Positioned dropdown at 86% from top with absolute positioning
- Ensured dropdown stays in place when scrolling
- Set max-width to 350px for optimal mobile experience

How it looked before:
<img width="395" height="827" alt="image" src="https://github.com/user-attachments/assets/f3013f8a-cab5-4176-ada3-a492ef87fc84" />


How it looks now:

<img width="628" height="1061" alt="image" src="https://github.com/user-attachments/assets/e415ae3b-f7c1-476a-9450-5264ccd1dace" />
