### PR TITLE
18093 Diagram SelfCall CSS Fix

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -629,7 +629,7 @@
         <!-- Self Call -->
         <fieldset id="localLoadField">
             <legend aria-hidden="true">Self Call</legend>
-            <div class="placementTypeBoxIcons diagramIcons" id="elementPlacement17" onclick="togglePlacementType(17); setElementPlacementType(17); setMouseMode(mouseModes.PLACING_ELEMENT);">
+            <div class="placementTypeBoxIcons diagramIcons toolbarMode" id="elementPlacement17" onclick="togglePlacementType(17); setElementPlacementType(17); setMouseMode(mouseModes.PLACING_ELEMENT);">
                 <img src="../Shared/icons/diagram_entity.svg" alt="Self Call" />
             </div>
         </fieldset>


### PR DESCRIPTION
The reason for the selfcall not losing its active class is due to how active class is being removed in mouseMode.js


<img width="1233" height="263" alt="image" src="https://github.com/user-attachments/assets/5f405a83-86a7-4dde-92c8-d04fa0128888" />

The only purpose of that class is to check and uncheck active mode.
So adding that class to the SelfCall element solves this issue
![chrome_G4vKDfTE3T](https://github.com/user-attachments/assets/a0bb2177-8df5-4d7c-abc1-443cbacf36f8)
