### PR TITLE
18094 Selfcall description implementation

### DIFF
--- a/DuggaSys/diagram.php
+++ b/DuggaSys/diagram.php
@@ -629,7 +629,7 @@
         <!-- Self Call -->
         <fieldset id="localLoadField">
             <legend aria-hidden="true">Self Call</legend>
-            <div class="placementTypeBoxIcons diagramIcons" id="elementPlacement17" onclick="togglePlacementType(17); setElementPlacementType(17); setMouseMode(mouseModes.PLACING_ELEMENT);">
+            <div class="placementTypeBoxIcons diagramIcons tooltip-target" id="elementPlacement17" onclick="togglePlacementType(17); setElementPlacementType(17); setMouseMode(mouseModes.PLACING_ELEMENT);" data-toolmode="Self_Call" data-toolid="26">
                 <img src="../Shared/icons/diagram_entity.svg" alt="Self Call" />
             </div>
         </fieldset>

--- a/DuggaSys/diagram/tooltip_information.js
+++ b/DuggaSys/diagram/tooltip_information.js
@@ -149,5 +149,9 @@ const tooltips = {
     "Replay_Exit":{
         header: "Exit",
         description: "Exit the replay-mode. "
+    },
+    "Self_Call":{
+        header: "Self Call",
+        description: "Create a self-referencing relationship for an entity."
     }
 };


### PR DESCRIPTION
Selfcall was missing a description on hover, and was missing attributes for it as well. I suspect it was added after tooltips were set up and was overlooked. I have now added it however it is missing a keybind as i was unaware of what keys were available still, may be looked into for another issue.

<img width="445" height="223" alt="image" src="https://github.com/user-attachments/assets/07296339-76cc-4109-af12-5c0aecc00bc3" />
