### PR TITLE
18085 Codeviwer heading cut off on mobile

### DIFF
--- a/DuggaSys/codeviewer.php
+++ b/DuggaSys/codeviewer.php
@@ -231,6 +231,9 @@ Testing Link:
 				include '../Shared/navheader.php';
 				echo "<div class='err'><span id='bummerMsg'>Bummer!</span> Course or Code Example does not seem to exist! <a href='./codeviewer.php?exampleid=1&courseid=1&cvers=2013'>Click here</a> to redirect to example 1.</div>";
 			}
+			if(isset($codeviewer)){
+				echo "<div id='mobileNavHeading'><span id='mobileExampleSection'></span><span id='mobileExampleName'></span></div>";
+			}
 			//This text is always shown at the beginning of the page load but is removed if all checks succeeds and all is well. It also serves as error message is all checks weren't successful
 			if($codeviewer) echo "<div id='div2'>If this text remains this means there is an uncaught error. Please contact the administrators</div>";
 			echo "</div>";

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1864,7 +1864,6 @@ div .navButt:hover {
         height: 25px;
         text-align: center;
         color: var(--color-text-header);
-        margin-top: 50px;
         background:#927b9e;
         padding: 4px;
         font-weight: bold;

--- a/Shared/navheader.php
+++ b/Shared/navheader.php
@@ -581,9 +581,7 @@
 
 			echo "</ul></div>";
 
-			if(isset($codeviewer)){
-				echo "<div id='mobileNavHeading'><span id='mobileExampleSection'></span><span id='mobileExampleName'></span></div>";
-			}
+			
 			//Cookie message
 			echo "<div id='cookiemsg' class='alertmsg'><p>This site uses cookies. By continuing to browse this page you accept the use of cookies.</p><input type='button' value='OK' class='submit-button' onclick='cookieMessage()'/></div>";
 	    ?>


### PR DESCRIPTION
moved mobile heading to reposition it outside of navbar, since it doesnt fit in the navbar on mobile width. This makes use of pervious empty white space and ensures long filenames will be displayed properly. See attached images for before/after

Before
<img width="588" height="149" alt="image" src="https://github.com/user-attachments/assets/23f02ba4-8e07-42c5-bc8c-41becdea1fa7" />

After
<img width="444" height="818" alt="image" src="https://github.com/user-attachments/assets/54b187c6-24e3-4906-850e-71a40447a9a2" />
