### PR TITLE
Fix #18067: Make 3D Dugga side panel fully visible on mobile

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -5116,6 +5116,66 @@ div.reset-pw:hover{
   border-bottom-right-radius: 10px;
 }
 
+@media screen and (max-width: 932px) {
+  
+  #container {
+    display: block !important;
+    flex-direction: initial !important;
+    justify-content: initial !important;
+    width: 100% !important;
+    padding: 10px !important;
+  }
+  
+  #foo {
+    width: 100% !important;
+    display: block !important;
+    margin-bottom: 20px !important;
+    order: 1 !important;
+  }
+  
+  #foo canvas {
+    width: 100% !important;
+    max-width: 100% !important;
+    height: auto !important;
+    display: block !important;
+    margin: 0 auto !important;
+  }
+  
+  #infoBox {
+    position: static !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    height: auto !important;
+    display: block !important;
+    flex-direction: initial !important;
+    margin: 20px 0 !important;
+    padding: 15px !important;
+    box-sizing: border-box !important;
+    background: white !important;
+    border: 2px solid #614875 !important;
+    border-radius: 8px !important;
+    order: 2 !important;
+  }
+  
+  #quizInstructions {
+    width: 100% !important;
+    display: block !important;
+  }
+  
+  .pane-container {
+    width: 100% !important;
+    display: block !important;
+    position: static !important;
+  }
+  
+  .pane-header,
+  .pane-body {
+    width: 100% !important;
+    display: block !important;
+    box-sizing: border-box !important;
+  }
+}
+
 .fab {
   position: fixed;
   width: 50px;


### PR DESCRIPTION
### Problem
The 3D Dugga "Vertice" panel was not fully visible on mobile devices, requiring users to scroll horizontally to access controls.

### Solution
- Restructured the container layout for mobile devices (max-width: 932px)
- Changed #container from flex to block layout
- Moved #infoBox (side panel) below #foo (canvas) using CSS order
- Overrode inline styles to ensure proper mobile display

### Testing
* Tested on mobile devices from 360px to 932px width
* Panel now displays fully visible under canvas on all mobile sizes
* No horizontal scrolling required
* Desktop layout unchanged

### Screenshots
Before changes:
<img width="301" height="657" alt="image" src="https://github.com/user-attachments/assets/a211428d-ae51-4a57-842e-86d7b3a3ccfa" />

After changes:

Showing two different mobile resolutions.

<img width="469" height="637" alt="image" src="https://github.com/user-attachments/assets/c3726aa3-fe54-4e41-a3f1-6a83fff72bb3" />
<img width="533" height="871" alt="image" src="https://github.com/user-attachments/assets/1f7b522d-a60a-4dac-a412-db1ff1cd4173" />


