### PR TITLE
#18077 Buttons in Dugga 5 are not darkmode 

### DIFF
--- a/DuggaSys/templates/dugga5.html
+++ b/DuggaSys/templates/dugga5.html
@@ -52,7 +52,7 @@
                     <td style="visibility: hidden;"><button onclick="moveVertexDown(this.parentNode);">&darr;</button></td>
                     <td style="visibility: hidden;"><button onclick="deleteVertex(this.parentNode);">X</button></td>
                 </tr>  
-                <tr><td style="visibility: hidden;">v00</td><td colspan="3"><button style="width:100%;" onclick="newVertex();">LÄGG TILL</button></td></tr>
+                <tr><td style="visibility: hidden;">v00</td><td colspan="3"><button class="addbutton"style="width:100%;" onclick="newVertex();">LÄGG TILL</button></td></tr>
                 <tr><td style="visibility: hidden;">v00</td><td colspan="6"><p id="vertexMsg" style="min-height:18px"></p></td></tr>
             </tbody>
         </table>    
@@ -84,7 +84,7 @@
                     <td><select style='width:100%;' id="tv3" onchange="checkTriangleInput();"></select></td>
                 </tr>  
                 <tr><td colspan="3"><button id="newTriangleButton" style="width:100%;" onclick="newTriangle();">LÄGG TILL</button></td></tr>
-                <tr><td colspan="3"><button style="float: left;" type="button" onclick="toggleWireframeMode();">Wire-Frame PÅ/AV</button><button style="float: right;" type="button" onclick="toggleRotate();">ROTATION PÅ/AV</button></td></tr>
+                <tr><td colspan="3"><button style="float: left;" class="addbutton" type="button" onclick="toggleWireframeMode();">Wire-Frame PÅ/AV</button><button style="float: right;" class="addbutton" type="button" onclick="toggleRotate();">ROTATION PÅ/AV</button></td></tr>
             </tbody>
         </table>    
         </div>

--- a/Shared/css/blackTheme.css
+++ b/Shared/css/blackTheme.css
@@ -1466,4 +1466,77 @@ border-left: 14px solid var(--color-sectioned-table-hi);
 .confirm { 
     background-color: #e9e9e9;
 }
+<<<<<<< Updated upstream
 /*/ END /*/
+=======
+
+
+
+/* styles for SVG dugga panes */
+#svg-leftpane {
+  border: 1px solid #4a9eff !important; 
+  background: #1a3a5f !important; 
+}
+
+#svg-rightpane {
+  border: 1px solid #ff8c42 !important; 
+  background: #5f3a1a !important; 
+}
+
+#svg-content {
+  border: 1px dotted #4ade80 !important; 
+}
+
+/* styles for SVG editor and CSS editor textareas */
+#svg-editor {
+  background-color: #2d2d2d !important; 
+  color: #e0e0e0 !important; 
+  border: 1px solid #555 !important; 
+}
+
+#svg-styleed {
+  background-color: #2d2d2d !important; 
+  color: #e0e0e0 !important; 
+  border: 1px solid #555 !important;
+}
+
+/* Dugga5 styling for buttons & inputs */
+#verticeList input,
+#triangleList2 input,
+#vertexX, #vertexY, #vertexZ, .addbutton {
+    background-color: var(--color-background-codeviewer);
+    color: var(--color-text-light);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 3px;
+    padding: 2px 4px;
+    font-size: 12px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+#newTriangleButton {
+    background-color: var(--color-primary);
+    color: var(--color-text-light);
+    border: none;
+    border-radius: 4px;
+    padding: 8px 12px;
+    font-size: 14px;
+    font-weight: bold;
+    cursor: pointer;
+    width: 100%;
+    margin-top: 5px;
+}
+
+#tv1, #tv2, #tv3 {
+    background-color: var(--color-background-codeviewer);
+    color: var(--color-text-light);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 3px;
+    padding: 4px;
+    font-size: 12px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+/*/ END /*/
+>>>>>>> Stashed changes

--- a/Shared/css/style.css
+++ b/Shared/css/style.css
@@ -10916,4 +10916,42 @@ button:disabled {
   max-height: 500px; /* Justera efter behov */
 }
 
+/* Dugga5 styling for buttons & inputs */
+#verticeList input,
+#triangleList2 input,
+#vertexX, #vertexY, #vertexZ, .addbutton {
+    background-color: white;
+    color: var(--color-text-dark);
+    border: 1px solid var(--color-border-2);
+    border-radius: 3px;
+    padding: 2px 4px;
+    font-size: 12px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+#newTriangleButton {
+    
+    color: var(--color-primary);
+    border: none;
+    border-radius: 4px;
+    padding: 8px 12px;
+    font-size: 14px;
+    font-weight: bold;
+    cursor: pointer;
+    width: 100%;
+    margin-top: 5px;
+}
+
+#tv1, #tv2, #tv3 {
+    background-color: var(--color-background-3);
+    color: var(--color-text-dark);
+    border: 1px solid var(--color-border-3);
+    border-radius: 3px;
+    padding: 4px;
+    font-size: 12px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
 /* END */


### PR DESCRIPTION
Added styling to make the darkmode version easier on the eyes and match the rest of the site. A lot of the html in this page is missing classes and proper styling, so had to use some alternative selectors. 

![chrome_y3KcLLYGkv](https://github.com/user-attachments/assets/043675b5-1ca0-4481-a5a9-0d77f0582a38)
