### PR TITLE
17950 Fix darkmode in SVG Dugga

### DIFF
--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1466,4 +1466,34 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 .confirm { 
     background-color: #e9e9e9;
 }
+
+
+
+/* styles for SVG dugga panes */
+#svg-leftpane {
+  border: 1px solid #4a9eff !important; 
+  background: #1a3a5f !important; 
+}
+
+#svg-rightpane {
+  border: 1px solid #ff8c42 !important; 
+  background: #5f3a1a !important; 
+}
+
+#svg-content {
+  border: 1px dotted #4ade80 !important; 
+}
+
+/* styles for SVG editor and CSS editor textareas */
+#svg-editor {
+  background-color: #2d2d2d !important; 
+  color: #e0e0e0 !important; 
+  border: 1px solid #555 !important; 
+}
+
+#svg-styleed {
+  background-color: #2d2d2d !important; 
+  color: #e0e0e0 !important; 
+  border: 1px solid #555 !important;
+}
 /*/ END /*/


### PR DESCRIPTION
Currently the example SVG Dugga in testing course is brigh white due to the css being written straight into the stylesheet and no variant in the blacktheme.css file. 
 I have added styling to make sure the svg editor also toggles theme on theme swap, and tried to keep the colour scheme as best as possible.
 
![chrome_DppOQE2fgM](https://github.com/user-attachments/assets/a70f7bef-f439-4c10-a1f3-fec217b7bbde)
