### PR TITLE
18088 Make edges of burgerbutton clickable

### DIFF
--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -1835,7 +1835,15 @@ div .navButt:hover {
 
 #codeBurger {
   display: table-cell;
+  padding: 8px; /* Required for full click coverage, pls dont remove */
+  cursor: pointer;
+  text-align: center;
+  vertical-align: middle;
 }
+#codeBurger img {
+  display: block; /* makes sure the burger image doesn't have extra space */
+}
+
 #burgerMenu {
   position: absolute;
   z-index: 9999;


### PR DESCRIPTION
As stated in issue https://github.com/HGustavs/LenaSYS/issues/18088 the burgerbutton is clickable but does not open the menu. The reason for this being the logic of a table-cell display format. Adding some padding makes sure the whole area is clickable, and triggers the onclick also.


![chrome_p1ELUD86O6](https://github.com/user-attachments/assets/7a93ef81-6127-403b-90c0-1a08383794ef)
